### PR TITLE
Default values for input object types are now displayed in Doc Explorer

### DIFF
--- a/css/doc-explorer.css
+++ b/css/doc-explorer.css
@@ -160,7 +160,7 @@
 }
 
 .graphiql-container .arg-default-value {
-  color: #0B7FC7;
+  color: #43A047;
 }
 
 .graphiql-container .doc-deprecation {

--- a/src/components/DocExplorer/Argument.js
+++ b/src/components/DocExplorer/Argument.js
@@ -8,8 +8,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { astFromValue, print } from 'graphql';
 import TypeLink from './TypeLink';
+import DefaultValue from './DefaultValue';
 
 export default function Argument({ arg, onClickType, showDefaultValue }) {
   return (
@@ -17,14 +17,7 @@ export default function Argument({ arg, onClickType, showDefaultValue }) {
       <span className="arg-name">{arg.name}</span>
       {': '}
       <TypeLink type={arg.type} onClick={onClickType} />
-      {arg.defaultValue !== undefined &&
-        showDefaultValue !== false &&
-        <span>
-          {' = '}
-          <span className="arg-default-value">
-            {print(astFromValue(arg.defaultValue, arg.type))}
-          </span>
-        </span>}
+      {showDefaultValue !== false && <DefaultValue field={arg} />}
     </span>
   );
 }

--- a/src/components/DocExplorer/DefaultValue.js
+++ b/src/components/DocExplorer/DefaultValue.js
@@ -1,0 +1,31 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { astFromValue, print } from 'graphql';
+
+export default function DefaultValue({ field }) {
+  const { type, defaultValue } = field;
+  if (defaultValue !== undefined) {
+    return (
+      <span>
+        {' = '}
+        <span className="arg-default-value">
+          {print(astFromValue(defaultValue, type))}
+        </span>
+      </span>
+    );
+  }
+
+  return null;
+}
+
+DefaultValue.propTypes = {
+  field: PropTypes.object.isRequired,
+};

--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -19,6 +19,7 @@ import {
 import Argument from './Argument';
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
+import DefaultValue from './DefaultValue';
 
 export default class TypeDoc extends React.Component {
   static propTypes = {
@@ -203,6 +204,7 @@ function Field({ type, field, onClickType, onClickField }) {
       ]}
       {': '}
       <TypeLink type={field.type} onClick={onClickType} />
+      <DefaultValue field={field} />
       {field.description &&
         <p className="field-short-description">{field.description}</p>}
       {field.deprecationReason &&

--- a/test/schema.js
+++ b/test/schema.js
@@ -28,12 +28,12 @@ const TestEnum = new GraphQLEnumType({
   values: {
     RED: { description: 'A rosy color' },
     GREEN: { description: 'The color of martians and slime' },
-    BLUE: { description: 'A feeling you might have if you can\'t use GraphQL' },
+    BLUE: { description: "A feeling you might have if you can't use GraphQL" },
     GRAY: {
       description: 'A really dull color',
-      deprecationReason: 'Colors are available now.'
+      deprecationReason: 'Colors are available now.',
     },
-  }
+  },
 });
 
 const TestInputObject = new GraphQLInputObjectType({
@@ -42,7 +42,7 @@ const TestInputObject = new GraphQLInputObjectType({
   fields: () => ({
     string: {
       type: GraphQLString,
-      description: 'Repeats back this string'
+      description: 'Repeats back this string',
     },
     int: { type: GraphQLInt },
     float: { type: GraphQLFloat },
@@ -50,6 +50,10 @@ const TestInputObject = new GraphQLInputObjectType({
     id: { type: GraphQLID },
     enum: { type: TestEnum },
     object: { type: TestInputObject },
+    defaultValue: {
+      type: GraphQLString,
+      defaultValue: 'test default value',
+    },
     // List
     listString: { type: new GraphQLList(GraphQLString) },
     listInt: { type: new GraphQLList(GraphQLInt) },
@@ -58,7 +62,7 @@ const TestInputObject = new GraphQLInputObjectType({
     listID: { type: new GraphQLList(GraphQLID) },
     listEnum: { type: new GraphQLList(TestEnum) },
     listObject: { type: new GraphQLList(TestInputObject) },
-  })
+  }),
 });
 
 const TestInterface = new GraphQLInterfaceType({
@@ -67,12 +71,12 @@ const TestInterface = new GraphQLInterfaceType({
   fields: () => ({
     name: {
       type: GraphQLString,
-      description: 'Common name string.'
-    }
+      description: 'Common name string.',
+    },
   }),
   resolveType: check => {
     return check ? UnionFirst : UnionSecond;
-  }
+  },
 });
 
 const UnionFirst = new GraphQLObjectType({
@@ -80,14 +84,16 @@ const UnionFirst = new GraphQLObjectType({
   fields: () => ({
     name: {
       type: GraphQLString,
-      description: 'Common name string for UnionFirst.'
+      description: 'Common name string for UnionFirst.',
     },
     first: {
       type: new GraphQLList(TestInterface),
-      resolve: () => { return true; }
-    }
+      resolve: () => {
+        return true;
+      },
+    },
   }),
-  interfaces: [ TestInterface ]
+  interfaces: [TestInterface],
 });
 
 const UnionSecond = new GraphQLObjectType({
@@ -95,22 +101,24 @@ const UnionSecond = new GraphQLObjectType({
   fields: () => ({
     name: {
       type: GraphQLString,
-      description: 'Common name string for UnionFirst.'
+      description: 'Common name string for UnionFirst.',
     },
     second: {
       type: TestInterface,
-      resolve: () => { return false; }
-    }
+      resolve: () => {
+        return false;
+      },
+    },
   }),
-  interfaces: [ TestInterface ]
+  interfaces: [TestInterface],
 });
 
 const TestUnion = new GraphQLUnionType({
   name: 'TestUnion',
-  types: [ UnionFirst, UnionSecond ],
+  types: [UnionFirst, UnionSecond],
   resolveType() {
     return UnionFirst;
-  }
+  },
 });
 
 const TestType = new GraphQLObjectType({
@@ -119,18 +127,19 @@ const TestType = new GraphQLObjectType({
     test: {
       type: TestType,
       description: '`test` field from `Test` type.',
-      resolve: () => ({})
+      resolve: () => ({}),
     },
     longDescriptionType: {
       type: TestType,
-      description: '`longDescriptionType` field from `Test` type, which ' +
-        'has a long, verbose, description to test inline field docs',
-      resolve: () => ({})
+      description:
+        '`longDescriptionType` field from `Test` type, which ' +
+          'has a long, verbose, description to test inline field docs',
+      resolve: () => ({}),
     },
     union: {
       type: TestUnion,
       description: '> union field from Test type, block-quoted.',
-      resolve: () => ({})
+      resolve: () => ({}),
     },
     id: {
       type: GraphQLID,
@@ -142,7 +151,7 @@ const TestType = new GraphQLObjectType({
       description: 'Is this a test schema? Sure it is.',
       resolve: () => {
         return true;
-      }
+      },
     },
     deprecatedField: {
       type: TestType,
@@ -162,6 +171,10 @@ const TestType = new GraphQLObjectType({
         id: { type: GraphQLID },
         enum: { type: TestEnum },
         object: { type: TestInputObject },
+        defaultValue: {
+          type: GraphQLString,
+          defaultValue: 'test default value',
+        },
         // List
         listString: { type: new GraphQLList(GraphQLString) },
         listInt: { type: new GraphQLList(GraphQLInt) },
@@ -170,9 +183,9 @@ const TestType = new GraphQLObjectType({
         listID: { type: new GraphQLList(GraphQLID) },
         listEnum: { type: new GraphQLList(TestEnum) },
         listObject: { type: new GraphQLList(TestInputObject) },
-      }
+      },
     },
-  })
+  }),
 });
 
 const TestMutationType = new GraphQLObjectType({
@@ -183,10 +196,10 @@ const TestMutationType = new GraphQLObjectType({
       type: GraphQLString,
       description: 'Set the string field',
       args: {
-        value: { type: GraphQLString }
-      }
-    }
-  }
+        value: { type: GraphQLString },
+      },
+    },
+  },
 });
 
 const TestSubscriptionType = new GraphQLObjectType({
@@ -197,16 +210,16 @@ const TestSubscriptionType = new GraphQLObjectType({
       type: TestType,
       description: 'Subscribe to the test type',
       args: {
-        id: { type: GraphQLString }
-      }
-    }
-  }
+        id: { type: GraphQLString },
+      },
+    },
+  },
 });
 
 const myTestSchema = new GraphQLSchema({
   query: TestType,
   mutation: TestMutationType,
-  subscription: TestSubscriptionType
+  subscription: TestSubscriptionType,
 });
 
 module.exports = myTestSchema;

--- a/test/schema.js
+++ b/test/schema.js
@@ -50,9 +50,17 @@ const TestInputObject = new GraphQLInputObjectType({
     id: { type: GraphQLID },
     enum: { type: TestEnum },
     object: { type: TestInputObject },
-    defaultValue: {
+    defaultValueString: {
       type: GraphQLString,
       defaultValue: 'test default value',
+    },
+    defaultValueBoolean: {
+      type: GraphQLBoolean,
+      defaultValue: false,
+    },
+    defaultValueInt: {
+      type: GraphQLInt,
+      defaultValue: 5,
     },
     // List
     listString: { type: new GraphQLList(GraphQLString) },


### PR DESCRIPTION
GraphiQL can now show default values for input object types. Currently, GraphiQL only shows default value for args that are scalar values, not input objects. This PR aims to solve this problem.

I think this solution is especially useful for a relay-compliant schemas where mutations are performed using a single `input`object argument.

Let me know what you think!

Here is a screenshot of what it looks like with the new addition:

<img width="352" alt="screen shot 2017-09-09 at 10 19 48" src="https://user-images.githubusercontent.com/19558321/30238516-f751afe0-9548-11e7-9e40-16730d2e1224.png">
