### PR TITLE
Fix readOnly prop type

### DIFF
--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -33,7 +33,7 @@ export class QueryEditor extends React.Component {
     schema: PropTypes.instanceOf(GraphQLSchema),
     value: PropTypes.string,
     onEdit: PropTypes.func,
-    readOnly: PropTypes.boolean,
+    readOnly: PropTypes.bool,
     onHintInformationRender: PropTypes.func,
     onClickReference: PropTypes.func,
     onPrettifyQuery: PropTypes.func,

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -29,7 +29,7 @@ export class VariableEditor extends React.Component {
     variableToType: PropTypes.object,
     value: PropTypes.string,
     onEdit: PropTypes.func,
-    readOnly: PropTypes.boolean,
+    readOnly: PropTypes.bool,
     onHintInformationRender: PropTypes.func,
     onPrettifyQuery: PropTypes.func,
     onRunQuery: PropTypes.func,


### PR DESCRIPTION
In v0.11.5 these errors display in the console:
```
Warning: Failed prop type: QueryEditor: prop type `readOnly` is invalid; it must be a function, usually from React.PropTypes.
Warning: Failed prop type: VariableEditor: prop type `readOnly` is invalid; it must be a function, usually from React.PropTypes.
```

Quick research looks like these prop types are invalid, and after changing this the errors go away 