### PR TITLE
Adds ability to set and edit names of queries in history and favorites

### DIFF
--- a/css/history.css
+++ b/css/history.css
@@ -1,9 +1,12 @@
-.graphiql-container .history-contents {
+.graphiql-container .history-contents,
+.graphiql-container .history-contents input {
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
   padding: 0;
 }
 
 .graphiql-container .history-contents p {
+  align-items: center;
+  display: flex;
   font-size: 12px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13,6 +16,22 @@
   border-bottom: 1px solid #e0e0e0;
 }
 
+.graphiql-container .history-contents p.editable {
+  padding-bottom: 6px;
+  padding-top: 7px;
+}
+
+.graphiql-container .history-contents input {
+  flex-grow: 1;
+  font-size: 12px;
+}
+
 .graphiql-container .history-contents p:hover {
   cursor: pointer;
+}
+
+.graphiql-container .history-contents p span.history-label {
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -118,10 +118,7 @@ export class QueryHistory extends React.Component {
       item.favorite = false;
       this.favoriteStore.delete(item);
     }
-    const historyQueries = this.historyStore.items;
-    const favoriteQueries = this.favoriteStore.items;
-    const queries = historyQueries.concat(favoriteQueries);
-    this.setState({ queries });
+    this.setState({ ...this.historyStore.items, ...this.favoriteStore.items });
   };
 
   editLabel = (query, variables, operationName, label, favorite) => {
@@ -136,9 +133,6 @@ export class QueryHistory extends React.Component {
     } else {
       this.historyStore.edit(item);
     }
-    const historyQueries = this.historyStore.items;
-    const favoriteQueries = this.favoriteStore.items;
-    const queries = historyQueries.concat(favoriteQueries);
-    this.setState({ queries });
+    this.setState({ ...this.historyStore.items, ...this.favoriteStore.items });
   };
 }

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -81,6 +81,7 @@ export class QueryHistory extends React.Component {
     const queryNodes = queries.map((query, i) => {
       return (
         <HistoryQuery
+          handleEditLabel={this.editLabel}
           handleToggleFavorite={this.toggleFavorite}
           key={i}
           onSelect={this.props.onSelectQuery}
@@ -103,11 +104,12 @@ export class QueryHistory extends React.Component {
     );
   }
 
-  toggleFavorite = (query, variables, operationName, favorite) => {
+  toggleFavorite = (query, variables, operationName, label, favorite) => {
     const item = {
       query,
       variables,
       operationName,
+      label,
     };
     if (!this.favoriteStore.contains(item)) {
       item.favorite = true;
@@ -115,6 +117,24 @@ export class QueryHistory extends React.Component {
     } else if (favorite) {
       item.favorite = false;
       this.favoriteStore.delete(item);
+    }
+    const historyQueries = this.historyStore.items;
+    const favoriteQueries = this.favoriteStore.items;
+    const queries = historyQueries.concat(favoriteQueries);
+    this.setState({ queries });
+  };
+
+  editLabel = (query, variables, operationName, label, favorite) => {
+    const item = {
+      query,
+      variables,
+      operationName,
+      label,
+    };
+    if (favorite) {
+      this.favoriteStore.edit({ ...item, favorite });
+    } else {
+      this.historyStore.edit(item);
     }
     const historyQueries = this.historyStore.items;
     const favoriteQueries = this.favoriteStore.items;

--- a/src/utility/QueryStore.js
+++ b/src/utility/QueryStore.js
@@ -19,27 +19,27 @@ export default class QueryStore {
   }
 
   edit(item) {
-    const index = this.items.findIndex(
+    const itemIndex = this.items.findIndex(
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
         x.operationName === item.operationName,
     );
-    if (index !== -1) {
-      this.items.splice(index, 1, item);
+    if (itemIndex !== -1) {
+      this.items.splice(itemIndex, 1, item);
       this.save();
     }
   }
 
   delete(item) {
-    const index = this.items.findIndex(
+    const itemIndex = this.items.findIndex(
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
         x.operationName === item.operationName,
     );
-    if (index !== -1) {
-      this.items.splice(index, 1);
+    if (itemIndex !== -1) {
+      this.items.splice(itemIndex, 1);
       this.save();
     }
   }

--- a/src/utility/QueryStore.js
+++ b/src/utility/QueryStore.js
@@ -18,6 +18,19 @@ export default class QueryStore {
     );
   }
 
+  edit(item) {
+    const index = this.items.findIndex(
+      x =>
+        x.query === item.query &&
+        x.variables === item.variables &&
+        x.operationName === item.operationName,
+    );
+    if (index !== -1) {
+      this.items.splice(index, 1, item);
+      this.save();
+    }
+  }
+
   delete(item) {
     const index = this.items.findIndex(
       x =>


### PR DESCRIPTION
Adds the ability to set and edit names of saved queries in history and favorites. Uses an inline text input field that is activated pressing a button, and dismissed on blur or **Enter**. Implements #637.

![screen shot 2017-12-31 at 22 32 10](https://user-images.githubusercontent.com/860099/34464330-7a31c3c0-ee7a-11e7-8355-ddbeaff0b734.png)

See screen recording: https://youtu.be/7Gbg9E9ryxc