### PR TITLE
Show deprecation warnings in hint typeahead

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -417,7 +417,7 @@
 }
 
 .CodeMirror-hint-information .infoType {
-  color: #30a;
+  color: #CA9800;
   cursor: pointer;
   display: inline;
   margin-right: 0.5em;

--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -127,7 +127,7 @@
 
 .graphiql-container .arg {
   display: block;
-  margin-left: 2ch;
+  margin-left: 1em;
 }
 
 .graphiql-container .arg:first-child:last-child,

--- a/css/show-hint.css
+++ b/css/show-hint.css
@@ -59,3 +59,49 @@ li.CodeMirror-hint-active {
   border-top: none;
   margin-bottom: -1px;
 }
+
+.CodeMirror-hint-deprecation {
+  background: #fffae8;
+  box-shadow: inset 0 1px 1px -1px #bfb063;
+  color: #867F70;
+  font-family:
+    system,
+    -apple-system,
+    'San Francisco',
+    '.SFNSDisplay-Regular',
+    'Segoe UI',
+    Segoe,
+    'Segoe WP',
+    'Helvetica Neue',
+    helvetica,
+    'Lucida Grande',
+    arial,
+    sans-serif;
+  font-size: 13px;
+  line-height: 16px;
+  margin-top: 4px;
+  max-height: 80px;
+  overflow: hidden;
+  padding: 6px;
+}
+
+.CodeMirror-hint-deprecation .deprecation-label {
+  color: #c79b2e;
+  cursor: default;
+  display: block;
+  font-size: 9px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  line-height: 1;
+  padding-bottom: 5px;
+  text-transform: uppercase;
+  user-select: none;
+}
+
+.CodeMirror-hint-deprecation .deprecation-label + * {
+  margin-top: 0;
+}
+
+.CodeMirror-hint-deprecation :last-child {
+  margin-bottom: 0;
+}

--- a/src/utility/onHasCompletion.js
+++ b/src/utility/onHasCompletion.js
@@ -19,6 +19,7 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
 
   let wrapper;
   let information;
+  let deprecation;
 
   // When a hint result is selected, we touch the UI.
   CodeMirror.on(data, 'select', (ctx, el) => {
@@ -57,12 +58,19 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
       // highlighted typeahead option.
       information = document.createElement('div');
       information.className = 'CodeMirror-hint-information';
+
+      // This "deprecation" node will contain info about deprecated usage.
+      deprecation = document.createElement('div');
+      deprecation.className = 'CodeMirror-hint-deprecation';
+
       if (bottom) {
+        wrapper.appendChild(deprecation);
         wrapper.appendChild(information);
         wrapper.appendChild(hintsUl);
       } else {
         wrapper.appendChild(hintsUl);
         wrapper.appendChild(information);
+        wrapper.appendChild(deprecation);
       }
 
       // When CodeMirror attempts to remove the hint UI, we detect that it was
@@ -82,7 +90,7 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
 
     // Now that the UI has been set up, add info to information.
     const description = ctx.description ?
-      marked(ctx.description, { smartypants: true }) :
+      marked(ctx.description, { sanitize: true }) :
       'Self descriptive.';
     const type = ctx.type ?
       '<span class="infoType">' + renderType(ctx.type) + '</span>' :
@@ -92,6 +100,18 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
       (description.slice(0, 3) === '<p>' ?
         '<p>' + type + description.slice(3) :
         type + description) + '</div>';
+
+    if (ctx.isDeprecated) {
+      const reason = ctx.deprecationReason ?
+        marked(ctx.deprecationReason, { sanitize: true }) :
+        '';
+      deprecation.innerHTML =
+        '<span class="deprecation-label">Deprecated</span>' +
+        reason;
+      deprecation.style.display = 'block';
+    } else {
+      deprecation.style.display = 'none';
+    }
 
     // Additional rendering?
     if (onHintInformationRender) {


### PR DESCRIPTION
This adds additional rendering in the hint typehead to indicate when a field hinted is deprecated. The styling matches that used in the info hover tooltips.

As mentioned in #273 