### PR TITLE
fix encoding problem when using min.js

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -38,7 +38,7 @@
       favored resource bundler.
      -->
     <link rel="stylesheet" href="./node_modules/graphiql/graphiql.css" />
-    <script src="./node_modules/graphiql/graphiql.js"></script>
+    <script src="./node_modules/graphiql/graphiql.js" charset="utf-8"></script>
 
   </head>
   <body>


### PR DESCRIPTION
It used to show Â for the cursor in code mirror.
The problem is due to the encoding.
Either setting charset in html or in building will help to fix it.