### PR TITLE
Provide variables as a JSON `Object` instead of a `String`

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -475,7 +475,19 @@ export class GraphiQL extends React.Component {
 
   _fetchQuery(query, variables, operationName, cb) {
     const fetcher = this.props.fetcher;
-    const fetch = fetcher({ query, variables, operationName });
+    let jsonVariables = null;
+
+    try {
+      jsonVariables = JSON.parse(variables);
+    } catch (error) {
+      jsonVariables = null;
+    }
+
+    const fetch = fetcher({
+      query,
+      variables: jsonVariables,
+      operationName
+    });
 
     if (isPromise(fetch)) {
       // If fetcher returned a Promise, then call the callback when the promise


### PR DESCRIPTION
During one of the discussions with @stubailo and @lacker at https://github.com/graphql/graphql.github.io we decided to suggest this change (tried to find the original discussion, but looks like it's gone due to fair amount of rebasing). 

Also current best practice documentation suggests that variables should be provided as a JSON object and not as a string (at the moment GraphiQL provides variables as a string with stringified JSON inside):

http://graphql.org/learn/serving-over-http/#post-request