### PR TITLE
Fix variable-editor height

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -161,7 +161,7 @@
 .graphiql-container .variable-editor {
   display: flex;
   flex-direction: column;
-  height: 29px;
+  height: 30px;
   position: relative;
 }
 


### PR DESCRIPTION
This height is should be `30px` to match the `2px` in vertical border, `14px` in line height and `14px` in vertical padding. It seems [it used to be but was inexplicably changed](https://github.com/graphql/graphiql/commit/d5f027ae851d357c6d83e6b908baba888b5b7282) quite a while ago (maybe not intentional?). Here's an example of the of the difference that fixes the annoying `1px` overflow problem:

![fix-height](https://user-images.githubusercontent.com/1181237/41848750-28de9134-7844-11e8-9c19-ee6cc93f8da1.gif)
