### PR TITLE
upgrade packages: React to 0.15.1 and express-graphql to 0.5.1

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,12 +11,14 @@
     ]
   },
   "dependencies": {
-    "express": "^4.12.4",
-    "express-graphql": "^0.4.5",
-    "graphiql": "../",
-    "graphql": "^0.4.16",
-    "react": "0.14.7",
-    "react-dom": "0.14.7"
+    "express": "^4.13.3",
+    "express-graphql": "^0.5.1",
+    "graphiql": "../"
+  },
+  "peerDependencies": {
+    "graphql": "^0.5.0",
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.6.5",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   },
   "peerDependencies": {
     "graphql": "^0.5.0",
-    "react": "^0.14.0 || ^15.0.0-rc",
-    "react-dom": "^0.14.0 || ^15.0.0-rc"
+    "react": "^15.0.1",
+    "react-dom": "^15.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.6.5",
@@ -69,9 +69,9 @@
     "graphql": "0.5.0",
     "jsdom": "8.3.0",
     "mocha": "2.4.5",
-    "react": "15.0.0",
-    "react-addons-test-utils": "15.0.0",
-    "react-dom": "15.0.0",
+    "react": "15.0.1",
+    "react-addons-test-utils": "15.0.1",
+    "react-dom": "15.0.1",
     "uglify-js": "^2.4.24",
     "uglifyify": "^3.0.1"
   }


### PR DESCRIPTION
addresses #123. d5f027a already supports React#0.15.0 - this just upgrades the packages and ensures there aren't problems.