### PR TITLE
Update babel configuration to target node for server packages

### DIFF
--- a/packages/codemirror-graphql/.gitignore
+++ b/packages/codemirror-graphql/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 coverage/
 /*.js
-!.babelrc.js
+!babel.config.js
 /utils
 /variables
 /results

--- a/packages/codemirror-graphql/babel.config.js
+++ b/packages/codemirror-graphql/babel.config.js
@@ -1,0 +1,9 @@
+
+module.exports = {
+  presets: [
+    require.resolve('@babel/preset-env'),
+    require.resolve('@babel/preset-flow'),
+    require.resolve('@babel/preset-react'),
+  ],
+  plugins: [require.resolve('@babel/plugin-proposal-class-properties')],
+};

--- a/packages/graphiql/babel.config.js
+++ b/packages/graphiql/babel.config.js
@@ -1,7 +1,7 @@
 
 module.exports = {
   presets: [
-    [require.resolve('@babel/preset-env'), { targets: { node: true }}],
+    require.resolve('@babel/preset-env'),
     require.resolve('@babel/preset-flow'),
     require.resolve('@babel/preset-react'),
   ],

--- a/packages/graphql-language-service-server/src/index.js
+++ b/packages/graphql-language-service-server/src/index.js
@@ -7,7 +7,6 @@
  *
  *  @flow
  */
-
 export { GraphQLCache, getGraphQLCache } from './GraphQLCache';
 
 export { GraphQLWatchman } from './GraphQLWatchman';

--- a/packages/graphql-language-service/bin/graphql.js
+++ b/packages/graphql-language-service/bin/graphql.js
@@ -12,5 +12,4 @@ if (process && process.env) {
   process.env.GRAPHQL_NO_NAME_WARNING = true;
 }
 
-require('@babel/polyfill');
 require('../dist/cli');

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -34,7 +34,6 @@
     "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "@babel/polyfill": "7.4.4",
     "graphql-config": "2.2.1",
     "graphql-language-service-interface": "^2.0.1",
     "graphql-language-service-server": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,7 +652,7 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@7.4.4", "@babel/polyfill@^7.0.0", "@babel/polyfill@^7.4.4":
+"@babel/polyfill@^7.0.0", "@babel/polyfill@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
   integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==


### PR DESCRIPTION
This updates the root babel configuration to target node for the server packages. This means the server packages can use native language features like async await, object spread, destructuring, etc.

This requires overriding configuration in the graphiql and codemirror-graphql packages to use the default configuration in @babel/preset-env.