### PR TITLE
[WIP] Fix subscriptions errors output

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -530,7 +530,9 @@ export class GraphiQL extends React.Component {
       .catch(error => {
         this.setState({
           schema: null,
-          response: error && String(error.stack || error),
+          response: error && error.stack
+            ? String(error.stack)
+            : JSON.stringify(error, null, 2),
         });
       });
   }

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -563,7 +563,9 @@ export class GraphiQL extends React.Component {
       fetch.then(cb).catch(error => {
         this.setState({
           isWaitingForResponse: false,
-          response: error && String(error.stack || error),
+          response: error && error.stack
+            ? String(error.stack)
+            : JSON.stringify(error, null, 2),
         });
       });
     } else if (isObservable(fetch)) {
@@ -575,7 +577,9 @@ export class GraphiQL extends React.Component {
         error: error => {
           this.setState({
             isWaitingForResponse: false,
-            response: error && String(error.stack || error),
+            response: error && error.stack
+              ? String(error.stack)
+              : JSON.stringify(error, null, 2),
             subscription: null,
           });
         },


### PR DESCRIPTION
Hi!

I've been using GraphiQL with `subscriptions-transport-ws` package and discovered, that in case of subscriptions if there're some issues on server side, GraphiQL shows `[object Object]` in output window, despite a message sent over WebSocket having correct stringified JSON.

![](https://user-images.githubusercontent.com/5000549/33243400-cdced968-d30f-11e7-90f8-7325ccdd2be6.png)

This happens because in case of an error (of errors), the error (or `error.stack`) just gets String casted, and if there's no `.stack`, an error is effectively swallowed by showing `[object Object]` instead. And the only way to debug this kind of server issues is to look at WebSocket messages directly, which isn't very convenient.

There're 3 places in code where errors get String casted. Despite me actually tracing this `[object Object]` issue to only one place, I think that all of them could lead to such inconvenience.

I propose that something should be done with this kind of situations (and with errors just being String casted). My PR isn't merge-ready, it's a matter of discussion.

So, what do you think?

This issue is indirectly mentioned in #17 and #88, and mentioned in apollographql/subscriptions-transport-ws#236 and apollographql/subscriptions-transport-ws#305.