### PR TITLE
Replace babylon with @babel/parser

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -18,8 +18,8 @@
 !<PROJECT_ROOT>/node_modules/graphql-language-service-parser
 !<PROJECT_ROOT>/node_modules/graphql-language-service-types
 !<PROJECT_ROOT>/node_modules/graphql-language-service-utils
-!<PROJECT_ROOT>/node_modules/babylon
 !<PROJECT_ROOT>/node_modules/glob
+!<PROJECT_ROOT>/node_modules/@babel/parser
 !<PROJECT_ROOT>/node_modules/vscode-languageserver
 !<PROJECT_ROOT>/node_modules/vscode-jsonrpc
 !<PROJECT_ROOT>/node_modules/vscode-languageserver-types

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -31,7 +31,7 @@
     "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "babylon": "^6.17.4",
+    "@babel/parser": "^7.4.5",
     "fb-watchman": "^2.0.0",
     "glob": "^7.1.2",
     "graphql-config": "2.2.1",

--- a/packages/graphql-language-service-server/src/findGraphQLTags.js
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.js
@@ -10,27 +10,37 @@
 
 import { Position, Range } from 'graphql-language-service-utils';
 
-import { parse } from 'babylon';
+import { parse } from '@babel/parser';
 
 // Attempt to be as inclusive as possible of source text.
-const BABYLON_OPTIONS = {
+const PARSER_OPTIONS = {
   allowImportExportEverywhere: true,
   allowReturnOutsideFunction: true,
   allowSuperOutsideMethod: true,
   sourceType: 'module',
   plugins: [
-    // Previously "*"
-    'asyncGenerators',
-    'classProperties',
-    'decorators',
-    'doExpressions',
-    'dynamicImport',
-    'exportExtensions',
     'flow',
+    'jsx',
+    'doExpressions',
+    'objectRestSpread',
+    ['decorators', {decoratorsBeforeExport: false}],
+    'classProperties',
+    'classPrivateProperties',
+    'classPrivateMethods',
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
+    'asyncGenerators',
     'functionBind',
     'functionSent',
-    'jsx',
-    'objectRestSpread',
+    'dynamicImport',
+    'numericSeparator',
+    'optionalChaining',
+    'importMeta',
+    'bigInt',
+    'optionalCatchBinding',
+    'throwExpressions',
+    ['pipelineOperator', {proposal: 'minimal'}],
+    'nullishCoalescingOperator',
   ],
   strictMode: false,
 };
@@ -39,7 +49,7 @@ export function findGraphQLTags(
   text: string,
 ): Array<{ tag: string, template: string, range: Range }> {
   const result = [];
-  const ast = parse(text, BABYLON_OPTIONS);
+  const ast = parse(text, PARSER_OPTIONS);
 
   const visitors = {
     CallExpression: node => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,10 +2304,6 @@ babelify@10.0.0:
   resolved "https://registry.yarnpkg.com/babelify/-/babelify-10.0.0.tgz#fe73b1a22583f06680d8d072e25a1e0d1d1d7fb5"
   integrity sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==
 
-babylon@^6.17.4:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -3751,7 +3747,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.137, electron-to-chromium@^1.3.164:
+electron-to-chromium@^1.3.164:
   version "1.3.165"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.165.tgz#51864c9e3c9bd9e1c020b9493fddcc0f49888e3a"
   integrity sha512-iIS8axR524EAnvUtWUNnREnYjQrS0zUvutIKYgTVuN3MzcjrV31EuJYKw7DGOtFO9DQw+JiXeaVDPQWMskG1wQ==
@@ -7148,7 +7144,7 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.21, node-releases@^1.1.23:
+node-releases@^1.1.23:
   version "1.1.23"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
   integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==


### PR DESCRIPTION
@babel/parser is the supported parser for babel v7. This
upgrades usage of babylon to @babel/parser and passes some
additional options.