### PR TITLE
The hint dom nodes lives outside the codemirror dom tree currently.

### DIFF
--- a/packages/graphiql/src/components/QueryEditor.js
+++ b/packages/graphiql/src/components/QueryEditor.js
@@ -95,6 +95,7 @@ export class QueryEditor extends React.Component {
         schema: this.props.schema,
         closeOnUnfocus: false,
         completeSingle: false,
+        container: this._node,
       },
       info: {
         schema: this.props.schema,

--- a/packages/graphiql/src/components/VariableEditor.js
+++ b/packages/graphiql/src/components/VariableEditor.js
@@ -84,6 +84,7 @@ export class VariableEditor extends React.Component {
         variableToType: this.props.variableToType,
         closeOnUnfocus: false,
         completeSingle: false,
+        container: this._node,
       },
       gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
       extraKeys: {


### PR DESCRIPTION
Submitting another PR because I missed two cases in my earlier PR https://github.com/graphql/graphiql/pull/791.