### PR TITLE
Fix broken GraphiQL minified build

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -35,6 +35,9 @@
       "git add"
     ]
   },
+  "browserify": {
+    "transform": [["babelify", { "presets": ["@babel/preset-env"] }]]
+  },
   "dependencies": {
     "codemirror": "^5.47.0",
     "codemirror-graphql": "^0.11.1",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "browserify": {
-    "transform": [["babelify", { "presets": ["@babel/preset-env"] }]]
+    "transform": ["babelify"]
   },
   "dependencies": {
     "codemirror": "^5.47.0",

--- a/packages/graphiql/resources/build.sh
+++ b/packages/graphiql/resources/build.sh
@@ -13,7 +13,7 @@ babel src --ignore __tests__ --out-dir dist/
 echo "Bundling graphiql.js..."
 browserify -g browserify-shim -s GraphiQL dist/index.js > graphiql.js
 echo "Bundling graphiql.min.js..."
-browserify -g browserify-shim -t uglifyify -s GraphiQL graphiql.min.js | uglifyjs -c > graphiql.min.js
+browserify -g browserify-shim -t uglifyify -s GraphiQL graphiql.js | uglifyjs -c > graphiql.min.js
 echo "Bundling graphiql.css..."
 postcss --no-map --use autoprefixer -d dist/ css/*.css
 cat dist/*.css > graphiql.css

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": false,
-    "target": "esnext",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": false,
-    "target": "es5",
+    "target": "esnext",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,


### PR DESCRIPTION
The current source used for minifying graphiql in the build script is wrong. Therefore the build is broken. After debugging for the reason while the build was failing, I figured out that in order to use the correct source for the build, we need all the packages used in the build to be transpiled to their es5 equivalents for the build process to work. Main reason being that uglify doesn't support es6 syntax and **requires** es5 to minify the file. Given that the tsconfig specified the target as `esnext`, the builds were transpiled to their es6/es7 equivalents, which is required by graphiql as a dependency, and so uglify breaks.

I'm not sure why we decided to set the tsconfig to `esnext`, but this question should be answered before merging this PR.

This closes #976 