### PR TITLE
let the toolbar elements to be overflowable

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -31,6 +31,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  overflow-x: hidden;
 }
 
 .graphiql-container .title {
@@ -45,6 +46,7 @@
 .graphiql-container .topBarWrap {
   display: flex;
   flex-direction: row;
+  overflow-x: hidden;
 }
 
 .graphiql-container .topBar {


### PR DESCRIPTION
For instance, if there are too many toolbar items and the window is small, the doc explorer will not expand, which makes it pretty difficult to use.
