### PR TITLE
fix: check `window` is defined before using it

### DIFF
--- a/packages/graphiql/src/utility/StorageAPI.js
+++ b/packages/graphiql/src/utility/StorageAPI.js
@@ -7,7 +7,7 @@
 
 export default class StorageAPI {
   constructor(storage) {
-    if (typeof window !== 'undefined') {
+    this.storage = storage || (typeof window !== 'undefined' ? window.localStorage : null);
       this.storage = storage || window.localStorage;
     }
   }

--- a/packages/graphiql/src/utility/StorageAPI.js
+++ b/packages/graphiql/src/utility/StorageAPI.js
@@ -7,7 +7,9 @@
 
 export default class StorageAPI {
   constructor(storage) {
-    this.storage = storage || window.localStorage;
+    if (typeof window !== 'undefined') {
+      this.storage = storage || window.localStorage;
+    }
   }
 
   get(name) {

--- a/packages/graphiql/src/utility/StorageAPI.js
+++ b/packages/graphiql/src/utility/StorageAPI.js
@@ -7,9 +7,8 @@
 
 export default class StorageAPI {
   constructor(storage) {
-    this.storage = storage || (typeof window !== 'undefined' ? window.localStorage : null);
-      this.storage = storage || window.localStorage;
-    }
+    this.storage =
+      storage || (typeof window !== 'undefined' ? window.localStorage : null);
   }
 
   get(name) {


### PR DESCRIPTION
Hi !

I was trying to use GraphiQL with Gatsby but I got `window is not defined` issue.
