### PR TITLE
[Dependencies] add support for React >=0.14.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   },
   "peerDependencies": {
     "graphql": "^0.6.0",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0"
+    "react": ">=0.14.8",
+    "react-dom": ">=0.14.8"
   },
   "devDependencies": {
     "babel-cli": "6.6.5",


### PR DESCRIPTION
Hey @leebyron, @spikebrehm and I were able to get GraphiQL successfully running on React 14.8 at Airbnb, but NPM install complains because it it has a peer dependency for React 15. Can you confirm that GraphiQL works properly with React 14?