### PR TITLE
Use port 8081 so example works with relay-starter-kit out of the box

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,4 +5,4 @@ Example GraphiQL Install
 2. Navigate to this directory (example) in Terminal
 3. `npm install`
 4. `npm start`
-5. Open your browser to [http://localhost:8080/]()
+5. Open your browser to [http://localhost:8081/]()

--- a/example/server.js
+++ b/example/server.js
@@ -27,8 +27,8 @@ app.use(express.static(__dirname));
 app.use('/graphql', graphqlHTTP(() => ({
   schema: TestSchema
 })));
-app.listen(8080);
-console.log('Started on http://localhost:8080/');
+app.listen(8081);
+console.log('Started on http://localhost:8081/');
 
 // Schema defined here
 


### PR DESCRIPTION
https://github.com/relayjs/relay-starter-kit binds the graphql server to port `8080` and serves it at `/graphql`. This means we can't use the example out of the box.

Changing the port to 8081 means that relay-starter-kit works with the precompiled GraphiQL example with zero changes.