### PR TITLE
Silence eslint warning about deprecated babel rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,8 +46,6 @@
   },
 
   "rules": {
-    "babel/no-await-in-loop": 2,
-
     "react/no-deprecated": 2,
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
@@ -124,6 +122,7 @@
     "newline-after-var": 0,
     "no-alert": 2,
     "no-array-constructor": 2,
+    "no-await-in-loop": 2,
     "no-bitwise": 0,
     "no-caller": 2,
     "no-catch-shadow": 0,


### PR DESCRIPTION
Silences:

> The babel/no-await-in-loop rule is deprecated. Please use the built in no-await-in-loop rule instead.

During `{npm,yarn} run test`.