### PR TITLE
.on('update') fires with a collection of identifiers, not functions

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -48,7 +48,7 @@ function makeBundle(then) {
       return;
     }
     bundleBuffer = buffer;
-    then && then();
+    (typeof then === 'function') && then();
   });
 }
 


### PR DESCRIPTION
https://github.com/substack/watchify#bonupdate-function-ids-

This addition causes bugs when saving more than once, fixed by checking typeof `then`.