### PR TITLE
Add a toolbar button to copy the existing query to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "codemirror": "^5.26.0",
     "codemirror-graphql": "^0.8.3",
+    "copy-to-clipboard": "^3.2.0",
     "markdown-it": "^8.4.0"
   },
   "peerDependencies": {

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
+import copyToClipboard from 'copy-to-clipboard';
 
 import { ExecuteButton } from './ExecuteButton';
 import { ImagePreview } from './ImagePreview';
@@ -57,6 +58,7 @@ export class GraphiQL extends React.Component {
       removeItem: PropTypes.func,
     }),
     defaultQuery: PropTypes.string,
+    onCopyQuery: PropTypes.func,
     onEditQuery: PropTypes.func,
     onEditVariables: PropTypes.func,
     onEditOperationName: PropTypes.func,
@@ -265,6 +267,11 @@ export class GraphiQL extends React.Component {
           label="Merge"
         />
         <ToolbarButton
+          onClick={this.handleCopyQuery}
+          title="Copy Query (Shift-Ctrl-C)"
+          label="Copy"
+        />
+        <ToolbarButton
           onClick={this.handleToggleHistory}
           title="Show History"
           label="History"
@@ -350,6 +357,7 @@ export class GraphiQL extends React.Component {
                 onEdit={this.handleEditQuery}
                 onHintInformationRender={this.handleHintInformationRender}
                 onClickReference={this.handleClickReference}
+                onCopyQuery={this.handleCopyQuery}
                 onPrettifyQuery={this.handlePrettifyQuery}
                 onMergeQuery={this.handleMergeQuery}
                 onRunQuery={this.handleEditorRunQuery}
@@ -740,6 +748,23 @@ export class GraphiQL extends React.Component {
       return this.props.onEditQuery(value);
     }
   });
+
+  handleCopyQuery = () => {
+    const editor = this.getQueryEditor();
+    const query = editor.getValue();
+
+    if (!query) {
+      return;
+    }
+
+    const formattedQuery = print(parse(query));
+
+    copyToClipboard(formattedQuery);
+
+    if (this.props.onCopyQuery) {
+      return this.props.onCopyQuery(formattedQuery);
+    }
+  }
 
   _updateQueryFacts = (query, operationName, prevOperations, schema) => {
     const queryFacts = getQueryFacts(schema, query);

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -757,12 +757,10 @@ export class GraphiQL extends React.Component {
       return;
     }
 
-    const formattedQuery = print(parse(query));
-
-    copyToClipboard(formattedQuery);
+    copyToClipboard(query);
 
     if (this.props.onCopyQuery) {
-      return this.props.onCopyQuery(formattedQuery);
+      return this.props.onCopyQuery(query);
     }
   }
 

--- a/src/components/QueryEditor.js
+++ b/src/components/QueryEditor.js
@@ -36,6 +36,7 @@ export class QueryEditor extends React.Component {
     readOnly: PropTypes.bool,
     onHintInformationRender: PropTypes.func,
     onClickReference: PropTypes.func,
+    onCopyQuery: PropTypes.func,
     onPrettifyQuery: PropTypes.func,
     onMergeQuery: PropTypes.func,
     onRunQuery: PropTypes.func,
@@ -120,6 +121,12 @@ export class QueryEditor extends React.Component {
         'Ctrl-Enter': () => {
           if (this.props.onRunQuery) {
             this.props.onRunQuery();
+          }
+        },
+
+        'Shift-Ctrl-C': () => {
+          if (this.props.onCopyQuery) {
+            this.props.onCopyQuery();
           }
         },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,6 +2111,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
+  integrity sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js-compat@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.0.1.tgz#bff73ba31ca8687431b9c88f78d3362646fb76f0"
@@ -7584,6 +7591,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toposort@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
### Summary

This PR adds a `Copy` button to the default toolbar.

![image](https://user-images.githubusercontent.com/8136030/57976779-99487600-799d-11e9-8b53-f14c1dd450b7.png)

Often times a query or mutation executed in GraphiQL will be copied to another destination. 

By adding a `Copy` button (as well as a keyboard shortcut), this allows a user a quick way of copying the specified query / mutation (in all fairness, `Command + A, Command + C` is not exactly a particularly time-intensive set of operations).

### Discussion

I can see a number of reasons why a `Copy` button in and of itself might be ambiguous (is this copying the query? the response?). That being said, I still think that there is _some_ utility in adding this button.

I can also see an argument to label the button `Copy Query`, but I was also trying to stay consistent with the `Prettify` and `Merge` buttons.

I also made the decision to copy a formatted query to clipboard - I thought it made the most sense from the end user's perspective.

Finally, to support copying to clipboard, I added [the `copy-to-clipboard` `npm` package](https://www.npmjs.com/package/copy-to-clipboard). It seems to be widely used, have good browser support, and a [reasonable bundle footprint](https://bundlephobia.com/result?p=copy-to-clipboard@3.2.0).

### TODO

- [x] Complete the CLA