### PR TITLE
Saving doc-exploreer status into storage, loading on mount

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -169,7 +169,8 @@ export class GraphiQL extends React.Component {
       variableEditorOpen: Boolean(variables),
       variableEditorHeight:
         Number(this._storageGet('variableEditorHeight')) || 200,
-      docExplorerOpen: false,
+      docExplorerOpen:
+        (this._storageGet('docExplorerOpen') === 'true') || false,
       docExplorerWidth: Number(this._storageGet('docExplorerWidth')) || 350,
       isWaitingForResponse: false,
       subscription: null,
@@ -252,6 +253,7 @@ export class GraphiQL extends React.Component {
     this._storageSet('editorFlex', this.state.editorFlex);
     this._storageSet('variableEditorHeight', this.state.variableEditorHeight);
     this._storageSet('docExplorerWidth', this.state.docExplorerWidth);
+    this._storageSet('docExplorerOpen', this.state.docExplorerOpen);
   }
 
   render() {


### PR DESCRIPTION
Addresses: https://github.com/graphql/graphiql/issues/187 by persisting doc-explorer state into storage, loading on mount