### PR TITLE
fix: componentWillReceiveProps warning messages

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -151,6 +151,9 @@ export class GraphiQL extends React.Component {
     // Ensure only the last executed editor query is rendered.
     this._editorQueryID = 0;
 
+    // Ref to QueryHistory component
+    this._queryHistory = null;
+
     // Subscribe to the browser window closing, treating it as an unmount.
     if (typeof window === 'object') {
       window.addEventListener('beforeunload', () =>
@@ -172,7 +175,9 @@ export class GraphiQL extends React.Component {
     global.g = this;
   }
 
-  componentWillReceiveProps(nextProps) {
+  // TODO: refactor and remove after updating to React 16
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) { 
     let nextSchema = this.state.schema;
     let nextQuery = this.state.query;
     let nextVariables = this.state.variables;
@@ -327,6 +332,7 @@ export class GraphiQL extends React.Component {
       <div className="graphiql-container">
         <div className="historyPaneWrap" style={historyPaneStyle}>
           <QueryHistory
+            ref={node => { this._queryHistory = node }}
             operationName={this.state.operationName}
             query={this.state.query}
             variables={this.state.variables}
@@ -686,6 +692,12 @@ export class GraphiQL extends React.Component {
         response: null,
         operationName,
       });
+
+      this._queryHistory.updateHistory(
+        editedQuery,
+        variables,
+        operationName
+      );
 
       // _fetchQuery may return a subscription.
       const subscription = this._fetchQuery(

--- a/packages/graphiql/src/components/QueryHistory.js
+++ b/packages/graphiql/src/components/QueryHistory.js
@@ -14,32 +14,29 @@ import HistoryQuery from './HistoryQuery';
 const MAX_QUERY_SIZE = 100000;
 const MAX_HISTORY_LENGTH = 20;
 
-const shouldSaveQuery = (nextProps, current, lastQuerySaved) => {
-  if (nextProps.queryID === current.queryID) {
-    return false;
-  }
+const shouldSaveQuery = (query, variables, lastQuerySaved) => {
   try {
-    parse(nextProps.query);
+    parse(query);
   } catch (e) {
     return false;
   }
   // Don't try to save giant queries
-  if (nextProps.query.length > MAX_QUERY_SIZE) {
+  if (query.length > MAX_QUERY_SIZE) {
     return false;
   }
   if (!lastQuerySaved) {
     return true;
   }
   if (
-    JSON.stringify(nextProps.query) === JSON.stringify(lastQuerySaved.query)
+    JSON.stringify(query) === JSON.stringify(lastQuerySaved.query)
   ) {
     if (
-      JSON.stringify(nextProps.variables) ===
+      JSON.stringify(variables) ===
       JSON.stringify(lastQuerySaved.variables)
     ) {
       return false;
     }
-    if (!nextProps.variables && !lastQuerySaved.variables) {
+    if (!variables && !lastQuerySaved.variables) {
       return false;
     }
   }
@@ -67,25 +64,6 @@ export class QueryHistory extends React.Component {
     this.state = { queries };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (
-      shouldSaveQuery(nextProps, this.props, this.historyStore.fetchRecent())
-    ) {
-      const item = {
-        query: nextProps.query,
-        variables: nextProps.variables,
-        operationName: nextProps.operationName,
-      };
-      this.historyStore.push(item);
-      const historyQueries = this.historyStore.items;
-      const favoriteQueries = this.favoriteStore.items;
-      const queries = historyQueries.concat(favoriteQueries);
-      this.setState({
-        queries,
-      });
-    }
-  }
-
   render() {
     const queries = this.state.queries.slice().reverse();
     const queryNodes = queries.map((query, i) => {
@@ -108,6 +86,24 @@ export class QueryHistory extends React.Component {
         <ul className="history-contents">{queryNodes}</ul>
       </section>
     );
+  }
+
+  updateHistory(query, variables, operationName) {
+    if (
+      shouldSaveQuery(query, variables, this.historyStore.fetchRecent())
+    ) {
+      this.historyStore.push({
+        query,
+        variables,
+        operationName,
+      });
+      const historyQueries = this.historyStore.items;
+      const favoriteQueries = this.favoriteStore.items;
+      const queries = historyQueries.concat(favoriteQueries);
+      this.setState({
+        queries,
+      });
+    }
   }
 
   toggleFavorite = (query, variables, operationName, label, favorite) => {


### PR DESCRIPTION
Fixes #970

* prefixed `componentWillReceiveProps` in `GraphiQL` with `UNSAFE_`
* removed use of `componentWillReceiveProps` in `QueryHistory` and added a class method to be called by parent component instead