### PR TITLE
Add readOnly prop and pass to `QueryEditor` and `VariableEditor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `editorTheme`: an optional string naming a CodeMirror theme to be applied to the `QueryEditor`, `ResultViewer`, and `Variables` panes. Defaults to the `graphiql` theme. See below for full usage.
 
+- `readOnly`: an optional boolean which when `true` will make the `QueryEditor` and `Variables` panes readOnly.
+
 **Children:**
 
 * `<GraphiQL.Logo>`: Replace the GraphiQL logo with your own.

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -63,6 +63,7 @@ export class GraphiQL extends React.Component {
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
     ResultsTooltip: PropTypes.any,
+    readOnly: PropTypes.bool,
   };
 
   constructor(props) {
@@ -338,6 +339,7 @@ export class GraphiQL extends React.Component {
                 onPrettifyQuery={this.handlePrettifyQuery}
                 onRunQuery={this.handleEditorRunQuery}
                 editorTheme={this.props.editorTheme}
+                readOnly={this.props.readOnly}
               />
               <div className="variable-editor" style={variableStyle}>
                 <div
@@ -357,6 +359,7 @@ export class GraphiQL extends React.Component {
                   onPrettifyQuery={this.handlePrettifyQuery}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
+                  readOnly={this.props.readOnly}
                 />
               </div>
             </div>


### PR DESCRIPTION
This change allows `readOnly` to be passed to GraphiQL (the default export) which will pass it to `QueryEditor` and `VariableEditor`. Both `QueryEditor` and `VariableEditor` already accept `readOnly`, this just exposes it.