### PR TITLE
🐛 Don't use initial query on every re-render

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -182,10 +182,10 @@ export class GraphiQL extends React.Component {
     if (nextProps.schema !== undefined) {
       nextSchema = nextProps.schema;
     }
-    if (nextProps.query !== undefined) {
+    if (nextProps.query !== undefined && this.props.query !== nextProps.query) {
       nextQuery = nextProps.query;
     }
-    if (nextProps.variables !== undefined) {
+    if (nextProps.variables !== undefined && this.props.variables !== nextProps.variables) {
       nextVariables = nextProps.variables;
     }
     if (nextProps.operationName !== undefined) {


### PR DESCRIPTION
Without this change then when using query to set the initial displayed query and then editing the query in the editor the state was reverted to the initial query on every render (since it reset to nextProps.query even if the prop was not changed).

With the change it behaves as expected (the prop is only used for the intial value and then as long as it isn't changed during the component lifetime, we'll not overwrite the state).