### PR TITLE
Upgrade codemirror-graphql to gls interface/parser 2.0x

### DIFF
--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror-graphql",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "GraphQL mode and helpers for CodeMirror.",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -40,8 +40,8 @@
     "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "graphql-language-service-interface": "^1.3.2",
-    "graphql-language-service-parser": "^1.2.2"
+    "graphql-language-service-interface": "^2.0.1",
+    "graphql-language-service-parser": "^2.0.1"
   },
   "devDependencies": {
     "chai": "4.1.1",

--- a/packages/codemirror-graphql/src/__tests__/hint-test.js
+++ b/packages/codemirror-graphql/src/__tests__/hint-test.js
@@ -8,7 +8,6 @@
  */
 
 import { expect } from 'chai';
-// 
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
 import { isCompositeType } from 'graphql';
@@ -76,13 +75,18 @@ describe('graphql-hint', () => {
       name => !fieldConfig[name].isDeprecated,
     );
     checkSuggestions(
-      fieldNames.concat(['__schema', '__type']),
+      fieldNames.concat(['__typename', '__schema', '__type']),
       suggestions.list,
     );
 
     const fieldTypes = fieldNames.map(name => fieldConfig[name].type);
     const expectedTypes = suggestions.list
-      .filter(item => item.text !== '__schema' && item.text !== '__type')
+      .filter(
+        item =>
+          item.text !== '__schema' &&
+          item.text !== '__type' &&
+          item.text !== '__typename',
+      )
       .map(item => item.type);
     expect(fieldTypes).to.deep.equal(expectedTypes);
   });
@@ -93,7 +97,10 @@ describe('graphql-hint', () => {
       ch: 21,
     });
     const fieldConfig = TestSchema.getType('First').getFields();
-    checkSuggestions(Object.keys(fieldConfig), suggestions.list);
+    checkSuggestions(
+      [...Object.keys(fieldConfig), '__typename'],
+      suggestions.list,
+    );
   });
 
   it('provides correct field name suggestion indentation', async () => {
@@ -241,6 +248,7 @@ describe('graphql-hint', () => {
       { line: 0, ch: 43 },
     );
     const fieldNames = Object.keys(TestSchema.getType('First').getFields());
+    fieldNames.push('__typename');
     checkSuggestions(fieldNames, suggestions.list);
   });
 
@@ -250,6 +258,7 @@ describe('graphql-hint', () => {
       { line: 0, ch: 30 },
     );
     const fieldNames = Object.keys(TestSchema.getType('First').getFields());
+    fieldNames.push('__typename');
     checkSuggestions(fieldNames, suggestions.list);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4828,17 +4828,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
-graphql-config@2.0.1:
-  version "2.0.1"
-  resolved "http://registry.npmjs.org/graphql-config/-/graphql-config-2.0.1.tgz#d34a9bdf1d7360af7b01db9b20260a342ddc7390"
-  integrity sha512-eb4FzlODifHE/Q+91QptAmkGw39wL5ToinJ2556UUsGt2drPc4tzifL+HSnHSaxiIbH8EUhc/Fa6+neinF04qA==
-  dependencies:
-    graphql-import "^0.4.4"
-    graphql-request "^1.5.0"
-    js-yaml "^3.10.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-
 graphql-config@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.2.1.tgz#5fd0ec77ac7428ca5fb2026cf131be10151a0cb2"
@@ -4850,13 +4839,6 @@ graphql-config@2.2.1:
     lodash "^4.17.4"
     minimatch "^3.0.4"
 
-graphql-import@^0.4.4:
-  version "0.4.5"
-  resolved "http://registry.npmjs.org/graphql-import/-/graphql-import-0.4.5.tgz#e2f18c28d335733f46df8e0733d8deb1c6e2a645"
-  integrity sha512-G/+I08Qp6/QGTb9qapknCm3yPHV0ZL7wbaalWFpxsfR8ZhZoTBe//LsbsCKlbALQpcMegchpJhpTSKiJjhaVqQ==
-  dependencies:
-    lodash "^4.17.4"
-
 graphql-import@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.7.1.tgz#4add8d91a5f752d764b0a4a7a461fcd93136f223"
@@ -4864,39 +4846,6 @@ graphql-import@^0.7.1:
   dependencies:
     lodash "^4.17.4"
     resolve-from "^4.0.0"
-
-graphql-language-service-interface@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-interface/-/graphql-language-service-interface-1.3.2.tgz#4bd5d49e23766c3d2ab65d110f26f10e321cc000"
-  integrity sha512-sOxFV5sBSnYtKIFHtlmAHHVdhok7CRbvCPLcuHvL4Q1RSgKRsPpeHUDKU+yCbmlonOKn/RWEKaYWrUY0Sgv70A==
-  dependencies:
-    graphql-config "2.0.1"
-    graphql-language-service-parser "^1.2.2"
-    graphql-language-service-types "^1.2.2"
-    graphql-language-service-utils "^1.2.2"
-
-graphql-language-service-parser@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-parser/-/graphql-language-service-parser-1.2.2.tgz#010c8a5fdfae4726c8e15714137eee822753d3ea"
-  integrity sha512-38zMqJibNKeQe3GheyJtBENoXMp+qc29smiiRQtHLZcwnQfsYtu6reJZKxxwzU7XOVh3SedNH15Gf3LjWJVkiQ==
-  dependencies:
-    graphql-config "2.0.1"
-    graphql-language-service-types "^1.2.2"
-
-graphql-language-service-types@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-types/-/graphql-language-service-types-1.2.2.tgz#078e0abc7936a593968c946a039502af136a9743"
-  integrity sha512-WEAYYCP4jSzbz/Mw0Klc7HHMgtUHLgtaPMV6zyMMmvefCg/yBUkv7wREXKmqF1k1u9+f5ZX3dki0BMaXiwmJug==
-  dependencies:
-    graphql-config "2.0.1"
-
-graphql-language-service-utils@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/graphql-language-service-utils/-/graphql-language-service-utils-1.2.2.tgz#d31d4b4288085bd31d1bb8efc35790d69e496cae"
-  integrity sha512-98hzn1Dg3sSAiB+TuvNwWAoBrzuHs8NylkTK26TFyBjozM5wBZttp+T08OvOt+9hCFYRa43yRPrWcrs78KH9Hw==
-  dependencies:
-    graphql-config "2.0.1"
-    graphql-language-service-types "^1.2.2"
 
 graphql-request@^1.5.0:
   version "1.8.2"


### PR DESCRIPTION
- Update tests to support `__typename` in object type hint suggestions :shrug:
- Quite a breaking change! This should bump codemirror-graphql to 0.9.0