### PR TITLE
[RFC] Use autoprefixer

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -352,30 +352,6 @@
   padding: 2px 4px 1px;
 }
 
-@-moz-keyframes insertionFade {
-  from, to {
-    background: rgba(255, 255, 255, 0);
-    border-color: rgba(255, 255, 255, 0);
-  }
-
-  15%, 85% {
-    background: #fbffc9;
-    border-color: #f0f3c0;
-  }
-}
-
-@-webkit-keyframes insertionFade {
-  from, to {
-    background: rgba(255, 255, 255, 0);
-    border-color: rgba(255, 255, 255, 0);
-  }
-
-  15%, 85% {
-    background: #fbffc9;
-    border-color: #f0f3c0;
-  }
-}
-
 @keyframes insertionFade {
   from, to {
     background: rgba(255, 255, 255, 0);

--- a/css/app.css
+++ b/css/app.css
@@ -48,10 +48,10 @@
   border-bottom: 1px solid #d0d0d0;
   cursor: default;
   display: flex;
+  flex-direction: row;
+  flex: 1;
   height: 34px;
   padding: 7px 14px 6px;
-  flex: 1;
-  flex-direction: row;
   user-select: none;
 }
 
@@ -68,8 +68,8 @@
   color: #3B5998;
   cursor: pointer;
   font-size: 14px;
-  outline: 0;
   margin: 0;
+  outline: 0;
   padding: 2px 20px 0 18px;
 }
 
@@ -87,22 +87,22 @@
 
 .graphiql-container .editorBar {
   display: flex;
-  flex: 1;
   flex-direction: row;
+  flex: 1;
 }
 
 .graphiql-container .queryWrap {
   display: flex;
-  flex: 1;
   flex-direction: column;
+  flex: 1;
 }
 
 .graphiql-container .resultWrap {
   border-left: solid 1px #e0e0e0;
   display: flex;
-  position: relative;
-  flex: 1;
   flex-direction: column;
+  flex: 1;
+  position: relative;
 }
 
 .graphiql-container .docExplorerWrap {
@@ -157,14 +157,14 @@
 
 .graphiql-container .codemirrorWrap {
   flex: 1;
-  position: relative;
   height: 100%;
+  position: relative;
 }
 
 .graphiql-container .result-window {
   flex: 1;
-  position: relative;
   height: 100%;
+  position: relative;
 }
 
 .graphiql-container .footer {
@@ -204,10 +204,10 @@
 .graphiql-container .toolbar-button {
   background: #fdfdfd;
   background: linear-gradient(#fbfbfb, #f8f8f8);
-  border-width: 0.5px;
-  border-style: solid;
   border-color: #d3d3d3 #d0d0d0 #bababa;
   border-radius: 4px;
+  border-style: solid;
+  border-width: 0.5px;
   box-shadow: 0 1px 1px -1px rgba(0, 0, 0, 0.13), inset 0 1px #fff;
   color: #444;
   cursor: pointer;
@@ -232,15 +232,15 @@
 }
 
 .graphiql-container .execute-button-wrap {
-  position: relative;
-  margin: 0 14px 0 28px;
   height: 34px;
+  margin: 0 14px 0 28px;
+  position: relative;
 }
 
 .graphiql-container .execute-button {
   background: linear-gradient(#fdfdfd, #d2d3d6);
-  border: 1px solid rgba(0,0,0,0.25);
   border-radius: 17px;
+  border: 1px solid rgba(0,0,0,0.25);
   box-shadow: 0 1px 0 #fff;
   cursor: pointer;
   fill: #444;
@@ -280,10 +280,10 @@
 }
 
 .graphiql-container .execute-options li {
-  padding: 2px 30px 4px 10px;
+  cursor: pointer;
   list-style: none;
   min-width: 100px;
-  cursor: pointer;
+  padding: 2px 30px 4px 10px;
 }
 
 .graphiql-container .execute-options li.selected {
@@ -366,8 +366,8 @@
 
 div.CodeMirror-lint-tooltip {
   background-color: white;
-  border: 0;
   border-radius: 2px;
+  border: 0;
   color: #141823;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   font-family:

--- a/css/app.css
+++ b/css/app.css
@@ -1,11 +1,7 @@
 .graphiql-container {
   color: #141823;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
   font-family:
     system,
     -apple-system,
@@ -27,15 +23,9 @@
 }
 
 .graphiql-container .editorWrap {
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex-direction: column;
+  flex: 1;
 }
 
 .graphiql-container .title {
@@ -48,36 +38,21 @@
 }
 
 .graphiql-container .topBarWrap {
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex-direction: row;
 }
 
 .graphiql-container .topBar {
-  -webkit-align-items: center;
-      -ms-align-items: center;
-          align-items: center;
-  background: -webkit-linear-gradient(#f7f7f7, #e2e2e2);
-  background:         linear-gradient(#f7f7f7, #e2e2e2);
+  align-items: center;
+  background: linear-gradient(#f7f7f7, #e2e2e2);
   border-bottom: 1px solid #d0d0d0;
   cursor: default;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 34px;
   padding: 7px 14px 6px;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
-  -webkit-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  flex: 1;
+  flex-direction: row;
+  user-select: none;
 }
 
 .graphiql-container .toolbar {
@@ -85,8 +60,7 @@
 }
 
 .graphiql-container .docExplorerShow {
-  background: -webkit-linear-gradient(#f7f7f7, #e2e2e2);
-  background:         linear-gradient(#f7f7f7, #e2e2e2);
+  background: linear-gradient(#f7f7f7, #e2e2e2);
   border-bottom: 1px solid #d0d0d0;
   border-left: 1px solid rgba(0, 0, 0, 0.2);
   border-right: none;
@@ -107,48 +81,28 @@
   height: 9px;
   margin: 0 3px -1px 0;
   position: relative;
-  -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-          transform: rotate(-45deg);
+  transform: rotate(-45deg);
   width: 9px;
 }
 
 .graphiql-container .editorBar {
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: row;
-      -ms-flex-direction: row;
-          flex-direction: row;
+  flex: 1;
+  flex-direction: row;
 }
 
 .graphiql-container .queryWrap {
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex: 1;
+  flex-direction: column;
 }
 
 .graphiql-container .resultWrap {
   border-left: solid 1px #e0e0e0;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   position: relative;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
+  flex: 1;
+  flex-direction: column;
 }
 
 .graphiql-container .docExplorerWrap {
@@ -176,20 +130,14 @@
 }
 
 .graphiql-container .query-editor {
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   position: relative;
 }
 
 .graphiql-container .variable-editor {
-  display: -webkit-flex;
-  display:     -ms-flex;
-  display:         flex;
+  display: flex;
+  flex-direction: column;
   height: 29px;
-  -webkit-flex-direction: column;
-      -ms-flex-direction: column;
-          flex-direction: column;
   position: relative;
 }
 
@@ -204,23 +152,17 @@
   line-height: 14px;
   padding: 6px 0 8px 43px;
   text-transform: lowercase;
-  -webkit-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .graphiql-container .codemirrorWrap {
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   position: relative;
   height: 100%;
 }
 
 .graphiql-container .result-window {
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
   position: relative;
   height: 100%;
 }
@@ -261,8 +203,7 @@
 
 .graphiql-container .toolbar-button {
   background: #fdfdfd;
-  background: -webkit-linear-gradient(#fbfbfb, #f8f8f8);
-  background:         linear-gradient(#fbfbfb, #f8f8f8);
+  background: linear-gradient(#fbfbfb, #f8f8f8);
   border-width: 0.5px;
   border-style: solid;
   border-color: #d3d3d3 #d0d0d0 #bababa;
@@ -277,8 +218,7 @@
 }
 
 .graphiql-container .toolbar-button:active {
-  background: -webkit-linear-gradient(#ececec, #d8d8d8);
-  background:         linear-gradient(#ececec, #d8d8d8);
+  background: linear-gradient(#ececec, #d8d8d8);
   border-color: #cacaca #c9c9c9 #b0b0b0;
   box-shadow:
     0 1px 0 #fff,
@@ -287,8 +227,7 @@
 }
 
 .graphiql-container .toolbar-button.error {
-  background: -webkit-linear-gradient(#fdf3f3, #e6d6d7);
-  background:         linear-gradient(#fdf3f3, #e6d6d7);
+  background: linear-gradient(#fdf3f3, #e6d6d7);
   color: #b00;
 }
 
@@ -299,8 +238,7 @@
 }
 
 .graphiql-container .execute-button {
-  background: -webkit-linear-gradient(#fdfdfd, #d2d3d6);
-  background:         linear-gradient(#fdfdfd, #d2d3d6);
+  background: linear-gradient(#fdfdfd, #d2d3d6);
   border: 1px solid rgba(0,0,0,0.25);
   border-radius: 17px;
   box-shadow: 0 1px 0 #fff;
@@ -317,8 +255,7 @@
 }
 
 .graphiql-container .execute-button:active {
-  background: -webkit-linear-gradient(#e6e6e6, #c0c0c0);
-  background:         linear-gradient(#e6e6e6, #c0c0c0);
+  background: linear-gradient(#e6e6e6, #c0c0c0);
   box-shadow:
     0 1px 0 #fff,
     inset 0 0 2px rgba(0, 0, 0, 0.3),
@@ -355,8 +292,7 @@
 }
 
 .graphiql-container .CodeMirror-scroll {
-  -webkit-overflow-scrolling: touch;
-      -ms-overflow-scrolling: touch;
+  overflow-scrolling: touch;
 }
 
 .graphiql-container .CodeMirror {
@@ -380,15 +316,12 @@
 }
 
 .CodeMirror-hint-information .content {
-  -webkit-box-orient: vertical;
-      -ms-box-orient: vertical;
-          box-orient: vertical;
+  box-orient: vertical;
   color: #141823;
-  display: -webkit-box;
+  display: flex;
   font-family: system, -apple-system, 'San Francisco', '.SFNSDisplay-Regular', 'Segoe UI', Segoe, 'Segoe WP', 'Helvetica Neue', helvetica, 'Lucida Grande', arial, sans-serif;
   font-size: 13px;
-  -webkit-line-clamp: 3;
-          line-clamp: 3;
+  line-clamp: 3;
   line-height: 16px;
   max-height: 48px;
   overflow: hidden;
@@ -411,14 +344,8 @@
 }
 
 .autoInsertedLeaf.cm-property {
-  -webkit-animation-duration: 6s;
-     -moz-animation-duration: 6s;
-      -ms-animation-duration: 6s;
-          animation-duration: 6s;
-  -webkit-animation-name: insertionFade;
-     -moz-animation-name: insertionFade;
-      -ms-animation-name: insertionFade;
-          animation-name: insertionFade;
+  animation-duration: 6s;
+  animation-name: insertionFade;
   border-bottom: 2px solid rgba(255, 255, 255, 0);
   border-radius: 2px;
   margin: -2px -4px -1px;
@@ -484,11 +411,7 @@ div.CodeMirror-lint-tooltip {
   line-height: 16px;
   opacity: 0;
   padding: 6px 10px;
-  -webkit-transition: opacity 0.15s;
-     -moz-transition: opacity 0.15s;
-      -ms-transition: opacity 0.15s;
-       -o-transition: opacity 0.15s;
-          transition: opacity 0.15s;
+  transition: opacity 0.15s;
 }
 
 div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
@@ -500,10 +423,7 @@ div.CodeMirror-lint-message-error, div.CodeMirror-lint-message-warning {
 .graphiql-container .CodeMirror-foldmarker {
   border-radius: 4px;
   background: #08f;
-  background: -webkit-linear-gradient(#43A8FF, #0F83E8);
-  background:    -moz-linear-gradient(#43A8FF, #0F83E8);
-  background:     -ms-linear-gradient(#43A8FF, #0F83E8);
-  background:         linear-gradient(#43A8FF, #0F83E8);
+  background: linear-gradient(#43A8FF, #0F83E8);
   box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.2),
     inset 0 0 0 1px rgba(0, 0, 0, 0.1);

--- a/css/codemirror.css
+++ b/css/codemirror.css
@@ -62,16 +62,6 @@
   border: 0;
   animation: blink 1.06s steps(1) infinite;
 }
-@-moz-keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
-}
-@-webkit-keyframes blink {
-  0% { background: #7e7; }
-  50% { background: none; }
-  100% { background: #7e7; }
-}
 @keyframes blink {
   0% { background: #7e7; }
   50% { background: none; }

--- a/css/codemirror.css
+++ b/css/codemirror.css
@@ -60,9 +60,6 @@
 .cm-animate-fat-cursor {
   width: auto;
   border: 0;
-  -webkit-animation: blink 1.06s steps(1) infinite;
-  -moz-animation: blink 1.06s steps(1) infinite;
-  -ms-animation: blink 1.06s steps(1) infinite;
   animation: blink 1.06s steps(1) infinite;
 }
 @-moz-keyframes blink {
@@ -219,9 +216,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   z-index: 4;
 }
 .CodeMirror-gutter-wrapper {
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 
@@ -231,7 +225,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 .CodeMirror pre {
   /* Reset some styles that the rest of the page might have set */
-  -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0;
+  border-radius: 0;
   border-width: 0;
   background: transparent;
   font-family: inherit;
@@ -245,7 +239,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   position: relative;
   overflow: visible;
   -webkit-tap-highlight-color: transparent;
-  -webkit-font-variant-ligatures: none;
+  font-variant-ligatures: none;
   font-variant-ligatures: none;
 }
 .CodeMirror-wrap pre {
@@ -278,7 +272,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-gutter,
 .CodeMirror-gutters,
 .CodeMirror-linenumber {
-  -moz-box-sizing: content-box;
   box-sizing: content-box;
 }
 

--- a/css/codemirror.css
+++ b/css/codemirror.css
@@ -2,9 +2,9 @@
 
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
+  color: black;
   font-family: monospace;
   height: 300px;
-  color: black;
 }
 
 /* PADDING */
@@ -29,10 +29,10 @@
 }
 .CodeMirror-linenumbers {}
 .CodeMirror-linenumber {
-  padding: 0 3px 0 5px;
-  min-width: 20px;
-  text-align: right;
   color: #999;
+  min-width: 20px;
+  padding: 0 3px 0 5px;
+  text-align: right;
   white-space: nowrap;
 }
 
@@ -49,18 +49,18 @@
   border-left: 1px solid silver;
 }
 .CodeMirror.cm-fat-cursor div.CodeMirror-cursor {
-  width: auto;
-  border: 0;
   background: #7e7;
+  border: 0;
+  width: auto;
 }
 .CodeMirror.cm-fat-cursor div.CodeMirror-cursors {
   z-index: 1;
 }
 
 .cm-animate-fat-cursor {
-  width: auto;
-  border: 0;
   animation: blink 1.06s steps(1) infinite;
+  border: 0;
+  width: auto;
 }
 @keyframes blink {
   0% { background: #7e7; }
@@ -129,43 +129,43 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
    the editor. You probably shouldn't touch them. */
 
 .CodeMirror {
-  position: relative;
-  overflow: hidden;
   background: white;
+  overflow: hidden;
+  position: relative;
 }
 
 .CodeMirror-scroll {
-  overflow: scroll !important; /* Things will break if this is overridden */
+  height: 100%;
   /* 30px is the magic margin used to hide the element's real scrollbars */
   /* See overflow: hidden in .CodeMirror */
   margin-bottom: -30px; margin-right: -30px;
-  padding-bottom: 30px;
-  height: 100%;
   outline: none; /* Prevent dragging from highlighting the element */
+  overflow: scroll !important; /* Things will break if this is overridden */
+  padding-bottom: 30px;
   position: relative;
 }
 .CodeMirror-sizer {
-  position: relative;
   border-right: 30px solid transparent;
+  position: relative;
 }
 
 /* The fake, visible scrollbars. Used to force redraw during scrolling
    before actual scrolling happens, thus preventing shaking and
    flickering artifacts. */
 .CodeMirror-vscrollbar, .CodeMirror-hscrollbar, .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+  display: none;
   position: absolute;
   z-index: 6;
-  display: none;
 }
 .CodeMirror-vscrollbar {
-  right: 0; top: 0;
   overflow-x: hidden;
   overflow-y: scroll;
+  right: 0; top: 0;
 }
 .CodeMirror-hscrollbar {
   bottom: 0; left: 0;
-  overflow-y: hidden;
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 .CodeMirror-scrollbar-filler {
   right: 0; bottom: 0;
@@ -175,25 +175,25 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-gutters {
-  position: absolute; left: 0; top: 0;
   min-height: 100%;
+  position: absolute; left: 0; top: 0;
   z-index: 3;
 }
 .CodeMirror-gutter {
-  white-space: normal;
-  height: 100%;
   display: inline-block;
-  vertical-align: top;
+  height: 100%;
   margin-bottom: -30px;
+  vertical-align: top;
+  white-space: normal;
   /* Hack to make IE7 behave */
   *zoom:1;
   *display:inline;
 }
 .CodeMirror-gutter-wrapper {
-  position: absolute;
-  z-index: 4;
   background: none !important;
   border: none !important;
+  position: absolute;
+  z-index: 4;
 }
 .CodeMirror-gutter-background {
   position: absolute;
@@ -201,8 +201,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   z-index: 4;
 }
 .CodeMirror-gutter-elt {
-  position: absolute;
   cursor: default;
+  position: absolute;
   z-index: 4;
 }
 .CodeMirror-gutter-wrapper {
@@ -214,23 +214,22 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   min-height: 1px; /* prevents collapsing before first draw */
 }
 .CodeMirror pre {
+  -webkit-tap-highlight-color: transparent;
   /* Reset some styles that the rest of the page might have set */
+  background: transparent;
   border-radius: 0;
   border-width: 0;
-  background: transparent;
+  color: inherit;
   font-family: inherit;
   font-size: inherit;
+  font-variant-ligatures: none;
+  line-height: inherit;
   margin: 0;
+  overflow: visible;
+  position: relative;
   white-space: pre;
   word-wrap: normal;
-  line-height: inherit;
-  color: inherit;
   z-index: 2;
-  position: relative;
-  overflow: visible;
-  -webkit-tap-highlight-color: transparent;
-  font-variant-ligatures: none;
-  font-variant-ligatures: none;
 }
 .CodeMirror-wrap pre {
   word-wrap: break-word;
@@ -245,9 +244,9 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-linewidget {
+  overflow: auto;
   position: relative;
   z-index: 2;
-  overflow: auto;
 }
 
 .CodeMirror-widget {}
@@ -266,19 +265,19 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 }
 
 .CodeMirror-measure {
-  position: absolute;
-  width: 100%;
   height: 0;
   overflow: hidden;
+  position: absolute;
   visibility: hidden;
+  width: 100%;
 }
 
 .CodeMirror-cursor { position: absolute; }
 .CodeMirror-measure pre { position: static; }
 
 div.CodeMirror-cursors {
-  visibility: hidden;
   position: relative;
+  visibility: hidden;
   z-index: 3;
 }
 div.CodeMirror-dragcursors {
@@ -320,13 +319,13 @@ div.CodeMirror-dragcursors {
 span.CodeMirror-selectedtext { background: none; }
 
 .CodeMirror-dialog {
-  position: absolute;
-  left: 0; right: 0;
   background: inherit;
-  z-index: 15;
-  padding: .1em .8em;
-  overflow: hidden;
   color: inherit;
+  left: 0; right: 0;
+  overflow: hidden;
+  padding: .1em .8em;
+  position: absolute;
+  z-index: 15;
 }
 
 .CodeMirror-dialog-top {
@@ -340,12 +339,12 @@ span.CodeMirror-selectedtext { background: none; }
 }
 
 .CodeMirror-dialog input {
-  border: 1px solid #d3d6db;
-  outline: none;
   background: transparent;
-  width: 20em;
+  border: 1px solid #d3d6db;
   color: inherit;
   font-family: monospace;
+  outline: none;
+  width: 20em;
 }
 
 .CodeMirror-dialog button {

--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -13,13 +13,13 @@
 }
 
 .graphiql-container .doc-explorer-title {
-  padding: 10px 0 10px 10px;
+  flex: 1;
   font-weight: bold;
+  overflow-x: hidden;
+  padding: 10px 0 10px 10px;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow-x: hidden;
-  flex: 1;
 }
 
 .graphiql-container .doc-explorer-back {
@@ -44,8 +44,8 @@
   height: 9px;
   margin: 0 3px -1px 0;
   position: relative;
-  width: 9px;
   transform: rotate(-45deg);
+  width: 9px;
 }
 
 .graphiql-container .doc-explorer-rhs {

--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -4,15 +4,12 @@
 
 .graphiql-container .doc-explorer-title-bar {
   cursor: default;
-  display: -webkit-flex;
-  display: -ms-flexbox;
   display: flex;
   height: 34px;
   line-height: 14px;
   padding: 8px 8px 5px;
   position: relative;
-  -webkit-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .graphiql-container .doc-explorer-title {
@@ -22,9 +19,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow-x: hidden;
-  -webkit-flex: 1;
-      -ms-flex: 1;
-          flex: 1;
+  flex: 1;
 }
 
 .graphiql-container .doc-explorer-back {
@@ -50,9 +45,7 @@
   margin: 0 3px -1px 0;
   position: relative;
   width: 9px;
-  -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-          transform: rotate(-45deg);
+  transform: rotate(-45deg);
 }
 
 .graphiql-container .doc-explorer-rhs {
@@ -104,9 +97,7 @@
   letter-spacing: 1px;
   margin: 0 -15px 10px 0;
   padding: 10px 0;
-  -webkit-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  user-select: none;
 }
 
 .graphiql-container .doc-category-item {

--- a/css/foldgutter.css
+++ b/css/foldgutter.css
@@ -1,9 +1,9 @@
 .CodeMirror-foldmarker {
   color: blue;
-  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
+  cursor: pointer;
   font-family: arial;
   line-height: .3;
-  cursor: pointer;
+  text-shadow: #b9f 1px 1px 2px, #b9f -1px -1px 2px, #b9f 1px -1px 2px, #b9f -1px 1px 2px;
 }
 .CodeMirror-foldgutter {
   width: .7em;

--- a/css/lint.css
+++ b/css/lint.css
@@ -5,20 +5,20 @@
 
 .CodeMirror-lint-tooltip {
   background-color: infobackground;
-  border: 1px solid black;
   border-radius: 4px 4px 4px 4px;
+  border: 1px solid black;
   color: infotext;
   font-family: monospace;
   font-size: 10pt;
+  max-width: 600px;
+  opacity: 0;
   overflow: hidden;
   padding: 2px 5px;
   position: fixed;
-  white-space: pre;
-  white-space: pre-wrap;
-  z-index: 100;
-  max-width: 600px;
-  opacity: 0;
   transition: opacity .4s;
+  white-space: pre-wrap;
+  white-space: pre;
+  z-index: 100;
 }
 
 .CodeMirror-lint-mark-error, .CodeMirror-lint-mark-warning {
@@ -42,15 +42,15 @@
   cursor: pointer;
   display: inline-block;
   height: 16px;
-  width: 16px;
-  vertical-align: middle;
   position: relative;
+  vertical-align: middle;
+  width: 16px;
 }
 
 .CodeMirror-lint-message-error, .CodeMirror-lint-message-warning {
-  padding-left: 18px;
   background-position: top left;
   background-repeat: no-repeat;
+  padding-left: 18px;
 }
 
 .CodeMirror-lint-marker-error, .CodeMirror-lint-message-error {
@@ -63,7 +63,7 @@
 
 .CodeMirror-lint-marker-multiple {
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAMAAADzjKfhAAAACVBMVEUAAAAAAAC/v7914kyHAAAAAXRSTlMAQObYZgAAACNJREFUeNo1ioEJAAAIwmz/H90iFFSGJgFMe3gaLZ0od+9/AQZ0ADosbYraAAAAAElFTkSuQmCC");
-  background-repeat: no-repeat;
   background-position: right bottom;
+  background-repeat: no-repeat;
   width: 100%; height: 100%;
 }

--- a/css/lint.css
+++ b/css/lint.css
@@ -19,10 +19,6 @@
   max-width: 600px;
   opacity: 0;
   transition: opacity .4s;
-  -moz-transition: opacity .4s;
-  -webkit-transition: opacity .4s;
-  -o-transition: opacity .4s;
-  -ms-transition: opacity .4s;
 }
 
 .CodeMirror-lint-mark-error, .CodeMirror-lint-mark-warning {

--- a/css/loading.css
+++ b/css/loading.css
@@ -14,30 +14,12 @@
   height: 24px;
   width: 24px;
   position: absolute;
-  -webkit-animation: rotation .6s infinite linear;
-  -moz-animation: rotation .6s infinite linear;
-  -o-animation: rotation .6s infinite linear;
   animation: rotation .6s infinite linear;
   border-left: 6px solid rgba(150, 150, 150, .15);
   border-right: 6px solid rgba(150, 150, 150, .15);
   border-bottom: 6px solid rgba(150, 150, 150, .15);
   border-top: 6px solid rgba(150, 150, 150, .8);
   border-radius: 100%;
-}
-
-@-webkit-keyframes rotation {
-  from { -webkit-transform: rotate(0deg); }
-  to { -webkit-transform: rotate(359deg); }
-}
-
-@-moz-keyframes rotation {
-  from { -moz-transform: rotate(0deg); }
-  to { -moz-transform: rotate(359deg); }
-}
-
-@-o-keyframes rotation {
-  from { -o-transform: rotate(0deg); }
-  to { -o-transform: rotate(359deg); }
 }
 
 @keyframes rotation {

--- a/css/loading.css
+++ b/css/loading.css
@@ -1,25 +1,25 @@
 .graphiql-container .spinner-container {
+  height: 36px;
+  left: 50%;
   position: absolute;
   top: 50%;
-  height: 36px;
-  width: 36px;
-  left: 50%;
   transform: translate(-50%, -50%);
+  width: 36px;
   z-index: 10;
 }
 
 .graphiql-container .spinner {
-  vertical-align: middle;
+  animation: rotation .6s infinite linear;
+  border-bottom: 6px solid rgba(150, 150, 150, .15);
+  border-left: 6px solid rgba(150, 150, 150, .15);
+  border-radius: 100%;
+  border-right: 6px solid rgba(150, 150, 150, .15);
+  border-top: 6px solid rgba(150, 150, 150, .8);
   display: inline-block;
   height: 24px;
-  width: 24px;
   position: absolute;
-  animation: rotation .6s infinite linear;
-  border-left: 6px solid rgba(150, 150, 150, .15);
-  border-right: 6px solid rgba(150, 150, 150, .15);
-  border-bottom: 6px solid rgba(150, 150, 150, .15);
-  border-top: 6px solid rgba(150, 150, 150, .8);
-  border-radius: 100%;
+  vertical-align: middle;
+  width: 24px;
 }
 
 @keyframes rotation {

--- a/css/show-hint.css
+++ b/css/show-hint.css
@@ -1,8 +1,6 @@
 .CodeMirror-hints {
   background: white;
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-     -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
   font-size: 13px;
   list-style: none;
@@ -18,18 +16,14 @@
 
 .CodeMirror-hints-wrapper {
   background: white;
-  -webkit-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-     -moz-box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
   margin-left: -6px;
   position: absolute;
   z-index: 10;
 }
 
 .CodeMirror-hints-wrapper .CodeMirror-hints {
-  -webkit-box-shadow: none;
-   -moz-box-shadow: none;
-        box-shadow: none;
+  box-shadow: none;
   position: relative;
   margin-left: 0;
   z-index: 0;

--- a/css/show-hint.css
+++ b/css/show-hint.css
@@ -4,8 +4,8 @@
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
   font-size: 13px;
   list-style: none;
-  margin: 0;
   margin-left: -6px;
+  margin: 0;
   max-height: 14.5em;
   overflow-y: auto;
   overflow: hidden;
@@ -24,8 +24,8 @@
 
 .CodeMirror-hints-wrapper .CodeMirror-hints {
   box-shadow: none;
-  position: relative;
   margin-left: 0;
+  position: relative;
   z-index: 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-dom": ">=0.14.8"
   },
   "devDependencies": {
+    "autoprefixer": "^6.5.4",
     "babel-cli": "6.18.0",
     "babel-eslint": "7.1.1",
     "babel-plugin-syntax-async-functions": "6.13.0",
@@ -73,6 +74,7 @@
     "graphql": "0.8.2",
     "jsdom": "9.8.3",
     "mocha": "3.2.0",
+    "postcss-cli": "^2.6.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",
     "react-test-renderer": "15.4.1",

--- a/resources/build.sh
+++ b/resources/build.sh
@@ -14,5 +14,6 @@ browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js
 echo "Bundling graphiql.min.js..."
 browserify -g browserify-shim -g uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c --screw-ie8 > graphiql.min.js 2> /dev/null
 echo "Bundling graphiql.css..."
-cat css/*.css > graphiql.css
+postcss --use autoprefixer css/*.css -d dist/
+cat dist/*.css > graphiql.css
 echo "Done"

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,6 +217,17 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+autoprefixer@^6.5.4:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.5.4.tgz#1386eb6708ccff36aefff70adc694ecfd60af1b0"
+  dependencies:
+    browserslist "~1.4.0"
+    caniuse-db "^1.0.30000597"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.6"
+    postcss-value-parser "^3.2.3"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -956,6 +967,12 @@ browserify@13.1.1, browserify@^13.0.0:
     vm-browserify "~0.0.1"
     xtend "^4.0.0"
 
+browserslist@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.4.0.tgz#9cfdcf5384d9158f5b70da2aa00b30e8ff019049"
+  dependencies:
+    caniuse-db "^1.0.30000539"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -971,6 +988,10 @@ buffer@^4.1.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+builtin-modules@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 builtin-status-codes@^2.0.0:
   version "2.0.0"
@@ -997,6 +1018,14 @@ callsites@^0.2.0:
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000597:
+  version "1.0.30000597"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000597.tgz#b52e6cbe9dc83669affb98501629feaee1af6588"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1031,7 +1060,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chokidar@^1.0.0:
+chokidar@^1.0.0, chokidar@^1.5.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   dependencies:
@@ -1073,6 +1102,14 @@ cliui@^2.1.0:
     center-align "^0.1.1"
     right-align "^0.1.1"
     wordwrap "0.0.2"
+
+cliui@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wrap-ansi "^2.0.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -1253,7 +1290,7 @@ debug@2.2.0, debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-decamelize@^1.0.0:
+decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1408,6 +1445,12 @@ encoding@^0.1.11:
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
     iconv-lite "~0.4.13"
+
+error-ex@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.0.tgz#e67b43f3e82c96ea3a584ffee0b9fc3325d802d9"
+  dependencies:
+    is-arrayish "^0.2.1"
 
 es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
@@ -1762,6 +1805,13 @@ find-parent-dir@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 flat-cache@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.1.tgz#6c837d6225a7de5659323740b36d5361f71691ff"
@@ -1841,6 +1891,10 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+gather-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
+
 gauge@~2.7.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.2.tgz#15cecc31b02d05345a5d6b0e171cdb3ad2307774"
@@ -1864,6 +1918,10 @@ generate-object-property@^1.1.0:
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
   dependencies:
     is-property "^1.0.0"
+
+get-caller-file@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1905,9 +1963,30 @@ glob@^5.0.15, glob@^5.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
+
+globby@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-4.1.0.tgz#080f54549ec1b82a6c60e631fc82e1211dbe95f8"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^6.0.1"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2010,6 +2089,10 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+hosted-git-info@^2.1.4:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
 html-encoding-sniffer@^1.0.1:
   version "1.0.1"
@@ -2127,9 +2210,17 @@ invariant@^2.2.0:
   dependencies:
     loose-envify "^1.0.0"
 
+invert-kv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
 ipaddr.js@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.1.1.tgz#c791d95f52b29c1247d5df80ada39b8a73647230"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -2140,6 +2231,12 @@ is-binary-path@^1.0.0:
 is-buffer@^1.0.2, is-buffer@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz#cfc86ccd5dc5a52fa80489111c6920c457e2d98b"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
 
 is-defined@~1.0.0:
   version "1.0.0"
@@ -2242,6 +2339,10 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-utf8@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
 isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -2276,6 +2377,10 @@ jodid25519@^1.0.0:
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
   dependencies:
     jsbn "~0.1.0"
+
+js-base64@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
 js-tokens@^2.0.0:
   version "2.0.0"
@@ -2398,6 +2503,12 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+lcid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
+  dependencies:
+    invert-kv "^1.0.0"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -2410,6 +2521,16 @@ lexical-scope@^1.2.0:
   resolved "https://registry.yarnpkg.com/lexical-scope/-/lexical-scope-1.2.0.tgz#fcea5edc704a4b3a8796cdca419c3a0afaf22df4"
   dependencies:
     astw "^2.0.0"
+
+load-json-file@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    strip-bom "^2.0.0"
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"
@@ -2433,6 +2554,10 @@ lodash._getnative@^3.0.0:
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.assign@^4.0.3, lodash.assign@^4.0.6:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash.create@3.1.1:
   version "3.1.1"
@@ -2625,6 +2750,10 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+neo-async@^1.0.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-1.8.2.tgz#31795888b79dd04357a7c52113a65183e93b6735"
+
 node-fetch@^1.0.1:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.6.3.tgz#dc234edd6489982d58e8f0db4f695029abcd8c04"
@@ -2652,9 +2781,22 @@ nopt@~3.0.6:
   dependencies:
     abbrev "1"
 
+normalize-package-data@^2.3.2:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.5.tgz#8d924f142960e1777e7ffe170543631cc7cb02df"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
+
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
 npmlog@^4.0.1:
   version "4.0.1"
@@ -2664,6 +2806,10 @@ npmlog@^4.0.1:
     console-control-strings "~1.1.0"
     gauge "~2.7.1"
     set-blocking "~2.0.0"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -2733,6 +2879,12 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+os-locale@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  dependencies:
+    lcid "^1.0.0"
+
 os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -2780,6 +2932,12 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
@@ -2796,6 +2954,12 @@ path-browserify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2811,6 +2975,14 @@ path-platform@~0.11.15:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-type@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+  dependencies:
+    graceful-fs "^4.1.2"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.9"
@@ -2835,6 +3007,33 @@ pinkie@^2.0.0:
 pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+postcss-cli@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/postcss-cli/-/postcss-cli-2.6.0.tgz#f0de393caa026fcfc1b1479822989af508ed515d"
+  dependencies:
+    globby "^4.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^1.0.0"
+    postcss "^5.0.0"
+    read-file-stdin "^0.2.0"
+    resolve "^1.1.6"
+    yargs "^4.7.1"
+  optionalDependencies:
+    chokidar "^1.5.1"
+
+postcss-value-parser@^3.2.3:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss@^5.0.0, postcss@^5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.6.tgz#a252cd67cd52585035f17e9ad12b35137a7bdd9e"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.1.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2959,11 +3158,32 @@ react@15.4.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+read-file-stdin@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/read-file-stdin/-/read-file-stdin-0.2.1.tgz#25eccff3a153b6809afacb23ee15387db9e0ee61"
+  dependencies:
+    gather-stream "^1.0.0"
+
 read-only-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-only-stream/-/read-only-stream-2.0.0.tgz#2724fd6a8113d73764ac288d4386270c1dbf17f0"
   dependencies:
     readable-stream "^2.0.2"
+
+read-pkg-up@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+  dependencies:
+    find-up "^1.0.0"
+    read-pkg "^1.0.0"
+
+read-pkg@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+  dependencies:
+    load-json-file "^1.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^1.0.0"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.1.0, readable-stream@^2.1.5:
   version "2.2.2"
@@ -3132,6 +3352,14 @@ request@^2.55.0, request@^2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-main-filename@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
+
 require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -3188,7 +3416,7 @@ sax@^1.1.4:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
-semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -3219,7 +3447,7 @@ serve-static@~1.11.1:
     parseurl "~1.3.1"
     send "0.14.1"
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
@@ -3285,7 +3513,7 @@ source-map-support@^0.4.2:
   dependencies:
     source-map "^0.5.3"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -3300,6 +3528,20 @@ source-map@~0.2.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+spdx-correct@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
+  dependencies:
+    spdx-license-ids "^1.0.2"
+
+spdx-expression-parse@~1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz#9bdf2f20e1f40ed447fbe273266191fced51626c"
+
+spdx-license-ids@^1.0.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -3384,6 +3626,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-bom@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
+  dependencies:
+    is-utf8 "^0.2.0"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -3398,7 +3646,7 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -3631,6 +3879,13 @@ v8flags@^2.0.10:
   dependencies:
     user-home "^1.1.1"
 
+validate-npm-package-license@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
+  dependencies:
+    spdx-correct "~1.0.0"
+    spdx-expression-parse "~1.0.0"
+
 vary@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.0.tgz#e1e5affbbd16ae768dd2674394b9ad3022653140"
@@ -3680,6 +3935,10 @@ whatwg-url@^3.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+
 wide-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.0.tgz#40edde802a71fea1f070da3e62dcda2e7add96ad"
@@ -3690,6 +3949,10 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
+window-size@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
+
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
@@ -3697,6 +3960,13 @@ wordwrap@0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+wrap-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  dependencies:
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -3721,6 +3991,36 @@ xtend@~2.1.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
   dependencies:
     object-keys "~0.4.0"
+
+y18n@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yargs-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
+
+yargs@^4.7.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.1"
+    which-module "^1.0.0"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.1"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Follow-up to 8b4fe782c3d713ce. We shouldn't have to be manually micro-managing our CSS prefixes, which is an error prone process.

Instead, let's use autoprefixer. This commit sets that up and also removes the now-unnecessary prefixes from the source CSS. To get a sense of what's changed, here are the diffs between:

- the original output; and:
- the original source files piped through autoprefixer:

  https://gist.github.com/wincent/bdc72e085b97158e4cc87e8c1226dd25

- the original output; and:
- the stripped down source files piped thorugh autoprefixer:

  https://gist.github.com/wincent/bd41cb2d0cb92c6b77eec74d02db0798

Exceptions: I didn't remove the `-o-ellipsis-lastline` prefix nor the `-webkit-tap-highlight-color` one, because those aren't handled by autoprefixer (it only deals with stuff in the caniuse.com tables).

Tested in Chrome and Firefox so far, but will test a couple more browsers while this is under review.