### PR TITLE
Fix display issues on older Firefox

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -2,6 +2,7 @@
   color: #141823;
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
   -webkit-flex-direction: row;
       -ms-flex-direction: row;
           flex-direction: row;
@@ -28,7 +29,7 @@
 .graphiql-container .editorWrap {
   display: -webkit-flex;
   display: -ms-flexbox;
-  display: -ms-flexbox;
+  display: flex;
   -webkit-flex-direction: column;
       -ms-flex-direction: column;
           flex-direction: column;
@@ -49,6 +50,7 @@
 .graphiql-container .topBarWrap {
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
   -webkit-flex-direction: row;
       -ms-flex-direction: row;
           flex-direction: row;
@@ -64,6 +66,7 @@
   cursor: default;
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
   height: 34px;
   padding: 7px 14px 6px;
   -webkit-flex: 1;
@@ -113,6 +116,7 @@
 .graphiql-container .editorBar {
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
   -webkit-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -124,6 +128,7 @@
 .graphiql-container .queryWrap {
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
   -webkit-flex: 1;
       -ms-flex: 1;
           flex: 1;
@@ -135,7 +140,8 @@
 .graphiql-container .resultWrap {
   border-left: solid 1px #e0e0e0;
   display: -webkit-flex;
-  display:         flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   -webkit-flex: 1;
       -ms-flex: 1;


### PR DESCRIPTION
Regression introduced in f9de00729998225a.

Tested on Firefox 45 (old, was broken), 49 (previous, still works), 50 (latest, still works) and Chrome 54 (current, still works).

Closes: https://github.com/graphql/graphiql/issues/250