### PR TITLE
Capture Cmd/Ctrl-G

### DIFF
--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -137,6 +137,8 @@ export class QueryEditor extends React.Component {
         // Persistent search box in Query Editor
         'Cmd-F': 'findPersistent',
         'Ctrl-F': 'findPersistent',
+        'Cmd-G': 'findPersistent',
+        'Ctrl-G': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',

--- a/src/components/ResultViewer.js
+++ b/src/components/ResultViewer.js
@@ -72,6 +72,8 @@ export class ResultViewer extends React.Component {
         // Persistent search box in Query Editor
         'Cmd-F': 'findPersistent',
         'Ctrl-F': 'findPersistent',
+        'Cmd-G': 'findPersistent',
+        'Ctrl-G': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',

--- a/src/components/VariableEditor.js
+++ b/src/components/VariableEditor.js
@@ -118,6 +118,8 @@ export class VariableEditor extends React.Component {
         // Persistent search box in Query Editor
         'Cmd-F': 'findPersistent',
         'Ctrl-F': 'findPersistent',
+        'Cmd-G': 'findPersistent',
+        'Ctrl-G': 'findPersistent',
 
         // Editor improvements
         'Ctrl-Left': 'goSubwordLeft',


### PR DESCRIPTION
My usage of search in Chrome/Firefox is generally:

1. Cmd-F to open the search input
2. Type my query
3. Type Cmd-G to iterate through the search results

When I do this out of muscle memory in GraphQL, I get suck since the
`Cmd-G` gets captured by the browser and puts my focus in the browsers
search input.

With this fix, my normal flow works as expected.

Tested on Chrome/Mac