### PR TITLE
Use port 8081 if 8080 is taken so example works with relay-starter-kit

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,8 +1,21 @@
 Example GraphiQL Install
 ========================
 
-1. Run `npm install` in root directory
+Without [relay-starter-kit](https://github.com/relayjs/relay-starter-kit)
+-------------------------------------------------------------------------
+1. Run `npm install` in the GraphiQL repository root directory
 2. Navigate to this directory (example) in Terminal
 3. `npm install`
 4. `npm start`
 5. Open your browser to [http://localhost:8080/]()
+
+
+With [relay-starter-kit](https://github.com/relayjs/relay-starter-kit)
+----------------------------------------------------------------------
+1. Run `npm start` in [relay-starter-kit](https://github.com/relayjs/relay-starter-kit)
+2. Open another Terminal window.
+3. Run `npm install` in the GraphiQL repository root directory
+4. Navigate to this directory (example) in Terminal
+5. `npm install`
+6. `npm start`
+6. Open your browser to [http://localhost:8081/]()

--- a/example/index.html
+++ b/example/index.html
@@ -71,7 +71,7 @@
 
       // Defines a GraphQL fetcher using the fetch API.
       function graphQLFetcher(graphQLParams) {
-        return fetch(window.location.origin + '/graphql', {
+        return fetch('http://localhost:8080/graphql', {
           method: 'post',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(graphQLParams),

--- a/example/server.js
+++ b/example/server.js
@@ -24,11 +24,24 @@ import {
 
 var app = express();
 app.use(express.static(__dirname));
-app.use('/graphql', graphqlHTTP(() => ({
-  schema: TestSchema
-})));
-app.listen(8080);
-console.log('Started on http://localhost:8080/');
+app.listen(8080, () => {
+  app.use('/graphql', graphqlHTTP(() => ({
+    schema: TestSchema
+  })));
+  console.log('Started with test schema on http://localhost:8080/');
+})
+.on('error', (e) => {
+  // If 8080 is in use, assume we are using realy-starter-kit
+  // and start on 8081.
+  if (e.code == 'EADDRINUSE') {
+    app.listen(8081, () => {
+      console.log('http://localhost:8080 is in use.');
+      console.log('Assuming relay-starter-kit is running.');
+      console.log('Free up port 8080 if not using relay-starter-kit.');
+      console.log('Started with no schema on http://localhost:8081/');
+    });
+  }
+})
 
 // Schema defined here
 


### PR DESCRIPTION
This makes it so we try to bind to `8080`. If it fails, we assume that they are using [relay-starter-kit](https://github.com/relayjs/relay-starter-kit) and instead bind to `8081`. A note is output in case something else is using `8080`.

This lets us use the Test/canned data when `8080` is free (current behavior) and defer to relay-starter-kit for its data when it has already started up on `8080`.

Test Plan
-------------

1. Start relay-starter-kit, see it works.
2. Stop relay-starter-kit.
3. Start GraphiQL example, see it uses Test data.
4. Stop  GraphiQL example.
5. Start relay-starter-kit, see it works.
6. Start GraphiQL example, see it uses relay-starter-kit data.

Goes hand-in-hand with https://github.com/relayjs/relay-starter-kit/pull/20, which is needed to do a query from `localhost:8081` (GraphiQL example)  to `localhost:8080` (relay-starter-kit data)