### PR TITLE
Fix "value cannot be null" warning.

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -195,7 +195,7 @@ class SearchBox extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { value: null };
+    this.state = { value: '' };
 
     this._debouncedOnSearch = debounce(200, () => {
       this.props.onSearch(this.state.value);


### PR DESCRIPTION
Resolves the fact that the `SearchBox` component causes a warning to thrown because the value passed to the `input` is null, rather than an empty string or undefined.