### PR TITLE
Remove option screw-ie8 from build.sh uglify command

### DIFF
--- a/resources/build.sh
+++ b/resources/build.sh
@@ -12,7 +12,7 @@ babel src --ignore __tests__ --out-dir dist/
 echo "Bundling graphiql.js..."
 browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js
 echo "Bundling graphiql.min.js..."
-browserify -g browserify-shim -g uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c --screw-ie8 > graphiql.min.js 2> /dev/null
+browserify -g browserify-shim -g uglifyify -s GraphiQL dist/index.js 2> /dev/null | uglifyjs -c > graphiql.min.js 2> /dev/null
 echo "Bundling graphiql.css..."
 postcss --no-map --use autoprefixer -d dist/ css/*.css
 cat dist/*.css > graphiql.css


### PR DESCRIPTION
`npm run build` currently fails due to an uglify option that is no longer supported.

The option `screw-ie8` is no longer supported with 3.0.x version of uglify. It has been superseded by the option `ie8` which has the opposite effect so does not need to be specified.



