### PR TITLE
GraphiQL.ExecuteButton as a child component

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -258,6 +258,10 @@
   color: #b00;
 }
 
+#graphiql-container .execute-button-container {
+  margin: auto 14px auto 28px;
+}
+
 #graphiql-container .execute-button {
   background: -webkit-linear-gradient(#fdfdfd, #d2d3d6);
   background:         linear-gradient(#fdfdfd, #d2d3d6);
@@ -267,7 +271,6 @@
   cursor: pointer;
   fill: #444;
   height: 34px;
-  margin: 0 14px 0 28px;
   padding: 0;
   width: 34px;
 }

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -16,19 +16,24 @@ import React, { PropTypes } from 'react';
  */
 export class ExecuteButton extends React.Component {
   static propTypes = {
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    customExecuteButton: React.Component
   }
 
   render() {
     return (
-      <button
-        className="execute-button"
+      <div
+        className="execute-button-container"
         onClick={this.props.onClick}
         title="Execute Query (Ctrl-Enter)">
-        <svg width="34" height="34">
-          <path d="M 11 9 L 24 16 L 11 23 z" />
-        </svg>
-      </button>
+        {this.props.customExecuteButton ||
+          <button className="execute-button">
+            <svg width="34" height="34">
+              <path d="M 11 9 L 24 16 L 11 23 z" />
+            </svg>
+          </button>
+        }
+      </div>
     );
   }
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -83,6 +83,8 @@ import {
  *
  *   - <GraphiQL.ToolbarButton> Add a button to the toolbar above GraphiQL.
  *
+ *   - <GraphiQL.ExecuteButton> Add a custom ExecuteButton look and feel.
+ *
  *   - <GraphiQL.Footer> Add a custom footer below GraphiQL Results.
  *
  *
@@ -272,6 +274,10 @@ export class GraphiQL extends React.Component {
     var toolbar = find(children, child => child.type === GraphiQL.Toolbar) ||
       <GraphiQL.Toolbar />;
 
+    const customExecuteButton = find(
+      children, child => child.type === GraphiQL.ExecuteButton
+    );
+
     var footer = find(children, child => child.type === GraphiQL.Footer);
 
     var queryWrapStyle = {
@@ -295,7 +301,10 @@ export class GraphiQL extends React.Component {
           <div className="topBarWrap">
             <div className="topBar">
               {logo}
-              <ExecuteButton onClick={this._runEditorQuery} />
+              <ExecuteButton
+                onClick={this._runEditorQuery}
+                customExecuteButton={customExecuteButton}
+              />
               <GraphiQL.ToolbarButton
                 onClick={this._prettifyQuery}
                 title="Prettify Query"
@@ -628,6 +637,17 @@ GraphiQL.Toolbar = class GraphiQLToolbar extends React.Component {
 
 // Add a button to the Toolbar.
 GraphiQL.ToolbarButton = ToolbarButton;
+
+// Add a custom ExecuteButton.
+GraphiQL.ExecuteButton = class GraphiQLExecuteButton extends React.Component {
+  render() {
+    return (
+      <div className="execute-button">
+        {this.props.children}
+      </div>
+    );
+  }
+}
 
 // Configure the UI by providing this Component as a child of GraphiQL.
 GraphiQL.Footer = class GraphiQLFooter extends React.Component {


### PR DESCRIPTION
This lets GraphiQL to consume ExecuteButton as a child component and change the look and feel of the execute button. #102 for the issue tracking.