### PR TITLE
Add unit test coverage for DocExplorer components

### DIFF
--- a/src/components/DocExplorer/__tests__/FieldDoc-test.js
+++ b/src/components/DocExplorer/__tests__/FieldDoc-test.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import FieldDoc from '../FieldDoc';
+
+import { GraphQLString, GraphQLObjectType } from 'graphql';
+
+const exampleObject = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    string: {
+      name: 'simpleStringField',
+      type: GraphQLString,
+    },
+    stringWithArgs: {
+      name: 'stringWithArgs',
+      type: GraphQLString,
+      description: 'Example String field with arguments',
+      args: {
+        stringArg: {
+          name: 'stringArg',
+          type: GraphQLString,
+        },
+      },
+    },
+  },
+});
+
+describe.only('FieldDoc', () => {
+  it('should render a simple string field', () => {
+    const W = mount(
+      <FieldDoc
+        field={exampleObject.getFields().string}
+        onClickType={jest.fn()}
+      />,
+    );
+    expect(W.find('MarkdownContent').text()).to.equal('No Description\n');
+    expect(W.find('TypeLink').text()).to.equal('String');
+    expect(W.find('Argument').length).to.equal(0);
+  });
+
+  it('should re-render on field change', () => {
+    const W = mount(
+      <FieldDoc
+        field={exampleObject.getFields().string}
+        onClickType={jest.fn()}
+      />,
+    );
+    expect(W.find('MarkdownContent').text()).to.equal('No Description\n');
+    expect(W.find('TypeLink').text()).to.equal('String');
+    expect(W.find('Argument').length).to.equal(0);
+  });
+
+  it('should render a string field with arguments', () => {
+    const W = mount(
+      <FieldDoc
+        field={exampleObject.getFields().stringWithArgs}
+        onClickType={jest.fn()}
+      />,
+    );
+    expect(
+      W.find('TypeLink')
+        .at(0)
+        .text(),
+    ).to.equal('String');
+    expect(
+      W.find('.doc-type-description')
+        .at(0)
+        .text(),
+    ).to.equal('Example String field with arguments\n');
+    expect(W.find('Argument').length).to.equal(1);
+    expect(W.find('Argument').text()).to.equal('stringArg: String');
+  });
+});

--- a/src/components/DocExplorer/__tests__/TypeDoc-test.js
+++ b/src/components/DocExplorer/__tests__/TypeDoc-test.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import { GraphQLString } from 'graphql';
+
+import TypeDoc from '../TypeDoc';
+
+import {
+  ExampleSchema,
+  ExampleQuery,
+  ExampleUnion,
+  ExampleEnum,
+} from '../../__tests__/ExampleSchema';
+
+describe('TypeDoc', () => {
+  it('renders a top-level query object type', () => {
+    const W = mount(
+      <TypeDoc
+        schema={ExampleSchema}
+        type={ExampleQuery}
+        onClickType={jest.fn()}
+      />,
+    );
+    const cats = W.find('.doc-category-item');
+    expect(cats.at(0).text()).to.equal('string: String');
+    expect(cats.at(1).text()).to.equal('union: exampleUnion');
+    expect(cats.at(2).text()).to.equal(
+      'fieldWithArgs(stringArg: String): String',
+    );
+  });
+  
+  it('handles onClickField and onClickType', () => {
+    const onClickType = jest.fn();
+    const onClickField = jest.fn();
+    const W = mount(
+      <TypeDoc
+        schema={ExampleSchema}
+        type={ExampleQuery}
+        onClickType={onClickType}
+        onClickField={onClickField}
+      />,
+    );
+    W.find('TypeLink')
+      .at(0)
+      .simulate('click');
+    expect(onClickType.mock.calls.length).to.equal(1);
+    expect(onClickType.mock.calls[0][0]).to.equal(GraphQLString);
+
+    W.find('.field-name')
+      .at(0)
+      .simulate('click');
+
+    expect(onClickField.mock.calls.length).to.equal(1);
+    expect(onClickField.mock.calls[0][0].name).to.equal('string');
+    expect(onClickField.mock.calls[0][0].type).to.equal(GraphQLString);
+    expect(onClickField.mock.calls[0][1]).to.equal(ExampleQuery);
+  });
+
+  it('renders deprecated fields when you click to see them', () => {
+    const W = mount(
+      <TypeDoc
+        schema={ExampleSchema}
+        type={ExampleQuery}
+        onClickType={jest.fn()}
+      />,
+    );
+    let cats = W.find('.doc-category-item');
+    expect(cats.length).to.equal(3);
+
+    W.find('.show-btn').simulate('click');
+
+    cats = W.find('.doc-category-item');
+    expect(cats.length).to.equal(4);
+    expect(
+      W.find('.field-name')
+        .at(3)
+        .text(),
+    ).to.equal('deprecatedField');
+    expect(
+      W.find('.doc-deprecation').at(0).text()
+    ).to.equal('example deprecation reason\n');
+  });
+
+  it('renders a Union type', () => {
+    const W = mount(<TypeDoc schema={ExampleSchema} type={ExampleUnion} />);
+    expect(
+      W.find('.doc-category-title')
+        .at(0)
+        .text(),
+    ).to.equal('possible types');
+  });
+
+  it('renders an Enum type', () => {
+    const W = mount(<TypeDoc schema={ExampleSchema} type={ExampleEnum} />);
+    expect(
+      W.find('.doc-category-title')
+        .at(0)
+        .text(),
+    ).to.equal('values');
+    const enums = W.find('EnumValue');
+    expect(enums.at(0).props().value.value).to.equal('Value 1');
+    expect(enums.at(1).props().value.value).to.equal('Value 2');
+  });
+
+  it('shows deprecated enum values on click', () => {
+    const W = mount(<TypeDoc schema={ExampleSchema} type={ExampleEnum} />);
+    expect(W.state().showDeprecated).to.equal(false);
+    const titles = W.find('.doc-category-title');
+    expect(titles.at(0).text()).to.equal('values');
+    expect(titles.at(1).text()).to.equal('deprecated values');
+    let enums = W.find('EnumValue');
+    expect(enums.length).to.equal(2);
+
+    // click button to show deprecated enum values
+    W.find('.show-btn').simulate('click');
+    expect(W.state().showDeprecated).to.equal(true);
+    enums = W.find('EnumValue');
+    expect(enums.length).to.equal(3);
+    expect(enums.at(2).props().value.value).to.equal('Value 3');
+    expect(
+      W.find('.doc-deprecation')
+        .at(1)
+        .text(),
+    ).to.equal('Only two are needed\n');
+  });
+});

--- a/src/components/DocExplorer/__tests__/TypeLink-test.js
+++ b/src/components/DocExplorer/__tests__/TypeLink-test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import TypeLink from '../TypeLink';
+
+import { GraphQLNonNull, GraphQLList, GraphQLString } from 'graphql';
+
+const nonNullType = new GraphQLNonNull(GraphQLString);
+const listType = new GraphQLList(GraphQLString);
+
+describe('TypeLink', () => {
+  it('should render a string', () => {
+    const instance = mount(<TypeLink type={GraphQLString} />);
+    expect(instance.text()).to.equal('String');
+    expect(instance.find('a').length).to.equal(1);
+    expect(instance.find('a').hasClass('type-name')).to.equal(true);
+  });
+  it('should render a nonnull type', () => {
+    const instance = mount(<TypeLink type={nonNullType} />);
+    expect(instance.text()).to.equal('String!');
+    expect(instance.find('span').length).to.equal(1);
+  });
+  it('should render a list type', () => {
+    const instance = mount(<TypeLink type={listType} />);
+    expect(instance.text()).to.equal('[String]');
+    expect(instance.find('span').length).to.equal(1);
+  });
+  it('should handle a click event', () => {
+    const op = jest.fn();
+    const instance = mount(<TypeLink type={listType} onClick={op} />);
+    instance.find('a').simulate('click');
+    expect(op.mock.calls.length).to.equal(1);
+    expect(op.mock.calls[0][0]).to.equal(GraphQLString);
+  });
+  it('should re-render on type change', () => {
+    const instance = mount(<TypeLink type={listType} />);
+    expect(instance.text()).to.equal('[String]');
+    instance.setProps({ type: GraphQLString });
+    expect(instance.text()).to.equal('String');
+  });
+});

--- a/src/components/__tests__/DocExplorer-test.js
+++ b/src/components/__tests__/DocExplorer-test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import { DocExplorer } from '../DocExplorer';
+
+describe('DocExplorer', () => {
+  it('renders spinner when no schema prop is present', () => {
+    const W = mount(<DocExplorer />);
+    const spinner = W.find('.spinner-container');
+    expect(spinner.length).to.equal(1);
+  });
+  it('renders with null schema', () => {
+    const W = mount(<DocExplorer schema={null} />);
+    const error = W.find('.error-container');
+    expect(error.length).to.equal(1);
+    expect(error.text()).to.equal('No Schema Available');
+  });
+});
+
+

--- a/src/components/__tests__/ExampleSchema.js
+++ b/src/components/__tests__/ExampleSchema.js
@@ -1,0 +1,96 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLSchema,
+  GraphQLUnionType,
+  GraphQLInterfaceType,
+  GraphQLBoolean,
+  GraphQLEnumType,
+} from 'graphql';
+
+export const ExampleInterface = new GraphQLInterfaceType({
+  name: 'exampleInterface',
+  fields: {
+    name: {
+      name: 'nameField',
+      type: GraphQLString,
+    },
+  },
+});
+
+export const ExampleEnum = new GraphQLEnumType({
+  name: 'exampleEnum',
+  values: {
+    value1: { value: 'Value 1' },
+    value2: { value: 'Value 2' },
+    value3: { value: 'Value 3', deprecationReason: 'Only two are needed' },
+  },
+});
+
+export const ExampleUnionType1 = new GraphQLObjectType({
+  name: 'Union Type 1',
+  interfaces: [ExampleInterface],
+  fields: {
+    name: {
+      name: 'nameField',
+      type: GraphQLString,
+    },
+    enum: {
+      name: 'enumField',
+      type: ExampleEnum,
+    },
+  },
+});
+
+export const ExampleUnionType2 = new GraphQLObjectType({
+  name: 'Union Type 2',
+  interfaces: [ExampleInterface],
+  fields: {
+    name: {
+      name: 'nameField',
+      type: GraphQLString,
+    },
+    string: {
+      name: 'stringField',
+      type: GraphQLString,
+    },
+  },
+});
+
+export const ExampleUnion = new GraphQLUnionType({
+  name: 'exampleUnion',
+  types: [ExampleUnionType1, ExampleUnionType2],
+});
+
+export const ExampleQuery = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    string: {
+      name: 'exampleString',
+      type: GraphQLString,
+    },
+    union: {
+      name: 'exampleUnion',
+      type: ExampleUnion,
+    },
+    fieldWithArgs: {
+      name: 'exampleWithArgs',
+      type: GraphQLString,
+      args: {
+        stringArg: {
+          name: 'exampleStringArg',
+          type: GraphQLString,
+        },
+      },
+    },
+    deprecatedField: {
+      name: 'booleanField',
+      type: GraphQLBoolean,
+      deprecationReason: 'example deprecation reason',
+    },
+  },
+});
+
+export const ExampleSchema = new GraphQLSchema({
+  query: ExampleQuery,
+});


### PR DESCRIPTION
Seemed like a good place to start
- create ExampleSchema for tests
- full coverage for `TypeLink`, `FieldDoc`
- extensive coverage for `TypeDoc`
- starting point for `DocExplorer`