### PR TITLE
Fixes #69: Show correct description text for each enum value.

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -294,7 +294,7 @@ class TypeDoc extends React.Component {
               </div>
               <Description
                 className="doc-value-description"
-                markdown={type.description}
+                markdown={value.description}
               />
             </div>
           )}


### PR DESCRIPTION
Fixes: #69 

The `DocExplorer` component was incorrectly showing the type description text instead of the individual enum value description text for each enum value. (`type.description` was being passed instead of the correct `value.description`).