### PR TITLE
Doc explorer fix

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -116,7 +116,7 @@ export class GraphiQL extends React.Component {
     let docExplorerOpen = props.docExplorerOpen || false;
 
     // but then local storage state overrides it
-    if (this._storage.get('docExplorerOpen')) {
+    if (this._storage && this._storage.get('docExplorerOpen')) {
       docExplorerOpen = this.__storage.get('docExplorerOpen') === 'true';
     }
 

--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -116,8 +116,8 @@ export class GraphiQL extends React.Component {
     let docExplorerOpen = props.docExplorerOpen || false;
 
     // but then local storage state overrides it
-    if (this._storage && this._storage.get('docExplorerOpen')) {
-      docExplorerOpen = this.__storage.get('docExplorerOpen') === 'true';
+    if (this._storage.get('docExplorerOpen')) {
+      docExplorerOpen = this._storage.get('docExplorerOpen') === 'true';
     }
 
     // Initialize state
@@ -225,7 +225,10 @@ export class GraphiQL extends React.Component {
       },
       () => {
         if (this.state.schema === undefined) {
-          this.docExplorerComponent.reset();
+          if (this.docExplorerComponent) {
+            this.docExplorerComponent.reset();
+          }
+
           this._fetchSchema();
         }
       },
@@ -298,7 +301,7 @@ export class GraphiQL extends React.Component {
     };
 
     const docWrapStyle = {
-      display: this.state.docExplorerOpen ? 'block' : 'none',
+      display: 'block',
       width: this.state.docExplorerWidth,
     };
     const docExplorerWrapClasses =
@@ -417,22 +420,24 @@ export class GraphiQL extends React.Component {
             </div>
           </div>
         </div>
-        <div className={docExplorerWrapClasses} style={docWrapStyle}>
-          <div
-            className="docExplorerResizer"
-            onDoubleClick={this.handleDocsResetResize}
-            onMouseDown={this.handleDocsResizeStart}
-          />
-          <DocExplorer
-            ref={c => {
-              this.docExplorerComponent = c;
-            }}
-            schema={this.state.schema}>
-            <div className="docExplorerHide" onClick={this.handleToggleDocs}>
-              {'\u2715'}
-            </div>
-          </DocExplorer>
-        </div>
+        {this.state.docExplorerOpen && (
+          <div className={docExplorerWrapClasses} style={docWrapStyle}>
+            <div
+              className="docExplorerResizer"
+              onDoubleClick={this.handleDocsResetResize}
+              onMouseDown={this.handleDocsResizeStart}
+            />
+            <DocExplorer
+              ref={c => {
+                this.docExplorerComponent = c;
+              }}
+              schema={this.state.schema}>
+              <div className="docExplorerHide" onClick={this.handleToggleDocs}>
+                {'\u2715'}
+              </div>
+            </DocExplorer>
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
@@ -116,4 +116,12 @@ describe('GraphiQL', () => {
     );
     expect(graphiQL.state().query).to.equal('GraphQL Party!!');
   });
+  it('accepts a docExplorerOpen prop', () => {
+    const graphiQL = mount(<GraphiQL fetcher={noOpFetcher} docExplorerOpen />);
+    expect(graphiQL.state().docExplorerOpen).to.equal(true);
+  });
+  it('defaults to closed docExplorer', () => {
+    const graphiQL = mount(<GraphiQL fetcher={noOpFetcher} />);
+    expect(graphiQL.state().docExplorerOpen).to.equal(false);
+  });
 });

--- a/packages/graphiql/test/index.html
+++ b/packages/graphiql/test/index.html
@@ -134,7 +134,8 @@
           operationName: parameters.operationName,
           onEditQuery: onEditQuery,
           onEditVariables: onEditVariables,
-          onEditOperationName: onEditOperationName
+          onEditOperationName: onEditOperationName,
+          docExplorerOpen: true
         }),
         document.getElementById('graphiql')
       );


### PR DESCRIPTION
This bug was introduced with the `docExplorerOpen` PR merge. The last PR I merged, for codemirror-graphql upgrades for graphiql, I hadn't manually checked after the rebase. It appears that I made a typo in this previous PR related to default `DocExplorer` state.

The potentially impactful change this makes is actually unmounting the docs component when it's closed. Is that an issue?