### PR TITLE
Handle null/undefined variables

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -247,7 +247,7 @@ export class GraphiQL extends React.Component {
   // that when the component is remounted, it will use the last used values.
   componentWillUnmount() {
     this._storageSet('query', this.state.query);
-    this._storageSet('variables', this.state.variables);
+    this._storageSet('variables', this.state.variables || '');
     this._storageSet('operationName', this.state.operationName);
     this._storageSet('editorFlex', this.state.editorFlex);
     this._storageSet('variableEditorHeight', this.state.variableEditorHeight);


### PR DESCRIPTION
Pretty often I end up in this kind of situation:

![graphiql-null-vars](https://cloud.githubusercontent.com/assets/156569/18649448/d09beb0e-7ebf-11e6-9fb2-26c5480ffc27.png)

Steps to reproduce it:

1. When creating a GraphiQL component, provide a prop: `variables: null`
2. Refresh a page couple of times
3. Remove `variables: null`
4. Refresh the page (the result is shown on the screenshot)

This PR tries to address this issue by preventing null/undefined variables from being stored.