### PR TITLE
prepare for next round of releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,31 @@
-## Codemirror GraphQL -  0.9 - 11 Aug, 2019
+Below is a temporary, manually maintained changelog that will eventually be controlled by something like `cz-conventional-changelog`. Until we get there, we have a manual publish strategy. Updates to `Contributing.md` with more details coming soon
+
+## GraphiQL 0.14.2 - 11 Aug, 2019
+
+### Fixes 
+- Fix SSR & use of window when introducing new `extraKeys` capability (#942)
+
+
+## GraphiQL 0.14.0 - 11 Aug, 2019
+
+### Features
+-  Add defaultVariableEditorOpen prop (#744) - @acao
+
+### Fixes 
+- Fix formatting of subscription errors -  #636, #722 - @benjie
+- preserve ctrl-f key for macOS - #759 - @pd4d10
+- Fix earlier 'Mode graphql failed to advance stream' on Linux by eating an exotic whitespace character - #735 closed by #932 - @benjie
+- Fix: check `this.editor` exists before `this.editor.off` in QueryEditor
+
+
+## Codemirror GraphQL - 0.9 - 11 Aug, 2019
 
 ### Chores
 - BREAKING: Update to gls-interface and gls-parser ^2.1
 - BREAKING: Deprecate support for GraphQL 0.11 and below
 - BREAKING: introduce MIT license
 - BREAKING: Support GraphQL 14
+
 
 ## GraphQL Language Service Server 2.1.0 - 11 Aug, 2019
 
@@ -19,10 +40,12 @@
 - update formatting for monorepo eslint/prettier rules
 - update readme, badges
 
+
 ## GraphQL Language Service Parser 2.1.0 - 11 Aug, 2019
 
 ### Fixes
 - Fix 'mode graphql failed to advance stream' error from shift-alt-space, etc - #932 - @benjie
+
 
 ## GraphQL Language Service Interface 2.1.0 - 11 Aug, 2019
 
@@ -31,13 +54,13 @@
 - Update sortText logic, so that field sort is schema driven rather than alphabetically sorted - (#884) @ganenome
 
 ### Chores
-- MINOR BREAKING: Support graphql 14
+- BREAKING: add peer support for graphql 14.x
 - MINOR BREAKING: Use MIT license
 - add test case for language service hover - @divyenduz @AGS-
 
 
 ## GraphQL Language Service  2.1.0
-- BREAKING: Support graphql 14
+- BREAKING: add peer support for graphql 14.x
 - BREAKING: remove incompatible dependencies on graphql 0.11 and below (b/c of gls-utils 2.x) 
 
 
@@ -57,6 +80,7 @@
 - update formatting for monorepo eslint/prettier rules
 - update readme, badges
 
+
 ## GraphiQL 0.13.2 - 21 June, 2019
 
 ### Features
@@ -65,18 +89,17 @@
 - Add operationName to introspection query - #664 - @jbblanchet
 - Image Preview Functionality - #789 - @dunnbobcat @asiandrummer
 
-
 ### Fixes
-- Destroy image hover tooltip when it isn't needed #874
+- Destroy image hover tooltip when it isn't needed - #874 - @acao
 - Copy non-formatted query to avoid stripping out comments - #832 - @jaebradley
 - Normalizes no-break spaces - #781 - @zouxuoz
 - Prevents crashing on Shift-Alt-Space - #781 - @zouxuoz
 - Fix UI state change after favoriting a query - #747 - @benjie
 
 ### Chores
-- BREAKING: Upgrade to `codemirror-graphql` 0.8.3 - #773 - @jonaskello, @acao
+- BREAKING: Upgrade to `codemirror-graphql` 0.8.3 - #773 - @jonaskello
 - BREAKING: Change copyright to GraphQL Contributors, License to MIT
-- Netlify deployments per PR @orta
+- Netlify deployments per PR - @orta
 - Add unit test coverage
 - Switch to Jest
 
@@ -85,15 +108,14 @@
 You will now be importing async methods from gls-interface 2.0.0, thus your bundler will require regenerator runtime
 
 ## Chores
-- BREAKING - Use GLS interface/parser 2.0.0 for graphql 14
-- BREAKING - This introduces
-
+- BREAKING - Use GLS interface/parser 2.1.0 for graphql 14
+- BREAKING - This introduces async/await
 
 ## GraphQL Language Service Interface 2.0.0 - 11 Sep, 2018
 
 ### Chores
-- BREAKING: upgrade internal dependencies - gls-parser, gls-types, and gls-utils to 2.0.0 @lostplan
-- BREAKING: remove incompatible dependencies on graphql 0.11 and below @lostplan
+- BREAKING: upgrade internal dependencies - gls-parser, gls-types, and gls-utils to 2.0.0 - @lostplan
+- BREAKING: remove incompatible dependencies on graphql 0.11 and below - @lostplan
 
 
 ## GraphQL Language Service Utils 2.0.0 - 11 Sep, 2018
@@ -107,6 +129,7 @@ You will now be importing async methods from gls-interface 2.0.0, thus your bund
 
 ### Chores
 -  add graphql-js 0.13 to peer deps of types package (graphql/graphql-language-service#241) 
+
 
 ## GraphQL Language Service Server 2.0.0 - 11 Sep, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,122 @@
+## Codemirror GraphQL -  0.9 - 11 Aug, 2019
+
+### Chores
+- BREAKING: Update to gls-interface and gls-parser ^2.1
+- BREAKING: Deprecate support for GraphQL 0.11 and below
+- BREAKING: introduce MIT license
+- BREAKING: Support GraphQL 14
+
+## GraphQL Language Service Server 2.1.0 - 11 Aug, 2019
+
+### Features
+- Replace babylon with @babel/parser (#879) @ganemone
+- Add support for gql template tags (#883) @ganemone @Neitsch
+
+### Chores
+- BREAKING: remove incompatible dependencies on graphql 0.11 and below 
+- BREAKING: add peer support for graphql 14.x
+- BREAKING: change copyright to MIT
+- update formatting for monorepo eslint/prettier rules
+- update readme, badges
+
+## GraphQL Language Service Parser 2.1.0 - 11 Aug, 2019
+
+### Fixes
+- Fix 'mode graphql failed to advance stream' error from shift-alt-space, etc - #932 - @benjie
+
+## GraphQL Language Service Interface 2.1.0 - 11 Aug, 2019
+
+### Features
+- add __typename field suggestion against object type - (#903) @yoshiakis
+- Update sortText logic, so that field sort is schema driven rather than alphabetically sorted - (#884) @ganenome
+
+### Chores
+- MINOR BREAKING: Support graphql 14
+- MINOR BREAKING: Use MIT license
+- add test case for language service hover - @divyenduz @AGS-
+
+
+## GraphQL Language Service  2.1.0
+- BREAKING: Support graphql 14
+- BREAKING: remove incompatible dependencies on graphql 0.11 and below (b/c of gls-utils 2.x) 
+
+
+## GraphQL Language Service Utils 2.1.0 - 11 Aug, 2019
+
+### Chores
+- BREAKING: change copyright to MIT
+- update formatting for monorepo eslint/prettier rules
+- update readme, badges
+
+
+## GraphQL Language Service Types 1.3.0 - 11 Aug, 2019
+
+### Chores
+- BREAKING: change copyright to MIT
+- BREAKING: add peer support for graphql 14.x
+- update formatting for monorepo eslint/prettier rules
+- update readme, badges
+
+## GraphiQL 0.13.2 - 21 June, 2019
+
+### Features
+- Hint/popup/etc DOM nodes use container rather than creating children of <body> - #791 - @codestryke
+- Add readOnly prop and pass to `QueryEditor` and `VariableEditor` - #718 - @TheSharpieOne
+- Add operationName to introspection query - #664 - @jbblanchet
+- Image Preview Functionality - #789 - @dunnbobcat @asiandrummer
+
+
+### Fixes
+- Destroy image hover tooltip when it isn't needed #874
+- Copy non-formatted query to avoid stripping out comments - #832 - @jaebradley
+- Normalizes no-break spaces - #781 - @zouxuoz
+- Prevents crashing on Shift-Alt-Space - #781 - @zouxuoz
+- Fix UI state change after favoriting a query - #747 - @benjie
+
+### Chores
+- BREAKING: Upgrade to `codemirror-graphql` 0.8.3 - #773 - @jonaskello, @acao
+- BREAKING: Change copyright to GraphQL Contributors, License to MIT
+- Netlify deployments per PR @orta
+- Add unit test coverage
+- Switch to Jest
+
+
+## Codemirror Graphql Mode 0.8.4 - 11 Aug, 2018
+You will now be importing async methods from gls-interface 2.0.0, thus your bundler will require regenerator runtime
+
+## Chores
+- BREAKING - Use GLS interface/parser 2.0.0 for graphql 14
+- BREAKING - This introduces
+
+
+## GraphQL Language Service Interface 2.0.0 - 11 Sep, 2018
+
+### Chores
+- BREAKING: upgrade internal dependencies - gls-parser, gls-types, and gls-utils to 2.0.0 @lostplan
+- BREAKING: remove incompatible dependencies on graphql 0.11 and below @lostplan
+
+
+## GraphQL Language Service Utils 2.0.0 - 11 Sep, 2018
+
+### Chores
+- BREAKING: deprecate support for graphql-js 0.11.x and below - @lostplan [graphql/graphql-language-service#256](https://github.com/graphql/graphql-language-service/pull/256) [new ref](https://github.com/graphql/graphiql/commit/895e68537fd802b8b6ddf2578a1f76f85982c773) because of [this change](https://github.com/graphql/graphiql/commit/068c57fdb4a147be3c2fc38167e2def74d217a82#diff-696ceb17e38e4a274d4a149d24513b78)
+- BREAKING: GraphQL 14.x support, peer dependency resolutions - #244 - @AGS-
+
+
+## GraphQL Language Service Utils 1.2.2 - 11 Sep, 2018
+
+### Chores
+-  add graphql-js 0.13 to peer deps of types package (graphql/graphql-language-service#241) 
+
+## GraphQL Language Service Server 2.0.0 - 11 Sep, 2019
+
+### Chores
+- add graphql-js 0.13 to peer dependencies (graphql/graphql-language-service#241) 
+- BREAKING: ugrade internal dependencies - gls-interface, gls-server and gls-utils to 2.0.0 @lostplan
+
+
+## GraphQL Language Service 2.0.0 - 11 Sep, 2018
+
+### Chores
+- BREAKING: ugrade internal dependencies - gls-interface, gls-server and gls-utils to 2.0.0 @Sol
+

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -37,11 +37,11 @@
   },
   "peerDependencies": {
     "codemirror": "^5.26.0",
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
-    "graphql-language-service-interface": "^2.0.1",
-    "graphql-language-service-parser": "^2.0.1"
+    "graphql-language-service-interface": "^2.1.0",
+    "graphql-language-service-parser": "^1.3.0"
   },
   "devDependencies": {
     "chai": "4.1.1",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql",
-  "version": "0.13.2",
+  "version": "0.14.2",
   "description": "An graphical interactive in-browser GraphQL IDE.",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",

--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-interface",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Interface to the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -28,12 +28,12 @@
     "prepublish": "node ../../resources/prepublish.js"
   },
   "peerDependencies": {
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-parser": "^2.0.1",
-    "graphql-language-service-types": "^2.0.1",
-    "graphql-language-service-utils": "^2.0.1"
+    "graphql-language-service-parser": "^1.3.0",
+    "graphql-language-service-types": "^1.3.0",
+    "graphql-language-service-utils": "^2.1.0"
   }
 }

--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-parser",
-  "version": "2.0.1",
+  "version": "1.3.0",
   "description": "An online parser for GraphQL for use in syntax-highlighters and code intelligence tools",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-types": "^2.0.1"
+    "graphql-language-service-types": "^1.3.0"
   }
 }

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-server",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Server process backing the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -28,16 +28,16 @@
     "prepublish": "node ../../resources/prepublish.js"
   },
   "peerDependencies": {
-    "graphql": "^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
     "@babel/parser": "^7.4.5",
     "fb-watchman": "^2.0.0",
     "glob": "^7.1.2",
     "graphql-config": "2.2.1",
-    "graphql-language-service-interface": "^2.0.1",
-    "graphql-language-service-types": "^2.0.1",
-    "graphql-language-service-utils": "^2.0.1",
+    "graphql-language-service-interface": "^2.1.0",
+    "graphql-language-service-types": "^1.3.0",
+    "graphql-language-service-utils": "^2.1.0",
     "nullthrows": "^1.0.0",
     "vscode-jsonrpc": "^3.3.0",
     "vscode-languageserver": "^3.3.0"

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-types",
-  "version": "2.0.1",
+  "version": "1.3.0",
   "description": "Types for building GraphQL language services for IDEs",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",

--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-utils",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Utilities to support the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net/)",
@@ -32,6 +32,6 @@
   },
   "dependencies": {
     "graphql-config": "2.2.1",
-    "graphql-language-service-types": "^2.0.1"
+    "graphql-language-service-types": "^1.3.0"
   }
 }

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "An interface for building GraphQL language services for IDEs",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",
@@ -31,14 +31,14 @@
     "prepublish": "node ../../resources/prepublish.js"
   },
   "peerDependencies": {
-    "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"
+    "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },
   "dependencies": {
     "@babel/polyfill": "7.4.4",
     "graphql-config": "2.2.1",
-    "graphql-language-service-interface": "^2.0.1",
-    "graphql-language-service-server": "^2.0.1",
-    "graphql-language-service-utils": "^2.0.1",
+    "graphql-language-service-interface": "^2.1.0",
+    "graphql-language-service-server": "^2.1.0",
+    "graphql-language-service-utils": "2.1.0",
     "yargs": "^3.32.0 || ^7.0.0"
   }
 }


### PR DESCRIPTION
- add changelog
- remove peer deps
- minor version bumps for GLS + codemirror because of license change
- everything ready for next release but GraphiQL