### PR TITLE
Use random port numbers in test and example apps

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -15,4 +15,7 @@ const app = express();
 app.use(express.static(__dirname));
 app.use('/graphql', graphqlHTTP(() => ({ schema })));
 
-app.listen(8080, () => console.log('Started on http://localhost:8080/'));
+app.listen(0, function() {
+  const port = this.address().port;
+  console.log(`Started on http://localhost:${port}/`);
+});

--- a/test/server.js
+++ b/test/server.js
@@ -60,5 +60,8 @@ app.use(express.static(__dirname));
 
 console.log('Initial build...');
 makeBundle(() => {
-  app.listen(8080, () => console.log('Started on http://localhost:8080/'));
+  app.listen(0, function() {
+    const port = this.address().port;
+    console.log(`Started on http://localhost:${port}/`);
+  });
 });


### PR DESCRIPTION
https://github.com/graphql/graphiql/pull/320 suggested changing the hard-coded port number in the example server so that it doesn't collide with the test app.

Instead of that, let's use random port numbers, which will strictly avoid any port collisions, including with apps that have nothing to do with this repo, because the OS will assign an unused port.

Tested by simultaneously launching:

    # In one terminal:
    cd example
    npm install
    npm run start # prints: Started on http://localhost:51638/

    # In another terminal:
    npm run dev # prints: Started on http://localhost:51578/

Then hit both links and see they work.