### PR TITLE
 update readme to match button

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
   default toolbar may contain common operations. Pass the empty
   `<GraphiQL.Toolbar />` if an empty toolbar is desired.
 
-* `<GraphiQL.Button>`: Add a button to the toolbar above GraphiQL.
+* `<GraphiQL.ToolbarButton>`: Add a button to the toolbar above GraphiQL.
 
 * `<GraphiQL.Menu>`: Add a dropdown menu to the toolbar above GraphiQL.
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ class CustomGraphiQL extends React.Component {
         <GraphiQL.Toolbar>
 
           // GraphiQL.Button usage
-          <GraphiQL.Button
+          <GraphiQL.ToolbarButton
             onClick={this.handleClickPrettifyButton}
             label="Prettify"
             title="Prettify Query (Shift-Ctrl-P)"


### PR DESCRIPTION
I'm not sure it was ever just button, but it changed from PrettifyButton to ToolbarButton in this commit. https://github.com/graphql/graphiql/commit/4dfa12b677f55fb7931712cc08ac19c7f88c282b#diff-a18c87224a76fc29336b97c2bf38aaaa