### PR TITLE
Display the toolbar's scrollbar only when needed

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -69,7 +69,7 @@
 }
 
 #graphiql-container .toolbar {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 #graphiql-container .docExplorerShow {


### PR DESCRIPTION
Everybody seems to be using an OS with invisible scrollbars, but at least on Linux, `overflow: scroll` makes the scrollbars always visible.

![screenshot_20160214_184528](https://cloud.githubusercontent.com/assets/61787/13035248/227bbd6c-d34b-11e5-87c9-dfdd29dcc5e5.png)