### PR TITLE
fire autocompletion by matching the actual key content typed in

### DIFF
--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -12,6 +12,8 @@ import marked from 'marked';
 
 import onHasCompletion from '../utility/onHasCompletion';
 
+const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
+
 
 /**
  * QueryEditor
@@ -178,7 +180,7 @@ export class QueryEditor extends React.Component {
   }
 
   _onKeyUp = (cm, event) => {
-    if (event.key.length === 1 && event.key.match(/[a-zA-Z0-9_@(]/)) {
+    if (AUTO_COMPLETE_AFTER_KEY.test(event.key)) {
       this.editor.execCommand('autocomplete');
     }
   }

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -178,14 +178,7 @@ export class QueryEditor extends React.Component {
   }
 
   _onKeyUp = (cm, event) => {
-    const code = event.keyCode;
-    if (
-      (code >= 65 && code <= 90) || // letters
-      (!event.shiftKey && code >= 48 && code <= 57) || // numbers
-      (event.shiftKey && code === 189) || // underscore
-      (event.shiftKey && code === 50) || // @
-      (event.shiftKey && code === 57) // (
-    ) {
+    if (event.key.length === 1 && event.key.match(/[a-zA-Z0-9_@(]/)) {
       this.editor.execCommand('autocomplete');
     }
   }


### PR DESCRIPTION
Discussed in #353. There is a bug in GraphiQL with non-QWERTY keyboards that, because the key mapping is different from the English keyboard, the autocompletion pop-up is shown for incorrect set of characters (in QWERTZ keyboard for instance, `Alt-8` types `{` character, which the code recognizes within the whitelisted boundary).

Fixed by matching the exact key character.