### PR TITLE
Ensure saving a non-value to storage actually removes it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `response`: an optional JSON string to use as the initial displayed response. If not provided, no response will be initially shown. You might provide this if illustrating the result of the initial query.
 
-- `storage`: an instance of [Storage][] GraphiQL will use to persist state. Only `getItem` and `setItem` are called. Default: `window.localStorage`
+- `storage`: an instance of [Storage][] GraphiQL will use to persist state. Default: `window.localStorage`.
 
 - `defaultQuery`: an optional GraphQL string to use when no query is provided and no stored query exists from a previous session. If `undefined` is provided, GraphiQL will use its own default query.
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -132,6 +132,8 @@ export class GraphiQL extends React.Component {
 
     // Utility for keeping CodeMirror correctly sized.
     this.codeMirrorSizer = new CodeMirrorSizer();
+
+    global.g = this;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -185,7 +187,7 @@ export class GraphiQL extends React.Component {
   // that when the component is remounted, it will use the last used values.
   componentWillUnmount() {
     this._storageSet('query', this.state.query);
-    this._storageSet('variables', this.state.variables || '');
+    this._storageSet('variables', this.state.variables);
     this._storageSet('operationName', this.state.operationName);
     this._storageSet('editorFlex', this.state.editorFlex);
     this._storageSet('variableEditorHeight', this.state.variableEditorHeight);
@@ -418,12 +420,24 @@ export class GraphiQL extends React.Component {
   }
 
   _storageGet(name) {
-    return this._storage && this._storage.getItem('graphiql:' + name);
+    if (this._storage) {
+      const value = this._storage.getItem('graphiql:' + name);
+      // Clean up any inadvertently saved null/undefined values.
+      if (value === 'null' || value === 'undefined') {
+        this._storage.removeItem('graphiql:' + name);
+      } else {
+        return value;
+      }
+    }
   }
 
   _storageSet(name, value) {
     if (this._storage) {
-      this._storage.setItem('graphiql:' + name, value);
+      if (value) {
+        this._storage.setItem('graphiql:' + name, value);
+      } else {
+        this._storage.removeItem('graphiql:' + name);
+      }
     }
   }
 


### PR DESCRIPTION
localStorage coerces everything to a String before saving it, so setting undefined results in getting "undefined". This change causes falsey values to be removed rather than being string coerced. It also introduces a fix to dirty storage from this issue.

Fixes #234