### PR TITLE
feat(definition): get scalar definition

### DIFF
--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -286,7 +286,8 @@ export class GraphQLLanguageService {
       definition =>
         definition.kind === OBJECT_TYPE_DEFINITION ||
         definition.kind === INPUT_OBJECT_TYPE_DEFINITION ||
-        definition.kind === ENUM_TYPE_DEFINITION,
+        definition.kind === ENUM_TYPE_DEFINITION ||
+        definition.kind === SCALAR_TYPE_DEFINITION,
     );
 
     const typeCastedDefs = (localObjectTypeDefinitions as any) as Array<

--- a/packages/graphql-language-service-interface/src/__tests__/getDefinition-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getDefinition-test.ts
@@ -51,6 +51,45 @@ describe('getDefinition', () => {
     });
   });
 
+  describe('getDefinitionQueryResultForNamedType for scalar', () => {
+    it('returns correct Position', async () => {
+      const query = `type Query {
+        hero(episode: Episode): Json
+      }
+
+      type Episode {
+        id: ID!
+      }
+
+      scalar Json
+      `;
+      const parsedQuery = parse(query);
+      // @ts-ignore
+      const namedTypeDefinition = parsedQuery.definitions[0].fields[0].type;
+
+      const result = await getDefinitionQueryResultForNamedType(
+        query,
+        {
+          ...namedTypeDefinition,
+        },
+
+        [
+          {
+            // @ts-ignore
+            file: 'someFile',
+            content: query,
+            definition: {
+              ...namedTypeDefinition,
+            },
+          },
+        ],
+      );
+      expect(result.definitions.length).toEqual(1);
+      expect(result.definitions[0].position.line).toEqual(1);
+      expect(result.definitions[0].position.character).toEqual(32);
+    });
+  });
+
   describe('getDefinitionQueryResultForFragmentSpread', () => {
     it('returns correct Position', async () => {
       const query = `query A {


### PR DESCRIPTION
This PR makes it possible to jump to the definition of a named scalar type. 

How this would look like once integrated into VSCode for example: 
![CleanShot-2020-02-04-at-213317](https://user-images.githubusercontent.com/746482/73786095-e4f3b780-4798-11ea-9839-dc73cc3c653b.gif)
