### PR TITLE
fix: exclusion for nonbreakable whitespace chars

### DIFF
--- a/packages/graphql-language-service-parser/src/Rules.ts
+++ b/packages/graphql-language-service-parser/src/Rules.ts
@@ -26,7 +26,8 @@ export const isIgnored = (ch: string) =>
   ch === ',' ||
   ch === '\n' ||
   ch === '\r' ||
-  ch === '\uFEFF';
+  ch === '\uFEFF' ||
+  ch === '\u00A0';
 
 /**
  * The lexer rules. These are exactly as described by the spec.


### PR DESCRIPTION
originally by @PascalSenn in graphql/graphql-language-service#220

- fixes `Mode graphql failed to advance stream` further down in the LSP
- same bug we worked around in GraphiQL or graphql-cm? months ago.
- resolves the issue at the LSP level (parser), for both server/browser contexts