### PR TITLE
Update README example to use ReactDOM instead of React for render

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ should be provided with a function for fetching from GraphQL, we recommend using
 the [fetch](https://fetch.spec.whatwg.org/) standard API.
 
 ```js
-import React from 'react';
+import ReactDOM from 'react-dom';
 import GraphiQL from 'graphiql';
 import fetch from 'isomorphic-fetch';
 
@@ -30,7 +30,7 @@ function graphQLFetcher(graphQLParams) {
   }).then(response => response.json());
 }
 
-React.render(<GraphiQL fetcher={graphQLFetcher} />, document.body);
+ReactDOM.render(<GraphiQL fetcher={graphQLFetcher} />, document.body);
 ```
 
 Build for the web with [webpack](http://webpack.github.io/) or


### PR DESCRIPTION
`React.render` is deprecated in favor of `ReactDOM.render`, this reflects that in the tiny example in the README