### PR TITLE
chore(examples): switch to using our own swapi-api

### DIFF
--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -76,10 +76,10 @@ function graphQLFetcher(graphQLParams) {
   // When working locally, the example expects a GraphQL server at the path /graphql.
   // In a PR preview, it connects to the Star Wars API externally.
   // Change this to point wherever you host your GraphQL server.
-  const isDev = !window.location.hostname.match(
-    /(^|\.)netlify\.com$|(^|\.)graphql\.org$/,
-  );
-  const api = isDev ? '/graphql' : 'https://swapi.graph.cool/';
+  const isDev = window.location.hostname.match(/localhost$/);
+  const api = isDev
+    ? '/graphql'
+    : 'https://swapi-graphql.netlify.com/.netlify/functions/index';
   return fetch(api, {
     method: 'post',
     headers: {
@@ -87,7 +87,7 @@ function graphQLFetcher(graphQLParams) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(graphQLParams),
-    credentials: 'include',
+    credentials: 'omit',
   })
     .then(function(response) {
       return response.text();


### PR DESCRIPTION
lets use our own swapi-api example as a reference example. because we use a wildcard we need to omit credentials in the example.