### PR TITLE
Sets MIT in the package.json now that GraphiQL is MIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "http://github.com/graphql/graphiql.git"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "main": "dist/index.js",
   "files": [
     "dist",


### PR DESCRIPTION
Now that the license is MIT, then I think this should be fine to move back to MIT so tooling can pick it up.