### PR TITLE
package.json: expand accepted peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "peerDependencies": {
     "graphql": "^0.10.0",
-    "prop-types": ">=15.5.10",
-    "react": "^0.14.9 || >=15.5.4",
-    "react-dom": "^0.14.9 || >=15.5.4"
+    "prop-types": ">=15.5.0",
+    "react": "^0.14.9 || >=15.3.0",
+    "react-dom": "^0.14.9 || >=15.3.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.0.0",


### PR DESCRIPTION
Make this library work with more peer-dependencies.

See: https://nodejs.org/en/blog/npm/peer-dependencies/

"One piece of advice: peer dependency requirements, unlike those for regular dependencies, should be lenient. You should not lock your peer dependencies down to specific patch versions. It would be really annoying if one Chai plugin peer-depended on Chai 1.4.1, while another depended on Chai 1.5.0, simply because the authors were lazy and didn't spend the time figuring out the actual minimum version of Chai they are compatible with."