### PR TITLE
fix an infinite loop caused by unclosed quotation tag

### DIFF
--- a/src/codemirror/lint/jsonLint.js
+++ b/src/codemirror/lint/jsonLint.js
@@ -183,6 +183,8 @@ function readString() {
         default:
           throw syntaxError('Bad character escape sequence.');
       }
+    } else if (end === strLen) {
+      throw syntaxError('Unterminated string.');
     }
   }
 


### PR DESCRIPTION
Self descriptive. It'll stay in the loop hoping to find `"`(34), only to fail.
Resolves #12.