### PR TITLE
single interface for fetch

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -897,21 +897,19 @@ function isPromise(value) {
   return typeof value === 'object' && typeof value.then === 'function';
 }
 
+// Duck-type Observable.take(1).toPromise()
 function observableToPromise(observable) {
-  if ( isPromise(observable) ) {
-    return observable;
-  }
   if ( !isObservable(observable) ) {
     return observable;
   }
   return new Promise((resolve, reject) => {
-    let lastValue;
-    observable.subscribe(v => {
-      lastValue = v;
+    const subscription = observable.subscribe(v => {
+      resolve(v);
+      subscription.unsubscribe();
     }, e => {
       reject(e);
     }, () => {
-      resolve(lastValue);
+      reject(new Error('no value resolved'));
     });
   });
 }

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -420,7 +420,7 @@ export class GraphiQL extends React.Component {
 
     const fetcher = this.props.fetcher;
 
-    const fetch = fetcher({ query: introspectionQuery });
+    const fetch = observableToPromise(fetcher({ query: introspectionQuery }));
     if (!isPromise(fetch)) {
       this.setState({
         response: 'Fetcher did not return a Promise for introspection.'
@@ -435,7 +435,9 @@ export class GraphiQL extends React.Component {
 
       // Try the stock introspection query first, falling back on the
       // sans-subscriptions query for services which do not yet support it.
-      const fetch2 = fetcher({ query: introspectionQuerySansSubscriptions });
+      const fetch2 = observableToPromise(fetcher({
+        query: introspectionQuerySansSubscriptions
+      }));
       if (!isPromise(fetch)) {
         throw new Error('Fetcher did not return a Promise for introspection.');
       }
@@ -893,6 +895,25 @@ const defaultQuery =
 // Duck-type promise detection.
 function isPromise(value) {
   return typeof value === 'object' && typeof value.then === 'function';
+}
+
+function observableToPromise(observable) {
+  if ( isPromise(observable) ) {
+    return observable;
+  }
+  if ( !isObservable(observable) ) {
+    return observable;
+  }
+  return new Promise((resolve, reject) => {
+    let lastValue;
+    observable.subscribe(v => {
+      lastValue = v;
+    }, e => {
+      reject(e);
+    }, () => {
+      resolve(lastValue);
+    });
+  });
 }
 
 // Duck-type observable detection.


### PR DESCRIPTION
since the fetcher shouldn't know if it is expected to return promise or observable,
it added a small logic to convert observable into promises when promise is a must.