### PR TITLE
Break many arguments onto separate lines in doc explorer.

### DIFF
--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -125,12 +125,20 @@
   color: #8B2BB9;
 }
 
-.graphiql-container .arg:after {
-  content: ', ';
+.graphiql-container .arg {
+  display: block;
+  margin-left: 2ch;
 }
 
-.graphiql-container .arg:last-child:after {
-  content: '';
+.graphiql-container .arg:first-child:last-child,
+.graphiql-container .arg:first-child:nth-last-child(2),
+.graphiql-container .arg:first-child:nth-last-child(2) ~ .arg {
+  display: inherit;
+  margin: inherit;
+}
+
+.graphiql-container .arg:first-child:nth-last-child(2):after {
+  content: ', ';
 }
 
 .graphiql-container .arg-default-value {

--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -79,33 +79,34 @@ export default class TypeDoc extends React.Component {
           <div className="doc-category-title">
             {'fields'}
           </div>
-          {fields.map(field => {
-
-            // Field arguments
-            let argsDef;
-            if (field.args && field.args.length > 0) {
-              argsDef = field.args.map(arg =>
-                <Argument key={arg.name} arg={arg} onClickType={onClickType} />
-              );
-            }
-
-            return (
-              <div key={field.name} className="doc-category-item">
-                <a
-                  className="field-name"
-                  onClick={event => onClickField(field, type, event)}>
-                  {field.name}
-                </a>
-                {argsDef && [ '(', <span key="args">{argsDef}</span>, ')' ]}
-                {': '}
-                <TypeLink type={field.type} onClick={onClickType} />
-                {
-                  (field.isDeprecated || field.deprecationReason) &&
-                  <span className="doc-alert-text">{' (DEPRECATED)'}</span>
-                }
-              </div>
-            );
-          })}
+          {fields.map(field =>
+            <div key={field.name} className="doc-category-item">
+              <a
+                className="field-name"
+                onClick={event => onClickField(field, type, event)}>
+                {field.name}
+              </a>
+              {field.args && field.args.length > 0 && [
+                '(',
+                <span key="args">
+                  {field.args.map(arg =>
+                    <Argument
+                      key={arg.name}
+                      arg={arg}
+                      onClickType={onClickType}
+                    />
+                  )}
+                </span>,
+                ')'
+              ]}
+              {': '}
+              <TypeLink type={field.type} onClick={onClickType} />
+              {
+                (field.isDeprecated || field.deprecationReason) &&
+                <span className="doc-alert-text">{' (DEPRECATED)'}</span>
+              }
+            </div>
+          )}
         </div>
       );
     }


### PR DESCRIPTION
Updates the CSS rules for the arguments of a field in the doc explorer to render one per line when there are more than one.

As suggested in #272 