### PR TITLE
Fix onToggleDocs behavior.

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -684,7 +684,9 @@ export class GraphiQL extends React.Component {
   }
 
   handleToggleDocs = () => {
-    this.props.onToggleDocs(!this.state.docExplorerOpen);
+    if (typeof this.props.onToggleDocs === 'function') {
+      this.props.onToggleDocs(!this.state.docExplorerOpen);
+    }
     this.setState({ docExplorerOpen: !this.state.docExplorerOpen });
   }
 


### PR DESCRIPTION
Right now, if the onToggleDocs prop is not provided, GraphiQL errors. Let's check for the presence of that function before trying to call it.