### PR TITLE
Support passing editorOptions override to the CodeMirror component

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `getDefaultFieldNames`: an optional function used to provide default fields to non-leaf fields which invalidly lack a selection set. Accepts a GraphQLType instance and returns an array of field names. If not provided, a default behavior will be used.
 
-- `editorTheme`: an optional string naming a CodeMirror theme to be applied to the `QueryEditor`, `ResultViewer`, and `Variables` panes. Defaults to the `graphiql` theme. See below for full usage.
+- `editorTheme`: an optional string naming a CodeMirror theme to be applied to the `QueryEditor`, `ResultViewer`, and `VariableEditor` panes. Defaults to the `graphiql` theme. See below for full usage.
+
+- `editorOptions`: an optional object for overriding CodeMirror options to be qpplied to the `QueryEditor`, `ResultViewer`, and `VariableEditor` panes.
 
 **Children:**
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -63,6 +63,7 @@ export class GraphiQL extends React.Component {
     onToggleDocs: PropTypes.func,
     getDefaultFieldNames: PropTypes.func,
     editorTheme: PropTypes.string,
+    editorOptions: PropTypes.object,
   }
 
   constructor(props) {
@@ -298,6 +299,7 @@ export class GraphiQL extends React.Component {
                 onClickReference={this.handleClickReference}
                 onRunQuery={this.handleEditorRunQuery}
                 editorTheme={this.props.editorTheme}
+                editorOptions={this.props.editorOptions}
               />
               <div className="variable-editor" style={variableStyle}>
                 <div
@@ -314,6 +316,7 @@ export class GraphiQL extends React.Component {
                   onHintInformationRender={this.handleHintInformationRender}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
+                  editorOptions={this.props.editorOptions}
                 />
               </div>
             </div>
@@ -328,6 +331,7 @@ export class GraphiQL extends React.Component {
                 ref={c => { this.resultComponent = c; }}
                 value={this.state.response}
                 editorTheme={this.props.editorTheme}
+                editorOptions={this.props.editorOptions}
               />
               {footer}
             </div>

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -34,6 +34,7 @@ export class QueryEditor extends React.Component {
     onClickReference: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
+    editorOptions: PropTypes.object,
   }
 
   constructor(props) {
@@ -116,7 +117,8 @@ export class QueryEditor extends React.Component {
         'Ctrl-Right': 'goSubwordRight',
         'Alt-Left': 'goGroupLeft',
         'Alt-Right': 'goGroupRight',
-      }
+      },
+      ...this.props.editorOptions
     });
 
     this.editor.on('change', this._onEdit);

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -22,6 +22,7 @@ export class ResultViewer extends React.Component {
   static propTypes = {
     value: PropTypes.string,
     editorTheme: PropTypes.string,
+    editorOptions: PropTypes.object,
   }
 
   componentDidMount() {
@@ -52,7 +53,8 @@ export class ResultViewer extends React.Component {
         'Ctrl-Right': 'goSubwordRight',
         'Alt-Left': 'goGroupLeft',
         'Alt-Right': 'goGroupRight',
-      }
+      },
+      ...this.props.editorOptions
     });
   }
 

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -31,6 +31,7 @@ export class VariableEditor extends React.Component {
     onHintInformationRender: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
+    editorOptions: PropTypes.object,
   }
 
   constructor(props) {
@@ -99,7 +100,8 @@ export class VariableEditor extends React.Component {
         'Ctrl-Right': 'goSubwordRight',
         'Alt-Left': 'goGroupLeft',
         'Alt-Right': 'goGroupRight',
-      }
+      },
+      ...this.props.editorOptions
     });
 
     this.editor.on('change', this._onEdit);


### PR DESCRIPTION
Resolves issue: https://github.com/graphql/graphiql/issues/361

This change allows the user to override ANY CodeMirror setting, not just the `editorTheme`.  Specifically, I wanted to support 4-space tabs but figured it was arbitrary to add another specific override.  Instead, this PR adds an optional `editorOptions` object which overrides any of the settings in the editor.  

This allows me to set the tab rule to 4 spaces:
```
editorOptions: {
    tabSize: 4,
    indentUnit: 4
}
```