### PR TITLE
Updated broken links to packages in README files

### DIFF
--- a/packages/graphql-language-service-interface/README.md
+++ b/packages/graphql-language-service-interface/README.md
@@ -2,4 +2,4 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-interface.svg?style=flat-square)](https://npmjs.com/graphql-language-service-interface)
 [![License](https://img.shields.io/npm/l/graphql-language-service-interface.svg?style=flat-square)](LICENSE)
 
-Interface to the [GraphQL Language Service](https://github.com/graphql/tree/master/packages/graphql-language-service).
+Interface to the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/master/packages/graphql-language-service).

--- a/packages/graphql-language-service-parser/README.md
+++ b/packages/graphql-language-service-parser/README.md
@@ -2,4 +2,4 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-parser.svg?style=flat-square)](https://npmjs.com/graphql-language-service-parser)
 [![License](https://img.shields.io/npm/l/graphql-language-service-parser.svg?style=flat-square)](LICENSE)
 
-An online immutable parser for [GraphQL](http://graphql.org/), designed to be used as part of syntax-highlighting and code intelligence tools such as for the [GraphQL Language Service](https://github.com/graphql/graphql-language-service) and [codemirror-graphql](https://github.com/graphql/codemirror-graphql).
+An online immutable parser for [GraphQL](http://graphql.org/), designed to be used as part of syntax-highlighting and code intelligence tools such as for the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/master/packages/graphql-language-service) and [codemirror-graphql](https://github.com/graphql/graphiql/tree/master/packages/codemirror-graphql).

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -2,4 +2,4 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-server.svg?style=flat-square)](https://npmjs.com/graphql-language-service-server)
 [![License](https://img.shields.io/npm/l/graphql-language-service-server.svg?style=flat-square)](LICENSE)
 
-Server process backing the [GraphQL Language Service](https://github.com/graphql/graphql-language-service).
+Server process backing the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/master/packages/graphql-language-service).

--- a/packages/graphql-language-service-types/README.md
+++ b/packages/graphql-language-service-types/README.md
@@ -2,4 +2,4 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-types.svg?style=flat-square)](https://npmjs.com/graphql-language-service-types)
 [![License](https://img.shields.io/npm/l/graphql-language-service-types.svg?style=flat-square)](LICENSE)
 
-[Flow](https://flowtype.org/) type definitions for the [GraphQL Language Service](https://github.com/graphql/graphql-language-service).
+[Flow](https://flowtype.org/) type definitions for the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/master/packages/graphql-language-service).

--- a/packages/graphql-language-service-utils/README.md
+++ b/packages/graphql-language-service-utils/README.md
@@ -2,4 +2,4 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-utils.svg?style=flat-square)](https://npmjs.com/graphql-language-service-utils)
 [![License](https://img.shields.io/npm/l/graphql-language-service-utils.svg?style=flat-square)](LICENSE)
 
-Utilities to support the [GraphQL Language Service](https://github.com/graphql/graphql-language-service).
+Utilities to support the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/master/packages/graphql-language-service).


### PR DESCRIPTION
Some of the links pointing to packages were broken following the move to the monorepo.