### PR TITLE
fix:(graphiql) - for SSR, regression from extraKeys bugfix, fixes #942 

### DIFF
--- a/packages/graphiql/src/utility/commonKeys.js
+++ b/packages/graphiql/src/utility/commonKeys.js
@@ -1,4 +1,8 @@
-const isMacOs = window.navigator.platform === 'MacIntel';
+let isMacOs = false
+
+if (typeof window === Object) {
+ isMacOs = window.navigator.platform === 'MacIntel';
+}
 
 const commonKeys = {
   // Persistent search box in Query Editor


### PR DESCRIPTION
- dont expect window to be present for extraKeys MacOs detection logic
- use existing graphiql convention for detecting the presence of window