### PR TITLE
Update package.json to rely on React ^0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "peerDependencies": {
     "graphql": "^0.4.7",
-    "react": "0.14.0",
-    "react-dom": "0.14.0"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
React has been upgraded to 0.14.2, so graphiql is now breaking my NPM install because it is relying on 0.14.0 exactly.  Is there a reason for it to rely exactly on 0.14.0?