### PR TITLE
Default toolbar with prettify button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 * `<GraphiQL.Logo>`: Replace the GraphiQL logo with your own.
 
-* `<GraphiQL.Toolbar>`: Add a custom toolbar above GraphiQL.
+* `<GraphiQL.Toolbar>`: Add a custom toolbar above GraphiQL. If not provided, a
+  default toolbar may contain common operations. Pass the empty
+  `<GraphiQL.Toolbar />` if an empty toolbar is desired.
 
 * `<GraphiQL.Button>`: Add a button to the toolbar above GraphiQL.
 
@@ -159,9 +161,13 @@ class CustomGraphiQL extends React.Component {
     };
   }
 
-  _onClickToolbarButton(event) {
+  // Example of using the GraphiQL Component API via a toolbar button.
+  handleClickPrettifyButton(event) {
     const editor = this.graphiql.getQueryEditor();
-    alert('Clicked toolbar button! Current query: ' + editor.getValue());
+    const currentText = editor.getValue();
+    const { parse, print } = require('graphql');
+    const prettyText = print(parse(currentText));
+    editor.setValue(prettyText);
   }
 
   render() {
@@ -171,15 +177,21 @@ class CustomGraphiQL extends React.Component {
           Custom Logo
         </GraphiQL.Logo>
         <GraphiQL.Toolbar>
+
           // GraphiQL.Button usage
           <GraphiQL.Button
-            onClick={this._onClickToolbarButton}
-            title="ToolbarButton"
-            label="Click Me as well!"
+            onClick={this.handleClickPrettifyButton}
+            label="Prettify"
+            title="Prettify Query"
           />
+
           // Some other possible toolbar items
-          <button name="GraphiQLButton">Click Me</button>
+          <GraphiQL.Toolbar.Menu title="File">
+            <GraphiQL.Toolbar.MenuItem title="Save" onClick={...}>
+          <GraphiQL.Toolbar.Menu>
+
           <OtherReactComponent someProps="true" />
+
         </GraphiQL.Toolbar>
         <GraphiQL.Footer>
           // Footer works the same as Toolbar

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -220,7 +220,13 @@ export class GraphiQL extends React.Component {
 
     const toolbar =
       find(children, child => child.type === GraphiQL.Toolbar) ||
-      <GraphiQL.Toolbar />;
+      <GraphiQL.Toolbar>
+        <ToolbarButton
+          onClick={this.handlePrettifyQuery}
+          title="Prettify Query"
+          label="Prettify"
+        />
+      </GraphiQL.Toolbar>;
 
     const footer = find(children, child => child.type === GraphiQL.Footer);
 
@@ -252,11 +258,6 @@ export class GraphiQL extends React.Component {
                 onRun={this.handleRunQuery}
                 onStop={this.handleStopQuery}
                 operations={this.state.operations}
-              />
-              <ToolbarButton
-                onClick={this.handlePrettifyQuery}
-                title="Prettify Query"
-                label="Prettify"
               />
               {toolbar}
             </div>


### PR DESCRIPTION
Currently there is a hard-coded prettify button in the toolbar, however not all clients of GraphQL wish to have that button, or to have that button in that particular position. This PR replaces hard-coding with a default toolbar that contains the prettify button.

This means if you pass a `<GraphiQL.Toolbar>` child to `<GraphiQL>` that the Prettify button will no longer appear. If you want the Prettify button, you can copy the existing source. Here is an example of adding a Toolbar with a Prettify button (elaborated in Readme example):

```js
class CustomGraphiQL extends React.Component {
  render() {
    return (
      <GraphiQL ref={c => this.graphiql = c} ...>
        <GraphiQL.Toolbar>
          <GraphiQL.Button title="Prettify" onClick={this.handlePrettify}>
        </GraphiQL.Toolbar>
      </GraphiQL>
    );
  }

  handlePrettify = () => {
    const { parse, print } = require('graphql');
    const editor = this.graphiql.getQueryEditor();
    editor.setValue(print(parse(editor.getValue())));
  }
}
```