### PR TITLE
Loading spinner when running editor queries and fetching the schema

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -106,6 +106,7 @@ html, body {
 }
 
 #graphiql-container .resultWrap {
+  position: relative;
   display: -webkit-flex;
   display:         flex;
   -webkit-flex-direction: column;

--- a/css/loading.css
+++ b/css/loading.css
@@ -1,0 +1,46 @@
+#graphiql-container .spinner-container {
+  position: absolute;
+  top: 50%;
+  height: 36px;
+  width: 36px;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10;
+}
+
+#graphiql-container .spinner {
+  vertical-align: middle;
+  display: inline-block;
+  height: 24px;
+  width: 24px;
+  position: absolute;
+  -webkit-animation: rotation .6s infinite linear;
+  -moz-animation: rotation .6s infinite linear;
+  -o-animation: rotation .6s infinite linear;
+  animation: rotation .6s infinite linear;
+  border-left: 6px solid rgba(150, 150, 150, .15);
+  border-right: 6px solid rgba(150, 150, 150, .15);
+  border-bottom: 6px solid rgba(150, 150, 150, .15);
+  border-top: 6px solid rgba(150, 150, 150, .8);
+  border-radius: 100%;
+}
+
+@-webkit-keyframes rotation {
+  from { -webkit-transform: rotate(0deg); }
+  to { -webkit-transform: rotate(359deg); }
+}
+
+@-moz-keyframes rotation {
+  from { -moz-transform: rotate(0deg); }
+  to { -moz-transform: rotate(359deg); }
+}
+
+@-o-keyframes rotation {
+  from { -o-transform: rotate(0deg); }
+  to { -o-transform: rotate(359deg); }
+}
+
+@keyframes rotation {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(359deg); }
+}

--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -119,6 +119,12 @@ export class DocExplorer extends React.Component {
       prevName = navStack[navStack.length - 2].name;
     }
 
+    var spinnerDiv = (
+      <div className="spinner-container">
+        <div className="spinner" />
+      </div>
+    );
+
     return (
       <div className="doc-explorer">
         <div className="doc-explorer-title-bar">
@@ -135,7 +141,7 @@ export class DocExplorer extends React.Component {
           </div>
         </div>
         <div className="doc-explorer-contents">
-          {content}
+          {this.props.schema ? content : spinnerDiv}
         </div>
       </div>
     );


### PR DESCRIPTION
A CSS-driven loading spinner when running editor queries and fetching the schema, in case they take a while. Shown in a result window and documentation explorer (since it needs a schema to be rendered).