### PR TITLE
Disable source map

### DIFF
--- a/resources/build.sh
+++ b/resources/build.sh
@@ -14,6 +14,6 @@ browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js
 echo "Bundling graphiql.min.js..."
 browserify -g browserify-shim -g uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c --screw-ie8 > graphiql.min.js 2> /dev/null
 echo "Bundling graphiql.css..."
-postcss --use autoprefixer -d dist/ css/*.css
+postcss --no-map --use autoprefixer -d dist/ css/*.css
 cat dist/*.css > graphiql.css
 echo "Done"


### PR DESCRIPTION
Disable source map to remove long line. Fix https://github.com/graphql/graphiql/issues/439.