### PR TITLE
First-pass at inline-field descriptions in doc-explorer

### DIFF
--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -121,6 +121,14 @@
   color: #1F61A0;
 }
 
+.graphiql-container .field-short-description {
+  margin-left: 5px;
+  color: #999;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .graphiql-container .enum-value {
   color: #0B7FC7;
 }

--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -122,11 +122,11 @@
 }
 
 .graphiql-container .field-short-description {
-  margin-left: 5px;
   color: #999;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  margin-left: 5px;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .graphiql-container .enum-value {

--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -197,6 +197,10 @@ function Field({ type, field, onClickType, onClickField }) {
       {': '}
       <TypeLink type={field.type} onClick={onClickType} />
       {
+        field.description &&
+        <p className="field-short-description">{field.description}</p>
+      }
+      {
         field.deprecationReason &&
         <MarkdownContent
           className="doc-deprecation"

--- a/test/schema.js
+++ b/test/schema.js
@@ -121,6 +121,12 @@ const TestType = new GraphQLObjectType({
       description: '`test` field from `Test` type.',
       resolve: () => ({})
     },
+    longDescriptionType: {
+      type: TestType,
+      description: '`longDescriptionType` field from `Test` type, which ' +
+        'has a long, verbose, description to test inline field docs',
+      resolve: () => ({})
+    },
     union: {
       type: TestUnion,
       description: '> union field from Test type, block-quoted.',


### PR DESCRIPTION
Wubalubadubdub! First pass at the old inline-field descriptions. There is an edge-case though, since the doc-explorer has a `min-width` of 300px. So when the explorer is <300px, the ellipsis gets lost. I'd hate to alter that behavior as it can introduce regressions elsewhere:

![inline-field-desc](https://cloud.githubusercontent.com/assets/1499985/22800466/52c4d0a0-eebe-11e6-9a5a-e68614f7aa7c.gif)

Addresses: #169