### PR TITLE
Default state for search box should not be null

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -195,7 +195,7 @@ class SearchBox extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { value: null };
+    this.state = { value: '' };
 
     this._debouncedOnSearch = debounce(200, () => {
       this.props.onSearch(this.state.value);


### PR DESCRIPTION
I'm getting the following warning when loading GraphiQL.

> warning.js:44 Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.

I believe the attached PR fixes the issue.