### PR TITLE
Fix 'Mode graphql failed to advance stream'

### DIFF
--- a/packages/graphql-language-service-parser/src/onlineParser.js
+++ b/packages/graphql-language-service-parser/src/onlineParser.js
@@ -109,7 +109,12 @@ function getToken(
 
   // If there's no matching token, skip ahead.
   if (!token) {
-    stream.match(/\S+/);
+    const matchedSomething = stream.match(/\S+/);
+    if (!matchedSomething) {
+      // We need to eat at least one character, and we couldn't match any
+      // non-whitespace, so it must be exotic whitespace.
+      stream.match(/\s/);
+    }
     pushRule(SpecialParseRules, state, 'Invalid');
     return 'invalidchar';
   }


### PR DESCRIPTION
Fixes https://github.com/graphql/graphiql/issues/735

Basically the bad token wasn't being "eaten" so it literally was failing to advance the stream. This fix consumes it.

![Screenshot_20190812_142416](https://user-images.githubusercontent.com/129910/62868175-f0e04e80-bd0c-11e9-9cb2-a4f8e6824ef0.png)
