### PR TITLE
make doc explorer scrolls down

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -120,6 +120,7 @@ html, body {
   z-index: 3;
   position: relative;
   background: white;
+  overflow:auto;
 }
 
 #graphiql-container .docExplorerResizer {


### PR DESCRIPTION
Make it overflowable, in the cases when there is too many fields they hidden.