### PR TITLE
chore: cypress container/action for cypress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,7 @@ jobs:
       - uses: bahmutov/npm-install@v1
       - run: yarn ci
   e2e:
-    runs-on: ubuntu-latest
-    name: cypress
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
       - uses: bahmutov/npm-install@v1


### PR DESCRIPTION
https://github.com/cypress-io/github-action#important ah we just need to fix the action to 16.04, actions rolled over to 18.04 overnight