### PR TITLE
Use prettier to prettify GraphQL queries from the editor

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -9,7 +9,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
+import { buildClientSchema, GraphQLSchema } from 'graphql';
+import prettier from 'prettier';
 
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
@@ -688,7 +689,8 @@ export class GraphiQL extends React.Component {
 
   handlePrettifyQuery = () => {
     const editor = this.getQueryEditor();
-    editor.setValue(print(parse(editor.getValue())));
+    const pretty = prettier.format(editor.getValue(), { parser: 'graphql' });
+    editor.setValue(pretty);
   };
 
   handleEditQuery = debounce(100, value => {


### PR DESCRIPTION
Resolves https://github.com/graphql/graphiql/issues/555 (keeping comments intact when prettifying) as well as other goodies introduced by actually prettifying the input instead of re-printing the parsed query.

It turns out, it worked really well during my tests, but...

## Problems

@AGS-, or any other project member, would you be able to help me with those?

### Built files are too big

Products of `npm run build` before this PR:

```sh
-rw-r--r--    1 jeremie  staff   1.4M Aug 21 23:09 graphiql.js
-rw-r--r--    1 jeremie  staff   824K Aug 21 23:09 graphiql.min.js
```

Products of `npm run build` after this PR:

```sh
-rw-r--r--    1 jeremie  staff   5.4M Aug 21 23:11 graphiql.js
-rw-r--r--    1 jeremie  staff     0B Aug 21 23:11 graphiql.min.js
```

Unminified version is almost 4x bigger, urgh!

However, the minified version is veeery lightweight, would load really fast on mobile! :trollface: 
But...

### `npm run build` fails

When running `npm run build`, it fails when building the minified version. When removing the erroring to `/dev/null`, I get this, which I'm not able to explain:

```js
> bash ./resources/build.sh

src/components/DocExplorer/Argument.js -> dist/components/DocExplorer/Argument.js
[...]
src/utility/onHasCompletion.js -> dist/utility/onHasCompletion.js
Bundling graphiql.js...
Bundling graphiql.min.js...
Parse error at 0:51170,33
  return { type: "concat", parts };
                                 ^
ERROR: Unexpected token: punc (})
    at JS_Parse_Error.get (eval at <anonymous> ([...]/graphiql/node_modules/uglify-js/tools/node.js:21:1), <anonymous>:79:23)
    at fatal ([...]/graphiql/node_modules/uglify-js/bin/uglifyjs:268:52)
    at run ([...]/graphiql/node_modules/uglify-js/bin/uglifyjs:225:9)
    at Socket.<anonymous> ([...]/graphiql/node_modules/uglify-js/bin/uglifyjs:163:9)
    at emitNone (events.js:91:20)
    at Socket.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

---

Prettifying with `prettier` has a lot of potential IMO. For example, I wanted to play with `prettier.formatWithCursor` so that once #379 makes it in, the cursor could be keep at the best possible location.
But I'd rather have input from maintainers first, and help if possible, before proceeding further.

❤️ 