### PR TITLE
fixed pipe character being removed when pasting

### DIFF
--- a/src/utility/normalizeWhitespace.js
+++ b/src/utility/normalizeWhitespace.js
@@ -12,7 +12,7 @@ export const invalidCharacters = Array.from({ length: 11 }, (x, i) => {
   return String.fromCharCode(0x2000 + i);
 }).concat(['\u2028', '\u2029', '\u202f']);
 
-const sanitizeRegex = new RegExp('[' + invalidCharacters.join('|') + ']', 'g');
+const sanitizeRegex = new RegExp('[' + invalidCharacters.join('') + ']', 'g');
 
 export function normalizeWhitespace(line) {
   return line.replace(sanitizeRegex, ' ');


### PR DESCRIPTION
When some text gets pasted into the editor, the pipe character ( | ) would be removed from the text.

I think the regex that normalizes the whitespace uses the character set so it doesn't need the pipe to mean "match any character in the set"