### PR TITLE
Fix/enable cookies for cross-domain requests

### DIFF
--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -54,6 +54,7 @@
       function graphQLFetcher(graphQLParams) {
         return fetch('https://swapi-graphql.netlify.com/.netlify/functions/index', {
           method: 'post',
+          credentials: 'include',
           headers: {
             Accept: 'application/json',
             'Content-Type': 'application/json',

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -78,6 +78,7 @@ The most minimal way to set up GraphiQL is a single index.html file:
       const graphQLFetcher = graphQLParams =>
         fetch('https://my/graphql', {
           method: 'post',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(graphQLParams),
         })

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -82,6 +82,7 @@ function graphQLFetcher(graphQLParams) {
   const api = isDev ? '/graphql' : 'https://swapi.graph.cool/';
   return fetch(api, {
     method: 'post',
+    credentials: 'include',
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -79,7 +79,7 @@ function graphQLFetcher(graphQLParams) {
   const isDev = !window.location.hostname.match(
     /(^|\.)netlify\.com$|(^|\.)graphql\.org$/,
   );
-  const api = isDev ? '/graphql' : 'https://deploy-preview-1128--graphiql-test.netlify.com/graphql';
+  const api = isDev ? '/graphql' : 'https://swapi-graphql.netlify.com/.netlify/functions/index';
   return fetch(api, {
     method: 'post',
     credentials: 'include',

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -79,7 +79,7 @@ function graphQLFetcher(graphQLParams) {
   const isDev = !window.location.hostname.match(
     /(^|\.)netlify\.com$|(^|\.)graphql\.org$/,
   );
-  const api = isDev ? '/graphql' : 'https://swapi.graph.cool/';
+  const api = isDev ? '/graphql' : 'https://deploy-preview-1128--graphiql-test.netlify.com/';
   return fetch(api, {
     method: 'post',
     credentials: 'include',

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -79,7 +79,7 @@ function graphQLFetcher(graphQLParams) {
   const isDev = !window.location.hostname.match(
     /(^|\.)netlify\.com$|(^|\.)graphql\.org$/,
   );
-  const api = isDev ? '/graphql' : 'https://deploy-preview-1128--graphiql-test.netlify.com/';
+  const api = isDev ? '/graphql' : 'https://deploy-preview-1128--graphiql-test.netlify.com/graphql';
   return fetch(api, {
     method: 'post',
     credentials: 'include',


### PR DESCRIPTION
This will enable user to make authenticated requests to another domain (if Cross-Origin Resource Sharing policy of this domain allows user to do so). Authentication should be done before in a separate tab.  