### PR TITLE
Add a keyboard shortcut to prettify the query from the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ class CustomGraphiQL extends React.Component {
           <GraphiQL.Button
             onClick={this.handleClickPrettifyButton}
             label="Prettify"
-            title="Prettify Query"
+            title="Prettify Query (Shift-Ctrl-P)"
           />
 
           // Some other possible toolbar items

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -248,7 +248,7 @@ export class GraphiQL extends React.Component {
       <GraphiQL.Toolbar>
         <ToolbarButton
           onClick={this.handlePrettifyQuery}
-          title="Prettify Query"
+          title="Prettify Query (Shift-Ctrl-P)"
           label="Prettify"
         />
         <ToolbarButton
@@ -336,6 +336,7 @@ export class GraphiQL extends React.Component {
                 onEdit={this.handleEditQuery}
                 onHintInformationRender={this.handleHintInformationRender}
                 onClickReference={this.handleClickReference}
+                onPrettifyQuery={this.handlePrettifyQuery}
                 onRunQuery={this.handleEditorRunQuery}
                 editorTheme={this.props.editorTheme}
               />
@@ -354,6 +355,7 @@ export class GraphiQL extends React.Component {
                   variableToType={this.state.variableToType}
                   onEdit={this.handleEditVariables}
                   onHintInformationRender={this.handleHintInformationRender}
+                  onPrettifyQuery={this.handlePrettifyQuery}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
                 />
@@ -1010,6 +1012,8 @@ const defaultQuery = `# Welcome to GraphiQL
 #     }
 #
 # Keyboard shortcuts:
+#
+#  Prettify Query:  Shift-Ctrl-P (or press the prettify button above)
 #
 #       Run Query:  Ctrl-Enter (or press the play button above)
 #

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -34,6 +34,7 @@ export class QueryEditor extends React.Component {
     onEdit: PropTypes.func,
     onHintInformationRender: PropTypes.func,
     onClickReference: PropTypes.func,
+    onPrettifyQuery: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
   };
@@ -110,6 +111,12 @@ export class QueryEditor extends React.Component {
         'Ctrl-Enter': () => {
           if (this.props.onRunQuery) {
             this.props.onRunQuery();
+          }
+        },
+
+        'Shift-Ctrl-P': () => {
+          if (this.props.onPrettifyQuery) {
+            this.props.onPrettifyQuery();
           }
         },
 

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -29,6 +29,7 @@ export class VariableEditor extends React.Component {
     value: PropTypes.string,
     onEdit: PropTypes.func,
     onHintInformationRender: PropTypes.func,
+    onPrettifyQuery: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
   };
@@ -91,6 +92,12 @@ export class VariableEditor extends React.Component {
         'Ctrl-Enter': () => {
           if (this.props.onRunQuery) {
             this.props.onRunQuery();
+          }
+        },
+
+        'Shift-Ctrl-P': () => {
+          if (this.props.onPrettifyQuery) {
+            this.props.onPrettifyQuery();
           }
         },
 


### PR DESCRIPTION
Resolves #379.

This applies from the query editor and the variable editor, just like the "Run Query" keyboard shortcut.

I have successfully tried this using `npm run dev`, and `npm test` passes locally.

It took me forever to find a key combination that was not already taken over by another part of the system, and none of those mentioned in #379 worked. In the end, <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>P</kbd> was the only combination that worked. I'm guessing CodeMirror (or else) attempts to leave it free for browser native behavior.
The real question is: does GraphiQL really need the print console to be accessible *from a keyboard shortcut* or not? If yes, feel free to pull this PR and play with different combinations.

(I am speaking at an event in less than a week where I am going to present GraphQL and GraphiQL, so I will not have a lot of time to spend on this unfortunately. This event/demo is also what brought me to make use of this feature 😅)