### PR TITLE
Provide props for operationName and onEditOperationName, similar to query and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ and children.
   query variables, if `undefined` is provided, the stored variables will
   be used.
 
+- `operationName`: an optional name of which GraphQL operation should be
+  executed.
+
 - `response`: an optional JSON string to use as the initial displayed
   response. If not provided, no response will be initialy shown. You might
   provide this if illustrating the result of the initial query.
@@ -99,6 +102,9 @@ and children.
 - `onEditVariables`: an optional function which will be called when the Query
   varible editor changes. The argument to the function will be the
   variables string.
+
+- `onEditOperationName`: an optional function which will be called when the
+  operation name to be executed changes.
 
 - `getDefaultFieldNames`: an optional function used to provide default fields
   to non-leaf fields which invalidly lack a selection set.

--- a/example/index.html
+++ b/example/index.html
@@ -70,8 +70,15 @@
         updateURL();
       }
 
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+
       function updateURL() {
-        var newSearch = '?' + Object.keys(parameters).map(function (key) {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
           return encodeURIComponent(key) + '=' +
             encodeURIComponent(parameters[key]);
         }).join('&');
@@ -105,8 +112,10 @@
           fetcher: graphQLFetcher,
           query: parameters.query,
           variables: parameters.variables,
+          operationName: parameters.operationName,
           onEditQuery: onEditQuery,
-          onEditVariables: onEditVariables
+          onEditVariables: onEditVariables,
+          onEditOperationName: onEditOperationName
         }),
         document.body
       );

--- a/src/utility/getQueryFacts.js
+++ b/src/utility/getQueryFacts.js
@@ -15,7 +15,7 @@ import { parse, typeFromAST } from 'graphql';
  *
  * If the query cannot be parsed, returns undefined.
  */
-export default function getQueryFacts(prevFacts, schema, documentStr) {
+export default function getQueryFacts(schema, documentStr) {
   if (!documentStr) {
     return;
   }
@@ -37,40 +37,7 @@ export default function getQueryFacts(prevFacts, schema, documentStr) {
     }
   });
 
-  // Determine what the selected operation should be.
-  const selectedOperation = getSelectedOperation(prevFacts, operations);
-
-  return { variableToType, operations, selectedOperation };
-}
-
-/**
- * Provided previous "queryFacts" and a list of operations, determine what the
- * next selected operation should be.
- */
-export function getSelectedOperation(prevFacts, operations) {
-  // If there are not enough operations to bother with, return nothing.
-  if (!operations || operations.length < 1) {
-    return;
-  }
-
-  // If a previous selection still exists, continue to use it.
-  const names = operations.map(op => op.name && op.name.value);
-  const prevSelectedOperation = prevFacts.selectedOperation;
-  if (prevSelectedOperation && names.indexOf(prevSelectedOperation) !== -1) {
-    return prevSelectedOperation;
-  }
-
-  // If a previous selection was the Nth operation, use the same Nth.
-  if (prevSelectedOperation && prevFacts.operations) {
-    const prevNames = prevFacts.operations.map(op => op.name && op.name.value);
-    const prevIndex = prevNames.indexOf(prevSelectedOperation);
-    if (prevIndex && prevIndex < names.length) {
-      return names[prevIndex];
-    }
-  }
-
-  // Use the first operation.
-  return names[0];
+  return { variableToType, operations };
 }
 
 /**

--- a/src/utility/getSelectedOperationName.js
+++ b/src/utility/getSelectedOperationName.js
@@ -1,0 +1,41 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE-examples file in the root directory of this source tree.
+ */
+
+/**
+ * Provided optional previous operations and selected name, and a next list of
+ * operations, determine what the next selected operation should be.
+ */
+export default function getSelectedOperationName(
+  prevOperations,
+  prevSelectedOperationName,
+  operations
+) {
+  // If there are not enough operations to bother with, return nothing.
+  if (!operations || operations.length < 1) {
+    return;
+  }
+
+  // If a previous selection still exists, continue to use it.
+  const names = operations.map(op => op.name && op.name.value);
+  if (prevSelectedOperationName &&
+      names.indexOf(prevSelectedOperationName) !== -1) {
+    return prevSelectedOperationName;
+  }
+
+  // If a previous selection was the Nth operation, use the same Nth.
+  if (prevSelectedOperationName && prevOperations) {
+    const prevNames = prevOperations.map(op => op.name && op.name.value);
+    const prevIndex = prevNames.indexOf(prevSelectedOperationName);
+    if (prevIndex && prevIndex < names.length) {
+      return names[prevIndex];
+    }
+  }
+
+  // Use the first operation.
+  return names[0];
+}


### PR DESCRIPTION
This provides hooks for explicitly providing `operationName` to GraphiQL at init time as well as providing a function to be called whenever the `operationName` changes.

This also updates the example to illustrate how to use these new props.

Fixes #108 