### PR TITLE
upgrade graphiql to codemirror-graphql 0.9.0, interface/parser 2.x

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -52,12 +52,13 @@
   },
   "dependencies": {
     "codemirror": "^5.47.0",
-    "codemirror-graphql": "^0.8.3",
+    "codemirror-graphql": "^0.9.0",
     "copy-to-clipboard": "^3.2.0",
-    "markdown-it": "^8.4.0"
+    "markdown-it": "^8.4.0",
+    "regenerator-runtime": "^0.13.3"
   },
   "peerDependencies": {
-    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0",
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0",
     "prop-types": ">=15.5.0",
     "react": "^15.6.0 || ^16.0.0",
     "react-dom": "^15.6.0 || ^16.0.0"
@@ -73,7 +74,7 @@
     "enzyme-adapter-react-15": "^1.4.0",
     "express": "5.0.0-alpha.5",
     "express-graphql": "0.6.7",
-    "graphql": "14.1.1",
+    "graphql": "14.4.2",
     "jest": "^24.8.0",
     "jsdom": "15.0.0",
     "postcss-cli": "6.1.2",

--- a/packages/graphiql/src/index.js
+++ b/packages/graphiql/src/index.js
@@ -5,5 +5,6 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
+import 'regenerator-runtime/runtime';
 // The primary React component to use.
 module.exports = require('./components/GraphiQL').GraphiQL;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,10 +4854,10 @@ graphql-request@^1.5.0:
   dependencies:
     cross-fetch "2.2.2"
 
-graphql@14.1.1:
-  version "14.1.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.1.tgz#d5d77df4b19ef41538d7215d1e7a28834619fac0"
-  integrity sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==
+graphql@14.4.2:
+  version "14.4.2"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz#553a7d546d524663eda49ed6df77577be3203ae3"
+  integrity sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==
   dependencies:
     iterall "^1.2.2"
 
@@ -8355,10 +8355,10 @@ regenerate@^1.4.0:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.14.0:
   version "0.14.0"


### PR DESCRIPTION
- upgrade graphiql to use codemirror-graphql 0.9.0
- because we are using parser/interface 2.x, we are using utils 2.x which deprecates support for graphql versions below 0.12.x, thus update peer resolutions to reflect this
- upgrade development graphql to latest
- add `regenerator-runtime`
- deduplicate lockfile
- extensive manual testing, looks good!

(had been broken before because it required a change to the example project which has been implemented)

(P.S. I know I'm foregoing the proper babel-runtime/etc plugin route, but requiring `regenerator-runtime` directly was much simpler, and tree shaking can take care of it in build environments that duplicate this config. we can get more clever with it at a later iteration)