### PR TITLE
Allow React 0.14.x in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "peerDependencies": {
     "graphql": "^0.4.7",
-    "react": "0.14.0",
-    "react-dom": "0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
If you try to use latest React 0.14.2 with graphiql, it won't work. This PR fix it