### PR TITLE
Update TypeDoc when schema changes

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -434,7 +434,10 @@ class TypeDoc extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.type !== nextProps.type;
+    return (
+      this.props.type !== nextProps.type ||
+      this.props.schema !== nextProps.schema
+    );
   }
 
   render() {


### PR DESCRIPTION
@asiandrummer this is something I found while trying to dynamically set schemas in a custom graphiql.

Changing the schema does not currently trigger an update on TypeDoc components. I feel like it should ? Right now the Doc pane shows the old fields even if the schema has been updated.

Let me know what you think!