### PR TITLE
[RFC] Support a fetcher that returns Observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ and children.
 **Props:**
 
 - `fetcher`: a function which accepts GraphQL-HTTP parameters and returns
-  a Promise which resolves to the GraphQL parsed JSON response.
+  a Promise or Observable which resolves to the GraphQL parsed JSON response.
 
 - `schema`: a GraphQLSchema instance or `null` if one is not to be used.
   If `undefined` is provided, GraphiQL will send an introspection query

--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -16,7 +16,8 @@ import React, { PropTypes } from 'react';
  */
 export class ExecuteButton extends React.Component {
   static propTypes = {
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    isRunning: PropTypes.bool
   }
 
   render() {
@@ -26,7 +27,10 @@ export class ExecuteButton extends React.Component {
         onClick={this.props.onClick}
         title="Execute Query (Ctrl-Enter)">
         <svg width="34" height="34">
-          <path d="M 11 9 L 24 16 L 11 23 z" />
+          { this.props.isRunning ?
+            <path d="M 10 10 L 23 10 L 23 23 L 10 23 z" /> :
+            <path d="M 11 9 L 24 16 L 11 23 z" />
+          }
         </svg>
       </button>
     );


### PR DESCRIPTION
This supports the fetcher returning an Observable, which will let us begin to experiment with support for GraphQL subscriptions and observable "live queries".

To test this, I added the crappiest possible Observable implementation to example/index.html:

```js
if (graphQLParams.query.indexOf('subscription') === 0) {
  // If the operation smells like a subscription (#clowntown) then return an "Observable".
  return {
    // The subscribe function accepts an "Observer" which has next, error, and complete functions.
    subscribe(observer) {
      try {
        var i = 0;
        var interval = setInterval(() => {
          if (i > 10) {
            clearInterval(interval);
            observer.complete && observer.complete();
          } else {
            observer.next && observer.next({ data: i++ });
          }
        }, 500);
      } catch (e) {
        clearInterval(interval);
        observer.error && observer.error(e);
      }

      // Return a "Subscription" object with an unsubscribe function.
      return {
        unsubscribe() {
          clearInterval(interval);
        }
      };
    }
  };
}
```

Read more about [Observable](https://github.com/zenparsing/es-observable)