### PR TITLE
catch the error fired when the storage quota exceeds

### DIFF
--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -29,7 +29,7 @@ const shouldSaveQuery = (nextProps, current, lastQuerySaved) => {
   return true;
 };
 
-const MAX_HISTORY_LENGTH = 20;
+const MAX_HISTORY_LENGTH = 10;
 
 export class QueryHistory extends React.Component {
   static propTypes = {

--- a/src/utility/HistoryStore.js
+++ b/src/utility/HistoryStore.js
@@ -32,7 +32,11 @@ export default class HistoryStore {
   }
 
   save() {
-    const payload = JSON.stringify({[this.key]: this.items});
-    this.storage.set(this.key, payload);
+    const items = this.items;
+    let value = JSON.stringify({[this.key]: items});
+    while (items.length >= 0 && !this.storage.set(this.key, value)) {
+      items.shift();
+      value = JSON.stringify({[this.key]: items});
+    }
   }
 }

--- a/src/utility/StorageAPI.js
+++ b/src/utility/StorageAPI.js
@@ -18,10 +18,31 @@ export default class StorageAPI {
   set(name, value) {
     if (this.storage) {
       if (value) {
-        this.storage.setItem('graphiql:' + name, value);
-      } else {
-        this.storage.removeItem('graphiql:' + name);
+        return trySetItem('graphiql:' + name, value);
       }
+      // Clean up by removing the item if there's no value to set
+      this.storage.removeItem('graphiql:' + name);
     }
+    return true;
+  }
+}
+
+function trySetItem(key, value, storage) {
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch (e) {
+    return e instanceof DOMException && (
+      // everything except Firefox
+      e.code === 22 ||
+      // Firefox
+      e.code === 1014 ||
+      // test name field too, because code might not be present
+      // everything except Firefox
+      e.name === 'QuotaExceededError' ||
+      // Firefox
+      e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+      // acknowledge QuotaExceededError only if there's something already stored
+      storage.length !== 0;
   }
 }


### PR DESCRIPTION
There are two possible scenarios where the storage quota may exceed:
- Obviously if we end up saving too many/large things
- When the mobile safari gets into the private browsing mode (the quota is set to 0)

GraphiQL started noticing this issue when there were too large of a query saved in the query history (`graphiql:queries`). Guard against this case by cleaning up the `HistoryStore` entries one by one until the saving is safe.