### PR TITLE
Add `subscription` operation support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
     "express": "^4.12.4",
     "express-graphql": "^0.3.0",
     "graphiql": "../",
-    "graphql": "^0.4.2",
+    "graphql": "^0.4.8",
     "react": "0.13.3"
   },
   "devDependencies": {

--- a/example/server.js
+++ b/example/server.js
@@ -186,7 +186,22 @@ var TestMutationType = new GraphQLObjectType({
   }
 });
 
+var TestSubscriptionType = new GraphQLObjectType({
+  name: 'SubscriptionType',
+  description: 'This is a simple subscription type',
+  fields: {
+    subscribeToTest: {
+      type: TestType,
+      description: 'Subscribe to the test type',
+      args: {
+        id: { type: GraphQLString }
+      }
+    }
+  }
+});
+
 const TestSchema = new GraphQLSchema({
   query: TestType,
-  mutation: TestMutationType
+  mutation: TestMutationType,
+  subscription: TestSubscriptionType
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "marked": "^0.3.5"
   },
   "peerDependencies": {
-    "graphql": "^0.4.7",
+    "graphql": "^0.4.8",
     "react": "^0.13 || ^0.14.0-beta"
   },
   "devDependencies": {
@@ -72,7 +72,7 @@
     "eslint": "1.2.1",
     "eslint-plugin-react": "3.2.3",
     "flow-bin": "0.16.0",
-    "graphql": "0.4.7",
+    "graphql": "0.4.8",
     "jsdom": "6.5.1",
     "mocha": "2.2.5",
     "react": "0.13.3",

--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -5,6 +5,7 @@
  *  This source code is licensed under the license found in the
  *  LICENSE-examples file in the root directory of this source tree.
  */
+/* eslint max-len:0 */
 
 import React, { PropTypes } from 'react';
 import Marked from 'marked';
@@ -152,6 +153,7 @@ class SchemaDoc extends React.Component {
     var schema = this.props.schema;
     var queryType = schema.getQueryType();
     var mutationType = schema.getMutationType();
+    var subscriptionType = schema.getSubscriptionType();
 
     return (
       <div>
@@ -175,7 +177,13 @@ class SchemaDoc extends React.Component {
               <span className="keyword">mutation</span>
               {': '}
               <TypeLink type={mutationType} onClick={this.props.onClickType} />
-            </div>
+            </div>}
+          {subscriptionType &&
+            <div className="doc-category-item">
+              <span className="keyword">subscription</span>
+              {': '}
+              <TypeLink type={subscriptionType} onClick={this.props.onClickType} />
+            </div>}
           }
         </div>
       </div>


### PR DESCRIPTION
Adds `subscription` operation support that landed in graphql-js 0.4.8.

Do not merge until https://github.com/graphql/codemirror-graphql/pull/2 is merged and dependency is updated here.