### PR TITLE
fix: linting issues, trailingCommas: all

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,25 +5,14 @@
 # specifically un-ignore the source code, configuration files, etc.
 #
 # First: ignore FILES (not folders!)
+/{packages,examples}/**/*.{js,jsx,ts,tsx}
 
-/packages/**/*.js
-/packages/**/*.jsx
-/packages/**/*.ts
-/packages/**/*.tsx
-
-/examples/**/*.js
-/examples/**/*.jsx
-/examples/**/*.ts
-/examples/**/*.tsx
 #
 # Now un-ignore source code, tests, configuration, etc
-!/packages/*/src/**
-!/packages/*/cypress/**
-!/packages/*/test/**
-!/packages/codemirror-graphql/resources/**
+!/{packages,examples}/*/{src,cypress,resources}/**
+
 !.eslintrc.js
 !babel.config.js
-!/examples/**/{src,resources,cypress}/*
 #
 # End of the ignore dance.
 #
@@ -33,7 +22,7 @@
 
 # ESLint automatically ignores node_modules _in the root_, so we only need to specify nested node_modules
 **/node_modules
-/examples/graphiql-cdn/graphiql*
+/packages/graphiql/graphiql.*
 
 # Build artifacts
 **/flow-typed

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,7 @@ module.exports = {
     'no-regex-spaces': 1,
     'no-sparse-arrays': 1,
     'no-template-curly-in-string': 0,
-    'no-unexpected-multiline': 1,
+    'no-unexpected-multiline': 0, // prettier --list-different
     'no-unreachable': 1,
     'no-unsafe-finally': 1,
     'no-unsafe-negation': 1,
@@ -102,7 +102,7 @@ module.exports = {
     'no-extra-bind': 1,
     'no-extra-label': 1,
     'no-fallthrough': 1,
-    'no-floating-decimal': 1,
+    'no-floating-decimal': 0, // prettier --list-different
     'no-global-assign': 1,
     'no-implicit-coercion': 1,
     'no-implicit-globals': 0,
@@ -187,7 +187,7 @@ module.exports = {
     'id-match': 0,
     indent: 0,
     'line-comment-position': 0,
-    'linebreak-style': 1,
+    'linebreak-style': 0, // prettier --list-different
     'lines-around-comment': 0,
     'lines-around-directive': 0,
     'max-depth': 0,
@@ -246,7 +246,7 @@ module.exports = {
     'no-useless-rename': 1,
     'no-var': 1,
     'object-shorthand': 1,
-    'prefer-arrow-callback': [1, { allowNamedFunctions: true }],
+    'prefer-arrow-callback': [0, { allowNamedFunctions: true }], // prettier --list-different
     'prefer-const': 1,
     'prefer-numeric-literals': 0,
     'prefer-rest-params': 0,
@@ -316,7 +316,7 @@ module.exports = {
       files: ['*.js', '*.jsx'],
       rules: {
         // flowtype (https://github.com/gajus/eslint-plugin-flowtype)
-        'flowtype/boolean-style': 1,
+        'flowtype/boolean-style': 0, // prettier --list-different
         'flowtype/define-flow-type': 1,
         'flowtype/no-dupe-keys': 0,
         'flowtype/no-primitive-constructor-types': 1,

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ As of December 2019 we are officially supporting Windows OS for development tool
 3. `yarn build-bundles` - builds webpack bundles that are used for releases
 4. `yarn build-demo` - builds demo projects for netlify; we run this on CI to make sure webpack can consume our project in a standalone project.
 5. `yarn test` - runs all of the above alongside linting and checks, jest mocha Cypress etc.
-6. `yarn pretty` - autoformats
+6. `yarn format` - autoformats with eslint --fix and prettier
 7. `yarn lint` - checks for linting issues
 8. `yarn e2e` - runs cypress headlessly against the minified bundle and a local schema server, like in CI.
-9. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn jest --watch` or `yarn jest DocExplorer` for example :D
+9.  `yarn jest` - runs global jest commands across the entire monorepo; try `yarn jest --watch` or `yarn jest DocExplorer` for example :D
 
 Learn more in [`CONTRIBUTING.md`](./CONTRIBUTING.md) documentation.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ As of December 2019 we are officially supporting Windows OS for development tool
 6. `yarn format` - autoformats with eslint --fix and prettier
 7. `yarn lint` - checks for linting issues
 8. `yarn e2e` - runs cypress headlessly against the minified bundle and a local schema server, like in CI.
-9.  `yarn jest` - runs global jest commands across the entire monorepo; try `yarn jest --watch` or `yarn jest DocExplorer` for example :D
+9. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn jest --watch` or `yarn jest DocExplorer` for example :D
 
 Learn more in [`CONTRIBUTING.md`](./CONTRIBUTING.md) documentation.
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,15 @@
     "packages/*",
     "examples/*"
   ],
+  "lint-staged": {
+    "*.{js,ts,jsx,tsx,md}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn pretty && yarn lint --fix && yarn lint",
+      "pre-commit": "lint-staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
@@ -30,6 +36,7 @@
     "check": "flow check --show-all-errors",
     "pretty": "node resources/pretty.js",
     "pretty-check": "node resources/pretty.js --check",
+    "format": "yarn eslint --fix && yarn pretty",
     "version-release": "lerna version",
     "version-prerelease": "lerna version --conventional-prerelease",
     "version-graduate": "lerna version --conventional-graduate"
@@ -74,6 +81,7 @@
     "jest-environment-jsdom": "^24.8.0",
     "jest-environment-jsdom-global": "^1.2.0",
     "lerna": "^3.16.4",
+    "lint-staged": "^10.0.0-beta.8",
     "mkdirp": "^0.5.1",
     "mocha": "6.1.4",
     "prettier": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "husky": {
     "hooks": {
-      "pre-commit": "yarn lint",
+      "pre-commit": "yarn pretty && yarn lint --fix && yarn lint",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
@@ -23,9 +23,9 @@
     "e2e": "yarn workspace graphiql e2e",
     "cypress-open": "yarn workspace graphiql cypress-open",
     "t": "yarn run testonly",
-    "eslint": "eslint",
-    "lint": "eslint --ext=ts,js,jsx,tsx .",
-    "lint-fix": "eslint --ext=ts,js,jsx,tsx . --fix",
+    "eslint": "eslint --ext=ts,js,jsx,tsx .",
+    "lint": "yarn eslint && yarn lint-check && yarn pretty-check",
+    "lint-fix": "yarn eslint --fix",
     "lint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "check": "flow check --show-all-errors",
     "pretty": "node resources/pretty.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "e2e": "yarn workspace graphiql e2e",
     "cypress-open": "yarn workspace graphiql cypress-open",
     "t": "yarn run testonly",
+    "eslint": "eslint",
     "lint": "eslint --ext=ts,js,jsx,tsx .",
     "lint-fix": "eslint --ext=ts,js,jsx,tsx . --fix",
     "lint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "e2e": "yarn workspace graphiql e2e",
     "cypress-open": "yarn workspace graphiql cypress-open",
     "t": "yarn run testonly",
-    "lint": "eslint --ext=ts,js,jsx,tsx . || (printf '\\033[33mTry: \\033[7m yarn format \\033[0m\\n' && exit 1)",
+    "lint": "eslint --ext=ts,js,jsx,tsx .",
     "lint-fix": "eslint --ext=ts,js,jsx,tsx . --fix",
     "lint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "check": "flow check --show-all-errors",

--- a/packages/codemirror-graphql/resources/watch.js
+++ b/packages/codemirror-graphql/resources/watch.js
@@ -101,14 +101,14 @@ function checkFiles(filepaths) {
     .then(testSuccess =>
       lintFiles(filepaths).then(lintSuccess =>
         typecheckStatus().then(
-          typecheckSuccess => testSuccess && lintSuccess && typecheckSuccess
-        )
-      )
+          typecheckSuccess => testSuccess && lintSuccess && typecheckSuccess,
+        ),
+      ),
     )
     .catch(() => false)
     .then(success => {
       process.stdout.write(
-        '\n' + (success ? '' : '\x07') + green(invert('watching...'))
+        '\n' + (success ? '' : '\x07') + green(invert('watching...')),
       );
     });
 }
@@ -129,7 +129,7 @@ function parseFiles(filepaths) {
           srcPath(filepath),
         ]);
       }
-    })
+    }),
   );
 }
 
@@ -141,8 +141,8 @@ function runTests(filepaths) {
     ['--reporter', 'progress', '--require', 'resources/mocha-bootload'].concat(
       allTests(filepaths)
         ? filepaths.map(srcPath)
-        : ['src/**/__tests__/**/*.js']
-    )
+        : ['src/**/__tests__/**/*.js'],
+    ),
   ).catch(() => false);
 }
 
@@ -158,14 +158,14 @@ function lintFiles(filepaths) {
             .catch(() => false)
             .then(success => {
               console.log(
-                CLEARLINE + '  ' + (success ? CHECK : X) + ' ' + filepath
+                CLEARLINE + '  ' + (success ? CHECK : X) + ' ' + filepath,
               );
               return prevSuccess && success;
             });
         }
         return prevSuccess;
       }),
-    Promise.resolve(true)
+    Promise.resolve(true),
   );
 }
 

--- a/packages/codemirror-graphql/src/__tests__/hint-test.js
+++ b/packages/codemirror-graphql/src/__tests__/hint-test.js
@@ -52,7 +52,7 @@ describe('graphql-hint', () => {
   it('attaches a GraphQL hint function with correct mode/hint options', async () => {
     const editor = await createEditorWithHint();
     expect(editor.getHelpers(editor.getCursor(), 'hint')).to.not.have.lengthOf(
-      0
+      0,
     );
   });
 
@@ -72,11 +72,11 @@ describe('graphql-hint', () => {
     const suggestions = await getHintSuggestions('{ ', { line: 0, ch: 2 });
     const fieldConfig = TestSchema.getQueryType().getFields();
     const fieldNames = Object.keys(fieldConfig).filter(
-      name => !fieldConfig[name].isDeprecated
+      name => !fieldConfig[name].isDeprecated,
     );
     checkSuggestions(
       fieldNames.concat(['__typename', '__schema', '__type']),
-      suggestions.list
+      suggestions.list,
     );
 
     const fieldTypes = fieldNames.map(name => fieldConfig[name].type);
@@ -85,7 +85,7 @@ describe('graphql-hint', () => {
         item =>
           item.text !== '__schema' &&
           item.text !== '__type' &&
-          item.text !== '__typename'
+          item.text !== '__typename',
       )
       .map(item => item.type);
     expect(fieldTypes).to.deep.equal(expectedTypes);
@@ -99,7 +99,7 @@ describe('graphql-hint', () => {
     const fieldConfig = TestSchema.getType('First').getFields();
     checkSuggestions(
       [...Object.keys(fieldConfig), '__typename'],
-      suggestions.list
+      suggestions.list,
     );
   });
 
@@ -161,7 +161,7 @@ describe('graphql-hint', () => {
   it('provides correct directive suggestions on args definitions', async () => {
     const suggestions = await getHintSuggestions(
       'type Type { field(arg: String @',
-      { line: 0, ch: 31 }
+      { line: 0, ch: 31 },
     );
     const directiveNames = ['onArg', 'onAllDefs'];
     checkSuggestions(directiveNames, suggestions.list);
@@ -209,7 +209,7 @@ describe('graphql-hint', () => {
       ch: 21,
     });
     const testInputNames = Object.keys(
-      TestSchema.getType('TestInput').getFields()
+      TestSchema.getType('TestInput').getFields(),
     );
     checkSuggestions(testInputNames, suggestions.list);
   });
@@ -217,7 +217,7 @@ describe('graphql-hint', () => {
   it('provides fragment name suggestion', async () => {
     const suggestions = await getHintSuggestions(
       'fragment Foo on Test { id }  query { ...',
-      { line: 0, ch: 40 }
+      { line: 0, ch: 40 },
     );
     checkSuggestions(['Foo'], suggestions.list);
   });
@@ -225,7 +225,7 @@ describe('graphql-hint', () => {
   it('provides fragment names for fragments defined lower', async () => {
     const suggestions = await getHintSuggestions(
       'query { ... } fragment Foo on Test { id }',
-      { line: 0, ch: 11 }
+      { line: 0, ch: 11 },
     );
     checkSuggestions(['Foo'], suggestions.list);
   });
@@ -237,7 +237,7 @@ describe('graphql-hint', () => {
         'fragment Baz on Second { name } ' +
         'fragment Qux on TestUnion { name } ' +
         'fragment Nrf on Test { id }',
-      { line: 0, ch: 31 }
+      { line: 0, ch: 31 },
     );
     checkSuggestions(['Bar', 'Baz', 'Qux'], suggestions.list);
   });
@@ -245,7 +245,7 @@ describe('graphql-hint', () => {
   it('provides correct field name suggestion inside inline fragment', async () => {
     const suggestions = await getHintSuggestions(
       'fragment Foo on TestUnion { ... on First { ',
-      { line: 0, ch: 43 }
+      { line: 0, ch: 43 },
     );
     const fieldNames = Object.keys(TestSchema.getType('First').getFields());
     fieldNames.push('__typename');
@@ -255,7 +255,7 @@ describe('graphql-hint', () => {
   it('provides correct field name suggestion inside typeless inline fragment', async () => {
     const suggestions = await getHintSuggestions(
       'fragment Foo on First { ... { ',
-      { line: 0, ch: 30 }
+      { line: 0, ch: 30 },
     );
     const fieldNames = Object.keys(TestSchema.getType('First').getFields());
     fieldNames.push('__typename');

--- a/packages/codemirror-graphql/src/__tests__/lint-test.js
+++ b/packages/codemirror-graphql/src/__tests__/lint-test.js
@@ -44,7 +44,7 @@ describe('graphql-lint', () => {
   it('attaches a GraphQL lint function with correct mode/lint options', () => {
     const editor = createEditorWithLint();
     expect(editor.getHelpers(editor.getCursor(), 'lint')).to.not.have.lengthOf(
-      0
+      0,
     );
   });
 

--- a/packages/codemirror-graphql/src/__tests__/mode-test.js
+++ b/packages/codemirror-graphql/src/__tests__/mode-test.js
@@ -39,7 +39,7 @@ describe('graphql-mode', () => {
 
   it('parses Relay-style anonymous FragmentDefinitions', () => {
     CodeMirror.runMode('fragment on Test { id }', 'graphql', (token, style) =>
-      expect(style).to.not.equal('invalidchar')
+      expect(style).to.not.equal('invalidchar'),
     );
   });
 
@@ -47,17 +47,17 @@ describe('graphql-mode', () => {
     CodeMirror.runMode(
       '{ ... on OptionalType { name } }',
       'graphql',
-      (token, style) => expect(style).to.not.equal('invalidchar')
+      (token, style) => expect(style).to.not.equal('invalidchar'),
     );
 
     CodeMirror.runMode('{ ... { name } }', 'graphql', (token, style) =>
-      expect(style).to.not.equal('invalidchar')
+      expect(style).to.not.equal('invalidchar'),
     );
 
     CodeMirror.runMode(
       '{ ... @optionalDirective { name } }',
       'graphql',
-      (token, style) => expect(style).to.not.equal('invalidchar')
+      (token, style) => expect(style).to.not.equal('invalidchar'),
     );
   });
 
@@ -88,7 +88,7 @@ describe('graphql-mode', () => {
   it('parses schema-kitchen-sink query without invalidchar', () => {
     const schemaKitchenSink = readFileSync(
       join(__dirname, '/schema-kitchen-sink.graphql'),
-      { encoding: 'utf8' }
+      { encoding: 'utf8' },
     );
 
     CodeMirror.runMode(schemaKitchenSink, 'graphql', (token, style) => {
@@ -110,7 +110,7 @@ describe('graphql-mode', () => {
       'graphql',
       (token, style) => {
         expect(style).to.not.equal('invalidchar');
-      }
+      },
     );
 
     CodeMirror.runMode(
@@ -124,7 +124,7 @@ describe('graphql-mode', () => {
       'graphql',
       (token, style) => {
         expect(style).to.not.equal('invalidchar');
-      }
+      },
     );
   });
 });

--- a/packages/codemirror-graphql/src/hint.js
+++ b/packages/codemirror-graphql/src/hint.js
@@ -39,7 +39,7 @@ CodeMirror.registerHelper('hint', 'graphql', (editor, options) => {
     schema,
     editor.getValue(),
     cur,
-    token
+    token,
   );
   /**
    * GraphQL language service responds to the autocompletion request with

--- a/packages/codemirror-graphql/src/utils/SchemaReference.js
+++ b/packages/codemirror-graphql/src/utils/SchemaReference.js
@@ -103,7 +103,7 @@ export function getEnumValueReference(typeInfo: any): EnumValueReference {
 // though it defaults to the current type.
 export function getTypeReference(
   typeInfo: any,
-  type?: GraphQLNamedType
+  type?: GraphQLNamedType,
 ): TypeReference {
   return {
     kind: 'Type',

--- a/packages/codemirror-graphql/src/utils/__tests__/jsonParse-test.js
+++ b/packages/codemirror-graphql/src/utils/__tests__/jsonParse-test.js
@@ -23,17 +23,17 @@ describe('jsonParse', () => {
     checkEscapedString(
       '{ "test": "\\"" }',
       { kind: 'String', start: 2, end: 8, value: 'test' },
-      { kind: 'String', start: 10, end: 14, value: '"' }
+      { kind: 'String', start: 10, end: 14, value: '"' },
     );
     checkEscapedString(
       '{ "test": "\\\\" }',
       { kind: 'String', start: 2, end: 8, value: 'test' },
-      { kind: 'String', start: 10, end: 14, value: '\\' }
+      { kind: 'String', start: 10, end: 14, value: '\\' },
     );
     checkEscapedString(
       '{ "slash": "\\/" }',
       { kind: 'String', start: 2, end: 9, value: 'slash' },
-      { kind: 'String', start: 11, end: 15, value: '/' }
+      { kind: 'String', start: 11, end: 15, value: '/' },
     );
   });
 });

--- a/packages/codemirror-graphql/src/utils/hintList.js
+++ b/packages/codemirror-graphql/src/utils/hintList.js
@@ -40,14 +40,14 @@ function filterAndSortList(list, text) {
 
   const conciseMatches = filterNonEmpty(
     filterNonEmpty(byProximity, pair => pair.proximity <= 2),
-    pair => !pair.entry.isDeprecated
+    pair => !pair.entry.isDeprecated,
   );
 
   const sortedMatches = conciseMatches.sort(
     (a, b) =>
       (a.entry.isDeprecated ? 1 : 0) - (b.entry.isDeprecated ? 1 : 0) ||
       a.proximity - b.proximity ||
-      a.entry.text.length - b.entry.text.length
+      a.entry.text.length - b.entry.text.length,
   );
 
   return sortedMatches.map(pair => pair.entry);
@@ -113,7 +113,7 @@ function lexicalDistance(a, b) {
       d[i][j] = Math.min(
         d[i - 1][j] + 1,
         d[i][j - 1] + 1,
-        d[i - 1][j - 1] + cost
+        d[i - 1][j - 1] + cost,
       );
 
       if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {

--- a/packages/codemirror-graphql/src/utils/info-addon.js
+++ b/packages/codemirror-graphql/src/utils/info-addon.js
@@ -69,10 +69,9 @@ function onMouseOver(cm, e) {
     onMouseHover(cm, box);
   };
 
-
   const hoverTime = getHoverTime(cm);
   state.hoverTimeout = setTimeout(onHover, hoverTime);
-  
+
   CodeMirror.on(document, 'mousemove', onMouseMove);
   CodeMirror.on(cm.getWrapperElement(), 'mouseout', onMouseOut);
 }

--- a/packages/codemirror-graphql/src/utils/jump-addon.js
+++ b/packages/codemirror-graphql/src/utils/jump-addon.js
@@ -134,7 +134,7 @@ function enableJumpMode(cm) {
       const marker = cm.markText(
         { line: pos.line, ch: token.start },
         { line: pos.line, ch: token.end },
-        { className: 'CodeMirror-jump-token' }
+        { className: 'CodeMirror-jump-token' },
       );
 
       cm.state.jump.marker = marker;

--- a/packages/codemirror-graphql/src/variables/__tests__/hint-test.js
+++ b/packages/codemirror-graphql/src/variables/__tests__/hint-test.js
@@ -54,7 +54,7 @@ describe('graphql-variables-hint', () => {
   it('attaches a GraphQL hint function with correct mode/hint options', async () => {
     const editor = await createEditorWithHint('{ f }');
     expect(editor.getHelpers(editor.getCursor(), 'hint')).to.not.have.lengthOf(
-      0
+      0,
     );
   });
 
@@ -68,7 +68,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($foo: String!, $bar: Int) { f }',
       '{ ',
-      { line: 0, ch: 2 }
+      { line: 0, ch: 2 },
     );
     checkSuggestions(['"foo": ', '"bar": '], suggestions.list);
   });
@@ -77,7 +77,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($foo: String!, $bar: Int) { f }',
       '{\n  ',
-      { line: 1, ch: 2 }
+      { line: 1, ch: 2 },
     );
     expect(suggestions.from).to.deep.equal({ line: 1, ch: 2, sticky: null });
     expect(suggestions.to).to.deep.equal({ line: 1, ch: 2, sticky: null });
@@ -87,7 +87,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($foo: String!, $bar: Int) { f }',
       '{\n  ba',
-      { line: 1, ch: 4 }
+      { line: 1, ch: 4 },
     );
     checkSuggestions(['"bar": '], suggestions.list);
     expect(suggestions.from).to.deep.equal({ line: 1, ch: 2, sticky: null });
@@ -98,7 +98,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($foo: String!, $bar: Int) { f }',
       '{\n  "',
-      { line: 1, ch: 4 }
+      { line: 1, ch: 4 },
     );
     checkSuggestions(['"foo": ', '"bar": '], suggestions.list);
     expect(suggestions.from).to.deep.equal({ line: 1, ch: 2, sticky: null });
@@ -109,12 +109,12 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($myEnum: TestEnum) { f }',
       '{\n  "myEnum": ',
-      { line: 1, ch: 12 }
+      { line: 1, ch: 12 },
     );
     const TestEnum = TestSchema.getType('TestEnum');
     checkSuggestions(
       TestEnum.getValues().map(value => `"${value.name}"`),
-      suggestions.list
+      suggestions.list,
     );
   });
 
@@ -122,7 +122,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($myInput: TestInput) { f }',
       '{\n  "myInput": ',
-      { line: 1, ch: 13 }
+      { line: 1, ch: 13 },
     );
     checkSuggestions(['{'], suggestions.list);
   });
@@ -131,12 +131,12 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($myInput: TestInput) { f }',
       '{\n  "myInput": {\n    ',
-      { line: 2, ch: 4 }
+      { line: 2, ch: 4 },
     );
     const TestInput = TestSchema.getType('TestInput');
     checkSuggestions(
       Object.keys(TestInput.getFields()).map(name => `"${name}": `),
-      suggestions.list
+      suggestions.list,
     );
     expect(suggestions.from).to.deep.equal({ line: 2, ch: 4, sticky: null });
     expect(suggestions.to).to.deep.equal({ line: 2, ch: 4, sticky: null });
@@ -146,7 +146,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($myInput: TestInput) { f }',
       '{\n  "myInput": {\n    bool',
-      { line: 2, ch: 8 }
+      { line: 2, ch: 8 },
     );
     checkSuggestions(['"boolean": ', '"listBoolean": '], suggestions.list);
     expect(suggestions.from).to.deep.equal({ line: 2, ch: 4, sticky: null });
@@ -157,7 +157,7 @@ describe('graphql-variables-hint', () => {
     const suggestions = await getHintSuggestions(
       'query ($myInput: TestInput) { f }',
       '{\n  "myInput": {\n    "boolean": ',
-      { line: 2, ch: 15 }
+      { line: 2, ch: 15 },
     );
     checkSuggestions(['true', 'false'], suggestions.list);
   });

--- a/packages/codemirror-graphql/src/variables/__tests__/lint-test.js
+++ b/packages/codemirror-graphql/src/variables/__tests__/lint-test.js
@@ -46,20 +46,20 @@ describe('graphql-variables-lint', () => {
   it('attaches a GraphQL lint function with correct mode/lint options', () => {
     const editor = createEditorWithLint();
     expect(editor.getHelpers(editor.getCursor(), 'lint')).to.not.have.lengthOf(
-      0
+      0,
     );
   });
 
   it('catches syntax errors', async () => {
     expect((await printLintErrors(null, '{ foo: "bar" }'))[0].message).to.equal(
-      'Expected String but found `foo`.'
+      'Expected String but found `foo`.',
     );
   });
 
   it('catches type validation errors', async () => {
     const errors = await printLintErrors(
       'query ($foo: Int) { f }',
-      ' { "foo": "NaN" }'
+      ' { "foo": "NaN" }',
     );
 
     expect(errors[0]).to.deep.equal({
@@ -74,7 +74,7 @@ describe('graphql-variables-lint', () => {
   it('reports unknown variable names', async () => {
     const errors = await printLintErrors(
       'query ($foo: Int) { f }',
-      ' { "food": "NaN" }'
+      ' { "food": "NaN" }',
     );
 
     expect(errors[0]).to.deep.equal({

--- a/packages/codemirror-graphql/src/variables/hint.js
+++ b/packages/codemirror-graphql/src/variables/hint.js
@@ -80,7 +80,7 @@ function getVariablesHint(cur, token, options) {
       variableNames.map(name => ({
         text: `"${name}": `,
         type: variableToType[name],
-      }))
+      })),
     );
   }
 
@@ -88,7 +88,7 @@ function getVariablesHint(cur, token, options) {
   if (kind === 'ObjectValue' || (kind === 'ObjectField' && step === 0)) {
     if (typeInfo.fields) {
       const inputFields = Object.keys(typeInfo.fields).map(
-        fieldName => typeInfo.fields[fieldName]
+        fieldName => typeInfo.fields[fieldName],
       );
       return hintList(
         cur,
@@ -97,7 +97,7 @@ function getVariablesHint(cur, token, options) {
           text: `"${field.name}": `,
           type: field.type,
           description: field.description,
-        }))
+        })),
       );
     }
   }
@@ -125,7 +125,7 @@ function getVariablesHint(cur, token, options) {
           text: `"${value.name}"`,
           type: namedInputType,
           description: value.description,
-        }))
+        })),
       );
     } else if (namedInputType === GraphQLBoolean) {
       return hintList(cur, token, [

--- a/packages/codemirror-graphql/src/variables/lint.js
+++ b/packages/codemirror-graphql/src/variables/lint.js
@@ -58,7 +58,7 @@ CodeMirror.registerHelper(
 
     // Then highlight any issues with the provided variables.
     return validateVariables(editor, variableToType, ast);
-  }
+  },
 );
 
 // Given a variableToType object, a source text, and a JSON AST, produces a
@@ -74,8 +74,8 @@ function validateVariables(editor, variableToType, variablesAST) {
         lintError(
           editor,
           member.key,
-          `Variable "$${variableName}" does not appear in any GraphQL query.`
-        )
+          `Variable "$${variableName}" does not appear in any GraphQL query.`,
+        ),
       );
     } else {
       validateValue(type, member.value).forEach(([node, message]) => {

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -21,13 +21,6 @@
     "graphiql.css",
     "graphiql.min.css"
   ],
-  "nyc": {
-    "report-dir": "coverage/cypress",
-    "reporter": [
-      "lcov",
-      "json"
-    ]
-  },
   "scripts": {
     "webpack": "webpack --config resources/webpack.config.js",
     "analyze-bundle": "cross-env NODE_ENV=production CDN=1 ANALYZE=1 yarn webpack -p",
@@ -46,12 +39,6 @@
     "e2e": "yarn e2e-server 'cypress run'",
     "e2e-server": "start-server-and-test 'cross-env PORT=8080 node test/e2e-server' 'http-get://localhost:8080/graphql?query={test { id }}'",
     "test": "cross-env ENZYME=true node ../../resources/runTests"
-  },
-  "lint-staged": {
-    "*.js": [
-      "prettier --write",
-      "git add"
-    ]
   },
   "dependencies": {
     "codemirror": "^5.47.0",

--- a/packages/graphiql/postcss.config.js
+++ b/packages/graphiql/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = ({ file, options, env }) => ({
+module.exports = ({ file, options }) => ({
   plugins: {
     'postcss-import': { root: file.dirname },
     // contains autoprefixer, etc

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -17,7 +17,7 @@ search
     var eq = entry.indexOf('=');
     if (eq >= 0) {
       parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
-        entry.slice(eq + 1)
+        entry.slice(eq + 1),
       );
     }
   });
@@ -28,7 +28,7 @@ if (parameters.variables) {
     parameters.variables = JSON.stringify(
       JSON.parse(parameters.variables),
       null,
-      2
+      2,
     );
   } catch (e) {
     // Do nothing, we want to display the invalid JSON as a string, rather
@@ -77,7 +77,7 @@ function graphQLFetcher(graphQLParams) {
   // In a PR preview, it connects to the Star Wars API externally.
   // Change this to point wherever you host your GraphQL server.
   const isDev = !window.location.hostname.match(
-    /(^|\.)netlify\.com$|(^|\.)graphql\.org$/
+    /(^|\.)netlify\.com$|(^|\.)graphql\.org$/,
   );
   const api = isDev ? '/graphql' : 'https://swapi.graph.cool/';
   return fetch(api, {
@@ -116,5 +116,5 @@ ReactDOM.render(
     defaultVariableEditorOpen: true,
     onEditOperationName: onEditOperationName,
   }),
-  document.getElementById('graphiql')
+  document.getElementById('graphiql'),
 );

--- a/packages/graphiql/src/components/DocExplorer/SearchBox.js
+++ b/packages/graphiql/src/components/DocExplorer/SearchBox.js
@@ -26,7 +26,9 @@ export default class SearchBox extends React.Component {
   render() {
     return (
       <label className="search-box">
-        <div className="search-box-icon" aria-hidden="true">{'\u26b2'}</div>
+        <div className="search-box-icon" aria-hidden="true">
+          {'\u26b2'}
+        </div>
         <input
           value={this.state.value}
           onChange={this.handleChange}

--- a/packages/graphiql/src/components/DocExplorer/SearchResults.js
+++ b/packages/graphiql/src/components/DocExplorer/SearchResults.js
@@ -60,7 +60,7 @@ export default class SearchResults extends React.Component {
         matchedTypes.push(
           <div className="doc-category-item" key={typeName}>
             <TypeLink type={type} onClick={onClickType} />
-          </div>
+          </div>,
         );
       }
 
@@ -73,7 +73,7 @@ export default class SearchResults extends React.Component {
           if (!isMatch(fieldName, searchValue)) {
             if (field.args && field.args.length) {
               matchingArgs = field.args.filter(arg =>
-                isMatch(arg.name, searchValue)
+                isMatch(arg.name, searchValue),
               );
               if (matchingArgs.length === 0) {
                 return;

--- a/packages/graphiql/src/components/DocExplorer/TypeLink.js
+++ b/packages/graphiql/src/components/DocExplorer/TypeLink.js
@@ -43,7 +43,13 @@ function renderType(type, onClick) {
     );
   }
   return (
-    <a className="type-name" onClick={event => {event.preventDefault(); onClick(type, event)}} href="#">
+    <a
+      className="type-name"
+      onClick={event => {
+        event.preventDefault();
+        onClick(type, event);
+      }}
+      href="#">
       {type.name}
     </a>
   );

--- a/packages/graphiql/src/components/DocExplorer/__tests__/FieldDoc.spec.js
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/FieldDoc.spec.js
@@ -39,7 +39,7 @@ describe('FieldDoc', () => {
       <FieldDoc
         field={exampleObject.getFields().string}
         onClickType={jest.fn()}
-      />
+      />,
     );
     expect(W.find('MarkdownContent').text()).toEqual('No Description\n');
     expect(W.find('TypeLink').text()).toEqual('String');
@@ -51,7 +51,7 @@ describe('FieldDoc', () => {
       <FieldDoc
         field={exampleObject.getFields().string}
         onClickType={jest.fn()}
-      />
+      />,
     );
     expect(W.find('MarkdownContent').text()).toEqual('No Description\n');
     expect(W.find('TypeLink').text()).toEqual('String');
@@ -63,17 +63,17 @@ describe('FieldDoc', () => {
       <FieldDoc
         field={exampleObject.getFields().stringWithArgs}
         onClickType={jest.fn()}
-      />
+      />,
     );
     expect(
       W.find('TypeLink')
         .at(0)
-        .text()
+        .text(),
     ).toEqual('String');
     expect(
       W.find('.doc-type-description')
         .at(0)
-        .text()
+        .text(),
     ).toEqual('Example String field with arguments\n');
     expect(W.find('Argument').length).toEqual(1);
     expect(W.find('Argument').text()).toEqual('stringArg: String');

--- a/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.js
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.js
@@ -26,13 +26,13 @@ describe('TypeDoc', () => {
         schema={ExampleSchema}
         type={ExampleQuery}
         onClickType={jest.fn()}
-      />
+      />,
     );
     const cats = W.find('.doc-category-item');
     expect(cats.at(0).text()).toEqual('string: String');
     expect(cats.at(1).text()).toEqual('union: exampleUnion');
     expect(cats.at(2).text()).toEqual(
-      'fieldWithArgs(stringArg: String): String'
+      'fieldWithArgs(stringArg: String): String',
     );
   });
 
@@ -45,7 +45,7 @@ describe('TypeDoc', () => {
         type={ExampleQuery}
         onClickType={onClickType}
         onClickField={onClickField}
-      />
+      />,
     );
     W.find('TypeLink')
       .at(0)
@@ -69,7 +69,7 @@ describe('TypeDoc', () => {
         schema={ExampleSchema}
         type={ExampleQuery}
         onClickType={jest.fn()}
-      />
+      />,
     );
     let cats = W.find('.doc-category-item');
     expect(cats.length).toEqual(3);
@@ -81,12 +81,12 @@ describe('TypeDoc', () => {
     expect(
       W.find('.field-name')
         .at(3)
-        .text()
+        .text(),
     ).toEqual('deprecatedField');
     expect(
       W.find('.doc-deprecation')
         .at(0)
-        .text()
+        .text(),
     ).toEqual('example deprecation reason\n');
   });
 
@@ -95,7 +95,7 @@ describe('TypeDoc', () => {
     expect(
       W.find('.doc-category-title')
         .at(0)
-        .text()
+        .text(),
     ).toEqual('possible types');
   });
 
@@ -104,7 +104,7 @@ describe('TypeDoc', () => {
     expect(
       W.find('.doc-category-title')
         .at(0)
-        .text()
+        .text(),
     ).toEqual('values');
     const enums = W.find('EnumValue');
     expect(enums.at(0).props().value.value).toEqual('Value 1');
@@ -129,7 +129,7 @@ describe('TypeDoc', () => {
     expect(
       W.find('.doc-deprecation')
         .at(1)
-        .text()
+        .text(),
     ).toEqual('Only two are needed\n');
   });
 });

--- a/packages/graphiql/src/components/GraphiQL.js
+++ b/packages/graphiql/src/components/GraphiQL.js
@@ -110,7 +110,7 @@ export class GraphiQL extends React.Component {
         : getSelectedOperationName(
             null,
             this._storage.get('operationName'),
-            queryFacts && queryFacts.operations
+            queryFacts && queryFacts.operations,
           );
 
     // prop can be supplied to open docExplorer initially
@@ -154,7 +154,7 @@ export class GraphiQL extends React.Component {
     // Subscribe to the browser window closing, treating it as an unmount.
     if (typeof window === 'object') {
       window.addEventListener('beforeunload', () =>
-        this.componentWillUnmount()
+        this.componentWillUnmount(),
       );
     }
   }
@@ -203,7 +203,7 @@ export class GraphiQL extends React.Component {
         nextQuery,
         nextOperationName,
         this.state.operations,
-        nextSchema
+        nextSchema,
       );
 
       if (updatedQueryAttributes !== undefined) {
@@ -238,7 +238,7 @@ export class GraphiQL extends React.Component {
 
           this._fetchSchema();
         }
-      }
+      },
     );
   }
 
@@ -268,11 +268,13 @@ export class GraphiQL extends React.Component {
   render() {
     const children = React.Children.toArray(this.props.children);
 
-    const logo = find(children, child => isChildComponentType(child, GraphiQL.Logo)) || (
-      <GraphiQL.Logo />
-    );
+    const logo = find(children, child =>
+      isChildComponentType(child, GraphiQL.Logo),
+    ) || <GraphiQL.Logo />;
 
-    const toolbar = find(children, child => isChildComponentType(child, GraphiQL.Toolbar)) || (
+    const toolbar = find(children, child =>
+      isChildComponentType(child, GraphiQL.Toolbar),
+    ) || (
       <GraphiQL.Toolbar>
         <ToolbarButton
           onClick={this.handlePrettifyQuery}
@@ -297,7 +299,9 @@ export class GraphiQL extends React.Component {
       </GraphiQL.Toolbar>
     );
 
-    const footer = find(children, child => isChildComponentType(child, GraphiQL.Footer));
+    const footer = find(children, child =>
+      isChildComponentType(child, GraphiQL.Footer),
+    );
 
     const queryWrapStyle = {
       WebkitFlex: this.state.editorFlex,
@@ -496,7 +500,7 @@ export class GraphiQL extends React.Component {
     const { insertions, result } = fillLeafs(
       this.state.schema,
       this.state.query,
-      this.props.getDefaultFieldNames
+      this.props.getDefaultFieldNames,
     );
     if (insertions && insertions.length > 0) {
       const editor = this.getQueryEditor();
@@ -513,8 +517,8 @@ export class GraphiQL extends React.Component {
               className: 'autoInsertedLeaf',
               clearOnEnter: true,
               title: 'Automatically added leaf fields',
-            }
-          )
+            },
+          ),
         );
         setTimeout(() => markers.forEach(marker => marker.clear()), 7000);
         let newCursorIndex = cursorIndex;
@@ -539,7 +543,7 @@ export class GraphiQL extends React.Component {
       fetcher({
         query: introspectionQuery,
         operationName: introspectionQueryName,
-      })
+      }),
     );
     if (!isPromise(fetch)) {
       this.setState({
@@ -560,11 +564,11 @@ export class GraphiQL extends React.Component {
           fetcher({
             query: introspectionQuerySansSubscriptions,
             operationName: introspectionQueryName,
-          })
+          }),
         );
         if (!isPromise(fetch)) {
           throw new Error(
-            'Fetcher did not return a Promise for introspection.'
+            'Fetcher did not return a Promise for introspection.',
           );
         }
         return fetch2;
@@ -699,7 +703,7 @@ export class GraphiQL extends React.Component {
               response: GraphiQL.formatResult(result),
             });
           }
-        }
+        },
       );
 
       this.setState({ subscription });
@@ -769,7 +773,7 @@ export class GraphiQL extends React.Component {
       const prettifiedVariableEditorContent = JSON.stringify(
         JSON.parse(variableEditorContent),
         null,
-        2
+        2,
       );
       if (prettifiedVariableEditorContent !== variableEditorContent) {
         variableEditor.setValue(prettifiedVariableEditorContent);
@@ -796,7 +800,7 @@ export class GraphiQL extends React.Component {
       value,
       this.state.operationName,
       this.state.operations,
-      this.state.schema
+      this.state.schema,
     );
     this.setState({
       query: value,
@@ -829,7 +833,7 @@ export class GraphiQL extends React.Component {
       const updatedOperationName = getSelectedOperationName(
         prevOperations,
         operationName,
-        queryFacts.operations
+        queryFacts.operations,
       );
 
       // Report changing of operationName if it changed.
@@ -868,7 +872,7 @@ export class GraphiQL extends React.Component {
       (onRemoveFn = () => {
         elem.removeEventListener('DOMNodeRemoved', onRemoveFn);
         elem.removeEventListener('click', this._onClickHintInformation);
-      })
+      }),
     );
   };
 
@@ -1182,7 +1186,7 @@ function observableToPromise(observable) {
       reject,
       () => {
         reject(new Error('no value resolved'));
-      }
+      },
     );
   });
 }

--- a/packages/graphiql/src/components/HistoryQuery.js
+++ b/packages/graphiql/src/components/HistoryQuery.js
@@ -77,7 +77,7 @@ export default class HistoryQuery extends React.Component {
       this.props.query,
       this.props.variables,
       this.props.operationName,
-      this.props.label
+      this.props.label,
     );
   }
 
@@ -88,7 +88,7 @@ export default class HistoryQuery extends React.Component {
       this.props.variables,
       this.props.operationName,
       this.props.label,
-      this.props.favorite
+      this.props.favorite,
     );
   }
 
@@ -100,7 +100,7 @@ export default class HistoryQuery extends React.Component {
       this.props.variables,
       this.props.operationName,
       e.target.value,
-      this.props.favorite
+      this.props.favorite,
     );
   }
 
@@ -113,7 +113,7 @@ export default class HistoryQuery extends React.Component {
         this.props.variables,
         this.props.operationName,
         e.target.value,
-        this.props.favorite
+        this.props.favorite,
       );
     }
   }

--- a/packages/graphiql/src/components/QueryHistory.js
+++ b/packages/graphiql/src/components/QueryHistory.js
@@ -58,7 +58,11 @@ export class QueryHistory extends React.Component {
 
   constructor(props) {
     super(props);
-    this.historyStore = new QueryStore('queries', props.storage, MAX_HISTORY_LENGTH);
+    this.historyStore = new QueryStore(
+      'queries',
+      props.storage,
+      MAX_HISTORY_LENGTH,
+    );
     // favorites are not automatically deleted, so there's no need for a max length
     this.favoriteStore = new QueryStore('favorites', props.storage, null);
     const historyQueries = this.historyStore.fetchAll();

--- a/packages/graphiql/src/components/ResultViewer.js
+++ b/packages/graphiql/src/components/ResultViewer.js
@@ -71,7 +71,7 @@ export class ResultViewer extends React.Component {
           }
           ReactDOM.render(<div>{infoElements}</div>, tooltipDiv);
           return tooltipDiv;
-        }
+        },
       );
     }
 

--- a/packages/graphiql/src/components/ToolbarSelect.js
+++ b/packages/graphiql/src/components/ToolbarSelect.js
@@ -47,7 +47,7 @@ export class ToolbarSelect extends React.Component {
         return (
           <ToolbarSelectOption {...child.props} onSelect={onChildSelect} />
         );
-      }
+      },
     );
     return (
       <a

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.js
@@ -58,8 +58,8 @@ describe('GraphiQL', () => {
   it('should throw error without fetcher', () => {
     expect(() =>
       mount(<GraphiQL />).simulateError(
-        Error('GraphiQL requires a fetcher function')
-      )
+        Error('GraphiQL requires a fetcher function'),
+      ),
     );
   });
 
@@ -100,7 +100,7 @@ describe('GraphiQL', () => {
 
   it('should not throw error if schema missing and query provided', () => {
     expect(() =>
-      mount(<GraphiQL fetcher={noOpFetcher} query="{}" />)
+      mount(<GraphiQL fetcher={noOpFetcher} query="{}" />),
     ).not.toThrow();
   });
 
@@ -111,7 +111,7 @@ describe('GraphiQL', () => {
 
   it('accepts a custom default query', () => {
     const graphiQL = mount(
-      <GraphiQL fetcher={noOpFetcher} defaultQuery="GraphQL Party!!" />
+      <GraphiQL fetcher={noOpFetcher} defaultQuery="GraphQL Party!!" />,
     );
     expect(graphiQL.state().query).toEqual('GraphQL Party!!');
   });
@@ -130,7 +130,7 @@ describe('GraphiQL', () => {
     expect(graphiQL.state().defaultVariableEditorOpen).toEqual(undefined);
 
     graphiQL = mount(
-      <GraphiQL fetcher={noOpFetcher} defaultVariableEditorOpen />
+      <GraphiQL fetcher={noOpFetcher} defaultVariableEditorOpen />,
     );
     expect(graphiQL.state().variableEditorOpen).toEqual(true);
 
@@ -139,14 +139,16 @@ describe('GraphiQL', () => {
         fetcher={noOpFetcher}
         variables="{test: 'value'}"
         defaultVariableEditorOpen={false}
-      />
+      />,
     );
     expect(graphiQL.state().variableEditorOpen).toEqual(false);
   });
 
   describe('children overrides', () => {
-    const MyFunctionalComponent = () => { return null; }
-    const wrap = (component) => () => <div>{component}</div>;
+    const MyFunctionalComponent = () => {
+      return null;
+    };
+    const wrap = component => () => <div>{component}</div>;
 
     it('properly ignores fragments', () => {
       const myFragment = (
@@ -157,9 +159,7 @@ describe('GraphiQL', () => {
       );
 
       const graphiQL = mount(
-        <GraphiQL fetcher={noOpFetcher}>
-          {myFragment}
-        </GraphiQL>
+        <GraphiQL fetcher={noOpFetcher}>{myFragment}</GraphiQL>,
       );
 
       expect(graphiQL.exists()).toEqual(true);
@@ -171,7 +171,7 @@ describe('GraphiQL', () => {
       const graphiQL = mount(
         <GraphiQL fetcher={noOpFetcher}>
           <MyFunctionalComponent />
-        </GraphiQL>
+        </GraphiQL>,
       );
 
       expect(graphiQL.exists()).toEqual(true);
@@ -181,13 +181,15 @@ describe('GraphiQL', () => {
 
     it('properly ignores non-override class components', () => {
       class MyClassComponent {
-        render() { return null };
+        render() {
+          return null;
+        }
       }
 
       const graphiQL = mount(
         <GraphiQL fetcher={noOpFetcher}>
           <MyClassComponent />
-        </GraphiQL>
+        </GraphiQL>,
       );
 
       expect(graphiQL.exists()).toEqual(true);
@@ -200,24 +202,32 @@ describe('GraphiQL', () => {
         const graphiQL = mount(
           <GraphiQL fetcher={noOpFetcher} data-test-selector="override-logo">
             <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>
-          </GraphiQL>
+          </GraphiQL>,
         );
 
-        expect(graphiQL.find({ 'data-test-selector': 'override-logo' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-logo' }).exists(),
+        ).toEqual(true);
       });
 
       it('can be overridden using a named component', () => {
-        const WrappedLogo = wrap(<GraphiQL.Logo data-test-selector="override-logo">{'My Great Logo'}</GraphiQL.Logo>);
+        const WrappedLogo = wrap(
+          <GraphiQL.Logo data-test-selector="override-logo">
+            {'My Great Logo'}
+          </GraphiQL.Logo>,
+        );
         WrappedLogo.displayName = 'GraphiQLLogo';
 
         const graphiQL = mount(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedLogo />
-          </GraphiQL>
+          </GraphiQL>,
         );
 
         expect(graphiQL.find(WrappedLogo).exists()).toEqual(true);
-        expect(graphiQL.find({ 'data-test-selector': 'override-logo' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-logo' }).exists(),
+        ).toEqual(true);
       });
     });
 
@@ -228,28 +238,32 @@ describe('GraphiQL', () => {
             <GraphiQL.Toolbar data-test-selector="override-toolbar">
               <GraphiQL.Button />
             </GraphiQL.Toolbar>
-          </GraphiQL>
+          </GraphiQL>,
         );
 
-        expect(graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists(),
+        ).toEqual(true);
       });
 
       it('can be overridden using a named component', () => {
         const WrappedToolbar = wrap(
           <GraphiQL.Toolbar data-test-selector="override-toolbar">
             <GraphiQL.Button />
-          </GraphiQL.Toolbar>
+          </GraphiQL.Toolbar>,
         );
         WrappedToolbar.displayName = 'GraphiQLToolbar';
 
         const graphiQL = mount(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedToolbar />
-          </GraphiQL>
+          </GraphiQL>,
         );
 
         expect(graphiQL.find(WrappedToolbar).exists()).toEqual(true);
-        expect(graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-toolbar' }).exists(),
+        ).toEqual(true);
       });
     });
 
@@ -260,28 +274,32 @@ describe('GraphiQL', () => {
             <GraphiQL.Footer data-test-selector="override-footer">
               <GraphiQL.Button />
             </GraphiQL.Footer>
-          </GraphiQL>
+          </GraphiQL>,
         );
 
-        expect(graphiQL.find({ 'data-test-selector': 'override-footer' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-footer' }).exists(),
+        ).toEqual(true);
       });
 
       it('can be overridden using a named component', () => {
         const WrappedFooter = wrap(
           <GraphiQL.Footer data-test-selector="override-footer">
             <GraphiQL.Button />
-          </GraphiQL.Footer>
+          </GraphiQL.Footer>,
         );
         WrappedFooter.displayName = 'GraphiQLFooter';
 
         const graphiQL = mount(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedFooter />
-          </GraphiQL>
+          </GraphiQL>,
         );
 
         expect(graphiQL.find(WrappedFooter).exists()).toEqual(true);
-        expect(graphiQL.find({ 'data-test-selector': 'override-footer' }).exists()).toEqual(true);
+        expect(
+          graphiQL.find({ 'data-test-selector': 'override-footer' }).exists(),
+        ).toEqual(true);
       });
     });
   });

--- a/packages/graphiql/src/utility/QueryStore.js
+++ b/packages/graphiql/src/utility/QueryStore.js
@@ -22,7 +22,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
-        x.operationName === item.operationName
+        x.operationName === item.operationName,
     );
   }
 
@@ -31,7 +31,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
-        x.operationName === item.operationName
+        x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {
       this.items.splice(itemIndex, 1, item);
@@ -44,7 +44,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
-        x.operationName === item.operationName
+        x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {
       this.items.splice(itemIndex, 1);
@@ -72,10 +72,14 @@ export default class QueryStore {
     }
 
     for (let attempts = 0; attempts < 5; attempts++) {
-      const response = this.storage.set(this.key, JSON.stringify({ [this.key]: items }));;
+      const response = this.storage.set(
+        this.key,
+        JSON.stringify({ [this.key]: items }),
+      );
       if (!response || !response.error) {
         this.items = items;
-      } else if (response.isQuotaError && this.maxSize) { // Only try to delete last items on LRU stores
+      } else if (response.isQuotaError && this.maxSize) {
+        // Only try to delete last items on LRU stores
         items.shift();
       } else {
         return; // We don't know what happened in this case, so just bailing out

--- a/packages/graphiql/src/utility/StorageAPI.js
+++ b/packages/graphiql/src/utility/StorageAPI.js
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-function isQuotaError (storage, e) {
+function isQuotaError(storage, e) {
   return (
     e instanceof DOMException &&
     // everything except Firefox
@@ -40,7 +40,7 @@ export default class StorageAPI {
       return value;
     }
 
-    return null
+    return null;
   }
 
   set(name, value) {
@@ -52,7 +52,7 @@ export default class StorageAPI {
       if (value) {
         try {
           this.storage.setItem(key, value);
-        } catch(e) {
+        } catch (e) {
           error = e;
           quotaError = isQuotaError(this.storage, e);
         }
@@ -64,7 +64,7 @@ export default class StorageAPI {
 
     return {
       isQuotaError: quotaError,
-      error
+      error,
     };
   }
 }

--- a/packages/graphiql/src/utility/__tests__/QueryStore.spec.js
+++ b/packages/graphiql/src/utility/__tests__/QueryStore.spec.js
@@ -14,14 +14,14 @@ class StorageMock {
     this.map = {};
   }
 
-  set (key, value) {
+  set(key, value) {
     this.count++;
 
     if (this.shouldThrow()) {
       return {
         error: {},
         isQuotaError: true,
-        storageAvailable: true
+        storageAvailable: true,
       };
     }
 
@@ -30,11 +30,11 @@ class StorageMock {
     return {
       error: null,
       isQuotaError: false,
-      storageAvailable: true
+      storageAvailable: true,
     };
   }
 
-  get (key) {
+  get(key) {
     return this.map[key] || null;
   }
 }
@@ -42,10 +42,7 @@ class StorageMock {
 describe('QueryStore', () => {
   describe('with no max items', () => {
     it('can push multiple items', () => {
-      const store = new QueryStore(
-        'normal',
-        new StorageAPI()
-      );
+      const store = new QueryStore('normal', new StorageAPI());
 
       for (let i = 0; i < 100; i++) {
         store.push(`item${i}`);
@@ -56,10 +53,7 @@ describe('QueryStore', () => {
 
     it('will fail silently on quota error', () => {
       let i = 0;
-      const store = new QueryStore(
-        'normal',
-        new StorageMock(() => i > 4)
-      );
+      const store = new QueryStore('normal', new StorageMock(() => i > 4));
 
       for (; i < 10; i++) {
         store.push(`item${i}`);
@@ -73,11 +67,7 @@ describe('QueryStore', () => {
 
   describe('with max items', () => {
     it('can push a limited number of items', () => {
-      const store = new QueryStore(
-        'limited',
-        new StorageAPI(),
-        20
-      );
+      const store = new QueryStore('limited', new StorageAPI(), 20);
 
       for (let i = 0; i < 100; i++) {
         store.push(`item${i}`);
@@ -98,7 +88,7 @@ describe('QueryStore', () => {
           retryCounter++;
           return shouldThrow();
         }),
-        10
+        10,
       );
 
       for (let i = 0; i < 20; i++) {
@@ -130,7 +120,7 @@ describe('QueryStore', () => {
           retryCounter++;
           return shouldTrow();
         }),
-        10
+        10,
       );
 
       for (let i = 0; i < 20; i++) {

--- a/packages/graphiql/src/utility/__tests__/StorageAPI.spec.js
+++ b/packages/graphiql/src/utility/__tests__/StorageAPI.spec.js
@@ -19,7 +19,7 @@ describe('StorageAPI', () => {
     let result = storage.set('key2', 'value');
     expect(result).toEqual({
       error: null,
-      isQuotaError: false
+      isQuotaError: false,
     });
 
     result = storage.get('key2');
@@ -30,13 +30,13 @@ describe('StorageAPI', () => {
     let result = storage.set('key3', 'value');
     expect(result).toEqual({
       error: null,
-      isQuotaError: false
+      isQuotaError: false,
     });
 
     result = storage.set('key3');
     expect(result).toEqual({
       error: null,
-      isQuotaError: false
+      isQuotaError: false,
     });
 
     result = storage.get('key3');
@@ -47,13 +47,13 @@ describe('StorageAPI', () => {
     let result = storage.set('key4', 'value');
     expect(result).toEqual({
       error: null,
-      isQuotaError: false
+      isQuotaError: false,
     });
 
     result = storage.set('key4', 'value2');
     expect(result).toEqual({
       error: null,
-      isQuotaError: false
+      isQuotaError: false,
     });
 
     result = storage.get('key4');
@@ -74,8 +74,10 @@ describe('StorageAPI', () => {
 
   it('returns any error while setting a value', () => {
     const throwingStorage = new StorageAPI({
-      setItem: () => { throw new DOMException('Terrible Error'); },
-      length: 1
+      setItem: () => {
+        throw new DOMException('Terrible Error');
+      },
+      length: 1,
     });
     const result = throwingStorage.set('key', 'value');
 
@@ -88,7 +90,7 @@ describe('StorageAPI', () => {
       setItem: () => {
         throw new DOMException('Terrible Error', 'QuotaExceededError');
       },
-      length: 1
+      length: 1,
     });
     const result = throwingStorage.set('key', 'value');
 

--- a/packages/graphiql/src/utility/__tests__/getQueryFacts.spec.js
+++ b/packages/graphiql/src/utility/__tests__/getQueryFacts.spec.js
@@ -44,7 +44,7 @@ describe('collectVariables', () => {
       TestSchema,
       parse(`
       query ($foo: Int, $bar: String) { id }
-    `)
+    `),
     );
     expect(Object.keys(variableToType)).toEqual(['foo', 'bar']);
     expect(variableToType.foo).toEqual(GraphQLInt);
@@ -57,7 +57,7 @@ describe('collectVariables', () => {
       parse(`
       query A($foo: Int, $bar: String) { id }
       query B($foo: Int, $baz: Float) { id }
-    `)
+    `),
     );
     expect(Object.keys(variableToType)).toEqual(['foo', 'bar', 'baz']);
     expect(variableToType.foo).toEqual(GraphQLInt);

--- a/packages/graphiql/src/utility/find.js
+++ b/packages/graphiql/src/utility/find.js
@@ -10,7 +10,7 @@
 
 export default function find<T>(
   list: Array<T>,
-  predicate: (item: T) => boolean
+  predicate: (item: T) => boolean,
 ): ?T {
   for (let i = 0; i < list.length; i++) {
     if (predicate(list[i])) {

--- a/packages/graphiql/src/utility/getSelectedOperationName.js
+++ b/packages/graphiql/src/utility/getSelectedOperationName.js
@@ -12,7 +12,7 @@
 export default function getSelectedOperationName(
   prevOperations,
   prevSelectedOperationName,
-  operations
+  operations,
 ) {
   // If there are not enough operations to bother with, return nothing.
   if (!operations || operations.length < 1) {

--- a/packages/graphiql/src/utility/mergeAst.js
+++ b/packages/graphiql/src/utility/mergeAst.js
@@ -22,8 +22,8 @@ function resolveDefinition(fragments, obj) {
             self.findIndex(
               _selection =>
                 _selection.kind === Kind.FRAGMENT_SPREAD &&
-                selection.name.value === _selection.name.value
-            )
+                selection.name.value === _selection.name.value,
+            ),
       )
       .map(selection => resolveDefinition(fragments, selection));
   }

--- a/packages/graphiql/src/utility/onHasCompletion.js
+++ b/packages/graphiql/src/utility/onHasCompletion.js
@@ -50,7 +50,7 @@ export default function onHasCompletion(cm, data, onHintInformationRender) {
             deprecation = null;
             onRemoveFn = null;
           }
-        })
+        }),
       );
     }
 

--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -24,7 +24,7 @@ import {
   GraphQLConfig,
   GraphQLProjectConfig,
   Uri,
-  Position
+  Position,
 } from 'graphql-language-service-types';
 
 // import { Position } from 'graphql-language-service-utils';
@@ -40,7 +40,11 @@ import {
   getDefinitionQueryResultForNamedType,
 } from './getDefinition';
 
-import { getASTNodeAtPosition, requireFile, resolveFile } from 'graphql-language-service-utils';
+import {
+  getASTNodeAtPosition,
+  requireFile,
+  resolveFile,
+} from 'graphql-language-service-utils';
 
 const {
   FRAGMENT_DEFINITION,

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -22,7 +22,7 @@ import {
   ContextToken,
   State,
   AllTypeInfo,
-  Position
+  Position,
 } from 'graphql-language-service-types';
 
 import {
@@ -299,9 +299,11 @@ function getSuggestionsForFragmentSpread(
       // Only include fragments which could possibly be spread here.
       isCompositeType(typeInfo.parentType) &&
       isCompositeType(typeMap[frag.typeCondition.name.value]) &&
-      doTypesOverlap(schema, typeInfo.parentType, typeMap[
-        frag.typeCondition.name.value
-      ] as GraphQLCompositeType),
+      doTypesOverlap(
+        schema,
+        typeInfo.parentType,
+        typeMap[frag.typeCondition.name.value] as GraphQLCompositeType,
+      ),
   );
 
   return hintList(

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -18,7 +18,7 @@ import {
 
 import {
   Diagnostic,
-  CustomValidationRule
+  CustomValidationRule,
 } from 'graphql-language-service-types';
 
 import invariant from 'assert';
@@ -26,7 +26,11 @@ import { findDeprecatedUsages, parse } from 'graphql';
 
 import { CharacterStream, onlineParser } from 'graphql-language-service-parser';
 
-import { Range, validateWithCustomRules, Position } from 'graphql-language-service-utils';
+import {
+  Range,
+  validateWithCustomRules,
+  Position,
+} from 'graphql-language-service-utils';
 
 export const SEVERITY = {
   ERROR: 1,

--- a/packages/graphql-language-service-interface/src/getHoverInformation.ts
+++ b/packages/graphql-language-service-interface/src/getHoverInformation.ts
@@ -20,7 +20,11 @@ import {
   GraphQLField,
   GraphQLFieldConfig,
 } from 'graphql';
-import { ContextToken, AllTypeInfo, Position } from 'graphql-language-service-types';
+import {
+  ContextToken,
+  AllTypeInfo,
+  Position,
+} from 'graphql-language-service-types';
 
 import { Hover } from 'vscode-languageserver-types';
 import { getTokenAtPosition, getTypeInfo } from './getAutocompleteSuggestions';
@@ -83,7 +87,7 @@ export function getHoverInformation(
     renderDescription(into, options, typeInfo.type);
     return into.join('').trim();
   }
-  return ''
+  return '';
 }
 
 function renderField(into: string[], typeInfo: AllTypeInfo, options: any) {
@@ -91,7 +95,11 @@ function renderField(into: string[], typeInfo: AllTypeInfo, options: any) {
   renderTypeAnnotation(into, typeInfo, options, typeInfo.type as GraphQLType);
 }
 
-function renderQualifiedField(into: string[], typeInfo: AllTypeInfo, options: any) {
+function renderQualifiedField(
+  into: string[],
+  typeInfo: AllTypeInfo,
+  options: any,
+) {
   if (!typeInfo.fieldDef) {
     return;
   }

--- a/packages/graphql-language-service-interface/src/getOutline.ts
+++ b/packages/graphql-language-service-interface/src/getOutline.ts
@@ -94,10 +94,12 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
 
   return {
     Field: (node: FieldNode) => {
-      const tokenizedText =
-        node.alias
-          ? [buildToken('plain', (node.alias as unknown) as string), buildToken('plain', ': ')]
-          : [];
+      const tokenizedText = node.alias
+        ? [
+            buildToken('plain', (node.alias as unknown) as string),
+            buildToken('plain', ': '),
+          ]
+        : [];
       tokenizedText.push(buildToken('plain', (node.name as unknown) as string));
       return { tokenizedText, ...meta(node) };
     },

--- a/packages/graphql-language-service-parser/src/RuleHelpers.ts
+++ b/packages/graphql-language-service-parser/src/RuleHelpers.ts
@@ -32,8 +32,8 @@ export function butNot(rule: Rule, exclusions: Array<Rule>) {
     }
     return (
       check &&
-      exclusions.every(exclusion => exclusion.match && !exclusion.match(token)));
-
+      exclusions.every(exclusion => exclusion.match && !exclusion.match(token))
+    );
   };
   return rule;
 }
@@ -48,6 +48,6 @@ export function p(value: string, style?: string): Rule {
   return {
     style: style || 'punctuation',
     match: (token: Token) =>
-    token.kind === 'Punctuation' && token.value === value };
-
+      token.kind === 'Punctuation' && token.value === value,
+  };
 }

--- a/packages/graphql-language-service-parser/src/Rules.ts
+++ b/packages/graphql-language-service-parser/src/Rules.ts
@@ -48,8 +48,6 @@ export const LexRules = {
   Comment: /^#.*/,
 };
 
-
-
 /**
  * The parser rules. These are very close to, but not exactly the same as the
  * spec. Minor deviations allow for a simpler implementation. The resulting
@@ -88,7 +86,6 @@ export const ParseRules: { [name: string]: ParseRule } = {
       case 'directive':
         return 'DirectiveDef';
     }
-
   },
   // Note: instead of "Operation", these rules have been separated out.
   ShortQuery: ['SelectionSet'],

--- a/packages/graphql-language-service-server/src/GraphQLCache.js
+++ b/packages/graphql-language-service-server/src/GraphQLCache.js
@@ -57,7 +57,7 @@ const {
 } = Kind;
 
 export async function getGraphQLCache(
-  configDir: Uri
+  configDir: Uri,
 ): Promise<GraphQLCacheInterface> {
   const graphQLConfig = await getGraphQLConfig(configDir);
   return new GraphQLCache(configDir, graphQLConfig);
@@ -87,7 +87,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   getFragmentDependencies = async (
     query: string,
-    fragmentDefinitions: ?Map<string, FragmentInfo>
+    fragmentDefinitions: ?Map<string, FragmentInfo>,
   ): Promise<Array<FragmentInfo>> => {
     // If there isn't context for fragment references,
     // return an empty array.
@@ -110,7 +110,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   getFragmentDependenciesForAST = async (
     parsedQuery: ASTNode,
-    fragmentDefinitions: Map<string, FragmentInfo>
+    fragmentDefinitions: Map<string, FragmentInfo>,
   ): Promise<Array<FragmentInfo>> => {
     if (!fragmentDefinitions) {
       return [];
@@ -160,7 +160,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   };
 
   getFragmentDefinitions = async (
-    projectConfig: GraphQLProjectConfig
+    projectConfig: GraphQLProjectConfig,
   ): Promise<Map<string, FragmentInfo>> => {
     // This function may be called from other classes.
     // If then, check the cache first.
@@ -171,10 +171,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
     const filesFromInputDirs = await this._readFilesFromInputDirs(
       rootDir,
-      projectConfig.includes
+      projectConfig.includes,
     );
     const list = filesFromInputDirs.filter(fileInfo =>
-      projectConfig.includesFile(fileInfo.filePath)
+      projectConfig.includesFile(fileInfo.filePath),
     );
 
     const {
@@ -190,7 +190,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   getObjectTypeDependencies = async (
     query: string,
-    objectTypeDefinitions: ?Map<string, ObjectTypeInfo>
+    objectTypeDefinitions: ?Map<string, ObjectTypeInfo>,
   ): Promise<Array<ObjectTypeInfo>> => {
     // If there isn't context for object type references,
     // return an empty array.
@@ -210,13 +210,13 @@ export class GraphQLCache implements GraphQLCacheInterface {
     }
     return this.getObjectTypeDependenciesForAST(
       parsedQuery,
-      objectTypeDefinitions
+      objectTypeDefinitions,
     );
   };
 
   getObjectTypeDependenciesForAST = async (
     parsedQuery: ASTNode,
-    objectTypeDefinitions: Map<string, ObjectTypeInfo>
+    objectTypeDefinitions: Map<string, ObjectTypeInfo>,
   ): Promise<Array<ObjectTypeInfo>> => {
     if (!objectTypeDefinitions) {
       return [];
@@ -272,7 +272,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   };
 
   getObjectTypeDefinitions = async (
-    projectConfig: GraphQLProjectConfig
+    projectConfig: GraphQLProjectConfig,
   ): Promise<Map<string, ObjectTypeInfo>> => {
     // This function may be called from other classes.
     // If then, check the cache first.
@@ -282,10 +282,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
     }
     const filesFromInputDirs = await this._readFilesFromInputDirs(
       rootDir,
-      projectConfig.includes
+      projectConfig.includes,
     );
     const list = filesFromInputDirs.filter(fileInfo =>
-      projectConfig.includesFile(fileInfo.filePath)
+      projectConfig.includesFile(fileInfo.filePath),
     );
     const {
       objectTypeDefinitions,
@@ -299,7 +299,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   handleWatchmanSubscribeEvent = (
     rootDir: string,
-    projectConfig: GraphQLProjectConfig
+    projectConfig: GraphQLProjectConfig,
   ) => (result: Object) => {
     if (result.files && result.files.length > 0) {
       const graphQLFileMap = this._graphQLFileListCache.get(rootDir);
@@ -351,8 +351,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
                 graphQLFileMap,
                 { size, mtime },
                 filePath,
-                exists
-              )
+                exists,
+              ),
             );
           }
 
@@ -365,7 +365,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   _readFilesFromInputDirs = (
     rootDir: string,
-    includes: string[]
+    includes: string[],
   ): Promise<Array<GraphQLFileMetadata>> => {
     let pattern: string;
 
@@ -403,21 +403,21 @@ export class GraphQLCache implements GraphQLCacheInterface {
           if (error) {
             reject(error);
           }
-        }
+        },
       );
       globResult.on('end', () => {
         resolve(
           Object.keys(globResult.statCache)
             .filter(
-              filePath => typeof globResult.statCache[filePath] === 'object'
+              filePath => typeof globResult.statCache[filePath] === 'object',
             )
             .map(filePath => ({
               filePath,
               mtime: Math.trunc(
-                globResult.statCache[filePath].mtime.getTime() / 1000
+                globResult.statCache[filePath].mtime.getTime() / 1000,
               ),
               size: globResult.statCache[filePath].size,
-            }))
+            })),
         );
       });
     });
@@ -427,7 +427,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     graphQLFileMap: Map<Uri, GraphQLFileInfo>,
     metrics: { size: number, mtime: number },
     filePath: Uri,
-    exists: boolean
+    exists: boolean,
   ): Promise<Map<Uri, GraphQLFileInfo>> {
     const fileAndContent = exists
       ? await this.promiseToReadGraphQLFile(filePath)
@@ -452,7 +452,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   async updateFragmentDefinition(
     rootDir: Uri,
     filePath: Uri,
-    contents: Array<CachedContent>
+    contents: Array<CachedContent>,
   ): Promise<void> {
     const cache = this._fragmentDefinitionsCache.get(rootDir);
     const asts = contents.map(({ query }) => {
@@ -495,7 +495,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   async updateFragmentDefinitionCache(
     rootDir: Uri,
     filePath: Uri,
-    exists: boolean
+    exists: boolean,
   ): Promise<void> {
     const fileAndContent = exists
       ? await this.promiseToReadGraphQLFile(filePath)
@@ -517,7 +517,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   async updateObjectTypeDefinition(
     rootDir: Uri,
     filePath: Uri,
-    contents: Array<CachedContent>
+    contents: Array<CachedContent>,
   ): Promise<void> {
     const cache = this._typeDefinitionsCache.get(rootDir);
     const asts = contents.map(({ query }) => {
@@ -564,7 +564,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   async updateObjectTypeDefinitionCache(
     rootDir: Uri,
     filePath: Uri,
-    exists: boolean
+    exists: boolean,
   ): Promise<void> {
     const fileAndContent = exists
       ? await this.promiseToReadGraphQLFile(filePath)
@@ -582,7 +582,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       this.updateObjectTypeDefinition(
         rootDir,
         filePath,
-        fileAndContent.queries
+        fileAndContent.queries,
       );
     }
   }
@@ -590,7 +590,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _extendSchema(
     schema: GraphQLSchema,
     schemaPath: ?string,
-    schemaCacheKey: ?string
+    schemaCacheKey: ?string,
   ): GraphQLSchema {
     const graphQLFileMap = this._graphQLFileListCache.get(this._configDir);
     const typeExtensions = [];
@@ -651,7 +651,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   getSchema = async (
     appName: ?string,
-    queryHasExtensions?: ?boolean = false
+    queryHasExtensions?: ?boolean = false,
   ): Promise<?GraphQLSchema> => {
     const projectConfig = this._graphQLConfig.getProjectConfig(appName);
 
@@ -662,7 +662,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     const schemaPath = projectConfig.schemaPath;
     const endpointInfo = this._getDefaultEndpoint(projectConfig);
     const { endpointKey, schemaKey } = this._getSchemaCacheKeysForProject(
-      projectConfig
+      projectConfig,
     );
 
     let schemaCacheKey = null;
@@ -712,7 +712,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
         parse(directivesSDL, {
           allowLegacySDLImplementsInterfaces: true,
           allowLegacySDLEmptyFields: true,
-        })
+        }),
       );
     }
 
@@ -732,7 +732,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   _invalidateSchemaCacheForProject(projectConfig: GraphQLProjectConfig) {
     const { endpointKey, schemaKey } = this._getSchemaCacheKeysForProject(
-      projectConfig
+      projectConfig,
     );
     endpointKey && this._schemaMap.delete(endpointKey);
     schemaKey && this._schemaMap.delete(schemaKey);
@@ -756,7 +756,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   }
 
   _getDefaultEndpoint(
-    projectConfig: GraphQLProjectConfig
+    projectConfig: GraphQLProjectConfig,
   ): ?{ endpointName: string, endpoint: GraphQLEndpoint } {
     // Jumping through hoops to get the default endpoint by name (needed for cache key)
     const endpointsExtension = projectConfig.endpointsExtension;
@@ -767,7 +767,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     const defaultRawEndpoint = endpointsExtension.getRawEndpoint();
     const rawEndpointsMap = endpointsExtension.getRawEndpointsMap();
     const endpointName = Object.keys(rawEndpointsMap).find(
-      name => rawEndpointsMap[name] === defaultRawEndpoint
+      name => rawEndpointsMap[name] === defaultRawEndpoint,
     );
 
     if (!endpointName) {
@@ -785,7 +785,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
    * and create fragmentDefinitions and GraphQL files cache.
    */
   readAllGraphQLFiles = async (
-    list: Array<GraphQLFileMetadata>
+    list: Array<GraphQLFileMetadata>,
   ): Promise<{
     objectTypeDefinitions: Map<string, ObjectTypeInfo>,
     fragmentDefinitions: Map<string, FragmentInfo>,
@@ -815,8 +815,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
               ...response,
               mtime: fileInfo.mtime,
               size: fileInfo.size,
-            })
-          )
+            }),
+          ),
       );
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
@@ -829,7 +829,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
    * map of fragmentDefinitions and GraphQL file cache.
    */
   processGraphQLFiles = (
-    responses: Array<GraphQLFileInfo>
+    responses: Array<GraphQLFileInfo>,
   ): {
     objectTypeDefinitions: Map<string, ObjectTypeInfo>,
     fragmentDefinitions: Map<string, FragmentInfo>,
@@ -885,7 +885,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
    * including a parsed AST.
    */
   promiseToReadGraphQLFile = (
-    filePath: Uri
+    filePath: Uri,
   ): Promise<{
     filePath: Uri,
     content: string,
@@ -915,8 +915,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
                 parse(query, {
                   allowLegacySDLImplementsInterfaces: true,
                   allowLegacySDLEmptyFields: true,
-                })
-              )
+                }),
+              ),
             );
           } catch (_) {
             // If query has syntax errors, go ahead and still resolve
@@ -926,7 +926,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
           }
         }
         resolve({ filePath, content, asts, queries });
-      })
+      }),
     );
   };
 }

--- a/packages/graphql-language-service-server/src/GraphQLWatchman.js
+++ b/packages/graphql-language-service-server/src/GraphQLWatchman.js
@@ -40,7 +40,7 @@ export class GraphQLWatchman {
             // {'version': '3.8.0', 'capabilities': {'relative_root': true}}.
             resolve();
           }
-        }
+        },
       );
       this._client.on('error', reject);
     });
@@ -48,7 +48,7 @@ export class GraphQLWatchman {
 
   async listFiles(
     entryPath: Uri,
-    options?: { [name: string]: any } = {}
+    options?: { [name: string]: any } = {},
   ): Promise<Array<any>> {
     const { watch, relative_path } = await this.watchProject(entryPath);
     const result = await this.runCommand('query', watch, {
@@ -83,7 +83,7 @@ export class GraphQLWatchman {
           reject(error);
         }
         resolve(response);
-      })
+      }),
     ).catch(error => {
       throw new Error(error);
     });
@@ -100,7 +100,7 @@ export class GraphQLWatchman {
 
   async subscribe(
     entryPath: Uri,
-    callback: (result: Object) => void
+    callback: (result: Object) => void,
   ): Promise<void> {
     const { watch, relative_path } = await this.watchProject(entryPath);
 

--- a/packages/graphql-language-service-server/src/Logger.js
+++ b/packages/graphql-language-service-server/src/Logger.js
@@ -40,7 +40,7 @@ export class Logger implements VSCodeLogger {
       dir,
       `graphql-language-service-log-${
         os.userInfo().username
-      }-${getDateString()}.log`
+      }-${getDateString()}.log`,
     );
 
     this._stream = null;

--- a/packages/graphql-language-service-server/src/MessageProcessor.js
+++ b/packages/graphql-language-service-server/src/MessageProcessor.js
@@ -83,7 +83,7 @@ export class MessageProcessor {
   async handleInitializeRequest(
     params: InitializeRequest.type,
     token: CancellationToken,
-    configDir?: string
+    configDir?: string,
   ): Promise<InitializeResult.type> {
     if (!params) {
       throw new Error('`params` argument is required to initialize.');
@@ -99,11 +99,11 @@ export class MessageProcessor {
     };
 
     const rootPath = dirname(
-      findGraphQLConfigFile(configDir ? configDir.trim() : params.rootPath)
+      findGraphQLConfigFile(configDir ? configDir.trim() : params.rootPath),
     );
     if (!rootPath) {
       throw new Error(
-        '`--configDir` option or `rootPath` argument is required.'
+        '`--configDir` option or `rootPath` argument is required.',
       );
     }
 
@@ -124,7 +124,7 @@ export class MessageProcessor {
       JSON.stringify({
         type: 'usage',
         messageType: 'initialize',
-      })
+      }),
     );
 
     return serverCapabilities;
@@ -134,7 +134,7 @@ export class MessageProcessor {
   // installed. Otherwise, rely on LSP watched files did change events.
   async _subcribeWatchman(
     config: GraphQLConfig,
-    watchmanClient: GraphQLWatchman
+    watchmanClient: GraphQLWatchman,
   ) {
     if (!watchmanClient) {
       return;
@@ -162,8 +162,8 @@ export class MessageProcessor {
           projectConfig.configDir,
           this._graphQLCache.handleWatchmanSubscribeEvent(
             config.configDir,
-            projectConfig
-          )
+            projectConfig,
+          ),
         );
       });
     } catch (err) {
@@ -179,7 +179,7 @@ export class MessageProcessor {
   }
 
   async handleDidOpenOrSaveNotification(
-    params: NotificationMessage
+    params: NotificationMessage,
   ): Promise<PublishDiagnosticsParams> {
     if (!this._isInitialized) {
       return null;
@@ -215,12 +215,12 @@ export class MessageProcessor {
         const results = await this._languageService.getDiagnostics(
           query,
           uri,
-          this._isRelayCompatMode(query) ? false : true
+          this._isRelayCompatMode(query) ? false : true,
         );
         if (results && results.length > 0) {
           diagnostics.push(...processDiagnosticsMessage(results, query, range));
         }
-      })
+      }),
     );
 
     this._logger.log(
@@ -231,14 +231,14 @@ export class MessageProcessor {
           .getGraphQLConfig()
           .getProjectNameForFile(uri),
         fileName: uri,
-      })
+      }),
     );
 
     return { uri, diagnostics };
   }
 
   async handleDidChangeNotification(
-    params: NotificationMessage
+    params: NotificationMessage,
   ): Promise<PublishDiagnosticsParams> {
     if (!this._isInitialized) {
       return null;
@@ -254,7 +254,7 @@ export class MessageProcessor {
       !params.textDocument.uri
     ) {
       throw new Error(
-        '`textDocument`, `textDocument.uri`, and `contentChanges` arguments are required.'
+        '`textDocument`, `textDocument.uri`, and `contentChanges` arguments are required.',
       );
     }
 
@@ -289,7 +289,7 @@ export class MessageProcessor {
         if (results && results.length > 0) {
           diagnostics.push(...processDiagnosticsMessage(results, query, range));
         }
-      })
+      }),
     );
 
     this._logger.log(
@@ -300,7 +300,7 @@ export class MessageProcessor {
           .getGraphQLConfig()
           .getProjectNameForFile(uri),
         fileName: uri,
-      })
+      }),
     );
 
     return { uri, diagnostics };
@@ -331,7 +331,7 @@ export class MessageProcessor {
           .getGraphQLConfig()
           .getProjectNameForFile(uri),
         fileName: uri,
-      })
+      }),
     );
   }
 
@@ -345,7 +345,7 @@ export class MessageProcessor {
   }
 
   validateDocumentAndPosition(
-    params: CompletionRequest.type | HoverRequest.type
+    params: CompletionRequest.type | HoverRequest.type,
   ): void {
     if (
       !params ||
@@ -354,14 +354,14 @@ export class MessageProcessor {
       !params.position
     ) {
       throw new Error(
-        '`textDocument`, `textDocument.uri`, and `position` arguments are required.'
+        '`textDocument`, `textDocument.uri`, and `position` arguments are required.',
       );
     }
   }
 
   async handleCompletionRequest(
     params: CompletionRequest.type,
-    token: CancellationToken
+    token: CancellationToken,
   ): Promise<CompletionList | Array<CompletionItem>> {
     if (!this._isInitialized) {
       // $FlowFixMe
@@ -404,7 +404,7 @@ export class MessageProcessor {
     const result = await this._languageService.getAutocompleteSuggestions(
       query,
       position,
-      textDocument.uri
+      textDocument.uri,
     );
 
     this._logger.log(
@@ -415,7 +415,7 @@ export class MessageProcessor {
           .getGraphQLConfig()
           .getProjectNameForFile(textDocument.uri),
         fileName: textDocument.uri,
-      })
+      }),
     );
 
     return { items: result, isIncomplete: false };
@@ -423,7 +423,7 @@ export class MessageProcessor {
 
   async handleHoverRequest(
     params: HoverRequest.type,
-    token: CancellationToken
+    token: CancellationToken,
   ): Promise<Hover> {
     if (!this._isInitialized) {
       return [];
@@ -459,7 +459,7 @@ export class MessageProcessor {
     const result = await this._languageService.getHoverInformation(
       query,
       position,
-      textDocument.uri
+      textDocument.uri,
     );
 
     return {
@@ -468,7 +468,7 @@ export class MessageProcessor {
   }
 
   async handleWatchedFilesChangedNotification(
-    params: DidChangeWatchedFilesParams
+    params: DidChangeWatchedFilesParams,
   ): Promise<PublishDiagnosticsParams> {
     if (!this._isInitialized || this._watchmanClient) {
       return null;
@@ -487,19 +487,21 @@ export class MessageProcessor {
           this._updateFragmentDefinition(uri, contents);
           this._updateObjectTypeDefinition(uri, contents);
 
-          const diagnostics = (await Promise.all(
-            contents.map(async ({ query, range }) => {
-              const results = await this._languageService.getDiagnostics(
-                query,
-                uri
-              );
-              if (results && results.length > 0) {
-                return processDiagnosticsMessage(results, query, range);
-              } else {
-                return [];
-              }
-            })
-          )).reduce((left, right) => left.concat(right));
+          const diagnostics = (
+            await Promise.all(
+              contents.map(async ({ query, range }) => {
+                const results = await this._languageService.getDiagnostics(
+                  query,
+                  uri,
+                );
+                if (results && results.length > 0) {
+                  return processDiagnosticsMessage(results, query, range);
+                } else {
+                  return [];
+                }
+              }),
+            )
+          ).reduce((left, right) => left.concat(right));
 
           this._logger.log(
             JSON.stringify({
@@ -509,7 +511,7 @@ export class MessageProcessor {
                 .getGraphQLConfig()
                 .getProjectNameForFile(uri),
               fileName: uri,
-            })
+            }),
           );
 
           return { uri, diagnostics };
@@ -517,21 +519,21 @@ export class MessageProcessor {
           this._graphQLCache.updateFragmentDefinitionCache(
             this._graphQLCache.getGraphQLConfig().configDir,
             change.uri,
-            false
+            false,
           );
           this._graphQLCache.updateObjectTypeDefinitionCache(
             this._graphQLCache.getGraphQLConfig().configDir,
             change.uri,
-            false
+            false,
           );
         }
-      })
+      }),
     );
   }
 
   async handleDefinitionRequest(
     params: DefinitionRequest.type,
-    token: CancellationToken
+    token: CancellationToken,
   ): Promise<Array<Location>> {
     if (!this._isInitialized) {
       return [];
@@ -567,7 +569,7 @@ export class MessageProcessor {
     const result = await this._languageService.getDefinition(
       query,
       position,
-      textDocument.uri
+      textDocument.uri,
     );
     const formatted = result
       ? result.definitions.map(res => {
@@ -596,7 +598,7 @@ export class MessageProcessor {
           .getGraphQLConfig()
           .getProjectNameForFile(textDocument.uri),
         fileName: textDocument.uri,
-      })
+      }),
     );
     return formatted;
   }
@@ -610,27 +612,27 @@ export class MessageProcessor {
 
   async _updateFragmentDefinition(
     uri: Uri,
-    contents: Array<CachedContent>
+    contents: Array<CachedContent>,
   ): Promise<void> {
     const rootDir = this._graphQLCache.getGraphQLConfig().configDir;
 
     await this._graphQLCache.updateFragmentDefinition(
       rootDir,
       new URL(uri).pathname,
-      contents
+      contents,
     );
   }
 
   async _updateObjectTypeDefinition(
     uri: Uri,
-    contents: Array<CachedContent>
+    contents: Array<CachedContent>,
   ): Promise<void> {
     const rootDir = this._graphQLCache.getGraphQLConfig().configDir;
 
     await this._graphQLCache.updateObjectTypeDefinition(
       rootDir,
       new URL(uri).pathname,
-      contents
+      contents,
     );
   }
 
@@ -648,7 +650,7 @@ export class MessageProcessor {
   _invalidateCache(
     textDocument: Object,
     uri: Uri,
-    contents: Array<CachedContent>
+    contents: Array<CachedContent>,
   ): void {
     if (this._textDocumentCache.has(uri)) {
       const cachedDocument = this._textDocumentCache.get(uri);
@@ -678,7 +680,7 @@ export class MessageProcessor {
 // are not found.
 export function getQueryAndRange(
   text: string,
-  uri: string
+  uri: string,
 ): Array<CachedContent> {
   // Check if the text content includes a GraphQLV query.
   // If the text doesn't include GraphQL queries, do not proceed.
@@ -700,7 +702,7 @@ export function getQueryAndRange(
     const lines = query.split('\n');
     const range = new Range(
       new Position(0, 0),
-      new Position(lines.length - 1, lines[lines.length - 1].length - 1)
+      new Position(lines.length - 1, lines[lines.length - 1].length - 1),
     );
     return [{ query, range }];
   }
@@ -709,14 +711,14 @@ export function getQueryAndRange(
 function processDiagnosticsMessage(
   results: Array<Diagnostic>,
   query: string,
-  range: ?RangeType
+  range: ?RangeType,
 ): Array<Diagnostic> {
   const queryLines = query.split('\n');
   const totalLines = queryLines.length;
   const lastLineLength = queryLines[totalLines - 1].length;
   const lastCharacterPosition = new Position(totalLines, lastLineLength);
   const processedResults = results.filter(diagnostic =>
-    diagnostic.range.end.lessThanOrEqualTo(lastCharacterPosition)
+    diagnostic.range.end.lessThanOrEqualTo(lastCharacterPosition),
   );
 
   if (range) {
@@ -726,12 +728,12 @@ function processDiagnosticsMessage(
       range: new Range(
         new Position(
           diagnostic.range.start.line + offset.line,
-          diagnostic.range.start.character
+          diagnostic.range.start.character,
         ),
         new Position(
           diagnostic.range.end.line + offset.line,
-          diagnostic.range.end.character
-        )
+          diagnostic.range.end.character,
+        ),
       ),
     }));
   }

--- a/packages/graphql-language-service-server/src/__mocks__/MockWatchmanClient.js
+++ b/packages/graphql-language-service-server/src/__mocks__/MockWatchmanClient.js
@@ -18,7 +18,7 @@ class MockWatchmanClient {
 
   listFiles(
     entryPath: Uri,
-    options?: { [name: string]: any } = {}
+    options?: { [name: string]: any } = {},
   ): Promise<Array<any>> {
     return Promise.resolve([]);
   }

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.js
@@ -81,7 +81,7 @@ describe('GraphQLCache', () => {
     it('extend the schema with appropriate custom directive', async () => {
       const schema = await cache.getSchema('testWithCustomDirectives');
       expect(
-        wihtoutASTNode(schema.getDirective('customDirective'))
+        wihtoutASTNode(schema.getDirective('customDirective')),
       ).toMatchObject(
         expect.objectContaining({
           args: [],
@@ -90,14 +90,14 @@ describe('GraphQLCache', () => {
           // isRepeatable: false,
           locations: ['FIELD'],
           name: 'customDirective',
-        })
+        }),
       );
     });
 
     it('extend the schema with appropriate custom directive 2', async () => {
       const schema = await cache.getSchema('testWithSchema');
       expect(
-        wihtoutASTNode(schema.getDirective('customDirective'))
+        wihtoutASTNode(schema.getDirective('customDirective')),
       ).toMatchObject(
         expect.objectContaining({
           args: [],
@@ -106,7 +106,7 @@ describe('GraphQLCache', () => {
           // isRepeatable: false,
           locations: ['FRAGMENT_SPREAD'],
           name: 'customDirective',
-        })
+        }),
       );
     });
   });
@@ -118,7 +118,7 @@ describe('GraphQLCache', () => {
       expect(cache._schemaMap.size).toEqual(1);
       const handler = cache.handleWatchmanSubscribeEvent(
         __dirname,
-        projectConfig
+        projectConfig,
       );
       const testResult = {
         root: __dirname,
@@ -139,7 +139,7 @@ describe('GraphQLCache', () => {
 
     it('handles invalidating the endpoint cache', async () => {
       const projectConfig = graphQLRC.getProjectConfig(
-        'testWithEndpointAndSchema'
+        'testWithEndpointAndSchema',
       );
       const introspectionResult = await graphQLRC
         .getProjectConfig('testWithSchema')
@@ -159,7 +159,7 @@ describe('GraphQLCache', () => {
       expect(cache._schemaMap.size).toEqual(1);
       const handler = cache.handleWatchmanSubscribeEvent(
         __dirname,
-        projectConfig
+        projectConfig,
       );
       const testResult = {
         root: __dirname,
@@ -216,7 +216,7 @@ describe('GraphQLCache', () => {
       const contents = getQueryAndRange(text, 'test.js');
       const result = await cache.getFragmentDependenciesForAST(
         parse(contents[0].query),
-        fragmentDefinitions
+        fragmentDefinitions,
       );
       expect(result.length).toEqual(2);
     });
@@ -226,7 +226,7 @@ describe('GraphQLCache', () => {
 
       const result = await cache.getFragmentDependenciesForAST(
         ast,
-        fragmentDefinitions
+        fragmentDefinitions,
       );
       expect(result.length).toEqual(1);
     });
@@ -289,7 +289,7 @@ describe('GraphQLCache', () => {
     it('finds named types referenced from the SDL', async () => {
       const result = await cache.getObjectTypeDependenciesForAST(
         parsedQuery,
-        namedTypeDefinitions
+        namedTypeDefinitions,
       );
       expect(result.length).toEqual(1);
     });

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.js
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.js
@@ -176,7 +176,7 @@ describe('MessageProcessor', () => {
         schemaPath,
         includes: `${queryDir}/*.graphql`,
       },
-      'not/a/real/config'
+      'not/a/real/config',
     );
 
     await messageProcessor._subcribeWatchman(config, mockWatchmanClient);
@@ -192,7 +192,7 @@ describe('MessageProcessor', () => {
           },
         },
       },
-      'not/a/real/config'
+      'not/a/real/config',
     );
 
     await messageProcessor._subcribeWatchman(config, mockWatchmanClient);

--- a/packages/graphql-language-service-server/src/findGraphQLTags.js
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.js
@@ -46,7 +46,7 @@ const PARSER_OPTIONS = {
 };
 
 export function findGraphQLTags(
-  text: string
+  text: string,
 ): Array<{ tag: string, template: string, range: Range }> {
   const result = [];
   const ast = parse(text, PARSER_OPTIONS);
@@ -77,7 +77,7 @@ export function findGraphQLTags(
             const loc = property.value.loc;
             const range = new Range(
               new Position(loc.start.line - 1, loc.start.column),
-              new Position(loc.end.line - 1, loc.end.column)
+              new Position(loc.end.line - 1, loc.end.column),
             );
             result.push({
               tag: tagName,
@@ -93,7 +93,7 @@ export function findGraphQLTags(
           const loc = fragments.loc;
           const range = new Range(
             new Position(loc.start.line - 1, loc.start.column),
-            new Position(loc.end.line - 1, loc.end.column)
+            new Position(loc.end.line - 1, loc.end.column),
           );
           result.push({
             tag: tagName,
@@ -114,7 +114,7 @@ export function findGraphQLTags(
         const loc = node.quasi.quasis[0].loc;
         const range = new Range(
           new Position(loc.start.line - 1, loc.start.column),
-          new Position(loc.end.line - 1, loc.end.column)
+          new Position(loc.end.line - 1, loc.end.column),
         );
         result.push({
           tag: tagName,

--- a/packages/graphql-language-service-server/src/startServer.js
+++ b/packages/graphql-language-service-server/src/startServer.js
@@ -61,7 +61,7 @@ export default (async function startServer(options: Options): Promise<void> {
         // Do that, and return at the end of this block.
         if (!options.port) {
           process.stderr.write(
-            '--port is required to establish socket connection.'
+            '--port is required to establish socket connection.',
           );
           process.exit(1);
           return;
@@ -102,79 +102,79 @@ export default (async function startServer(options: Options): Promise<void> {
 function addHandlers(
   connection: MessageConnection,
   configDir?: string,
-  logger: Logger
+  logger: Logger,
 ): void {
   const messageProcessor = new MessageProcessor(logger, new GraphQLWatchman());
   connection.onNotification(
     DidOpenTextDocumentNotification.type,
     async params => {
       const diagnostics = await messageProcessor.handleDidOpenOrSaveNotification(
-        params
+        params,
       );
       if (diagnostics) {
         connection.sendNotification(
           PublishDiagnosticsNotification.type,
-          diagnostics
+          diagnostics,
         );
       }
-    }
+    },
   );
   connection.onNotification(
     DidSaveTextDocumentNotification.type,
     async params => {
       const diagnostics = await messageProcessor.handleDidOpenOrSaveNotification(
-        params
+        params,
       );
       if (diagnostics) {
         connection.sendNotification(
           PublishDiagnosticsNotification.type,
-          diagnostics
+          diagnostics,
         );
       }
-    }
+    },
   );
   connection.onNotification(
     DidChangeTextDocumentNotification.type,
     async params => {
       const diagnostics = await messageProcessor.handleDidChangeNotification(
-        params
+        params,
       );
       if (diagnostics) {
         connection.sendNotification(
           PublishDiagnosticsNotification.type,
-          diagnostics
+          diagnostics,
         );
       }
-    }
+    },
   );
 
   connection.onNotification(DidCloseTextDocumentNotification.type, params =>
-    messageProcessor.handleDidCloseNotification(params)
+    messageProcessor.handleDidCloseNotification(params),
   );
   connection.onRequest(ShutdownRequest.type, () =>
-    messageProcessor.handleShutdownRequest()
+    messageProcessor.handleShutdownRequest(),
   );
   connection.onNotification(ExitNotification.type, () =>
-    messageProcessor.handleExitNotification()
+    messageProcessor.handleExitNotification(),
   );
 
   // Ignore cancel requests
   connection.onNotification('$/cancelRequest', () => ({}));
 
   connection.onRequest(InitializeRequest.type, (params, token) =>
-    messageProcessor.handleInitializeRequest(params, token, configDir)
+    messageProcessor.handleInitializeRequest(params, token, configDir),
   );
   connection.onRequest(CompletionRequest.type, params =>
-    messageProcessor.handleCompletionRequest(params)
+    messageProcessor.handleCompletionRequest(params),
   );
   connection.onRequest(CompletionResolveRequest.type, item => item);
   connection.onRequest(DefinitionRequest.type, params =>
-    messageProcessor.handleDefinitionRequest(params)
+    messageProcessor.handleDefinitionRequest(params),
   );
   connection.onRequest(HoverRequest.type, params =>
-    messageProcessor.handleHoverRequest(params)
+    messageProcessor.handleHoverRequest(params),
   );
   connection.onNotification(DidChangeWatchedFilesNotification.type, params =>
-    messageProcessor.handleWatchedFilesChangedNotification(params)
+    messageProcessor.handleWatchedFilesChangedNotification(params),
   );
 }

--- a/packages/graphql-language-service-utils/src/Range.ts
+++ b/packages/graphql-language-service-utils/src/Range.ts
@@ -8,7 +8,10 @@
  */
 
 import { Location } from 'graphql/language';
-import { Range as RangeInterface, Position as PositionInterface } from 'graphql-language-service-types';
+import {
+  Range as RangeInterface,
+  Position as PositionInterface,
+} from 'graphql-language-service-types';
 
 export class Range implements RangeInterface {
   start: PositionInterface;
@@ -34,8 +37,8 @@ export class Range implements RangeInterface {
     } else {
       return this.start.line <= position.line && this.end.line >= position.line;
     }
-  };}
-
+  };
+}
 
 export class Position implements PositionInterface {
   line: number;
@@ -54,9 +57,9 @@ export class Position implements PositionInterface {
   }
 
   lessThanOrEqualTo = (position: PositionInterface): boolean =>
-  this.line < position.line ||
-  this.line === position.line && this.character <= position.character;}
-
+    this.line < position.line ||
+    (this.line === position.line && this.character <= position.character);
+}
 
 export function offsetToPosition(text: string, loc: number): Position {
   const EOL = '\n';

--- a/packages/graphql-language-service-utils/src/validateWithCustomRules.ts
+++ b/packages/graphql-language-service-utils/src/validateWithCustomRules.ts
@@ -62,11 +62,10 @@ export function validateWithCustomRules(
       if (error.message.indexOf('Unknown directive') === -1) {
         return true;
       }
-      if (error.nodes && error.nodes[0] as TypeDefinitionNode) {
+      if (error.nodes && (error.nodes[0] as TypeDefinitionNode)) {
         const node = <TypeDefinitionNode>error.nodes[0];
         return !(
-          node.name &&
-          node.name.value === 'arguments' ||
+          (node.name && node.name.value === 'arguments') ||
           node.name.value === 'argumentDefinitions'
         );
       }

--- a/packages/graphql-language-service/src/cli.js
+++ b/packages/graphql-language-service/src/cli.js
@@ -23,14 +23,14 @@ const { argv } = yargs
       '    [-f | --file] {filePath}\n' +
       '    [-s | --schema] {schemaPath}\n' +
       '    [-m | --method] {method}\n' +
-      '    [-p | --port] {port}\n'
+      '    [-p | --port] {port}\n',
   )
   .help('h')
   .alias('h', 'help')
   .demand(
     1,
     'At least one command is required.\n' +
-      'Commands: "server, validate, autocomplete, outline"\n'
+      'Commands: "server, validate, autocomplete, outline"\n',
   )
   .option('t', {
     alias: 'text',
@@ -99,7 +99,7 @@ switch (command) {
   case 'server':
     process.on('uncaughtException', error => {
       process.stdout.write(
-        'An error was thrown from GraphQL language service: ' + String(error)
+        'An error was thrown from GraphQL language service: ' + String(error),
       );
       process.exit(0);
     });
@@ -107,7 +107,7 @@ switch (command) {
     watchmanClient.capabilityCheck({}, (error, res) => {
       if (error) {
         process.stderr.write(
-          `Cannot find installed watchman service with an error: ${error}`
+          `Cannot find installed watchman service with an error: ${error}`,
         );
         process.exit(0);
       }

--- a/packages/graphql-language-service/src/client.js
+++ b/packages/graphql-language-service/src/client.js
@@ -41,7 +41,7 @@ export default function main(command: string, argv: Object): void {
   const filePath = argv.file && argv.file.trim();
   invariant(
     argv.text || argv.file,
-    'A path to the GraphQL file or its contents is required.'
+    'A path to the GraphQL file or its contents is required.',
   );
 
   const text = ensureText(argv.text, filePath);
@@ -72,11 +72,11 @@ export default function main(command: string, argv: Object): void {
 function _getAutocompleteSuggestions(
   queryText: string,
   point: Position,
-  schemaPath: string
+  schemaPath: string,
 ): EXIT_CODE {
   invariant(
     schemaPath,
-    'A schema path is required to provide GraphQL autocompletion'
+    'A schema path is required to provide GraphQL autocompletion',
   );
 
   try {
@@ -99,7 +99,7 @@ function _getAutocompleteSuggestions(
 function _getDiagnostics(
   filePath: string,
   queryText: string,
-  schemaPath?: string
+  schemaPath?: string,
 ): EXIT_CODE {
   try {
     // `schema` is not strictly requied as GraphQL diagnostics may still notify

--- a/resources/pretty.js
+++ b/resources/pretty.js
@@ -14,8 +14,9 @@ const INVERSE = '\x1b[7m';
 const RESET = '\x1b[0m';
 const YELLOW = '\x1b[33m';
 
-const options = ['--trailing-comma=es5'];
-const glob = '{packages/*/{resources,src},resources,src}/**/*.{js,ts,md,json5,toml,json}';
+const options = ['--trailing-comma=all'];
+const glob =
+  '{packages/*/{resources,src},resources,src}/**/*.{js,ts,md,json5,toml,json}';
 const root = join(__dirname, '..');
 const executable = join(root, 'node_modules', '.bin', 'prettier');
 

--- a/resources/pretty.js
+++ b/resources/pretty.js
@@ -15,7 +15,7 @@ const RESET = '\x1b[0m';
 const YELLOW = '\x1b[33m';
 
 const options = ['--trailing-comma=es5'];
-const glob = '{packages/*/{resources,src},resources,src}/**/*.js';
+const glob = '{packages/*/{resources,src},resources,src}/**/*.{js,ts,md,json5,toml,json}';
 const root = join(__dirname, '..');
 const executable = join(root, 'node_modules', '.bin', 'prettier');
 

--- a/resources/pretty.js
+++ b/resources/pretty.js
@@ -14,7 +14,6 @@ const INVERSE = '\x1b[7m';
 const RESET = '\x1b[0m';
 const YELLOW = '\x1b[33m';
 
-const options = ['--trailing-comma=all'];
 const glob =
   '{packages/*/{resources,src},resources,src}/**/*.{js,ts,md,json5,toml,json}';
 const root = join(__dirname, '..');
@@ -24,11 +23,7 @@ const check = process.argv.indexOf('--check') !== -1;
 const mode = check ? '--list-different' : '--write';
 process.chdir(root);
 
-const { stdout, stderr, status, error } = spawnSync(executable, [
-  ...options,
-  mode,
-  glob,
-]);
+const { stdout, stderr, status, error } = spawnSync(executable, [mode, glob]);
 const out = stdout.toString().trim();
 const err = stderr.toString().trim();
 
@@ -43,7 +38,7 @@ if (status) {
   print(err);
   if (check) {
     print(`\n${YELLOW}The files listed above are not correctly formatted.`);
-    print(`Try: ${INVERSE} yarn run pretty ${RESET}`);
+    print(`Try: ${INVERSE} yarn pretty ${RESET}`);
   }
 }
 if (error) {

--- a/resources/pretty.js
+++ b/resources/pretty.js
@@ -15,7 +15,7 @@ const RESET = '\x1b[0m';
 const YELLOW = '\x1b[33m';
 
 const glob =
-  '{packages/*/{resources,src},resources,src}/**/*.{js,ts,md,json5,toml,json}';
+  '{packages/*/{resources,src},resources,src}/**/*.{js,ts,jsx,tsx,md,json5,toml,json}';
 const root = join(__dirname, '..');
 const executable = join(root, 'node_modules', '.bin', 'prettier');
 

--- a/resources/runTests.js
+++ b/resources/runTests.js
@@ -14,5 +14,5 @@ exec(
   'jest',
   '--config',
   path.join(__dirname, '../', 'jest.config.js'),
-  '--rootDir'
+  '--rootDir',
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,6 +787,13 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime@^7.6.3":
+  version "7.7.6"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz#d18c511121aff1b4f2cd1d452f1bac9601dd830f"
+  integrity sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.4.0", "@babel/template@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
@@ -1996,6 +2003,13 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
+"@samverschueren/stream-to-observable@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
+  integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
+  dependencies:
+    any-observable "^0.3.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -2028,6 +2042,11 @@
   integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -2094,6 +2113,11 @@
   version "2.4.0"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -2538,10 +2562,23 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
+  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
 ansi-wrap@0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
   integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
+
+any-observable@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
+  integrity sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -3077,6 +3114,13 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
+
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -3452,6 +3496,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -3562,7 +3614,7 @@ cli-cursor@^1.0.2:
   dependencies:
     restore-cursor "^1.0.1"
 
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
@@ -3689,12 +3741,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4111,6 +4170,17 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.1.0, cosmiconfig@^5.2.0, cosmiconfig@^5.2.1:
     is-directory "^0.3.1"
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
+
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
 
 create-ecdh@^4.0.0:
   version "4.0.3"
@@ -5482,6 +5552,22 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz#c08ed4550ef65d858fac269ffc8572446f37eb89"
+  integrity sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 executable@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
@@ -5910,6 +5996,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@~1.0.0:
   version "1.0.6"
   resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
@@ -6208,6 +6301,11 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
 
 get-pkg-repo@^1.0.0:
   version "1.4.0"
@@ -6647,6 +6745,11 @@ has-flag@^3.0.0:
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-glob@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz#a261c4c2a6c667e0c77b700a7f297c39ef3aa589"
@@ -6939,6 +7042,11 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+human-signals@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -7025,6 +7133,14 @@ import-fresh@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz#6d33fa1dcef6df930fae003446f33415af905118"
   integrity sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
+  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -7471,10 +7587,22 @@ is-number@^4.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
 
-is-obj@^1.0.0:
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^1.0.0, is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  integrity sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+  dependencies:
+    symbol-observable "^1.1.0"
 
 is-path-cwd@^2.0.0:
   version "2.2.0"
@@ -7542,6 +7670,11 @@ is-regex@^1.0.4:
   integrity sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha1-/S2INUXEa6xaYz57mgnof6LLUGk=
 
 is-relative@^0.2.1:
   version "0.2.1"
@@ -8395,6 +8528,24 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+lint-staged@^10.0.0-beta.8:
+  version "10.0.0-beta.8"
+  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.0-beta.8.tgz#9d7f746a249b75ea88eb74d28e534d9168f51d57"
+  integrity sha512-rIiPGp84O9xBGNnIG3Gkp0ghIBX+SdFFBjF5OgIsUEUUZLowyirULelKnQi/XEZnywwx4lyn9JIP5BHp6qpPbA==
+  dependencies:
+    chalk "^3.0.0"
+    commander "^4.0.1"
+    cosmiconfig "^6.0.0"
+    debug "^4.1.1"
+    dedent "^0.7.0"
+    execa "^3.4.0"
+    listr "^0.14.3"
+    log-symbols "^3.0.0"
+    micromatch "^4.0.2"
+    normalize-path "^3.0.0"
+    please-upgrade-node "^3.2.0"
+    stringify-object "^3.3.0"
+
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -8414,6 +8565,20 @@ listr-update-renderer@^0.2.0:
     log-update "^1.0.2"
     strip-ansi "^3.0.1"
 
+listr-update-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz#4ea8368548a7b8aecb7e06d8c95cb45ae2ede6a2"
+  integrity sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^2.3.0"
+    strip-ansi "^3.0.1"
+
 listr-verbose-renderer@^0.4.0:
   version "0.4.1"
   resolved "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
@@ -8423,6 +8588,16 @@ listr-verbose-renderer@^0.4.0:
     cli-cursor "^1.0.2"
     date-fns "^1.27.2"
     figures "^1.7.0"
+
+listr-verbose-renderer@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz#f1132167535ea4c1261102b9f28dac7cba1e03db"
+  integrity sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+  dependencies:
+    chalk "^2.4.1"
+    cli-cursor "^2.1.0"
+    date-fns "^1.27.2"
+    figures "^2.0.0"
 
 listr@0.12.0:
   version "0.12.0"
@@ -8445,6 +8620,21 @@ listr@0.12.0:
     rxjs "^5.0.0-beta.11"
     stream-to-observable "^0.1.0"
     strip-ansi "^3.0.1"
+
+listr@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz#2fea909604e434be464c50bddba0d496928fa586"
+  integrity sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.5.0"
+    listr-verbose-renderer "^0.5.0"
+    p-map "^2.0.0"
+    rxjs "^6.3.3"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -8703,6 +8893,13 @@ log-symbols@^1.0.2:
   dependencies:
     chalk "^1.0.0"
 
+log-symbols@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz#f3a08516a5dea893336a7dee14d18a1cfdab77c4"
+  integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
+  dependencies:
+    chalk "^2.4.2"
+
 log-update@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
@@ -8710,6 +8907,15 @@ log-update@^1.0.2:
   dependencies:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
+
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
+  integrity sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+  dependencies:
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 loglevel@^1.6.4:
   version "1.6.6"
@@ -9027,6 +9233,14 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+micromatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -9651,6 +9865,13 @@ npm-run-path@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
   integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
+
+npm-run-path@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.0.tgz#d644ec1bd0569187d2a52909971023a0a58e8438"
+  integrity sha512-8eyAOAH+bYXFPSnNnKr3J+yoybe8O87Is5rtAQ8qRczJz1ajcsjg8l2oZqP+Ppx15Ii3S1vUTjQN2h4YO2tWWQ==
   dependencies:
     path-key "^3.0.0"
 
@@ -10284,6 +10505,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
 pathval@^1.0.0, pathval@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
@@ -10316,6 +10542,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picomatch@^2.0.5:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz#ecdfbea7704adb5fe6fb47f9866c4c0e15e905c5"
+  integrity sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -12052,7 +12283,7 @@ rxjs@^5.0.0-beta.11:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.4.0:
+rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.5.3"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
@@ -12835,6 +13066,15 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -12984,6 +13224,13 @@ supports-color@^2.0.0:
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
+supports-color@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
 svgo@^1.0.0:
   version "1.3.2"
   resolved "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"
@@ -13007,6 +13254,11 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"
@@ -13241,6 +13493,13 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
@@ -14066,6 +14325,14 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+
 wrap-ansi@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
@@ -14185,6 +14452,13 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yaml@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
+  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
 
 yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"


### PR DESCRIPTION
addresses a number of annoying issues:

- prettier `trailingCommas` all (thats the big commit)
- `lint-staged` at the root
- `eslint --fix` and then`pretty --write`
- fix root commands as well
- `yarn lint` checks prettier and eslint rules for clashes

resolves #1033 by deprecating that statement for an alternative thats already built into resources/pretty.js and is implicitly multi-os