### PR TITLE
Add getVariableEditor() and refresh()

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -342,6 +342,26 @@ export class GraphiQL extends React.Component {
   }
 
   /**
+   * Get the variable editor CodeMirror instance.
+   *
+   * @public
+   */
+  getVariableEditor() {
+    return this.variableEditorComponent.getCodeMirror();
+  }
+
+  /**
+   * Refresh all CodeMirror instances.
+   *
+   * @public
+   */
+  refresh() {
+    this.queryEditorComponent.getCodeMirror().refresh();
+    this.variableEditorComponent.getCodeMirror().refresh();
+    this.resultComponent.getCodeMirror().refresh();
+  }
+
+  /**
    * Inspect the query, automatically filling in selection sets for non-leaf
    * fields which do not yet have them.
    *


### PR DESCRIPTION
Closes #152

This adds two new public API methods to the `<GraphiQL>` component.

`getVariableEditor()` gets the CodeMirror instance for editing variables.

`refresh()` will refresh all CodeMirror instances, this may be helpful after changing the size of the containing element or after making it visible for the first time.