### PR TITLE
Reset docs to root when fetcher is updated. Closes #312

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -18,6 +18,11 @@ import SearchBox from './DocExplorer/SearchBox';
 import SearchResults from './DocExplorer/SearchResults';
 import TypeDoc from './DocExplorer/TypeDoc';
 
+const initialNav = {
+  name: 'Schema',
+  title: 'Documentation Explorer',
+};
+
 /**
  * DocExplorer
  *
@@ -41,11 +46,6 @@ export class DocExplorer extends React.Component {
 
   constructor() {
     super();
-
-    const initialNav = {
-      name: 'Schema',
-      title: 'Documentation Explorer',
-    };
 
     this.state = { navStack: [ initialNav ] };
   }
@@ -175,6 +175,10 @@ export class DocExplorer extends React.Component {
     const topNav = navStack[navStack.length - 1];
     navStack[navStack.length - 1] = { ...topNav, search };
     this.setState({ navStack });
+  }
+
+  reset() {
+    this.setState({ navStack: [ initialNav ] });
   }
 
   handleNavBackClick = () => {

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -184,6 +184,7 @@ export class GraphiQL extends React.Component {
       response: nextResponse,
     }, () => {
       if (this.state.schema === undefined) {
+        this.docExplorerComponent.reset();
         this._fetchSchema();
       }
     });


### PR DESCRIPTION
Adds a private `reset` method to `DocExplorer` which resets its `navStack`, returning it to the root doc page.

When `fetcher` is changed and introspection query re-runs, the docs need to be reset (#312)
