### PR TITLE
docs: fix CDN example fetcher text fallback

### DIFF
--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -61,11 +61,8 @@
           body: JSON.stringify(graphQLParams),
           credentials: 'include',
         }).then(function(response) {
-          try {
-            return response.json();
-          } catch (error) {
-            return response.text();
-          }
+          return response.json()
+            .catch(function () { return response.text(); });
         });
       }
 


### PR DESCRIPTION
Missed out from this review comment: https://github.com/graphql/graphiql/pull/1061/files#r356005286

(`response.json()` [returns a promise](https://developer.mozilla.org/en-US/docs/Web/API/Body/json)) so it'll never throw synchronously assuming `response` is a response object, so the `try/catch` wasn't doing anything.