### PR TITLE
Docs: syntax-highlight code-block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ More examples available from: [GraphQL Queries](http://graphql.org/docs/queries/
 **Mutation**
 
 Given this schema,
-```
+```js
 const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     fields: {


### PR DESCRIPTION
Just a tinsie-tiny one to add syntax highlighting to one of the code blocks in README.md. 
I noticed that this wasn't highlighted while installing GraphiQL earlier today and thought it could use a bit of color! 💅