### PR TITLE
Fix `false` being passed as `className` to ExecuteButton's  menu list

### DIFF
--- a/src/components/ExecuteButton.js
+++ b/src/components/ExecuteButton.js
@@ -45,7 +45,7 @@ export class ExecuteButton extends React.Component {
           {operations.map(operation =>
             <li
               key={operation.name ? operation.name.value : '*'}
-              className={operation === highlight && 'selected'}
+              className={operation === highlight && 'selected' || null}
               onMouseOver={() => this.setState({ highlight: operation })}
               onMouseOut={() => this.setState({ highlight: null })}
               onMouseUp={() => this._onOptionSelected(operation)}>


### PR DESCRIPTION
Currently hovering away from a menu item is causing the following exception:

```js
Warning: Received `false` for non-boolean attribute `className`. If this is expected, cast the value to a string.
    in li (created by ExecuteButton)
    in ul (created by ExecuteButton)
    in div (created by ExecuteButton)
    in ExecuteButton (created by GraphiQL)
    in div (created by GraphiQL)
    in div (created by GraphiQL)
    in div (created by GraphiQL)
    in div (created by GraphiQL)
```
As a result every menu item that gets highlighted stays permanently highlighted.
Culprit is the `selected` condition passing `false` as `className` , which is invalid. Returning `null` fixes this bug.