### PR TITLE
Update query facts with a next available query

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -219,7 +219,7 @@ export class GraphiQL extends React.Component {
     if (nextSchema !== this.state.schema ||
         nextQuery !== this.state.query ||
         nextOperationName !== this.state.operationName) {
-      this._updateQueryFacts();
+      this._updateQueryFacts(nextQuery);
     }
 
     this.setState({


### PR DESCRIPTION
During receiving new `props`, update query facts with a next available query string. This will update `operationName` appropriately.