### PR TITLE
Add completion priority logic for tagged template completion requests

### DIFF
--- a/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.js
+++ b/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.js
@@ -50,6 +50,26 @@ describe('getAutocompleteSuggestions', () => {
       });
   }
 
+  it('provides correct sortText response', () => {
+    const result = getAutocompleteSuggestions(schema, `{ h`, new Position(0, 3))
+      .map(({sortText, label, detail}) => ({sortText, label, detail}))
+    expect(result).to.deep.equal([{
+      sortText: '0hero',
+      label: 'hero',
+      detail: 'Character',
+    },
+    {
+      sortText: '1human',
+      label: 'human',
+      detail: 'Human',
+    },
+    {
+      sortText: '6__schema',
+      label: '__schema',
+      detail: '__Schema!',
+    }]);
+  });
+
   it('provides correct initial keywords', () => {
     expect(testSuggestions('', new Position(0, 0))).to.deep.equal([
       { label: '{' },

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.js
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.js
@@ -182,7 +182,9 @@ function getSuggestionsForFieldNames(
     }
     return hintList(
       token,
-      fields.map(field => ({
+      fields.map((field, index) => ({
+        // This will sort the fields in the same order they are listed in the schema
+        sortText: String(index) + field.name,
         label: field.name,
         detail: String(field.type),
         documentation: field.description,


### PR DESCRIPTION
This has the sortText in completion items reflect the order in which they appear in the schema. This appears to add more value then alphabetical sorting, since fields are often ordered and grouped semantically.

This also ensures completion items returned from the graphql language server are sorted at the top of the completion list when working inside tagged templates.