### PR TITLE
Loosen codemirror peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha"
   },
   "dependencies": {
-    "codemirror": "5.25.2",
+    "codemirror": "^5.25.2",
     "codemirror-graphql": "^0.6.4",
     "marked": "0.3.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,7 +1147,7 @@ codemirror-graphql@^0.6.4:
     graphql-language-service-interface "0.0.10"
     graphql-language-service-parser "^0.0.9"
 
-codemirror@5.25.2:
+codemirror@^5.25.2:
   version "5.25.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.25.2.tgz#8c77677ca9c9248d757d3a07ed1e89a8404850b7"
 


### PR DESCRIPTION
To match the one in codemirror-graphql.

Partially addresses: https://github.com/graphql/graphiql/issues/453