### PR TITLE
fix(accessibility): improve accessibility of all components

### DIFF
--- a/packages/graphiql/css/app.css
+++ b/packages/graphiql/css/app.css
@@ -78,7 +78,6 @@
   cursor: pointer;
   font-size: 14px;
   margin: 0;
-  outline: 0;
   padding: 2px 20px 0 18px;
 }
 
@@ -151,6 +150,9 @@
   font-size: 18px;
   margin: -7px -8px -6px 0;
   padding: 18px 16px 15px 12px;
+  background: 0;
+  border: 0;
+  line-height: 14px;
 }
 
 .graphiql-container div .query-editor {
@@ -229,6 +231,7 @@
 .graphiql-container .toolbar-button {
   background: #fdfdfd;
   background: linear-gradient(#f9f9f9, #ececec);
+  border: 0;
   border-radius: 3px;
   box-shadow:
     inset 0 0 0 1px rgba(0,0,0,0.20),
@@ -310,10 +313,6 @@
     inset 0 0 6px rgba(0, 0, 0, 0.1);
 }
 
-.graphiql-container .execute-button:focus {
-  outline: 0;
-}
-
 .graphiql-container .toolbar-menu,
 .graphiql-container .toolbar-select {
   position: relative;
@@ -380,8 +379,8 @@
 .graphiql-container .toolbar-select-options > li.hover,
 .graphiql-container .toolbar-select-options > li:active,
 .graphiql-container .toolbar-select-options > li:hover,
-.graphiql-container .history-contents > p:hover,
-.graphiql-container .history-contents > p:active {
+.graphiql-container .history-contents > li:hover,
+.graphiql-container .history-contents > li:active {
   background: #e10098;
   color: #fff;
 }

--- a/packages/graphiql/css/doc-explorer.css
+++ b/packages/graphiql/css/doc-explorer.css
@@ -33,6 +33,9 @@
   padding: 17px 12px 16px 16px;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: 0;
+  border: 0;
+  line-height: 14px;
 }
 
 .doc-explorer-narrow .doc-explorer-back {
@@ -219,8 +222,7 @@
   position: relative;
 }
 
-.graphiql-container .search-box:before {
-  content: '\26b2';
+.graphiql-container .search-box-icon {
   cursor: pointer;
   display: block;
   font-size: 24px;
@@ -241,6 +243,7 @@
   right: 3px;
   top: 8px;
   user-select: none;
+  border: 0;
 }
 
 .graphiql-container .search-box .search-box-clear:hover {

--- a/packages/graphiql/css/history.css
+++ b/packages/graphiql/css/history.css
@@ -1,10 +1,13 @@
-.graphiql-container .history-contents,
-.graphiql-container .history-contents input {
+.graphiql-container .history-contents {
   font-family: 'Consolas', 'Inconsolata', 'Droid Sans Mono', 'Monaco', monospace;
+}
+
+.graphiql-container .history-contents {
+  margin: 0;
   padding: 0;
 }
 
-.graphiql-container .history-contents p {
+.graphiql-container .history-contents li {
   align-items: center;
   display: flex;
   font-size: 12px;
@@ -16,21 +19,41 @@
   border-bottom: 1px solid #e0e0e0;
 }
 
-.graphiql-container .history-contents p.editable {
-  padding-bottom: 6px;
-  padding-top: 7px;
+.graphiql-container .history-contents li button:not(.history-label) {
+  display: none;
+  margin-left: 10px;
+}
+
+.graphiql-container .history-contents li:hover button:not(.history-label),
+.graphiql-container .history-contents li:focus-within button:not(.history-label) {
+  display: inline-block;
+}
+
+.graphiql-container .history-contents input,
+.graphiql-container .history-contents button {
+  padding: 0;
+  background: 0;
+  border: 0;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 14px;
+  color: inherit;
 }
 
 .graphiql-container .history-contents input {
   flex-grow: 1;
-  font-size: 12px;
 }
 
-.graphiql-container .history-contents p:hover {
+.graphiql-container .history-contents input::placeholder {
+  color: inherit;
+}
+
+.graphiql-container .history-contents button {
   cursor: pointer;
+  text-align: left;
 }
 
-.graphiql-container .history-contents p span.history-label {
+.graphiql-container .history-contents .history-label {
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/graphiql/src/components/DocExplorer.js
+++ b/packages/graphiql/src/components/DocExplorer.js
@@ -112,14 +112,18 @@ export class DocExplorer extends React.Component {
     }
 
     return (
-      <div className="doc-explorer" key={navItem.name}>
+      <section
+        className="doc-explorer"
+        key={navItem.name}
+        aria-label="Documentation Explorer">
         <div className="doc-explorer-title-bar">
           {prevName && (
-            <div
+            <button
               className="doc-explorer-back"
-              onClick={this.handleNavBackClick}>
+              onClick={this.handleNavBackClick}
+              aria-label={`Go back to ${prevName}`}>
               {prevName}
-            </div>
+            </button>
           )}
           <div className="doc-explorer-title">
             {navItem.title || navItem.name}
@@ -136,7 +140,7 @@ export class DocExplorer extends React.Component {
           )}
           {content}
         </div>
-      </div>
+      </section>
     );
   }
 

--- a/packages/graphiql/src/components/DocExplorer/SearchBox.js
+++ b/packages/graphiql/src/components/DocExplorer/SearchBox.js
@@ -26,16 +26,21 @@ export default class SearchBox extends React.Component {
   render() {
     return (
       <label className="search-box">
+        <div className="search-box-icon" aria-hidden="true">{'\u26b2'}</div>
         <input
           value={this.state.value}
           onChange={this.handleChange}
           type="text"
           placeholder={this.props.placeholder}
+          aria-label={this.props.placeholder}
         />
         {this.state.value && (
-          <div className="search-box-clear" onClick={this.handleClear}>
+          <button
+            className="search-box-clear"
+            onClick={this.handleClear}
+            aria-label="Clear search input">
             {'\u2715'}
-          </div>
+          </button>
         )}
       </label>
     );

--- a/packages/graphiql/src/components/DocExplorer/TypeLink.js
+++ b/packages/graphiql/src/components/DocExplorer/TypeLink.js
@@ -43,7 +43,7 @@ function renderType(type, onClick) {
     );
   }
   return (
-    <a className="type-name" onClick={event => onClick(type, event)}>
+    <a className="type-name" onClick={event => {event.preventDefault(); onClick(type, event)}} href="#">
       {type.name}
     </a>
   );

--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -122,7 +122,10 @@ export class GraphiQL extends React.Component {
     }
 
     // initial variable editor pane open
-    const variableEditorOpen = props.defaultVariableEditorOpen !== undefined ? props.defaultVariableEditorOpen : Boolean(variables);
+    const variableEditorOpen =
+      props.defaultVariableEditorOpen !== undefined
+        ? props.defaultVariableEditorOpen
+        : Boolean(variables);
 
     // Initialize state
     this.state = {
@@ -333,9 +336,12 @@ export class GraphiQL extends React.Component {
             onSelectQuery={this.handleSelectHistoryQuery}
             storage={this._storage}
             queryID={this._editorQueryID}>
-            <div className="docExplorerHide" onClick={this.handleToggleHistory}>
+            <button
+              className="docExplorerHide"
+              onClick={this.handleToggleHistory}
+              aria-label="Close History">
               {'\u2715'}
-            </div>
+            </button>
           </QueryHistory>
         </div>
         <div className="editorWrap">
@@ -353,7 +359,8 @@ export class GraphiQL extends React.Component {
             {!this.state.docExplorerOpen && (
               <button
                 className="docExplorerShow"
-                onClick={this.handleToggleDocs}>
+                onClick={this.handleToggleDocs}
+                aria-label="Open Documentation Explorer">
                 {'Docs'}
               </button>
             )}
@@ -382,9 +389,13 @@ export class GraphiQL extends React.Component {
                 editorTheme={this.props.editorTheme}
                 readOnly={this.props.readOnly}
               />
-              <div className="variable-editor" style={variableStyle}>
+              <section
+                className="variable-editor"
+                style={variableStyle}
+                aria-label="Query Variables">
                 <div
                   className="variable-editor-title"
+                  id="variable-editor-title"
                   style={{ cursor: variableOpen ? 'row-resize' : 'n-resize' }}
                   onMouseDown={this.handleVariableResizeStart}>
                   {'Query Variables'}
@@ -403,7 +414,7 @@ export class GraphiQL extends React.Component {
                   editorTheme={this.props.editorTheme}
                   readOnly={this.props.readOnly}
                 />
-              </div>
+              </section>
             </div>
             <div className="resultWrap">
               {this.state.isWaitingForResponse && (
@@ -436,9 +447,12 @@ export class GraphiQL extends React.Component {
                 this.docExplorerComponent = c;
               }}
               schema={this.state.schema}>
-              <div className="docExplorerHide" onClick={this.handleToggleDocs}>
+              <button
+                className="docExplorerHide"
+                onClick={this.handleToggleDocs}
+                aria-label="Close Documentation Explorer">
                 {'\u2715'}
-              </div>
+              </button>
             </DocExplorer>
           </div>
         )}
@@ -1045,7 +1059,11 @@ GraphiQL.Logo = function GraphiQLLogo(props) {
 
 // Configure the UI by providing this Component as a child of GraphiQL.
 GraphiQL.Toolbar = function GraphiQLToolbar(props) {
-  return <div className="toolbar">{props.children}</div>;
+  return (
+    <div className="toolbar" role="toolbar" aria-label="Editor Commands">
+      {props.children}
+    </div>
+  );
 };
 
 // Export main windows/panes to be used separately if desired.

--- a/packages/graphiql/src/components/HistoryQuery.js
+++ b/packages/graphiql/src/components/HistoryQuery.js
@@ -24,20 +24,11 @@ export default class HistoryQuery extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      showButtons: false,
       editable: false,
     };
   }
 
   render() {
-    const editStyles = {
-      display: this.state.showButtons ? '' : 'none',
-      marginLeft: '10px',
-    };
-    const starStyles = {
-      display: this.props.favorite || this.state.showButtons ? '' : 'none',
-      marginLeft: '10px',
-    };
     const displayName =
       this.props.label ||
       this.props.operationName ||
@@ -47,11 +38,7 @@ export default class HistoryQuery extends React.Component {
         .join('');
     const starIcon = this.props.favorite ? '\u2605' : '\u2606';
     return (
-      <p
-        className={this.state.editable ? 'editable' : undefined}
-        onClick={this.handleClick.bind(this)}
-        onMouseEnter={this.handleMouseEnter.bind(this)}
-        onMouseLeave={this.handleMouseLeave.bind(this)}>
+      <li className={this.state.editable ? 'editable' : undefined}>
         {this.state.editable ? (
           <input
             type="text"
@@ -62,27 +49,28 @@ export default class HistoryQuery extends React.Component {
             placeholder="Type a label"
           />
         ) : (
-          <span className="history-label">{displayName}</span>
+          <button
+            className="history-label"
+            onClick={this.handleClick.bind(this)}>
+            {displayName}
+          </button>
         )}
-        <span onClick={this.handleEditClick.bind(this)} style={editStyles}>
+        <button
+          onClick={this.handleEditClick.bind(this)}
+          aria-label="Edit label">
           {'\u270e'}
-        </span>
-        <span onClick={this.handleStarClick.bind(this)} style={starStyles}>
+        </button>
+        <button
+          className={this.props.favorite ? 'favorited' : undefined}
+          onClick={this.handleStarClick.bind(this)}
+          aria-label={this.props.favorite ? 'Remove favorite' : 'Add favorite'}>
           {starIcon}
-        </span>
-      </p>
+        </button>
+      </li>
     );
   }
 
   editField = null;
-
-  handleMouseEnter() {
-    this.setState({ showButtons: true });
-  }
-
-  handleMouseLeave() {
-    this.setState({ showButtons: false });
-  }
 
   handleClick() {
     this.props.onSelect(

--- a/packages/graphiql/src/components/QueryEditor.js
+++ b/packages/graphiql/src/components/QueryEditor.js
@@ -202,8 +202,9 @@ export class QueryEditor extends React.Component {
 
   render() {
     return (
-      <div
+      <section
         className="query-editor"
+        aria-label="Query Editor"
         ref={node => {
           this._node = node;
         }}

--- a/packages/graphiql/src/components/QueryHistory.js
+++ b/packages/graphiql/src/components/QueryHistory.js
@@ -85,25 +85,25 @@ export class QueryHistory extends React.Component {
 
   render() {
     const queries = this.state.queries.slice().reverse();
-    const queryNodes = queries.map((query, i) => {
+    const queryNodes = queries.map(query => {
       return (
         <HistoryQuery
           handleEditLabel={this.editLabel}
           handleToggleFavorite={this.toggleFavorite}
-          key={i}
+          key={query.query}
           onSelect={this.props.onSelectQuery}
           {...query}
         />
       );
     });
     return (
-      <div>
+      <section aria-label="History">
         <div className="history-title-bar">
           <div className="history-title">{'History'}</div>
           <div className="doc-explorer-rhs">{this.props.children}</div>
         </div>
-        <div className="history-contents">{queryNodes}</div>
-      </div>
+        <ul className="history-contents">{queryNodes}</ul>
+      </section>
     );
   }
 

--- a/packages/graphiql/src/components/ResultViewer.js
+++ b/packages/graphiql/src/components/ResultViewer.js
@@ -105,8 +105,11 @@ export class ResultViewer extends React.Component {
 
   render() {
     return (
-      <div
+      <section
         className="result-window"
+        aria-label="Result Window"
+        aria-live="polite"
+        aria-atomic="true"
         ref={node => {
           this._node = node;
         }}

--- a/packages/graphiql/src/components/ToolbarButton.js
+++ b/packages/graphiql/src/components/ToolbarButton.js
@@ -28,18 +28,18 @@ export class ToolbarButton extends React.Component {
   render() {
     const { error } = this.state;
     return (
-      <a
+      <button
         className={'toolbar-button' + (error ? ' error' : '')}
-        onMouseDown={preventDefault}
         onClick={this.handleClick}
-        title={error ? error.message : this.props.title}>
+        title={error ? error.message : this.props.title}
+        aria-invalid={error ? 'true' : 'false'}
+        aria-description={error ? error.message : null}>
         {this.props.label}
-      </a>
+      </button>
     );
   }
 
-  handleClick = e => {
-    e.preventDefault();
+  handleClick = () => {
     try {
       this.props.onClick();
       this.setState({ error: null });
@@ -47,8 +47,4 @@ export class ToolbarButton extends React.Component {
       this.setState({ error });
     }
   };
-}
-
-function preventDefault(e) {
-  e.preventDefault();
 }


### PR DESCRIPTION
This pull request brings a baseline of accessibility to the various GraphiQL components with a focus on making them usable by keyboard and/or screen readers. Some highlights worth mentioning:

- The various sections of the interface are now implemented as regions (using `<section>` elements) with proper accessible names (using `aria-label`) for identifying their purpose. This is especially important for users who rely on screen readers as it's otherwise very difficult to identify and navigate the different parts of the interface, in particular the query editor and the results viewer.

- All components are now navigable by keyboard, with especially the history pane benefitting from this. Previously, the history pane could not be navigated by keyboard at all as interactions relied solely on mouse events (`mouseenter` and `mouseleave`).

- In extension of the previous point, all interactive components are now implemented as `<button>` elements, ensuring that they correctly communicate to users of assistive technology that they can be interacted with and that standard keyboard interaction works as expected. This was especially critical for the history pane components, which were previously implemented as `<span>` elements without any indicators that users could interact with them beyond a cursor pointer.

- All interactive icons now have accessible names, ensuring that their behaviour is communicated to users of assistive technology. Previously, one would have to guess what these components did when interacted with as the only thing announced were words such as "cross" for the "close" icon or "neuter" for the "search" icon.

- The results viewer is now a live region, ensuring that users of screen readers are made aware of changes to results when queries are evaluated.

I'd love to hear from @cmoody if there are other critical issues not addressed in this pull request that could help solve #954.