### PR TITLE
Fixes #48: add a prettify query button

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -215,6 +215,21 @@ html, body {
   padding-left: 3px;
 }
 
+#graphiql-container .tool-button {
+  cursor: pointer;
+  text-decoration: none;
+  font-family: sans-serif;
+  color: #333;
+  padding: 2px 4px;
+  margin: 0 4px;
+}
+#graphiql-container .tool-button:active {
+  color: #999;
+}
+#graphiql-container .tool-button.error {
+  color: #c00;
+}
+
 #graphiql-container .execute-button {
   background: -webkit-linear-gradient(#fdfdfd, #d2d3d6);
   background:         linear-gradient(#fdfdfd, #d2d3d6);

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -8,10 +8,13 @@
 
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import { print } from 'graphql/language/printer';
+import { parse } from 'graphql/language/parser';
 import { GraphQLSchema } from 'graphql/type';
 import { buildClientSchema } from 'graphql/utilities';
 import find from 'graphql/jsutils/find';
 import { ExecuteButton } from './ExecuteButton';
+import { PrettifyButton } from './PrettifyButton';
 import { QueryEditor } from './QueryEditor';
 import { VariableEditor } from './VariableEditor';
 import { ResultViewer } from './ResultViewer';
@@ -261,6 +264,7 @@ export class GraphiQL extends React.Component {
             <div className="topBar">
               {logo}
               <ExecuteButton onClick={this._runEditorQuery} />
+              <PrettifyButton onClick={this._prettifyQuery} />
               {toolbar}
             </div>
             {!this.state.docsOpen &&
@@ -347,6 +351,12 @@ export class GraphiQL extends React.Component {
         this.setState({ response: JSON.stringify(result, null, 2) });
       }
     });
+  }
+
+  _prettifyQuery = () => {
+    const query = print(parse(this.state.query));
+    const editor = this.refs.queryEditor.getCodeMirror();
+    editor.setValue(query);
   }
 
   _onEditQuery = value => {

--- a/src/components/PrettifyButton.js
+++ b/src/components/PrettifyButton.js
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE-examples file in the root directory of this source tree.
+ */
+
+import React, { PropTypes } from 'react';
+
+
+/**
+ * PrettifyButton
+ *
+ * A {} button that allows to unminify a graphql query
+ */
+export class PrettifyButton extends React.Component {
+  static propTypes = {
+    onClick: PropTypes.func
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: null
+    };
+  }
+
+  onClick = e => {
+    e.preventDefault();
+    try {
+      this.props.onClick();
+      this.setState({ error: null });
+    } catch (error) {
+      this.setState({ error });
+    }
+  };
+
+  render() {
+    const { error } = this.state;
+    return (
+      <a
+        className={'tool-button' + (error ? ' error' : '')}
+        onClick={this.onClick}
+        title={error ? error.message : 'Prettify Query'}>
+        {'{ }'}
+      </a>
+    );
+  }
+}


### PR DESCRIPTION
addresses #48

it adds a **`{}`** prettify button. this is implemented using `graphql` parse & print function: `print(parse(this.state.query))`

(pretty useful when you paste an obfuscated relay query and want to debug it)

<img width="629" alt="screen shot 2015-11-28 at 11 14 35" src="https://cloud.githubusercontent.com/assets/211411/11451295/7aa91218-95c1-11e5-93c4-275ca21e4d4b.png">

on hover:

<img width="612" alt="screen shot 2015-11-28 at 11 14 42" src="https://cloud.githubusercontent.com/assets/211411/11451296/7aabe646-95c1-11e5-9f59-4d23abddd2c5.png">

after clicking:

<img width="466" alt="screen shot 2015-11-28 at 11 14 57" src="https://cloud.githubusercontent.com/assets/211411/11451298/7ab04aa6-95c1-11e5-8f5e-fa3e381b92e7.png">