### PR TITLE
Remove font-family for hover error message

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -480,19 +480,6 @@ div.CodeMirror-lint-tooltip {
   border: 0;
   color: #141823;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
-  font-family:
-    system,
-    -apple-system,
-    'San Francisco',
-    '.SFNSDisplay-Regular',
-    'Segoe UI',
-    Segoe,
-    'Segoe WP',
-    'Helvetica Neue',
-    helvetica,
-    'Lucida Grande',
-    arial,
-    sans-serif;
   font-size: 13px;
   line-height: 16px;
   max-width: 430px;


### PR DESCRIPTION
Hi, I came across this issue where an overridden style prevents the GraphQL error message from being displayed in `monospace`. This prevents the alignment of source code columns from working properly..

For example:

![screen_shot_2018-02-12_at_3_26_54_pm](https://user-images.githubusercontent.com/39946/36125625-977be84c-1009-11e8-8efa-bb0b18ef1ba1.jpg)



The illegal char is the silly "smart" quote, but the `^` points to the `m`

It works just fine if the font override is removed....

<img width="529" alt="screen shot 2018-02-12 at 3 21 25 pm" src="https://user-images.githubusercontent.com/39946/36125516-1c7e1732-1009-11e8-8da0-6c4032311947.png">


