### PR TITLE
resolving broken deprecation message in docs

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -496,7 +496,7 @@ class TypeDoc extends React.Component {
                 {': '}
                 <TypeLink type={field.type} onClick={onClickType} />
                 {
-                  field.deprecationReason &&
+                  (field.isDeprecated || field.deprecationReason) &&
                     <span className="doc-alert-text">{' (DEPRECATED)'}</span>
                 }
               </div>
@@ -518,7 +518,7 @@ class TypeDoc extends React.Component {
               <div className="enum-value">
                 {value.name}
                 {
-                  value.deprecationReason &&
+                  (value.isDeprecated || value.deprecationReason) &&
                     <span className="doc-alert-text">{' (DEPRECATED)'}</span>
                 }
               </div>

--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -496,7 +496,7 @@ class TypeDoc extends React.Component {
                 {': '}
                 <TypeLink type={field.type} onClick={onClickType} />
                 {
-                  field.isDeprecated &&
+                  field.deprecationReason &&
                     <span className="doc-alert-text">{' (DEPRECATED)'}</span>
                 }
               </div>
@@ -518,7 +518,7 @@ class TypeDoc extends React.Component {
               <div className="enum-value">
                 {value.name}
                 {
-                  value.isDeprecated &&
+                  value.deprecationReason &&
                     <span className="doc-alert-text">{' (DEPRECATED)'}</span>
                 }
               </div>


### PR DESCRIPTION
Relates to:
https://github.com/graphql/graphiql/pull/157#issuecomment-245028499

Correcting usages of `field.isDeprecated` in docs to look at `field.deprecationReason` instead restores this functionality.

<img width="369" alt="screen shot 2016-09-15 at 2 09 26 pm" src="https://cloud.githubusercontent.com/assets/489331/18568448/3660a450-7b52-11e6-83b5-5acca93b1ced.png">

--
**CC:** @davidcelis @globegitter