### PR TITLE
fix(GraphiQL) fallback to defaultQuery if there's no stored query

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -132,7 +132,7 @@ export class GraphiQL extends React.Component {
     // Determine the initial query to display.
     const query =
       props.query !== undefined ? props.query :
-      this._storageGet('query') !== undefined ? this._storageGet('query') :
+      this._storageGet('query') !== null ? this._storageGet('query') :
       props.defaultQuery !== undefined ? props.defaultQuery :
       defaultQuery;
 

--- a/src/components/__tests__/GraphiQL-test.js
+++ b/src/components/__tests__/GraphiQL-test.js
@@ -13,6 +13,24 @@ import { renderIntoDocument } from 'react-addons-test-utils';
 
 import { GraphiQL } from '../GraphiQL';
 
+const mockStorage = (function () {
+  let store = {};
+  return {
+    getItem(key) {
+      return store.hasOwnProperty(key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    }
+  };
+}());
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockStorage,
+});
 
 describe('GraphiQL', () => {
   const noOpFetcher = () => {};
@@ -35,5 +53,21 @@ describe('GraphiQL', () => {
     expect(() => renderIntoDocument(
       <GraphiQL fetcher={noOpFetcher} query="{}" />
     )).to.not.throw();
+  });
+
+  it('defaults to the built-in default query', () => {
+    const graphiQL = renderIntoDocument(<GraphiQL fetcher={noOpFetcher} />);
+    expect(graphiQL.state.query).to.include('# Welcome to GraphiQL');
+  });
+
+  it('accepts a custom default query', () => {
+    const graphiQL = renderIntoDocument(
+      <GraphiQL
+        fetcher={noOpFetcher}
+        defaultQuery='GraphQL Party!!'
+      />
+    );
+
+    expect(graphiQL.state.query).to.equal('GraphQL Party!!');
   });
 });


### PR DESCRIPTION
Hi there, is GraphiQL correctly falling back to `props.defaultQuery`? 

I find that if I open http://graphql-swapi.parseapp.com/ with an incognito window, the query window is blank. But, I think it should include `defaultQuery` defined at the bottom of `GraphiQL.js`. 

I think the problem is that `this._storageGet("query")` returns `null` (https://developer.mozilla.org/en-US/docs/Web/API/Storage/getItem) if it is unset -- but the we treat that as useful value since it's `!== undefined`.

So, can we test it against `null` instead? 

I tried to write tests for this but I couldn't quite get it: `node.textContent` didn't contain the query string and `component.state` had `query: null`, so I think it may not have been initialized. Should I add a test for this? Happy to do it, but I'll need a little guidance :)
