### PR TITLE
fix undefined exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jsdom": "8.1.0",
     "mocha": "2.4.5",
     "react": "0.14.7",
+    "react-addons-test-utils": "0.14.7",
     "react-dom": "0.14.7",
     "uglify-js": "^2.4.24",
     "uglifyify": "^3.0.1"

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -150,7 +150,7 @@ export class GraphiQL extends React.Component {
       getSelectedOperationName(
         null,
         this._storageGet('operationName'),
-        queryFacts.operations
+        (queryFacts !== undefined ? queryFacts.operations : undefined)
       );
 
     // Initialize state

--- a/src/components/__tests__/GraphiQL-test.js
+++ b/src/components/__tests__/GraphiQL-test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+
+import { GraphiQL } from '../GraphiQL';
+
+const render = (props = {}) => {
+  if (props.storage === undefined) {
+    props.storage = createStorage();
+  }
+  return () => {
+    return TestUtils.renderIntoDocument(React.createElement(GraphiQL, props));
+  };
+};
+
+const createStorage = () => {
+  const backing = {};
+  return {
+    getItem(key) {
+      return backing[key];
+    },
+    setItem(key, value) {
+      backing[key] = value;
+    }
+  };
+};
+
+const createFetcher = () => {
+  return () => {};
+};
+
+describe('GraphiQL', () => {
+  it('should throw error without fetcher', () => {
+    expect(render()).to.throw('GraphiQL requires a fetcher function');
+  });
+
+  it('should not throw error if schema missing and query provided', () => {
+    const renderFn = render({ fetcher: createFetcher(), query: '{}'});
+    expect(renderFn).to.not.throw(Error);
+  });
+
+  it('should construct correctly with fetcher', () => {
+    expect(render({ fetcher: createFetcher() })).to.not.throw(Error);
+  });
+});


### PR DESCRIPTION
Hi, this happens when `queryFacts` is undefined, which occurs when either the schema or an initial query doesn't exist - the schema being absent is quite common by default