### PR TITLE
deps: yarn-deduplicate

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
@@ -87,6 +87,7 @@ describe('GraphQLCache', () => {
       ).to.deep.equal({
         args: [],
         description: undefined,
+        isRepeatable: false,
         locations: ['FIELD'],
         name: 'customDirective',
       });
@@ -99,6 +100,7 @@ describe('GraphQLCache', () => {
       ).to.deep.equal({
         args: [],
         description: undefined,
+        isRepeatable: false,
         locations: ['FRAGMENT_SPREAD'],
         name: 'customDirective',
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,17 +4854,10 @@ graphql-request@^1.5.0:
   dependencies:
     cross-fetch "2.2.2"
 
-graphql@14.4.2:
+graphql@14.4.2, graphql@^14.0.2, graphql@^14.3.1:
   version "14.4.2"
   resolved "https://registry.npmjs.org/graphql/-/graphql-14.4.2.tgz#553a7d546d524663eda49ed6df77577be3203ae3"
   integrity sha512-6uQadiRgnpnSS56hdZUSvFrVcQ6OF9y6wkxJfKquFtHlnl7+KSuWwSJsdwiK1vybm1HgcdbpGkCpvhvsVQ0UZQ==
-  dependencies:
-    iterall "^1.2.2"
-
-graphql@^14.0.2, graphql@^14.3.1:
-  version "14.3.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
-  integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
Result of running `npx yarn-deduplicate && yarn install --force` - turns out we had duplicate GraphQL modules installed.

Incidentally I decided `deps:` is better than `chore(deps):`; thoughts?