### PR TITLE
Don't assume server is mounted at `/graphql`

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -90,7 +90,7 @@
 
       // Defines a GraphQL fetcher using the fetch API.
       function graphQLFetcher(graphQLParams) {
-        return fetch(window.location.origin + '/graphql', {
+        return fetch(window.location.origin + window.location.pathname, {
           method: 'post',
           headers: {
             'Accept': 'application/json',


### PR DESCRIPTION
The GraphQL server happens to be mounted at `graphql` in this case (https://github.com/graphql/graphiql/blob/master/example/server.js#L28), but we shouldn't assume that.

This fix should allow the GraphQL server to be mounted anywhere.

The reason this is important is that we use this template in [GraphQL Elixir](https://github.com/graphql-elixir/graphql) (other implementations would likely do something similar). Our template can be found here https://github.com/graphql-elixir/plug_graphql/blob/master/templates/graphiql.eex

We found some issues when we took this template verbatim before line 111.