### PR TITLE
Fix formatting of GraphiQL errors

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -579,7 +579,7 @@ export class GraphiQL extends React.Component {
       .catch(error => {
         this.setState({
           schema: null,
-          response: error && String(error.stack || error),
+          response: error ? GraphiQL.formatError(error) : null,
         });
       });
   }
@@ -611,7 +611,7 @@ export class GraphiQL extends React.Component {
       fetch.then(cb).catch(error => {
         this.setState({
           isWaitingForResponse: false,
-          response: error && String(error.stack || error),
+          response: error ? GraphiQL.formatError(error) : null,
         });
       });
     } else if (isObservable(fetch)) {
@@ -623,7 +623,7 @@ export class GraphiQL extends React.Component {
         error: error => {
           this.setState({
             isWaitingForResponse: false,
-            response: error && String(error.stack || error),
+            response: error ? GraphiQL.formatError(error) : null,
             subscription: null,
           });
         },
@@ -1071,6 +1071,18 @@ GraphiQL.Footer = function GraphiQLFooter(props) {
 
 GraphiQL.formatResult = function(result) {
   return JSON.stringify(result, null, 2);
+};
+
+GraphiQL.formatError = function(error) {
+  const formattedError = JSON.stringify(error, null, 2);
+  if (formattedError === '{}' && error.message) {
+    return JSON.stringify(
+      { message: error.message, stack: error.stack },
+      null,
+      2,
+    );
+  }
+  return formattedError;
 };
 
 const defaultQuery = `# Welcome to GraphiQL


### PR DESCRIPTION
Fixes https://github.com/graphql/graphiql/pull/636  
Fixes https://github.com/graphql/graphiql/pull/722

This approach allows overriding the error handler. By default it uses `JSON.stringify` on the error; if the result is `'{}'` then it will instead create a `{message,stack}` error to stringify (since `JSON.stringify(new Error("Something"))` is `'{}'`).