### PR TITLE
Add merge feature

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -28,6 +28,7 @@ import debounce from '../utility/debounce';
 import find from '../utility/find';
 import { fillLeafs } from '../utility/fillLeafs';
 import { getLeft, getTop } from '../utility/elementPosition';
+import { mergeAst } from '../utility/mergeAst';
 import {
   introspectionQuery,
   introspectionQuerySansSubscriptions,
@@ -251,6 +252,11 @@ export class GraphiQL extends React.Component {
           label="Prettify"
         />
         <ToolbarButton
+          onClick={this.handleMergeQuery}
+          title="Merge Query (Shift-Ctrl-M)"
+          label="Merge"
+        />
+        <ToolbarButton
           onClick={this.handleToggleHistory}
           title="Show History"
           label="History"
@@ -336,6 +342,7 @@ export class GraphiQL extends React.Component {
                 onHintInformationRender={this.handleHintInformationRender}
                 onClickReference={this.handleClickReference}
                 onPrettifyQuery={this.handlePrettifyQuery}
+                onMergeQuery={this.handleMergeQuery}
                 onRunQuery={this.handleEditorRunQuery}
                 editorTheme={this.props.editorTheme}
               />
@@ -355,6 +362,7 @@ export class GraphiQL extends React.Component {
                   onEdit={this.handleEditVariables}
                   onHintInformationRender={this.handleHintInformationRender}
                   onPrettifyQuery={this.handlePrettifyQuery}
+                  onMergeQuery={this.handleMergeQuery}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
                 />
@@ -694,6 +702,18 @@ export class GraphiQL extends React.Component {
     editor.setValue(print(parse(editor.getValue())));
   };
 
+  handleMergeQuery = () => {
+    const editor = this.getQueryEditor();
+    const query = editor.getValue();
+
+    if (!query) {
+      return;
+    }
+
+    const ast = parse(query);
+    editor.setValue(print(mergeAst(ast)));
+  };
+
   handleEditQuery = debounce(100, value => {
     const queryFacts = this._updateQueryFacts(
       value,
@@ -1018,6 +1038,8 @@ const defaultQuery = `# Welcome to GraphiQL
 # Keyboard shortcuts:
 #
 #  Prettify Query:  Shift-Ctrl-P (or press the prettify button above)
+#
+#     Merge Query:  Shift-Ctrl-M (or press the merge button above)
 #
 #       Run Query:  Ctrl-Enter (or press the play button above)
 #

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -37,6 +37,7 @@ export class QueryEditor extends React.Component {
     onHintInformationRender: PropTypes.func,
     onClickReference: PropTypes.func,
     onPrettifyQuery: PropTypes.func,
+    onMergeQuery: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
   };
@@ -124,6 +125,12 @@ export class QueryEditor extends React.Component {
         'Shift-Ctrl-P': () => {
           if (this.props.onPrettifyQuery) {
             this.props.onPrettifyQuery();
+          }
+        },
+
+        'Shift-Ctrl-M': () => {
+          if (this.props.onMergeQuery) {
+            this.props.onMergeQuery();
           }
         },
 

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -31,6 +31,7 @@ export class VariableEditor extends React.Component {
     readOnly: PropTypes.bool,
     onHintInformationRender: PropTypes.func,
     onPrettifyQuery: PropTypes.func,
+    onMergeQuery: PropTypes.func,
     onRunQuery: PropTypes.func,
     editorTheme: PropTypes.string,
   };
@@ -105,6 +106,12 @@ export class VariableEditor extends React.Component {
         'Shift-Ctrl-P': () => {
           if (this.props.onPrettifyQuery) {
             this.props.onPrettifyQuery();
+          }
+        },
+
+        'Shift-Ctrl-M': () => {
+          if (this.props.onMergeQuery) {
+            this.props.onMergeQuery();
           }
         },
 

--- a/src/utility/__tests__/mergeAst-fixture.js
+++ b/src/utility/__tests__/mergeAst-fixture.js
@@ -1,0 +1,98 @@
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+export const fixtures = [
+  {
+    desc: 'does not modify query with no fragments',
+    query: `
+      query Test {
+        id
+      }`,
+    mergedQuery: `
+      query Test {
+        id
+      }`,
+  },
+  {
+    desc: 'inlines simple nested fragment',
+    query: `
+      query Test {
+        ...Frag1
+      }
+      
+      fragment Frag1 on Test {
+        id
+      }`,
+    mergedQuery: `
+      query Test {
+        ...on Test {
+          id
+        }
+      }`,
+  },
+  {
+    desc: 'inlines triple nested fragment',
+    query: `
+      query Test {
+        ...Fragment1
+      }
+      
+      fragment Fragment1 on Test {
+        ...Fragment2
+      }
+      
+      fragment Fragment2 on Test {
+        ...Fragment3
+      }
+      
+      fragment Fragment3 on Test {
+        id
+      }`,
+    mergedQuery: `
+      query Test {
+        ...on Test {
+          ...on Test {
+            ...on Test {
+              id
+            }
+          }
+        }
+      }`,
+  },
+  {
+    desc: 'inlines multiple fragments',
+    query: `
+      query Test {
+        ...Fragment1
+        ...Fragment2
+        ...Fragment3
+      }
+      
+      fragment Fragment1 on Test {
+        id
+      }
+      
+      fragment Fragment2 on Test {
+        id
+      }
+      
+      fragment Fragment3 on Test {
+        id
+      }`,
+    mergedQuery: `
+      query Test {
+        ...on Test {
+          id
+        }
+        ...on Test {
+          id
+        }
+        ...on Test {
+          id
+        }
+      }`,
+  },
+];

--- a/src/utility/__tests__/mergeAst-fixture.js
+++ b/src/utility/__tests__/mergeAst-fixture.js
@@ -20,10 +20,10 @@ export const fixtures = [
     desc: 'inlines simple nested fragment',
     query: `
       query Test {
-        ...Frag1
+        ...Fragment1
       }
       
-      fragment Frag1 on Test {
+      fragment Fragment1 on Test {
         id
       }`,
     mergedQuery: `
@@ -90,6 +90,24 @@ export const fixtures = [
         ...on Test {
           id
         }
+        ...on Test {
+          id
+        }
+      }`,
+  },
+  {
+    desc: 'removes duplicate fragment spreads',
+    query: `
+      query Test {
+        ...Fragment1
+        ...Fragment1
+      }
+      
+      fragment Fragment1 on Test {
+        id
+      }`,
+    mergedQuery: `
+      query Test {
         ...on Test {
           id
         }

--- a/src/utility/__tests__/mergeAst-test.js
+++ b/src/utility/__tests__/mergeAst-test.js
@@ -1,0 +1,23 @@
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { parse, print } from 'graphql';
+
+import { mergeAst } from '../mergeAst';
+
+import { fixtures } from './mergeAst-fixture';
+
+describe('MergeAst', () => {
+  fixtures.forEach(fixture => {
+    it(fixture.desc, () => {
+      const result = print(mergeAst(parse(fixture.query))).replace(/\s/g, '');
+      expect(result).to.equal(fixture.mergedQuery.replace(/\s/g, ''));
+    });
+  });
+});

--- a/src/utility/mergeAst.js
+++ b/src/utility/mergeAst.js
@@ -13,9 +13,17 @@ function resolveDefinition(fragments, obj) {
   }
 
   if (definition.selectionSet) {
-    definition.selectionSet.selections = definition.selectionSet.selections.map(
-      selection => resolveDefinition(fragments, selection),
-    );
+    definition.selectionSet.selections = definition.selectionSet.selections
+      .filter((selection, idx, self) => 
+        selection.kind !== Kind.FRAGMENT_SPREAD || 
+        idx === self.findIndex(_selection => (
+          _selection.kind === Kind.FRAGMENT_SPREAD &&
+          selection.name.value === _selection.name.value
+        ))
+      )
+      .map(
+        selection => resolveDefinition(fragments, selection),
+      );
   }
 
   return definition;

--- a/src/utility/mergeAst.js
+++ b/src/utility/mergeAst.js
@@ -1,0 +1,43 @@
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+import { Kind } from 'graphql/language/kinds';
+
+function resolveDefinition(fragments, obj) {
+  let definition = obj;
+  if (definition.kind === Kind.FRAGMENT_SPREAD) {
+    definition = fragments[definition.name.value];
+  }
+
+  if (definition.selectionSet) {
+    definition.selectionSet.selections = definition.selectionSet.selections.map(
+      selection => resolveDefinition(fragments, selection),
+    );
+  }
+
+  return definition;
+}
+
+export function mergeAst(queryAst) {
+  const fragments = {};
+  queryAst.definitions
+    .filter(elem => {
+      return elem.kind === Kind.FRAGMENT_DEFINITION;
+    })
+    .forEach(frag => {
+      const copyFragment = Object.assign({}, frag);
+      copyFragment.kind = Kind.INLINE_FRAGMENT;
+      fragments[frag.name.value] = copyFragment;
+    });
+
+  const copyAst = Object.assign({}, queryAst);
+  copyAst.definitions = queryAst.definitions
+    .filter(elem => {
+      return elem.kind !== Kind.FRAGMENT_DEFINITION;
+    }).map(op => resolveDefinition(fragments, op));
+
+  return copyAst;
+}


### PR DESCRIPTION
Create a button on the toolbar to defragment a query.

All fragments found on the editor pane will be stripped and their contents will be inserted as InlineFragment in all of their usage on queries and mutations.

This feature will improve readability and debugging, since it's hard to understand how strongly-fragmented queries relate to each other.

Before:
```
query TestQuery {
  ...Fragment
}

fragment Fragment on Test {
  id
}
```

After:
```
query TestQuery {
  ... on Test {
    id
  }
}
```