### PR TITLE
feat(gls-types): add more type aliases

### DIFF
--- a/packages/graphql-language-service-types/src/index.js.flow
+++ b/packages/graphql-language-service-types/src/index.js.flow
@@ -222,6 +222,16 @@ export type ContextToken = {
   style: string,
 };
 
+export type ContextTokenForCodeMirror = {
+  start: number,
+  end: number,
+  string: string,
+  type: string | null,
+  state: State,
+};
+
+export type ContextTokenUnion = ContextToken | ContextTokenForCodeMirror;
+
 export type TypeInfo = {
   type: ?GraphQLType,
   parentType: ?GraphQLType,
@@ -269,6 +279,19 @@ export type CompletionItem = {
   documentation?: ?string,
   // GraphQL Deprecation information
   isDeprecated?: ?boolean,
+  deprecationReason?: ?string,
+};
+
+export type CompletionItemBase = {
+  label: string,
+  isDeprecated?: boolean,
+};
+
+export type CompletionItemForCodeMirror = {
+  label: string,
+  type?: GraphQLType,
+  documentation?: ?string,
+  isDeprecated?: boolean,
   deprecationReason?: ?string,
 };
 

--- a/packages/graphql-language-service-types/src/index.ts
+++ b/packages/graphql-language-service-types/src/index.ts
@@ -247,6 +247,16 @@ export type ContextToken = {
   style: string;
 };
 
+export type ContextTokenForCodeMirror = {
+  start: number;
+  end: number;
+  string: string;
+  type: string | null;
+  state: State;
+};
+
+export type ContextTokenUnion = ContextToken | ContextTokenForCodeMirror;
+
 export type AllTypeInfo = {
   type: GraphQLType | null | undefined;
   parentType: GraphQLType | null | undefined;
@@ -283,9 +293,22 @@ export type CustomValidationRule = (
 
 export type Diagnostic = DiagnosticType;
 
+export type CompletionItemBase = {
+  label: string;
+  isDeprecated?: boolean;
+};
+
 export type CompletionItem = CompletionItemType & {
   isDeprecated?: boolean;
   deprecationReason?: string;
+};
+
+export type CompletionItemForCodeMirror = {
+  label: string;
+  type?: GraphQLType;
+  documentation: string | null | undefined;
+  isDeprecated?: boolean;
+  deprecationReason: string | null | undefined;
 };
 
 // Below are basically a copy-paste from Nuclide rpc types for definitions.


### PR DESCRIPTION
This change adds and exports more type aliases so `graphql-language-service-interface` and `codemirror-graphql` can use them (#902 , #1264 ).