### PR TITLE
Display defaultValue of parameters on the Docs

### DIFF
--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -134,7 +134,7 @@
 }
 
 .graphiql-container .arg-default-value {
-  color: #008000;
+  color: #0B7FC7;
 }
 
 .graphiql-container .doc-alert-text {

--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -133,6 +133,10 @@
   content: '';
 }
 
+.graphiql-container .arg-default-value {
+  color: #008000;
+}
+
 .graphiql-container .doc-alert-text {
   color: #F00F00;
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -15,11 +15,6 @@ export default class Argument extends React.Component {
     onClickType: PropTypes.func.isRequired,
   }
 
-  shouldComponentUpdate(nextProps) {
-    return this.props.arg !== nextProps.arg ||
-      this.props.onClickType !== nextProps.onClickType;
-  }
-
   render() {
     const arg = this.props.arg;
 

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -16,8 +16,7 @@ export default class Argument extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.arg !== nextProps.arg ||
-      this.props.arg.name !== nextProps.arg.name ||
+    return this.props.arg.name !== nextProps.arg.name ||
       this.props.arg.type !== nextProps.arg.type ||
       this.props.arg.defaultValue !== nextProps.arg.defaultValue ||
       this.props.onClickType !== nextProps.onClickType;

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -1,3 +1,11 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
 import React, { PropTypes } from 'react';
 import TypeLink from './TypeLink';
 

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -9,35 +9,38 @@
 import React, { PropTypes } from 'react';
 import TypeLink from './TypeLink';
 
-const Argument = ({ arg, onClickType }) => {
-  return (
-    <span className="arg">
-      <span className="arg-name">{arg.name}</span>
-      {': '}
-      <TypeLink type={arg.type} onClick={onClickType} />
-      { renderDefaultValue(arg) }
-    </span>
-  );
-};
-
-function renderDefaultValue(arg) {
-  if (arg.defaultValue === undefined) {
-    return null;
+export default class Argument extends React.Component {
+  static propTypes = {
+    arg: PropTypes.object.isRequired,
+    onClickType: PropTypes.func.isRequired,
   }
 
-  return (
-    <span>
-      {' = '}
-      <span className="arg-default-value">
-        { arg.defaultValue === '' ? '""' : arg.defaultValue }
+  shouldComponentUpdate(nextProps) {
+    return this.props.arg !== nextProps.arg ||
+      this.props.arg.name !== nextProps.arg.name ||
+      this.props.arg.type !== nextProps.arg.type ||
+      this.props.arg.defaultValue !== nextProps.arg.defaultValue ||
+      this.props.onClickType !== nextProps.onClickType;
+  }
+
+  render() {
+    const arg = this.props.arg;
+
+    return (
+      <span className="arg">
+        <span className="arg-name">{arg.name}</span>
+        {': '}
+        <TypeLink type={arg.type} onClick={this.props.onClickType} />
+        {
+          arg.defaultValue !== undefined &&
+          <span>
+            {' = '}
+            <span className="arg-default-value">
+              { arg.defaultValue === '' ? '""' : arg.defaultValue }
+            </span>
+          </span>
+        }
       </span>
-    </span>
-  );
+    );
+  }
 }
-
-Argument.propTypes = {
-  arg: PropTypes.object.isRequired,
-  onClickType: PropTypes.func.isRequired,
-};
-
-export default Argument;

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -1,0 +1,35 @@
+import React, { PropTypes } from 'react';
+import TypeLink from './TypeLink';
+
+const Argument = ({ arg, onClickType }) => {
+  return (
+    <span className="arg">
+      <span className="arg-name">{arg.name}</span>
+      {': '}
+      <TypeLink type={arg.type} onClick={onClickType} />
+      { renderDefaultValue(arg) }
+    </span>
+  );
+};
+
+function renderDefaultValue(arg) {
+  if (arg.defaultValue === undefined) {
+    return null;
+  }
+
+  return (
+    <span>
+      {' = '}
+      <span className="arg-default-value">
+        { arg.defaultValue === '' ? '""' : arg.defaultValue }
+      </span>
+    </span>
+  );
+}
+
+Argument.propTypes = {
+  arg: PropTypes.object.isRequired,
+  onClickType: PropTypes.func.isRequired,
+};
+
+export default Argument;

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -16,9 +16,7 @@ export default class Argument extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.arg.name !== nextProps.arg.name ||
-      this.props.arg.type !== nextProps.arg.type ||
-      this.props.arg.defaultValue !== nextProps.arg.defaultValue ||
+    return this.props.arg !== nextProps.arg ||
       this.props.onClickType !== nextProps.onClickType;
   }
 

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -10,30 +10,25 @@ import React, { PropTypes } from 'react';
 import { astFromValue, print } from 'graphql';
 import TypeLink from './TypeLink';
 
-export default class Argument extends React.Component {
-  static propTypes = {
-    arg: PropTypes.object.isRequired,
-    onClickType: PropTypes.func.isRequired,
-  }
-
-  render() {
-    const arg = this.props.arg;
-
-    return (
-      <span className="arg">
-        <span className="arg-name">{arg.name}</span>
-        {': '}
-        <TypeLink type={arg.type} onClick={this.props.onClickType} />
-        {
-          arg.defaultValue !== undefined &&
-          <span>
-            {' = '}
-            <span className="arg-default-value">
-              {print(astFromValue(arg.defaultValue, arg.type))}
-            </span>
+export default function Argument({ arg, onClickType }) {
+  return (
+    <span className="arg">
+      <span className="arg-name">{arg.name}</span>
+      {': '}
+      <TypeLink type={arg.type} onClick={onClickType} />
+      {arg.defaultValue !== undefined &&
+        <span>
+          {' = '}
+          <span className="arg-default-value">
+            {print(astFromValue(arg.defaultValue, arg.type))}
           </span>
-        }
-      </span>
-    );
-  }
+        </span>
+      }
+    </span>
+  );
 }
+
+Argument.propTypes = {
+  arg: PropTypes.object.isRequired,
+  onClickType: PropTypes.func.isRequired,
+};

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -7,6 +7,7 @@
  */
 
 import React, { PropTypes } from 'react';
+import { astFromValue, print } from 'graphql';
 import TypeLink from './TypeLink';
 
 export default class Argument extends React.Component {
@@ -28,7 +29,7 @@ export default class Argument extends React.Component {
           <span>
             {' = '}
             <span className="arg-default-value">
-              { arg.defaultValue === '' ? '""' : arg.defaultValue }
+              {print(astFromValue(arg.defaultValue, arg.type))}
             </span>
           </span>
         }

--- a/src/components/DocExplorer/FieldDoc.js
+++ b/src/components/DocExplorer/FieldDoc.js
@@ -8,9 +8,9 @@
 
 import React, { PropTypes } from 'react';
 
+import Argument from './Argument';
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
-import Argument from './Argument';
 
 export default class FieldDoc extends React.Component {
   static propTypes = {

--- a/src/components/DocExplorer/FieldDoc.js
+++ b/src/components/DocExplorer/FieldDoc.js
@@ -10,6 +10,7 @@ import React, { PropTypes } from 'react';
 
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
+import Argument from './Argument';
 
 export default class FieldDoc extends React.Component {
   static propTypes = {
@@ -34,9 +35,7 @@ export default class FieldDoc extends React.Component {
           {field.args.map(arg =>
             <div key={arg.name} className="doc-category-item">
               <div>
-                <span className="arg-name">{arg.name}</span>
-                {': '}
-                <TypeLink type={arg.type} onClick={this.props.onClickType} />
+                <Argument arg={arg} onClickType={this.props.onClickType} />
               </div>
               <MarkdownContent
                 className="doc-value-description"

--- a/src/components/DocExplorer/SearchResults.js
+++ b/src/components/DocExplorer/SearchResults.js
@@ -9,6 +9,7 @@
 import React, { PropTypes } from 'react';
 
 import TypeLink from './TypeLink';
+import Argument from './Argument';
 
 export default class SearchResults extends React.Component {
   static propTypes = {
@@ -84,11 +85,11 @@ export default class SearchResults extends React.Component {
                   {'('}
                   <span>
                     {matches.map(arg =>
-                      <span className="arg" key={arg.name}>
-                        <span className="arg-name">{arg.name}</span>
-                        {': '}
-                        <TypeLink type={arg.type} onClick={onClickType} />
-                      </span>
+                      <Argument
+                        key={arg.name}
+                        arg={arg}
+                        onClickType={onClickType}
+                      />
                     )}
                   </span>
                   {')'}

--- a/src/components/DocExplorer/SearchResults.js
+++ b/src/components/DocExplorer/SearchResults.js
@@ -8,8 +8,8 @@
 
 import React, { PropTypes } from 'react';
 
-import TypeLink from './TypeLink';
 import Argument from './Argument';
+import TypeLink from './TypeLink';
 
 export default class SearchResults extends React.Component {
   static propTypes = {

--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -15,9 +15,9 @@ import {
   GraphQLEnumType,
 } from 'graphql';
 
+import Argument from './Argument';
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
-import Argument from './Argument';
 
 export default class TypeDoc extends React.Component {
   static propTypes = {

--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -17,6 +17,7 @@ import {
 
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
+import Argument from './Argument';
 
 export default class TypeDoc extends React.Component {
   static propTypes = {
@@ -84,11 +85,7 @@ export default class TypeDoc extends React.Component {
             let argsDef;
             if (field.args && field.args.length > 0) {
               argsDef = field.args.map(arg =>
-                <span className="arg" key={arg.name}>
-                  <span className="arg-name">{arg.name}</span>
-                  {': '}
-                  <TypeLink type={arg.type} onClick={onClickType} />
-                </span>
+                <Argument key={arg.name} arg={arg} onClickType={onClickType} />
               );
             }
 


### PR DESCRIPTION
As requested on issue #133, this PR displays the default value of a parameter on the Docs sidebar.

About the tests, I was thinking about adding `enzyme` to test the components, or we should keep the `react-test-renderer` only?

That's how it looks, let me know what do you think or if I should do something different:

![arguments](https://cloud.githubusercontent.com/assets/4459232/21938304/0c1b60b4-d9bb-11e6-8098-42108b6b9b6f.png)
![search](https://cloud.githubusercontent.com/assets/4459232/21938305/0c1c1662-d9bb-11e6-8eec-50e83f8491bf.png)
![query](https://cloud.githubusercontent.com/assets/4459232/21938306/0c1db03a-d9bb-11e6-9a92-9f776d164676.png)
