### PR TITLE
Add button in doc explorer to print the full graphql schema to the co…

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -16,7 +16,8 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLList,
-  GraphQLNonNull
+  GraphQLNonNull,
+  printSchema,
 } from 'graphql';
 
 import debounce from '../utility/debounce';
@@ -117,6 +118,14 @@ export class DocExplorer extends React.Component {
       content.type === SearchDoc || content.type === SchemaDoc
     );
 
+    const printSchemaButton = (
+      <div>
+        <button onClick={this.handlePrintSchema} className='toolbar-button'>
+          {'Print full schema to console'}
+        </button>
+      </div>
+    );
+
     return (
       <div className="doc-explorer">
         <div className="doc-explorer-title-bar">
@@ -140,6 +149,7 @@ export class DocExplorer extends React.Component {
             onSearch={this.handleSearch}
           />
           {this.props.schema ? content : spinnerDiv}
+          {this.props.schema ? printSchemaButton : null}
         </div>
       </div>
     );
@@ -183,6 +193,11 @@ export class DocExplorer extends React.Component {
       name: 'Search Results',
       searchValue: value
     });
+  }
+
+  handlePrintSchema = () => {
+    // eslint-disable-next-line no-console
+    console.log(printSchema(this.props.schema));
   }
 }
 


### PR DESCRIPTION
…nsole.

We have had the case sometimes now where it was useful for us to print the whole graphql schema. We could add a script or some build rule in our system, but I thought this is a nice additional feature for graphiql, so here we go:

![screenshot from 2016-06-01 15 21 46](https://cloud.githubusercontent.com/assets/2580254/15713038/a3693600-280c-11e6-9d2e-8c8e5e12733e.png)

Apart from the fact that the button now says 'Print full schema to console'.
