### PR TITLE
Relax peerDependencies back to where they were

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0",
     "prop-types": ">=15.5.0",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^15.6.0",
+    "react-dom": "^15.6.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.0.0",


### PR DESCRIPTION
Undoes #512.

We generally want to keep peerDependencies as liberal as possible.