### PR TITLE
Add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Angel Gomez Salazar <agomezs@fb.com>
+Angel Gomez Salazar <agomezs@fb.com> Angel Gomez <AGS-@users.noreply.github.com>
+Angel Gomez Salazar <agomezs@fb.com> angel.gomez <angelegomezsd@gmail.com>
+Greenkeeper <support@greenkeeper.io> greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>
+Hyohyeon Jeong <asiandrummer@fb.com> Hyo Jeong <asiandrummer@users.noreply.github.com>


### PR DESCRIPTION
Cleans up duplicate entries from `git shortlog` output. For example, these entries:

    26  Angel Gomez
    11  Angel Gomez Salazar
     3  Greenkeeper
    46  Hyo Jeong
    51  Hyohyeon Jeong
     5  angel.gomez
    98  greenkeeper[bot]

Get consolidated to:

     42  Angel Gomez Salazar
    101  Greenkeeper
     97  Hyohyeon Jeong