### PR TITLE
Fix: typeahead breaks on scroll.

### DIFF
--- a/css/show-hint.css
+++ b/css/show-hint.css
@@ -14,21 +14,6 @@
   z-index: 10;
 }
 
-.CodeMirror-hints-wrapper {
-  background: white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-  margin-left: -6px;
-  position: absolute;
-  z-index: 10;
-}
-
-.CodeMirror-hints-wrapper .CodeMirror-hints {
-  box-shadow: none;
-  margin-left: 0;
-  position: relative;
-  z-index: 0;
-}
-
 .CodeMirror-hint {
   border-top: solid 1px #f7f7f7;
   color: #141823;

--- a/src/utility/onHasCompletion.js
+++ b/src/utility/onHasCompletion.js
@@ -17,72 +17,35 @@ import marked from 'marked';
 export default function onHasCompletion(cm, data, onHintInformationRender) {
   const CodeMirror = require('codemirror');
 
-  let wrapper;
   let information;
   let deprecation;
 
-  // When a hint result is selected, we touch the UI.
+  // When a hint result is selected, we augment the UI with information.
   CodeMirror.on(data, 'select', (ctx, el) => {
     // Only the first time (usually when the hint UI is first displayed)
-    // do we create the wrapping node.
-    if (!wrapper) {
-      // Wrap the existing hint UI, so we have a place to put information.
+    // do we create the information nodes.
+    if (!information) {
       const hintsUl = el.parentNode;
-      const container = hintsUl.parentNode;
-      wrapper = document.createElement('div');
-      container.appendChild(wrapper);
-
-      // CodeMirror vertically inverts the hint UI if there is not enough
-      // space below the cursor. Since this modified UI appends to the bottom
-      // of CodeMirror's existing UI, it could cover the cursor. This adjusts
-      // the positioning of the hint UI to accomodate.
-      let top = hintsUl.style.top;
-      let bottom = '';
-      const cursorTop = cm.cursorCoords().top;
-      if (parseInt(top, 10) < cursorTop) {
-        top = '';
-        bottom = (window.innerHeight - cursorTop + 3) + 'px';
-      }
-
-      // Style the wrapper, remove positioning from hints. Note that usage
-      // of this option will need to specify CSS to remove some styles from
-      // the existing hint UI.
-      wrapper.className = 'CodeMirror-hints-wrapper';
-      wrapper.style.left = hintsUl.style.left;
-      wrapper.style.top = top;
-      wrapper.style.bottom = bottom;
-      hintsUl.style.left = '';
-      hintsUl.style.top = '';
 
       // This "information" node will contain the additional info about the
       // highlighted typeahead option.
       information = document.createElement('div');
       information.className = 'CodeMirror-hint-information';
+      hintsUl.appendChild(information);
 
       // This "deprecation" node will contain info about deprecated usage.
       deprecation = document.createElement('div');
       deprecation.className = 'CodeMirror-hint-deprecation';
-
-      if (bottom) {
-        wrapper.appendChild(deprecation);
-        wrapper.appendChild(information);
-        wrapper.appendChild(hintsUl);
-      } else {
-        wrapper.appendChild(hintsUl);
-        wrapper.appendChild(information);
-        wrapper.appendChild(deprecation);
-      }
+      hintsUl.appendChild(deprecation);
 
       // When CodeMirror attempts to remove the hint UI, we detect that it was
-      // removed from our wrapper and in turn remove the wrapper from the
-      // original container.
+      // removed and in turn remove the information nodes.
       let onRemoveFn;
-      wrapper.addEventListener('DOMNodeRemoved', onRemoveFn = event => {
+      hintsUl.addEventListener('DOMNodeRemoved', onRemoveFn = event => {
         if (event.target === hintsUl) {
-          wrapper.removeEventListener('DOMNodeRemoved', onRemoveFn);
-          wrapper.parentNode.removeChild(wrapper);
-          wrapper = null;
+          hintsUl.removeEventListener('DOMNodeRemoved', onRemoveFn);
           information = null;
+          deprecation = null;
           onRemoveFn = null;
         }
       });


### PR DESCRIPTION
Codemirror has behavior for scrolling with the typeahead open to track the current token. Our previous wrapping technique broke with this behavior. This PR simplifies the augmenting technique which no longer breaks.

Fixes #284