### PR TITLE
Pluggable schema loading

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLCache.js
+++ b/packages/graphql-language-service-server/src/GraphQLCache.js
@@ -669,7 +669,6 @@ export class GraphQLCache implements GraphQLCacheInterface {
       if (this._schemaMap.has(schemaCacheKey)) {
         return this._schemaMap.get(schemaCacheKey);
       }
-      console.log(schemaLoaderExtension);
       schema = await schemaLoaderExtension.getSchemaLoader().getSchema();
       this._schemaMap.set(schemaCacheKey, schema);
       return schema;

--- a/packages/graphql-language-service-server/src/GraphQLSchemaLoaderExtension.js
+++ b/packages/graphql-language-service-server/src/GraphQLSchemaLoaderExtension.js
@@ -1,0 +1,26 @@
+import {GraphQLSchema} from 'graphql';
+
+export type GraphQLSchemaLoaderPackage = {
+  init: (loaderArgs: any) => GraphQLSchemaLoader,
+}
+
+export type GraphQLSchemaLoader = {
+  getSchema: () => Promise<?GraphQLSchema>,
+}
+
+export type GraphQLSchemaConfigData = {
+  loaderPackage: string,
+  loaderArgs: any,
+}
+
+export class GraphQLSchemaLoaderExtension {
+  _raw: GraphQLSchemaConfigData;
+
+  constructor(schemaConfig: GraphQLSchemaConfigData) {
+      this.raw = schemaConfig;
+  }
+
+  getSchemaLoader(): GraphQLSchemaLoader {
+    return require(this.raw.loaderPackage).init(this.raw.loaderArgs);
+  }
+}

--- a/packages/graphql-language-service-server/src/__tests__/.graphqlconfig
+++ b/packages/graphql-language-service-server/src/__tests__/.graphqlconfig
@@ -24,6 +24,14 @@
     },
     "testWithoutSchema": {
     },
+    "testWithSchemaLoader": {
+      "extensions": {
+        "schema-loader": {
+          "loaderPackage": "./__tests__/fake-loader.js",
+          "loaderArgs": {}
+        }
+      }
+    },
     "testWithCustomDirectives": {
       "schemaPath": "__schema__/StarWarsSchema.graphql",
       "extensions": {

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
@@ -80,6 +80,11 @@ describe('GraphQLCache', () => {
       expect(schema instanceof GraphQLSchema).to.equal(false);
     });
 
+    it('it leverages schema extension if no schema is set', async () => {
+      const schema = await cache.getSchema('testWithSchemaLoader');
+      expect(schema instanceof GraphQLSchema).to.equal(true);
+    });
+
     it('extend the schema with appropriate custom directive', async () => {
       const schema = await cache.getSchema('testWithCustomDirectives');
       expect(
@@ -188,7 +193,7 @@ describe('GraphQLCache', () => {
     const query = `type Query {
         hero(episode: Episode): Character
       }
-      
+
       type Episode {
         id: ID!
       }

--- a/packages/graphql-language-service-server/src/__tests__/fake-loader.js
+++ b/packages/graphql-language-service-server/src/__tests__/fake-loader.js
@@ -1,0 +1,9 @@
+import {buildSchema} from 'graphql'
+
+module.exports = {
+  init: () => {
+    return {
+      getSchema: () => buildSchema(`type Test {id:ID}`)
+    }
+  }
+}


### PR DESCRIPTION
So, to get us started, I've implemented pluggable schema loading. How this works is the following:
* We have a new extension key `schema-loader` that contains two fields `loaderPackage` and `loaderArgs`. The loader package will be dynamically loaded. Subsequently we call `init(loaderArgs)` for it to initialize. (Alternatively we could use ES6 classes)
* The dynamically loaded package exposes a function `getSchema`, that if called returns the GraphQL Schema it loaded.

A couple caveats:
* This PR per se does not add any functionality. It relies on subsequent PRs actually adding schema loaders that conform to the interface.
* I am not sure wether simply calling `require()` is a good way to do this, but at least the new test passes
* This does not add all of the functionality I suggested in the original issue (#915)
* Right now we instantiate a new schema loader every time. We should probably cache it if it becomes a bottleneck.