### PR TITLE
Reset initial size of main and doc panels when double-clicking their resize area

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -319,7 +319,8 @@ export class GraphiQL extends React.Component {
               this.editorBarComponent = n;
             }}
             className="editorBar"
-            onMouseDown={this.handleResizeStart}>
+            onMouseDown={this.handleResizeStart}
+            onDoubleClick={this.handleResetResize}>
             <div className="queryWrap" style={queryWrapStyle}>
               <QueryEditor
                 ref={n => {
@@ -373,6 +374,7 @@ export class GraphiQL extends React.Component {
           <div
             className="docExplorerResizer"
             onMouseDown={this.handleDocsResizeStart}
+            onDoubleClick={this.handleDocsResetResize}
           />
           <DocExplorer
             ref={c => {
@@ -821,6 +823,10 @@ export class GraphiQL extends React.Component {
     document.addEventListener('mouseup', onMouseUp);
   };
 
+  handleResetResize = () => {
+    this.setState({ editorFlex: 1 });
+  };
+
   _didClickDragBar(event) {
     // Only for primary unmodified clicks
     if (event.button !== 0 || event.ctrlKey) {
@@ -880,6 +886,12 @@ export class GraphiQL extends React.Component {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+  };
+
+  handleDocsResetResize = () => {
+    this.setState({
+      docExplorerWidth: 350,
+    });
   };
 
   handleVariableResizeStart = downEvent => {


### PR DESCRIPTION
It is fairly common to see tools with this capability (e.g. left/right panels in Atom), so I mechanically tried to double-click the resize area to reset the main section to 50%/50% before realizing I was not on a desktop tool :)

After adding this to the main section, I figured docs section could benefit from it as well. Because of how toggling variables section works (single click), it is not possible to add this to the variables section at the moment. I did not have enough time to investigate more as this would require a bigger UI change, which I would not do without starting a discussion anyway, so it is better left to a future work. This already adds value as it is, I think.

![graphiql_reset_resize](https://user-images.githubusercontent.com/113730/29241980-710cd934-7f52-11e7-956f-6d4e331d3990.gif)

(The circle around the mouse on click is a thing from the screencast tool, not my PR obviously 😅)