### PR TITLE
Added missing null check

### DIFF
--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -142,8 +142,9 @@ export class VariableEditor extends React.Component {
       this.props.value !== prevProps.value &&
       this.props.value !== this.cachedValue
     ) {
-      this.cachedValue = this.props.value;
-      this.editor.setValue(this.props.value);
+      const thisValue = this.props.value || '';
+      this.cachedValue = thisValue;
+      this.editor.setValue(thisValue);
     }
     this.ignoreChangeEvent = false;
   }


### PR DESCRIPTION
If you use graphiql as a controlled component with `variables`. CodeMirror will throw a NPE when selecting a history entry that has no variables previously set.

See here to reproduce:
https://codesandbox.io/s/734mznnyzx

Reproduction:

- Write anything the in query field, remove the default variables
- Click play
- Write something else in the query field
- Pick the old history entry
- NP: `Cannot read property 'split' of null`