### PR TITLE
fix custom graphiql example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ and children.
 ```js
 class CustomGraphiQL extends React.Component {
   constructor(props) {
+    super(props);
     this.state = {
       // REQUIRED:
       // `fetcher` must be provided in order for GraphiQL to operate


### PR DESCRIPTION
Hey, this is kind of a trivial pull, but the CustomGraphiQL example fails to compile because of the error:

    Syntax error: 'this' is not allowed before super()
    ...
    constructor(props) {
      this.state = {
      ^
    ....

Thanks!