### PR TITLE
fix: hints vertical scroll

### DIFF
--- a/packages/graphiql/css/show-hint.css
+++ b/packages/graphiql/css/show-hint.css
@@ -7,8 +7,8 @@
   margin-left: -6px;
   margin: 0;
   max-height: 14.5em;
-  overflow-y: auto;
   overflow: hidden;
+  overflow-y: auto;
   padding: 0;
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
As I understand, `graphiql` have copied CodeMirror CSS files and sorted properties by alphabet, but it causes the problem: `overflow` override `overflow-y` and disable vertical scroll for the hints.

CodeMirror source file for the hints: https://github.com/codemirror/CodeMirror/blob/master/addon/hint/show-hint.css#L21

![graphiql-hints-scroll](https://user-images.githubusercontent.com/9217163/69816126-d1f8c000-1208-11ea-9664-2e9771ce60b2.gif)
