### PR TITLE
Fix persistent search box shortcut key to Alt+F

### DIFF
--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -129,8 +129,7 @@ export class QueryEditor extends React.Component {
         },
 
         // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
+        'Alt-F': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -71,8 +71,7 @@ export class ResultViewer extends React.Component {
       info: Boolean(this.props.ResultsTooltip),
       extraKeys: {
         // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
+        'Alt-F': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -110,8 +110,7 @@ export class VariableEditor extends React.Component {
         },
 
         // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
+        'Alt-F': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',


### PR DESCRIPTION
[This pull request](https://github.com/graphql/graphiql/pull/600) implements a persistent search box and binds its shortcut to Ctrl or Cmd+F key.
But that conflicts Emacs cursor shortcut Ctrl+F on Mac. Mac users often use emacs keybindings.

CodeMirror extraKeys option seems to have no ability to distinguish between Mac and Windows.
So I changed the shortcut Ctrl or Cmd+F to Alt+F separately.
I think it seems naturally because [CodeMirror official demo](https://codemirror.net/demo/search.html) also binds its shortcut to Alt+F. 

