### PR TITLE
fix(css): added minimum width for result panel in GraphiQL

### DIFF
--- a/packages/graphiql/css/app.css
+++ b/packages/graphiql/css/app.css
@@ -119,6 +119,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
+  flex-basis: 1em;
   position: relative;
 }
 


### PR DESCRIPTION
# fix(css): Added minimum width for result panel in GraphiQl (#969), solves #969

As discussed in #969 this is a simple fix, just added a `flex-basis: 1em` value to `graphiql/packages/graphiql/css/app.css`.

Since the goal is to keep the panel from disappearing when resized all the way to the left, any value small enough to allow the panel to still be visible and "draggable" by the mouse should work.

I think is a simple solution, nothing in the UI breaks by using the value, but I'm open to listen to other ways or recommendations to implement this change.