### PR TITLE
Add css property so that toolbar truncates instead of stacking

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -62,6 +62,7 @@
 
 .graphiql-container .toolbar {
   overflow-x: visible;
+  display: flex;
 }
 
 .graphiql-container .docExplorerShow {


### PR DESCRIPTION
This is an quick initial fix for #328, it would be nice to leave the issue open anyway so that we can get some sort of overflow menu in. 