### PR TITLE
Have arrays of errors output message if available

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -1073,16 +1073,18 @@ GraphiQL.formatResult = function(result) {
   return JSON.stringify(result, null, 2);
 };
 
-GraphiQL.formatError = function(error) {
-  const formattedError = JSON.stringify(error, null, 2);
-  if (formattedError === '{}' && error.message) {
-    return JSON.stringify(
-      { message: error.message, stack: error.stack },
-      null,
-      2,
-    );
-  }
-  return formattedError;
+const formatSingleError = error => ({
+  ...error,
+  // Raise these details even if they're non-enumerable
+  message: error.message,
+  stack: error.stack,
+});
+
+GraphiQL.formatError = function(rawError) {
+  const result = Array.isArray(rawError)
+    ? rawError.map(formatSingleError)
+    : formatSingleError(rawError);
+  return JSON.stringify(result, null, 2);
 };
 
 const defaultQuery = `# Welcome to GraphiQL


### PR DESCRIPTION
Sorry @acao, turns out there's situations where arrays of errors are returned which then outputs:

```json
[
  {}
]
```

which is not super useful. This PR replaces the new formatError function with one that handles this situation better.

#### Unknown errors (e.g. when they don't return `{"errors": ...}`):

![Screenshot_20190812_170029](https://user-images.githubusercontent.com/129910/62879330-cac5a900-bd22-11e9-88dc-4fbafe42a3d0.png)

(Note this error message comes from `subscriptions-transport-ws` rather than from us)

#### Known errors:

![Screenshot_20190812_170705](https://user-images.githubusercontent.com/129910/62879729-b7ffa400-bd23-11e9-9f54-5f33b5fe0461.png)
