### PR TITLE
Warn when trying to build before having run `npm install`

### DIFF
--- a/resources/build.sh
+++ b/resources/build.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ ! -d "node_modules/.bin" ]; then
+  echo "Be sure to run \`npm install\` before building GraphiQL."
+  exit 1;
+fi
+
 rm -rf dist/ && mkdir -p dist/ &&
 babel src --ignore __tests__ --out-dir dist/ &&
 browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js &&


### PR DESCRIPTION
This should prevent struggles like this one: http://stackoverflow.com/questions/35096635/error-in-building-graphiql/35470669#35470669