### PR TITLE
Sort fields and enum values by name in Doc Explorer

### DIFF
--- a/src/components/DocExplorer/TypeDoc.js
+++ b/src/components/DocExplorer/TypeDoc.js
@@ -65,14 +65,12 @@ export default class TypeDoc extends React.Component {
     if (types && types.length > 0) {
       typesDef = (
         <div className="doc-category">
-          <div className="doc-category-title">
-            {typesTitle}
-          </div>
-          {types.map(subtype =>
+          <div className="doc-category-title">{typesTitle}</div>
+          {types.map(subtype => (
             <div key={subtype.name} className="doc-category-item">
               <TypeLink type={subtype} onClick={onClickType} />
-            </div>,
-          )}
+            </div>
+          ))}
         </div>
       );
     }
@@ -82,23 +80,23 @@ export default class TypeDoc extends React.Component {
     let deprecatedFieldsDef;
     if (type.getFields) {
       const fieldMap = type.getFields();
-      const fields = Object.keys(fieldMap).map(name => fieldMap[name]);
+      const fields = Object.keys(fieldMap)
+        .sort((a, b) => a.localeCompare(b))
+        .map(name => fieldMap[name]);
       fieldsDef = (
         <div className="doc-category">
-          <div className="doc-category-title">
-            {'fields'}
-          </div>
+          <div className="doc-category-title">{'fields'}</div>
           {fields
             .filter(field => !field.isDeprecated)
-            .map(field =>
+            .map(field => (
               <Field
                 key={field.name}
                 type={type}
                 field={field}
                 onClickType={onClickType}
                 onClickField={onClickField}
-              />,
-            )}
+              />
+            ))}
         </div>
       );
 
@@ -106,24 +104,22 @@ export default class TypeDoc extends React.Component {
       if (deprecatedFields.length > 0) {
         deprecatedFieldsDef = (
           <div className="doc-category">
-            <div className="doc-category-title">
-              {'deprecated fields'}
-            </div>
-            {!this.state.showDeprecated
-              ? <button
-                  className="show-btn"
-                  onClick={this.handleShowDeprecated}>
-                  {'Show deprecated fields...'}
-                </button>
-              : deprecatedFields.map(field =>
-                  <Field
-                    key={field.name}
-                    type={type}
-                    field={field}
-                    onClickType={onClickType}
-                    onClickField={onClickField}
-                  />,
-                )}
+            <div className="doc-category-title">{'deprecated fields'}</div>
+            {!this.state.showDeprecated ? (
+              <button className="show-btn" onClick={this.handleShowDeprecated}>
+                {'Show deprecated fields...'}
+              </button>
+            ) : (
+              deprecatedFields.map(field => (
+                <Field
+                  key={field.name}
+                  type={type}
+                  field={field}
+                  onClickType={onClickType}
+                  onClickField={onClickField}
+                />
+              ))
+            )}
           </div>
         );
       }
@@ -132,12 +128,12 @@ export default class TypeDoc extends React.Component {
     let valuesDef;
     let deprecatedValuesDef;
     if (type instanceof GraphQLEnumType) {
-      const values = type.getValues();
+      const values = type
+        .getValues()
+        .sort((a, b) => a.name.localeCompare(b.name));
       valuesDef = (
         <div className="doc-category">
-          <div className="doc-category-title">
-            {'values'}
-          </div>
+          <div className="doc-category-title">{'values'}</div>
           {values
             .filter(value => !value.isDeprecated)
             .map(value => <EnumValue key={value.name} value={value} />)}
@@ -148,18 +144,16 @@ export default class TypeDoc extends React.Component {
       if (deprecatedValues.length > 0) {
         deprecatedValuesDef = (
           <div className="doc-category">
-            <div className="doc-category-title">
-              {'deprecated values'}
-            </div>
-            {!this.state.showDeprecated
-              ? <button
-                  className="show-btn"
-                  onClick={this.handleShowDeprecated}>
-                  {'Show deprecated values...'}
-                </button>
-              : deprecatedValues.map(value =>
-                  <EnumValue key={value.name} value={value} />,
-                )}
+            <div className="doc-category-title">{'deprecated values'}</div>
+            {!this.state.showDeprecated ? (
+              <button className="show-btn" onClick={this.handleShowDeprecated}>
+                {'Show deprecated values...'}
+              </button>
+            ) : (
+              deprecatedValues.map(value => (
+                <EnumValue key={value.name} value={value} />
+              ))
+            )}
           </div>
         );
       }
@@ -193,25 +187,27 @@ function Field({ type, field, onClickType, onClickField }) {
         {field.name}
       </a>
       {field.args &&
-      field.args.length > 0 && [
-        '(',
-        <span key="args">
-          {field.args.map(arg =>
-            <Argument key={arg.name} arg={arg} onClickType={onClickType} />,
-          )}
-        </span>,
-        ')',
-      ]}
+        field.args.length > 0 && [
+          '(',
+          <span key="args">
+            {field.args.map(arg => (
+              <Argument key={arg.name} arg={arg} onClickType={onClickType} />
+            ))}
+          </span>,
+          ')',
+        ]}
       {': '}
       <TypeLink type={field.type} onClick={onClickType} />
       <DefaultValue field={field} />
-      {field.description &&
-        <p className="field-short-description">{field.description}</p>}
-      {field.deprecationReason &&
+      {field.description && (
+        <p className="field-short-description">{field.description}</p>
+      )}
+      {field.deprecationReason && (
         <MarkdownContent
           className="doc-deprecation"
           markdown={field.deprecationReason}
-        />}
+        />
+      )}
     </div>
   );
 }
@@ -226,18 +222,17 @@ Field.propTypes = {
 function EnumValue({ value }) {
   return (
     <div className="doc-category-item">
-      <div className="enum-value">
-        {value.name}
-      </div>
+      <div className="enum-value">{value.name}</div>
       <MarkdownContent
         className="doc-value-description"
         markdown={value.description}
       />
-      {value.deprecationReason &&
+      {value.deprecationReason && (
         <MarkdownContent
           className="doc-deprecation"
           markdown={value.deprecationReason}
-        />}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
I noticed that the current doc explorer displays fields and enum values in no particular order, since the underlying value is an object which has no guaranteed enumeration order for keys. I generally get the behavior of following the order defined in my source file, but that's just a coincidence.

This PR sorts fields and enum values by their name in alphabetical order, using [String.localeCompare()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare). My primary goal is that this large schemas would be easier to scan.

~~The diff is a lot bigger than I expected, which came from `prettier` being run automatically during `precommit`. (I can point out the relevant parts of my PR if desired)~~