### PR TITLE
remove babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   ],
   "babel": {
     "optional": [
-      "runtime",
       "es7.classProperties"
     ],
     "loose": [
@@ -54,7 +53,6 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.20",
     "codemirror": "^5.6.0",
     "codemirror-graphql": "^0.1.1",
     "marked": "^0.3.5"


### PR DESCRIPTION
Thus minimizing the dependency. Ran tests + built successfully from a fresh repo + example works.