### PR TITLE
preserve `ctrl-f` for macOS for moving forward

### DIFF
--- a/packages/graphiql/src/components/QueryEditor.js
+++ b/packages/graphiql/src/components/QueryEditor.js
@@ -11,6 +11,7 @@ import { GraphQLSchema } from 'graphql';
 import MD from 'markdown-it';
 import { normalizeWhitespace } from '../utility/normalizeWhitespace';
 import onHasCompletion from '../utility/onHasCompletion';
+import commonKeys from '../utility/commonKeys';
 
 const md = new MD();
 const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
@@ -148,17 +149,7 @@ export class QueryEditor extends React.Component {
           }
         },
 
-        // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
-        'Cmd-G': 'findPersistent',
-        'Ctrl-G': 'findPersistent',
-
-        // Editor improvements
-        'Ctrl-Left': 'goSubwordLeft',
-        'Ctrl-Right': 'goSubwordRight',
-        'Alt-Left': 'goGroupLeft',
-        'Alt-Right': 'goGroupRight',
+        ...commonKeys,
       },
     });
 
@@ -197,7 +188,7 @@ export class QueryEditor extends React.Component {
       this.editor.off('change', this._onEdit);
       this.editor.off('keyup', this._onKeyUp);
       this.editor.off('hasCompletion', this._onHasCompletion);
-      this.editor = null;  
+      this.editor = null;
     }
   }
 

--- a/packages/graphiql/src/components/ResultViewer.js
+++ b/packages/graphiql/src/components/ResultViewer.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import commonKeys from '../utility/commonKeys';
 
 /**
  * ResultViewer
@@ -86,19 +87,7 @@ export class ResultViewer extends React.Component {
       },
       gutters: ['CodeMirror-foldgutter'],
       info: Boolean(this.props.ResultsTooltip || this.props.ImagePreview),
-      extraKeys: {
-        // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
-        'Cmd-G': 'findPersistent',
-        'Ctrl-G': 'findPersistent',
-
-        // Editor improvements
-        'Ctrl-Left': 'goSubwordLeft',
-        'Ctrl-Right': 'goSubwordRight',
-        'Alt-Left': 'goGroupLeft',
-        'Alt-Right': 'goGroupRight',
-      },
+      extraKeys: commonKeys,
     });
   }
 

--- a/packages/graphiql/src/components/VariableEditor.js
+++ b/packages/graphiql/src/components/VariableEditor.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import onHasCompletion from '../utility/onHasCompletion';
+import commonKeys from '../utility/commonKeys';
 
 /**
  * VariableEditor
@@ -132,17 +133,7 @@ export class VariableEditor extends React.Component {
           }
         },
 
-        // Persistent search box in Query Editor
-        'Cmd-F': 'findPersistent',
-        'Ctrl-F': 'findPersistent',
-        'Cmd-G': 'findPersistent',
-        'Ctrl-G': 'findPersistent',
-
-        // Editor improvements
-        'Ctrl-Left': 'goSubwordLeft',
-        'Ctrl-Right': 'goSubwordRight',
-        'Alt-Left': 'goGroupLeft',
-        'Alt-Right': 'goGroupRight',
+        ...commonKeys,
       },
     });
 

--- a/packages/graphiql/src/utility/commonKeys.js
+++ b/packages/graphiql/src/utility/commonKeys.js
@@ -1,0 +1,15 @@
+const commonKeys = {
+  // Persistent search box in Query Editor
+  'Cmd-F': 'findPersistent',
+  'Ctrl-F': 'findPersistent',
+  'Cmd-G': 'findPersistent',
+  'Ctrl-G': 'findPersistent',
+
+  // Editor improvements
+  'Ctrl-Left': 'goSubwordLeft',
+  'Ctrl-Right': 'goSubwordRight',
+  'Alt-Left': 'goGroupLeft',
+  'Alt-Right': 'goGroupRight',
+};
+
+export default commonKeys;

--- a/packages/graphiql/src/utility/commonKeys.js
+++ b/packages/graphiql/src/utility/commonKeys.js
@@ -1,7 +1,8 @@
+const isMacOs = window.navigator.platform === 'MacIntel';
+
 const commonKeys = {
   // Persistent search box in Query Editor
-  'Cmd-F': 'findPersistent',
-  'Ctrl-F': 'findPersistent',
+  [isMacOs ? 'Cmd-F' : 'Ctrl-F']: 'findPersistent',
   'Cmd-G': 'findPersistent',
   'Ctrl-G': 'findPersistent',
 


### PR DESCRIPTION
1. Extract common keys to utility
2. Preserve `ctrl-f` for macOS for moving forward (Emacs style key binding)