### PR TITLE
Client can set different editor options

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -103,7 +103,8 @@ export class GraphiQL extends React.Component {
     variables: PropTypes.string,
     onEditQuery: PropTypes.func,
     onEditVariables: PropTypes.func,
-    getDefaultFieldNames: PropTypes.func
+    getDefaultFieldNames: PropTypes.func,
+    editorOptions: PropTypes.object
   }
 
   /**
@@ -322,6 +323,7 @@ export class GraphiQL extends React.Component {
                 value={this.state.query}
                 onEdit={this._onEditQuery}
                 onHintInformationRender={this._onHintInformationRender}
+                editorOptions={this._getEditorOptions()}
               />
               <div className="variable-editor" style={variableStyle}>
                 <div
@@ -426,6 +428,19 @@ export class GraphiQL extends React.Component {
     if (this.props.onEditVariables) {
       this.props.onEditVariables(value);
     }
+  }
+
+  _getEditorOptions = () => {
+    let editorOptions = {};
+    const json = this._storageGet('editorOptions');
+    if (json) {
+      try {
+        editorOptions = JSON.parse(json);
+      }
+      catch(e) {
+      }
+    }
+    return editorOptions;
   }
 
   _onHintInformationRender = elem => {

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -436,8 +436,8 @@ export class GraphiQL extends React.Component {
     if (json) {
       try {
         editorOptions = JSON.parse(json);
-      }
-      catch(e) {
+      } catch (e) {
+        this._storageSet('editorOptions', '{}');
       }
     }
     return editorOptions;

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -40,7 +40,8 @@ export class QueryEditor extends React.Component {
   static propTypes = {
     schema: PropTypes.instanceOf(GraphQLSchema),
     value: PropTypes.string,
-    onEdit: PropTypes.func
+    onEdit: PropTypes.func,
+    editorOptions: PropTypes.object
   }
 
   constructor(props) {
@@ -94,7 +95,8 @@ export class QueryEditor extends React.Component {
         'Ctrl-Right': 'goSubwordRight',
         'Alt-Left': 'goGroupLeft',
         'Alt-Right': 'goGroupRight',
-      }
+      },
+      ...this.props.editorOptions
     });
 
     this.editor.on('change', this._onEdit);


### PR DESCRIPTION
I find myself wanting to change the CodeMirror editor options whenever I use GraphiQL (auto closing brackets make me angry). I'm not sure I love this approach for enabling that, but it is at least something.

Changing options requires that I open the developer console and set a magic item on our storage item with the JSON representation of those items I want to override.

`localStorage.setItem('graphiql:editorOptions', JSON.stringify({ autoCloseBrackets: false }))`

It might be nice if there was a cleaner way to expose this, though we'd still likely want to persist these override options via storage. I'm happy to explore suggestions for other approaches.