### PR TITLE
check if subscription/mutation types exist before trying to access them

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -151,8 +151,9 @@ class SchemaDoc extends React.Component {
   render() {
     var schema = this.props.schema;
     var queryType = schema.getQueryType();
-    var mutationType = schema.getMutationType();
-    var subscriptionType = schema.getSubscriptionType();
+    var mutationType = schema.getMutationType && schema.getMutationType();
+    var subscriptionType =
+      schema.getSubscriptionType && schema.getSubscriptionType();
 
     return (
       <div>


### PR DESCRIPTION
With a schema without subscription/mutation types, this shows a console error. Check if the methods exist before executing them.