### PR TITLE
friendly hotkey for switch panels & schema search for non-english developer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "codemirror": "^5.26.0",
     "codemirror-graphql": "^0.6.11",
-    "markdown-it": "^8.4.0"
+    "markdown-it": "^8.4.0",
+    "react-hot-keys": "^1.2.0"
   },
   "peerDependencies": {
     "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0",

--- a/src/components/DocExplorer/SearchResults.js
+++ b/src/components/DocExplorer/SearchResults.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 
 import Argument from './Argument';
 import TypeLink from './TypeLink';
+import MarkdownContent from './MarkdownContent';
 
 export default class SearchResults extends React.Component {
   static propTypes = {
@@ -71,7 +72,10 @@ export default class SearchResults extends React.Component {
           const field = fields[fieldName];
           let matchingArgs;
 
-          if (!isMatch(fieldName, searchValue)) {
+          if (
+            !isMatch(fieldName, searchValue) &&
+            !isMatch(field.description || '', searchValue)
+          ) {
             if (field.args && field.args.length) {
               matchingArgs = field.args.filter(arg =>
                 isMatch(arg.name, searchValue),
@@ -109,6 +113,10 @@ export default class SearchResults extends React.Component {
                 </span>,
                 ')',
               ]}
+              <MarkdownContent
+                className="doc-type-description"
+                markdown={field.description || 'No Description'}
+              />
             </div>
           );
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
 
+import Hotkeys from 'react-hot-keys';
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
 import { ToolbarGroup } from './ToolbarGroup';
@@ -35,6 +36,7 @@ import {
 } from '../utility/introspectionQueries';
 
 const DEFAULT_DOC_EXPLORER_WIDTH = 350;
+const DEFAULT_VARIABLE_EXPLORER_HEIGHT = 200;
 
 /**
  * The top-level React component for GraphiQL, intended to encompass the entire
@@ -111,7 +113,8 @@ export class GraphiQL extends React.Component {
       editorFlex: Number(this._storage.get('editorFlex')) || 1,
       variableEditorOpen: Boolean(variables),
       variableEditorHeight:
-        Number(this._storage.get('variableEditorHeight')) || 200,
+        Number(this._storage.get('variableEditorHeight')) ||
+          DEFAULT_VARIABLE_EXPLORER_HEIGHT,
       docExplorerOpen: this._storage.get('docExplorerOpen') === 'true' || false,
       historyPaneOpen: this._storage.get('historyPaneOpen') === 'true' || false,
       docExplorerWidth:
@@ -236,6 +239,51 @@ export class GraphiQL extends React.Component {
     this._storage.set('historyPaneOpen', this.state.historyPaneOpen);
   }
 
+  onKeyUp(keyName, e, handle) {
+    console.log('test:onKeyUp', e, handle);
+    this.setState({
+      output: `onKeyUp ${keyName}`,
+    });
+  }
+
+  onKeyDown(keyName, e, handle) {
+    console.log('test:onKeyDown', keyName, e, handle);
+    if ('ctrl+d' == keyName.toLowerCase()) {
+      if (!this.state.docExplorerOpen) {
+        this.setState({ docExplorerOpen: true });
+      } else if (
+        this.state.docExplorerWidth >=
+        3 * DEFAULT_DOC_EXPLORER_WIDTH
+      ) {
+        this.setState({
+          docExplorerOpen: false,
+          docExplorerWidth: DEFAULT_DOC_EXPLORER_WIDTH,
+        });
+      } else {
+        this.setState({ docExplorerWidth: 3 * DEFAULT_DOC_EXPLORER_WIDTH });
+      }
+    } else if ('ctrl+h' == keyName.toLowerCase()) {
+      let doccfg = { historyPaneOpen: !this.state.historyPaneOpen };
+      this.setState(doccfg);
+    } else if ('ctrl+q' == keyName.toLowerCase()) {
+      if (!this.state.variableEditorOpen) {
+        this.setState({ variableEditorOpen: true });
+      } else if (
+        this.state.variableEditorHeight >=
+        3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT
+      ) {
+        this.setState({
+          variableEditorOpen: false,
+          variableEditorHeight: DEFAULT_VARIABLE_EXPLORER_HEIGHT,
+        });
+      } else {
+        this.setState({
+          variableEditorHeight: 3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT,
+        });
+      }
+    }
+  }
+
   render() {
     const children = React.Children.toArray(this.props.children);
 
@@ -286,141 +334,148 @@ export class GraphiQL extends React.Component {
     };
 
     return (
-      <div className="graphiql-container">
-        <div className="historyPaneWrap" style={historyPaneStyle}>
-          <QueryHistory
-            operationName={this.state.operationName}
-            query={this.state.query}
-            variables={this.state.variables}
-            onSelectQuery={this.handleSelectHistoryQuery}
-            storage={this._storage}
-            queryID={this._editorQueryID}>
-            <div className="docExplorerHide" onClick={this.handleToggleHistory}>
-              {'\u2715'}
-            </div>
-          </QueryHistory>
-        </div>
-        <div className="editorWrap">
-          <div className="topBarWrap">
-            <div className="topBar">
-              {logo}
-              <ExecuteButton
-                isRunning={Boolean(this.state.subscription)}
-                onRun={this.handleRunQuery}
-                onStop={this.handleStopQuery}
-                operations={this.state.operations}
-              />
-              {toolbar}
-            </div>
-            {!this.state.docExplorerOpen &&
-              <button
-                className="docExplorerShow"
-                onClick={this.handleToggleDocs}>
-                {'Docs'}
-              </button>}
+      <Hotkeys
+        keyName="ctrl+d,ctrl+h,ctrl+q"
+        onKeyDown={this.onKeyDown.bind(this)}
+        onKeyUp={this.onKeyUp.bind(this)}>
+        <div className="graphiql-container">
+          <div className="historyPaneWrap" style={historyPaneStyle}>
+            <QueryHistory
+              operationName={this.state.operationName}
+              query={this.state.query}
+              variables={this.state.variables}
+              onSelectQuery={this.handleSelectHistoryQuery}
+              storage={this._storage}
+              queryID={this._editorQueryID}>
+              <div
+                className="docExplorerHide"
+                onClick={this.handleToggleHistory}>
+                {'\u2715'}
+              </div>
+            </QueryHistory>
           </div>
-          <div
-            ref={n => {
-              this.editorBarComponent = n;
-            }}
-            className="editorBar"
-            onDoubleClick={this.handleResetResize}
-            onMouseDown={this.handleResizeStart}>
-            <div className="queryWrap" style={queryWrapStyle}>
-              <QueryEditor
-                ref={n => {
-                  this.queryEditorComponent = n;
-                }}
-                schema={this.state.schema}
-                value={this.state.query}
-                onEdit={this.handleEditQuery}
-                onHintInformationRender={this.handleHintInformationRender}
-                onClickReference={this.handleClickReference}
-                onPrettifyQuery={this.handlePrettifyQuery}
-                onRunQuery={this.handleEditorRunQuery}
-                editorTheme={this.props.editorTheme}
-              />
-              <div className="variable-editor" style={variableStyle}>
-                <div
-                  className="variable-editor-title"
-                  style={{ cursor: variableOpen ? 'row-resize' : 'n-resize' }}
-                  onMouseDown={this.handleVariableResizeStart}>
-                  {'Query Variables'}
-                </div>
-                <VariableEditor
+          <div className="editorWrap">
+            <div className="topBarWrap">
+              <div className="topBar">
+                {logo}
+                <ExecuteButton
+                  isRunning={Boolean(this.state.subscription)}
+                  onRun={this.handleRunQuery}
+                  onStop={this.handleStopQuery}
+                  operations={this.state.operations}
+                />
+                {toolbar}
+              </div>
+              {!this.state.docExplorerOpen &&
+                <button
+                  className="docExplorerShow"
+                  onClick={this.handleToggleDocs}>
+                  {'Docs'}
+                </button>}
+            </div>
+            <div
+              ref={n => {
+                this.editorBarComponent = n;
+              }}
+              className="editorBar"
+              onDoubleClick={this.handleResetResize}
+              onMouseDown={this.handleResizeStart}>
+              <div className="queryWrap" style={queryWrapStyle}>
+                <QueryEditor
                   ref={n => {
-                    this.variableEditorComponent = n;
+                    this.queryEditorComponent = n;
                   }}
-                  value={this.state.variables}
-                  variableToType={this.state.variableToType}
-                  onEdit={this.handleEditVariables}
+                  schema={this.state.schema}
+                  value={this.state.query}
+                  onEdit={this.handleEditQuery}
                   onHintInformationRender={this.handleHintInformationRender}
+                  onClickReference={this.handleClickReference}
                   onPrettifyQuery={this.handlePrettifyQuery}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
                 />
+                <div className="variable-editor" style={variableStyle}>
+                  <div
+                    className="variable-editor-title"
+                    style={{ cursor: variableOpen ? 'row-resize' : 'n-resize' }}
+                    onMouseDown={this.handleVariableResizeStart}>
+                    {'Query Variables'}
+                  </div>
+                  <VariableEditor
+                    ref={n => {
+                      this.variableEditorComponent = n;
+                    }}
+                    value={this.state.variables}
+                    variableToType={this.state.variableToType}
+                    onEdit={this.handleEditVariables}
+                    onHintInformationRender={this.handleHintInformationRender}
+                    onPrettifyQuery={this.handlePrettifyQuery}
+                    onRunQuery={this.handleEditorRunQuery}
+                    editorTheme={this.props.editorTheme}
+                  />
+                </div>
+              </div>
+              <div className="resultWrap">
+                {this.state.isWaitingForResponse &&
+                  <div className="spinner-container">
+                    <div className="spinner" />
+                  </div>}
+                <ResultViewer
+                  ref={c => {
+                    this.resultComponent = c;
+                  }}
+                  value={this.state.response}
+                  editorTheme={this.props.editorTheme}
+                  ResultsTooltip={this.props.ResultsTooltip}
+                />
+                {footer}
               </div>
             </div>
-            <div className="resultWrap">
-              {this.state.isWaitingForResponse &&
-                <div className="spinner-container">
-                  <div className="spinner" />
-                </div>}
-              <ResultViewer
-                ref={c => {
-                  this.resultComponent = c;
-                }}
-                value={this.state.response}
-                editorTheme={this.props.editorTheme}
-                ResultsTooltip={this.props.ResultsTooltip}
-              />
-              {footer}
-            </div>
+          </div>
+          <div className={docExplorerWrapClasses} style={docWrapStyle}>
+            <div
+              className="docExplorerResizer"
+              onDoubleClick={this.handleDocsResetResize}
+              onMouseDown={this.handleDocsResizeStart}
+            />
+            <DocExplorer
+              ref={c => {
+                this.docExplorerComponent = c;
+              }}
+              schema={this.state.schema}>
+              <div className="docExplorerHide" onClick={this.handleToggleDocs}>
+                {'\u2715'}
+              </div>
+            </DocExplorer>
           </div>
         </div>
-        <div className={docExplorerWrapClasses} style={docWrapStyle}>
-          <div
-            className="docExplorerResizer"
-            onDoubleClick={this.handleDocsResetResize}
-            onMouseDown={this.handleDocsResizeStart}
-          />
-          <DocExplorer
-            ref={c => {
-              this.docExplorerComponent = c;
-            }}
-            schema={this.state.schema}>
-            <div className="docExplorerHide" onClick={this.handleToggleDocs}>
-              {'\u2715'}
-            </div>
-          </DocExplorer>
-        </div>
-      </div>
+      </Hotkeys>
     );
   }
 
   /**
-   * Get the query editor CodeMirror instance.
-   *
-   * @public
-   */
+     * Get the query editor CodeMirror instance.
+     *
+     * @public
+     */
   getQueryEditor() {
     return this.queryEditorComponent.getCodeMirror();
   }
 
   /**
-   * Get the variable editor CodeMirror instance.
-   *
-   * @public
-   */
+     * Get the variable editor CodeMirror instance.
+     *
+     * @public
+     */
   getVariableEditor() {
     return this.variableEditorComponent.getCodeMirror();
   }
 
   /**
-   * Refresh all CodeMirror instances.
-   *
-   * @public
-   */
+     * Refresh all CodeMirror instances.
+     *
+     * @public
+     */
   refresh() {
     this.queryEditorComponent.getCodeMirror().refresh();
     this.variableEditorComponent.getCodeMirror().refresh();
@@ -428,11 +483,11 @@ export class GraphiQL extends React.Component {
   }
 
   /**
-   * Inspect the query, automatically filling in selection sets for non-leaf
-   * fields which do not yet have them.
-   *
-   * @public
-   */
+     * Inspect the query, automatically filling in selection sets for non-leaf
+     * fields which do not yet have them.
+     *
+     * @public
+     */
   autoCompleteLeafs() {
     const { insertions, result } = fillLeafs(
       this.state.schema,
@@ -1019,11 +1074,13 @@ const defaultQuery = `# Welcome to GraphiQL
 # Keyboard shortcuts:
 #
 #  Prettify Query:  Shift-Ctrl-P (or press the prettify button above)
-#
 #       Run Query:  Ctrl-Enter (or press the play button above)
-#
 #   Auto Complete:  Ctrl-Space (or just start typing)
-#
+
+#  switch History Panel：Ctrl+H
+#  switch Docs Panel：Ctrl+D
+#  switch Query Variable panel：Ctrl+Q
+
 
 `;
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -239,51 +239,6 @@ export class GraphiQL extends React.Component {
     this._storage.set('historyPaneOpen', this.state.historyPaneOpen);
   }
 
-  onKeyUp(keyName, e, handle) {
-    console.log('test:onKeyUp', e, handle);
-    this.setState({
-      output: `onKeyUp ${keyName}`,
-    });
-  }
-
-  onKeyDown(keyName, e, handle) {
-    console.log('test:onKeyDown', keyName, e, handle);
-    if ('ctrl+d' == keyName.toLowerCase()) {
-      if (!this.state.docExplorerOpen) {
-        this.setState({ docExplorerOpen: true });
-      } else if (
-        this.state.docExplorerWidth >=
-        3 * DEFAULT_DOC_EXPLORER_WIDTH
-      ) {
-        this.setState({
-          docExplorerOpen: false,
-          docExplorerWidth: DEFAULT_DOC_EXPLORER_WIDTH,
-        });
-      } else {
-        this.setState({ docExplorerWidth: 3 * DEFAULT_DOC_EXPLORER_WIDTH });
-      }
-    } else if ('ctrl+h' == keyName.toLowerCase()) {
-      let doccfg = { historyPaneOpen: !this.state.historyPaneOpen };
-      this.setState(doccfg);
-    } else if ('ctrl+q' == keyName.toLowerCase()) {
-      if (!this.state.variableEditorOpen) {
-        this.setState({ variableEditorOpen: true });
-      } else if (
-        this.state.variableEditorHeight >=
-        3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT
-      ) {
-        this.setState({
-          variableEditorOpen: false,
-          variableEditorHeight: DEFAULT_VARIABLE_EXPLORER_HEIGHT,
-        });
-      } else {
-        this.setState({
-          variableEditorHeight: 3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT,
-        });
-      }
-    }
-  }
-
   render() {
     const children = React.Children.toArray(this.props.children);
 
@@ -336,8 +291,7 @@ export class GraphiQL extends React.Component {
     return (
       <Hotkeys
         keyName="ctrl+d,ctrl+h,ctrl+q"
-        onKeyDown={this.onKeyDown.bind(this)}
-        onKeyUp={this.onKeyUp.bind(this)}>
+        onKeyDown={this.onKeyDown.bind(this)}>
         <div className="graphiql-container">
           <div className="historyPaneWrap" style={historyPaneStyle}>
             <QueryHistory
@@ -451,6 +405,42 @@ export class GraphiQL extends React.Component {
         </div>
       </Hotkeys>
     );
+  }
+
+  onKeyDown(keyName, e, handle) {
+    if (keyName.toLowerCase() === 'ctrl+d') {
+      if (!this.state.docExplorerOpen) {
+        this.setState({ docExplorerOpen: true });
+      } else if (
+        this.state.docExplorerWidth >=
+        3 * DEFAULT_DOC_EXPLORER_WIDTH
+      ) {
+        this.setState({
+          docExplorerOpen: false,
+          docExplorerWidth: DEFAULT_DOC_EXPLORER_WIDTH,
+        });
+      } else {
+        this.setState({ docExplorerWidth: 3 * DEFAULT_DOC_EXPLORER_WIDTH });
+      }
+    } else if (keyName.toLowerCase() === 'ctrl+h') {
+      this.setState({ historyPaneOpen: !this.state.historyPaneOpen });
+    } else if (keyName.toLowerCase() === 'ctrl+q') {
+      if (!this.state.variableEditorOpen) {
+        this.setState({ variableEditorOpen: true });
+      } else if (
+        this.state.variableEditorHeight >=
+        3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT
+      ) {
+        this.setState({
+          variableEditorOpen: false,
+          variableEditorHeight: DEFAULT_VARIABLE_EXPLORER_HEIGHT,
+        });
+      } else {
+        this.setState({
+          variableEditorHeight: 3 * DEFAULT_VARIABLE_EXPLORER_HEIGHT,
+        });
+      }
+    }
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,6 +2285,10 @@ hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
+hotkeys-js@^3.3.1:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.3.8.tgz#c8615cf4dd61b3f0b8cec9cc64831a2a9454d9c7"
+
 html-encoding-sniffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
@@ -3645,6 +3649,12 @@ react-dom@15.5.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "~15.5.7"
+
+react-hot-keys@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-hot-keys/-/react-hot-keys-1.2.0.tgz#1ac434bfeb8da8b4955f0260e54dffe167c8b39e"
+  dependencies:
+    hotkeys-js "^3.3.1"
 
 react-test-renderer@15.6.1:
   version "15.6.1"


### PR DESCRIPTION
1.set hotkeys for switch panels (history, docs , query variables) , it'll be friendly for our programmers.
ctrl+d for switching docs panel,
ctrl+h for switching history panel,
and i think you guess out,ctrl+q for switching query variables panel,

2.when a developer can't remember the mutation field name, he/she can search by a piece of description, may be useful for non-english developer since they write description with native language. yes. i'm chinese dev, and some of my guys want this feature definitely.
thinking further in the way,description in search result is also helpful.