### PR TITLE
fix: prefer displayName over type equality for children overrides

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -268,14 +268,11 @@ export class GraphiQL extends React.Component {
   render() {
     const children = React.Children.toArray(this.props.children);
 
-    const logo = find(children, child => child.type === GraphiQL.Logo) || (
+    const logo = find(children, child => isChildComponentType(child, GraphiQL.Logo)) || (
       <GraphiQL.Logo />
     );
 
-    const toolbar = find(
-      children,
-      child => child.type === GraphiQL.Toolbar
-    ) || (
+    const toolbar = find(children, child => isChildComponentType(child, GraphiQL.Toolbar)) || (
       <GraphiQL.Toolbar>
         <ToolbarButton
           onClick={this.handlePrettifyQuery}
@@ -300,7 +297,7 @@ export class GraphiQL extends React.Component {
       </GraphiQL.Toolbar>
     );
 
-    const footer = find(children, child => child.type === GraphiQL.Footer);
+    const footer = find(children, child => isChildComponentType(child, GraphiQL.Footer));
 
     const queryWrapStyle = {
       WebkitFlex: this.state.editorFlex,
@@ -1077,6 +1074,7 @@ GraphiQL.Logo = function GraphiQLLogo(props) {
     </div>
   );
 };
+GraphiQL.Logo.displayName = 'GraphiQLLogo';
 
 // Configure the UI by providing this Component as a child of GraphiQL.
 GraphiQL.Toolbar = function GraphiQLToolbar(props) {
@@ -1086,6 +1084,7 @@ GraphiQL.Toolbar = function GraphiQLToolbar(props) {
     </div>
   );
 };
+GraphiQL.Toolbar.displayName = 'GraphiQLToolbar';
 
 // Export main windows/panes to be used separately if desired.
 GraphiQL.QueryEditor = QueryEditor;
@@ -1111,6 +1110,7 @@ GraphiQL.SelectOption = ToolbarSelectOption;
 GraphiQL.Footer = function GraphiQLFooter(props) {
   return <div className="footer">{props.children}</div>;
 };
+GraphiQL.Footer.displayName = 'GraphiQLFooter';
 
 GraphiQL.formatResult = function(result) {
   return JSON.stringify(result, null, 2);
@@ -1190,4 +1190,13 @@ function observableToPromise(observable) {
 // Duck-type observable detection.
 function isObservable(value) {
   return typeof value === 'object' && typeof value.subscribe === 'function';
+}
+
+// Determines if the React child is of the same type of the provided React component
+function isChildComponentType(child, component) {
+  if (child.type && child.type.displayName === component.displayName) {
+    return true;
+  }
+
+  return child.type === component;
 }

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
@@ -143,4 +143,146 @@ describe('GraphiQL', () => {
     );
     expect(graphiQL.state().variableEditorOpen).toEqual(false);
   });
+
+  describe('children overrides', () => {
+    const MyFunctionalComponent = () => { return null; }
+    const wrap = (component) => () => <div>{component}</div>;
+
+    it('properly ignores fragments', () => {
+      const myFragment = (
+        <React.Fragment>
+          <MyFunctionalComponent />
+          <MyFunctionalComponent />
+        </React.Fragment>
+      );
+
+      const graphiQL = mount(
+        <GraphiQL fetcher={noOpFetcher}>
+          {myFragment}
+        </GraphiQL>
+      );
+
+      expect(graphiQL.exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Logo).exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Toolbar).exists()).toEqual(true);
+    });
+
+    it('properly ignores non-override children components', () => {
+      const graphiQL = mount(
+        <GraphiQL fetcher={noOpFetcher}>
+          <MyFunctionalComponent />
+        </GraphiQL>
+      );
+
+      expect(graphiQL.exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Logo).exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Toolbar).exists()).toEqual(true);
+    });
+
+    it('properly ignores non-override class components', () => {
+      class MyClassComponent {
+        render() { return null };
+      }
+
+      const graphiQL = mount(
+        <GraphiQL fetcher={noOpFetcher}>
+          <MyClassComponent />
+        </GraphiQL>
+      );
+
+      expect(graphiQL.exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Logo).exists()).toEqual(true);
+      expect(graphiQL.find(GraphiQL.Toolbar).exists()).toEqual(true);
+    });
+
+    describe('GraphiQL.Logo', () => {
+      it('can be overridden using the exported type', () => {
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher} data-test-selector="override-logo">
+            <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find({ 'data-test-selector': 'override-logo' }).exists()).toEqual(true);
+      });
+
+      it('can be overridden using a named component', () => {
+        const WrappedLogo = wrap(<GraphiQL.Logo data-test-selector="override-logo">{'My Great Logo'}</GraphiQL.Logo>);
+        WrappedLogo.displayName = 'GraphiQLLogo';
+
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedLogo />
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find(WrappedLogo).exists()).toEqual(true);
+        expect(graphiQL.find({ 'data-test-selector': 'override-logo' }).exists()).toEqual(true);
+      });
+    });
+
+    describe('GraphiQL.Toolbar', () => {
+      it('can be overridden using the exported type', () => {
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher}>
+            <GraphiQL.Toolbar data-test-selector="override-toolbar">
+              <GraphiQL.Button />
+            </GraphiQL.Toolbar>
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists()).toEqual(true);
+      });
+
+      it('can be overridden using a named component', () => {
+        const WrappedToolbar = wrap(
+          <GraphiQL.Toolbar data-test-selector="override-toolbar">
+            <GraphiQL.Button />
+          </GraphiQL.Toolbar>
+        );
+        WrappedToolbar.displayName = 'GraphiQLToolbar';
+
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedToolbar />
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find(WrappedToolbar).exists()).toEqual(true);
+        expect(graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists()).toEqual(true);
+      });
+    });
+
+    describe('GraphiQL.Footer', () => {
+      it('can be overridden using the exported type', () => {
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher}>
+            <GraphiQL.Footer data-test-selector="override-footer">
+              <GraphiQL.Button />
+            </GraphiQL.Footer>
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find({ 'data-test-selector': 'override-footer' }).exists()).toEqual(true);
+      });
+
+      it('can be overridden using a named component', () => {
+        const WrappedFooter = wrap(
+          <GraphiQL.Footer data-test-selector="override-footer">
+            <GraphiQL.Button />
+          </GraphiQL.Footer>
+        );
+        WrappedFooter.displayName = 'GraphiQLFooter';
+
+        const graphiQL = mount(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedFooter />
+          </GraphiQL>
+        );
+
+        expect(graphiQL.find(WrappedFooter).exists()).toEqual(true);
+        expect(graphiQL.find({ 'data-test-selector': 'override-footer' }).exists()).toEqual(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This should fix #671.

The core issue here was that when `GraphiQL.xxx` got wrapped by some other component, `.type` would on the child would be of that wrapper causing the the type equality check to fail. 

By checking for `displayName` first, consumers can set `displayName` on their wrapped components and still be able to override graphiql components.