### PR TITLE
Use CoreMirror's key maps instead of global event handler to run query at a cursor

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -194,9 +194,6 @@ export class GraphiQL extends React.Component {
 
     // Utility for keeping CodeMirror correctly sized.
     this.codeMirrorSizer = new CodeMirrorSizer();
-
-    // Add shortcut for running a query.
-    document.addEventListener('keydown', this._keyHandler, true);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -255,8 +252,6 @@ export class GraphiQL extends React.Component {
     this._storageSet('editorFlex', this.state.editorFlex);
     this._storageSet('variableEditorHeight', this.state.variableEditorHeight);
     this._storageSet('docExplorerWidth', this.state.docExplorerWidth);
-
-    document.removeEventListener('keydown', this._keyHandler, true);
   }
 
   render() {
@@ -323,6 +318,7 @@ export class GraphiQL extends React.Component {
                 value={this.state.query}
                 onEdit={this.handleEditQuery}
                 onHintInformationRender={this.handleHintInformationRender}
+                onRunQuery={this.handleEditorRunQuery}
               />
               <div className="variable-editor" style={variableStyle}>
                 <div
@@ -337,6 +333,7 @@ export class GraphiQL extends React.Component {
                   variableToType={this.state.variableToType}
                   onEdit={this.handleEditVariables}
                   onHintInformationRender={this.handleHintInformationRender}
+                  onRunQuery={this.handleEditorRunQuery}
                 />
               </div>
             </div>
@@ -575,14 +572,6 @@ export class GraphiQL extends React.Component {
     return;
   }
 
-  _keyHandler = event => {
-    // "Run Query" event.
-    if ((event.metaKey || event.ctrlKey) && event.keyCode === 13) {
-      event.preventDefault();
-      this._runQueryAtCursor();
-    }
-  }
-
   _runQueryAtCursor() {
     if (this.state.subscription) {
       this.handleStopQuery();
@@ -666,6 +655,10 @@ export class GraphiQL extends React.Component {
       elem.removeEventListener('DOMNodeRemoved', onRemoveFn);
       elem.removeEventListener('click', this._onClickHintInformation);
     });
+  }
+
+  handleEditorRunQuery = () => {
+    this._runQueryAtCursor();
   }
 
   _onClickHintInformation = event => {

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -43,6 +43,7 @@ export class QueryEditor extends React.Component {
     value: PropTypes.string,
     onEdit: PropTypes.func,
     onHintInformationRender: PropTypes.func,
+    onRunQuery: PropTypes.func,
   }
 
   constructor(props) {
@@ -82,6 +83,17 @@ export class QueryEditor extends React.Component {
         'Ctrl-Space': () => this.editor.showHint({ completeSingle: true }),
         'Alt-Space': () => this.editor.showHint({ completeSingle: true }),
         'Shift-Space': () => this.editor.showHint({ completeSingle: true }),
+
+        'Cmd-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
+        'Ctrl-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -41,6 +41,7 @@ export class VariableEditor extends React.Component {
     value: PropTypes.string,
     onEdit: PropTypes.func,
     onHintInformationRender: PropTypes.func,
+    onRunQuery: PropTypes.func,
   }
 
   constructor(props) {
@@ -78,6 +79,17 @@ export class VariableEditor extends React.Component {
         'Ctrl-Space': () => this.editor.showHint({ completeSingle: false }),
         'Alt-Space': () => this.editor.showHint({ completeSingle: false }),
         'Shift-Space': () => this.editor.showHint({ completeSingle: false }),
+
+        'Cmd-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
+        'Ctrl-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',


### PR DESCRIPTION
An alternative solution for a issue discussed in #152. The original solution can be found in #154.