### PR TITLE
Initial POC for alphabetic sorting of the info exposed in the docs.

### DIFF
--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -19,6 +19,7 @@ import {
 import Argument from './Argument';
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
+import sortAlphabetically from '../../utility/sortAlphabetically';
 
 export default class TypeDoc extends React.Component {
   static propTypes = {
@@ -81,7 +82,8 @@ export default class TypeDoc extends React.Component {
     let deprecatedFieldsDef;
     if (type.getFields) {
       const fieldMap = type.getFields();
-      const fields = Object.keys(fieldMap).map(name => fieldMap[name]);
+      let fields = Object.keys(fieldMap).map(name => fieldMap[name]);
+      fields = sortAlphabetically(fields);
       fieldsDef = (
         <div className="doc-category">
           <div className="doc-category-title">

--- a/src/utility/sortAlphabetically.js
+++ b/src/utility/sortAlphabetically.js
@@ -1,0 +1,21 @@
+/**
+ *  Copyright (c) Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+export default function(objects) {
+  const sortedObject = objects.concat();
+  sortedObject.sort((a, b) => {
+    if (a.name < b.name) {
+      return -1;
+    }
+    if (a.name > b.name) {
+      return 1;
+    }
+    return 0;
+  });
+  return sortedObject;
+}


### PR DESCRIPTION
In a large schema it can sometimes be challenging to find a specific field/type.

I created this PR to simplify the process of finding info in the Doc Explorer by introducing alphabetical sorting for the info. 

Note, this is just a POC that only enables sorting for fields for now. Before continuing I am curious to hear what everyone thinks of this idea.

BEFORE SORTING: 

<img width="341" alt="screen shot 2017-09-30 at 15 50 33" src="https://user-images.githubusercontent.com/19558321/31046344-21745f16-a5f7-11e7-837a-0dae0c614189.png">

AFTER SORTING:

<img width="342" alt="screen shot 2017-09-30 at 15 51 55" src="https://user-images.githubusercontent.com/19558321/31046359-52d01974-a5f7-11e7-8bdc-371a8e9c0d04.png">

