### PR TITLE
Fix updating UI after favoriting

### DIFF
--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -118,7 +118,9 @@ export class QueryHistory extends React.Component {
       item.favorite = false;
       this.favoriteStore.delete(item);
     }
-    this.setState({ ...this.historyStore.items, ...this.favoriteStore.items });
+    this.setState({
+      queries: [...this.historyStore.items, ...this.favoriteStore.items],
+    });
   };
 
   editLabel = (query, variables, operationName, label, favorite) => {
@@ -133,6 +135,8 @@ export class QueryHistory extends React.Component {
     } else {
       this.historyStore.edit(item);
     }
-    this.setState({ ...this.historyStore.items, ...this.favoriteStore.items });
+    this.setState({
+      queries: [...this.historyStore.items, ...this.favoriteStore.items],
+    });
   };
 }


### PR DESCRIPTION
Tiny fix; without this you have to refresh the page after clicking a star in the history to see it updated.

Before:

![before](https://user-images.githubusercontent.com/129910/48922164-b7c12f00-ee9c-11e8-9999-17cd313a9b9f.gif)


After:


![after](https://user-images.githubusercontent.com/129910/48922170-bd1e7980-ee9c-11e8-9736-1901276582e9.gif)
