### PR TITLE
Add Jump-to-docs and Info tooltips

### DIFF
--- a/css/info.css
+++ b/css/info.css
@@ -1,0 +1,111 @@
+.CodeMirror-info {
+  background: white;
+  border-radius: 2px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  box-sizing: border-box;
+  color: #555;
+  font-family:
+    system,
+    -apple-system,
+    'San Francisco',
+    '.SFNSDisplay-Regular',
+    'Segoe UI',
+    Segoe,
+    'Segoe WP',
+    'Helvetica Neue',
+    helvetica,
+    'Lucida Grande',
+    arial,
+    sans-serif;
+  font-size: 13px;
+  line-height: 16px;
+  margin: 8px -8px;
+  max-width: 400px;
+  opacity: 0;
+  overflow: hidden;
+  padding: 8px 8px;
+  position: fixed;
+  transition: opacity 0.15s;
+  z-index: 50;
+}
+
+.CodeMirror-info :first-child {
+  margin-top: 0;
+}
+
+.CodeMirror-info :last-child {
+  margin-bottom: 0;
+}
+
+.CodeMirror-info p {
+  margin: 1em 0;
+}
+
+.CodeMirror-info .info-description {
+  color: #777;
+  line-height: 16px;
+  margin-top: 1em;
+  max-height: 80px;
+  overflow: hidden;
+}
+
+.CodeMirror-info .info-deprecation {
+  background: #fffae8;
+  box-shadow: inset 0 1px 1px -1px #bfb063;
+  color: #867F70;
+  line-height: 16px;
+  margin: -8px;
+  margin-top: 8px;
+  max-height: 80px;
+  overflow: hidden;
+  padding: 8px;
+}
+
+.CodeMirror-info .info-deprecation-label {
+  color: #c79b2e;
+  cursor: default;
+  display: block;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.CodeMirror-info .info-deprecation-label + * {
+  margin-top: 0;
+}
+
+.CodeMirror-info a {
+  text-decoration: none;
+}
+
+.CodeMirror-info a:hover {
+  text-decoration: underline;
+}
+
+.CodeMirror-info .type-name {
+  color: #CA9800;
+}
+
+.CodeMirror-info .field-name {
+  color: #1F61A0;
+}
+
+.CodeMirror-info .value-name {
+  color: #0B7FC7;
+}
+
+.CodeMirror-info .arg-name {
+  color: #8B2BB9;
+}
+
+.CodeMirror-info .directive-name {
+  color: #B33086;
+}
+
+.CodeMirror-info .enum-value {
+  color: #0B7FC7;
+}

--- a/css/jump.css
+++ b/css/jump.css
@@ -1,0 +1,4 @@
+.CodeMirror-jump-token {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "codemirror": "5.22.2",
-    "codemirror-graphql": "^0.6.1",
-    "marked": "^0.3.5"
+    "codemirror-graphql": "0.6.1",
+    "marked": "0.3.6"
   },
   "peerDependencies": {
     "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b",

--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -165,6 +165,19 @@ export class DocExplorer extends React.Component {
   }
 
   // Public API
+  showDocForReference(reference) {
+    if (reference.kind === 'Type') {
+      this.showDoc(reference.type);
+    } else if (reference.kind === 'Field') {
+      this.showDoc(reference.field);
+    } else if (reference.kind === 'Argument' && reference.field) {
+      this.showDoc(reference.field);
+    } else if (reference.kind === 'EnumValue' && reference.type) {
+      this.showDoc(reference.type);
+    }
+  }
+
+  // Public API
   showSearch(searchItem) {
     let navStack = this.state.navStack;
     const lastEntry = navStack.length > 0 && navStack[navStack.length - 1];

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -264,6 +264,7 @@ export class GraphiQL extends React.Component {
                 value={this.state.query}
                 onEdit={this.handleEditQuery}
                 onHintInformationRender={this.handleHintInformationRender}
+                onClickReference={this.handleClickReference}
                 onRunQuery={this.handleEditorRunQuery}
               />
               <div className="variable-editor" style={variableStyle}>
@@ -496,6 +497,12 @@ export class GraphiQL extends React.Component {
     } else {
       throw new Error('Fetcher did not return Promise or Observable.');
     }
+  }
+
+  handleClickReference = reference => {
+    this.setState({ docExplorerOpen: true }, () => {
+      this.docExplorerComponent.showDocForReference(reference);
+    });
   }
 
   handleRunQuery = selectedOperationName => {

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -8,6 +8,7 @@
 
 import React, { PropTypes } from 'react';
 import { GraphQLSchema } from 'graphql';
+import marked from 'marked';
 
 import onHasCompletion from '../utility/onHasCompletion';
 
@@ -30,6 +31,7 @@ export class QueryEditor extends React.Component {
     value: PropTypes.string,
     onEdit: PropTypes.func,
     onHintInformationRender: PropTypes.func,
+    onClickReference: PropTypes.func,
     onRunQuery: PropTypes.func,
   }
 
@@ -56,6 +58,8 @@ export class QueryEditor extends React.Component {
     require('codemirror/keymap/sublime');
     require('codemirror-graphql/hint');
     require('codemirror-graphql/lint');
+    require('codemirror-graphql/info');
+    require('codemirror-graphql/jump');
     require('codemirror-graphql/mode');
 
     this.editor = CodeMirror(this._node, {
@@ -78,6 +82,15 @@ export class QueryEditor extends React.Component {
         schema: this.props.schema,
         closeOnUnfocus: false,
         completeSingle: false,
+      },
+      info: {
+        schema: this.props.schema,
+        renderDescription: text => marked(text, { sanitize: true }),
+        onClick: reference => this.props.onClickReference(reference),
+      },
+      jump: {
+        schema: this.props.schema,
+        onClick: reference => this.props.onClickReference(reference),
       },
       gutters: [ 'CodeMirror-linenumbers', 'CodeMirror-foldgutter' ],
       extraKeys: {
@@ -120,6 +133,8 @@ export class QueryEditor extends React.Component {
     if (this.props.schema !== prevProps.schema) {
       this.editor.options.lint.schema = this.props.schema;
       this.editor.options.hintOptions.schema = this.props.schema;
+      this.editor.options.info.schema = this.props.schema;
+      this.editor.options.jump.schema = this.props.schema;
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
     if (this.props.value !== prevProps.value &&

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,8 @@
     <link rel="stylesheet" href="css/codemirror.css" />
     <link rel="stylesheet" href="css/doc-explorer.css" />
     <link rel="stylesheet" href="css/foldgutter.css" />
+    <link rel="stylesheet" href="css/info.css" />
+    <link rel="stylesheet" href="css/jump.css" />
     <link rel="stylesheet" href="css/lint.css" />
     <link rel="stylesheet" href="css/loading.css" />
     <link rel="stylesheet" href="css/show-hint.css" />

--- a/test/schema.js
+++ b/test/schema.js
@@ -24,15 +24,21 @@ const {
 // Test Schema
 const TestEnum = new GraphQLEnumType({
   name: 'TestEnum',
+  description: 'An enum of super cool colors.',
   values: {
     RED: { description: 'A rosy color' },
     GREEN: { description: 'The color of martians and slime' },
     BLUE: { description: 'A feeling you might have if you can\'t use GraphQL' },
+    GRAY: {
+      description: 'A really dull color',
+      deprecationReason: 'Colors are available now.'
+    },
   }
 });
 
 const TestInputObject = new GraphQLInputObjectType({
   name: 'TestInput',
+  description: 'Test all sorts of inputs in this input object type.',
   fields: () => ({
     string: {
       type: GraphQLString,
@@ -131,6 +137,11 @@ const TestType = new GraphQLObjectType({
       resolve: () => {
         return true;
       }
+    },
+    deprecatedField: {
+      type: TestType,
+      description: 'This field is an example of a deprecated field',
+      deprecationReason: 'No longer in use, try `test` instead.',
     },
     hasArgs: {
       type: GraphQLString,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,13 +1126,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codemirror-graphql@^0.5.9:
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/codemirror-graphql/-/codemirror-graphql-0.5.9.tgz#b5ca2a84bd0deae7660c726f7feba15149bac8fd"
+codemirror-graphql@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/codemirror-graphql/-/codemirror-graphql-0.6.1.tgz#eead37a698ffc49e63feb7de1f8b2eabacab7b61"
 
-codemirror@5.22.0:
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.22.0.tgz#281ec76ed991ef24db4071fdf4deb746e80bff18"
+codemirror@5.22.2:
+  version "5.22.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.22.2.tgz#38274c20e3628b4f7a982bffc2cddb61ceed6a09"
 
 combine-source-map@~0.7.1:
   version "0.7.2"
@@ -1566,9 +1566,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-babel@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.0.0.tgz#a92114e2c493ac3034b030d7ecf96e174a76ef3f"
+eslint-plugin-babel@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-4.0.1.tgz#77de74dabd67a6bef3b16bf258f5804e971e7349"
 
 eslint-plugin-react@6.9.0:
   version "6.9.0"
@@ -1846,9 +1846,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.37.4:
-  version "0.37.4"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.37.4.tgz#3d8da2ef746e80e730d166e09040f4198969b76b"
+flow-bin@0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.38.0.tgz#3ae096d401c969cc8b5798253fb82381e2d0237a"
 
 for-in@^0.1.5:
   version "0.1.6"
@@ -2665,7 +2665,7 @@ map-obj@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@^0.3.5:
+marked@0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 


### PR DESCRIPTION
This leverages https://github.com/graphql/codemirror-graphql/pull/96 to provide cmd+click to jump to the docs for tokens in the query and mouse-over tool tops to provide in context documentation as well.

Closes #97