### PR TITLE
docs: correct the examples links

### DIFF
--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -44,11 +44,11 @@ function graphQLFetcher(graphQLParams) {
 ReactDOM.render(<GraphiQL fetcher={graphQLFetcher} />, document.body);
 ```
 
-Build for the web with [webpack](https://webpack.js.org/) or [browserify](http://browserify.org/), or use the pre-bundled `graphiql.js` file. See the [example](./example) in the git repository to see how to use the pre-bundled file.
+Build for the web with [webpack](https://webpack.js.org/) or [browserify](http://browserify.org/), or use the pre-bundled `graphiql.js` file. See the [example](../graphiql-examples/cdn/) in the git repository to see how to use the pre-bundled file.
 
 Don't forget to include the CSS file on the page! If you're using `npm` or `yarn`, you can find it in `node_modules/graphiql/graphiql.css`, or you can download it from the [releases page](https://github.com/graphql/graphiql/releases).
 
-For an example of setting up a GraphiQL, check out the [example](./example) in this repository which also includes a few useful features highlighting GraphiQL's API.
+For an example of setting up a GraphiQL, check out the [example](../graphiql-examples/cdn/) in this repository which also includes a few useful features highlighting GraphiQL's API.
 
 
 ### Features


### PR DESCRIPTION
According to [this](https://github.com/graphql/graphiql/commit/07fc6fee2780cb65668c1ca6b03688cdb82fcf44) commit, apparently the files from `graphiql/example` were moved to `packages/graphiql-examples/cdn/` but the README.md still points to the old files. This PR fixes this.