### PR TITLE
Add coverage check for jest in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,9 @@
     "prettier": "prettier --write src/**/*.{js,jsx}",
     "prepublish": ". ./resources/prepublish.sh",
     "preversion": ". ./resources/checkgit.sh && npm test",
-    "test": "yarn check --integrity && npm run lint && npm run check && npm run testonly && npm run build",
-    "testonly": "jest"
+    "test": "yarn check --integrity && npm run lint && npm run check && npm run test:coverage && npm run build",
+    "testonly": "jest",
+    "test:coverage": "jest --coverage"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Waiting for `CODECOV_TOKEN` to be added in Travis CI, then we will add the badge to the Readme.md in this PR and we will have visible coverage reporting!