### PR TITLE
Allow to specify result tooltip as prop (was: Implement hover trace display)

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -61,6 +61,7 @@ export class GraphiQL extends React.Component {
     getDefaultFieldNames: PropTypes.func,
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
+    ResultsTooltip: PropTypes.any,
   };
 
   constructor(props) {
@@ -364,6 +365,7 @@ export class GraphiQL extends React.Component {
                 }}
                 value={this.state.response}
                 editorTheme={this.props.editorTheme}
+                ResultsTooltip={this.props.ResultsTooltip}
               />
               {footer}
             </div>

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -28,7 +28,6 @@ export class ResultViewer extends React.Component {
   };
   constructor() {
     super();
-    this._tooltip = document.createElement('div');
   }
 
   componentDidMount() {
@@ -44,13 +43,14 @@ export class ResultViewer extends React.Component {
 
     if (this.props.ResultsTooltip) {
       require('codemirror-graphql/utils/info-addon');
+      const tooltipDiv = document.createElement('div');
       CodeMirror.registerHelper(
         'info',
         'graphql-results',
         (token, options, cm, pos) => {
           const Tooltip = this.props.ResultsTooltip;
-          ReactDOM.render(<Tooltip pos={pos} />, this._tooltip);
-          return this._tooltip;
+          ReactDOM.render(<Tooltip pos={pos} />, tooltipDiv);
+          return tooltipDiv;
         },
       );
     }

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
 /**
@@ -23,7 +24,12 @@ export class ResultViewer extends React.Component {
   static propTypes = {
     value: PropTypes.string,
     editorTheme: PropTypes.string,
+    ResultsTooltip: PropTypes.any,
   };
+  constructor() {
+    super();
+    this._tooltip = document.createElement('div');
+  }
 
   componentDidMount() {
     // Lazily require to ensure requiring GraphiQL outside of a Browser context
@@ -36,6 +42,19 @@ export class ResultViewer extends React.Component {
     require('codemirror/keymap/sublime');
     require('codemirror-graphql/results/mode');
 
+    if (this.props.ResultsTooltip) {
+      require('codemirror-graphql/utils/info-addon');
+      CodeMirror.registerHelper(
+        'info',
+        'graphql-results',
+        (token, options, cm, pos) => {
+          const Tooltip = this.props.ResultsTooltip;
+          ReactDOM.render(<Tooltip pos={pos} />, this._tooltip);
+          return this._tooltip;
+        },
+      );
+    }
+
     this.viewer = CodeMirror(this._node, {
       lineWrapping: true,
       value: this.props.value || '',
@@ -47,6 +66,7 @@ export class ResultViewer extends React.Component {
         minFoldSize: 4,
       },
       gutters: ['CodeMirror-foldgutter'],
+      info: Boolean(this.props.ResultsTooltip),
       extraKeys: {
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',


### PR DESCRIPTION
Fixes #569 

If you specify environment variable `TRACING=true yarn dev` it adds tracing information to dev server. ResultViewer component removes tracing info from response and shows it as tooltip when you hover part of response.

For this to work patch to codemirror-graphql is needed, I will submit PR there in just a moment.

Screenshot:
![image](https://user-images.githubusercontent.com/21140749/29281289-b5eca71e-811e-11e7-8d81-0731c242d32e.png)
