### PR TITLE
chore: refactor introspection utility for easier maintenance

### DIFF
--- a/packages/graphiql/src/utility/introspectionQueries.ts
+++ b/packages/graphiql/src/utility/introspectionQueries.ts
@@ -5,9 +5,9 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { getOperationAST, parse, introspectionQuery } from 'graphql';
+import { getIntrospectionQuery, getOperationAST, parse } from 'graphql';
 
-export { introspectionQuery } from 'graphql';
+export const introspectionQuery = getIntrospectionQuery();
 
 export const staticName = 'introspectionQuery';
 const operationDocument = getOperationAST(parse(introspectionQuery), null);
@@ -19,95 +19,7 @@ export const introspectionQueryName = operationDocument
 // Some GraphQL services do not support subscriptions and fail an introspection
 // query which includes the `subscriptionType` field as the stock introspection
 // query does. This backup query removes that field.
-export const introspectionQuerySansSubscriptions = /* GraphQL */ `
-  query ${introspectionQueryName} {
-    __schema {
-      queryType { name }
-      mutationType { name }
-      types {
-        ...FullType
-      }
-      directives {
-        name
-        description
-        locations
-        args {
-          ...InputValue
-        }
-      }
-    }
-  }
-
-  fragment FullType on __Type {
-    kind
-    name
-    description
-    fields(includeDeprecated: true) {
-      name
-      description
-      args {
-        ...InputValue
-      }
-      type {
-        ...TypeRef
-      }
-      isDeprecated
-      deprecationReason
-    }
-    inputFields {
-      ...InputValue
-    }
-    interfaces {
-      ...TypeRef
-    }
-    enumValues(includeDeprecated: true) {
-      name
-      description
-      isDeprecated
-      deprecationReason
-    }
-    possibleTypes {
-      ...TypeRef
-    }
-  }
-
-  fragment InputValue on __InputValue {
-    name
-    description
-    type { ...TypeRef }
-    defaultValue
-  }
-
-  fragment TypeRef on __Type {
-    kind
-    name
-    ofType {
-      kind
-      name
-      ofType {
-        kind
-        name
-        ofType {
-          kind
-          name
-          ofType {
-            kind
-            name
-            ofType {
-              kind
-              name
-              ofType {
-                kind
-                name
-                ofType {
-                  kind
-                  name
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+export const introspectionQuerySansSubscriptions = introspectionQuery.replace(
+  'subscriptionType { name }',
+  '',
+);

--- a/packages/graphiql/src/utility/introspectionQueries.ts
+++ b/packages/graphiql/src/utility/introspectionQueries.ts
@@ -5,16 +5,13 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { getIntrospectionQuery, getOperationAST, parse } from 'graphql';
+import { getIntrospectionQuery } from 'graphql';
 
 export const introspectionQuery = getIntrospectionQuery();
 
-export const staticName = 'introspectionQuery';
-const operationDocument = getOperationAST(parse(introspectionQuery), null);
+export const staticName = 'IntrospectionQuery';
 
-export const introspectionQueryName = operationDocument
-  ? operationDocument.name?.value || staticName
-  : staticName;
+export const introspectionQueryName = staticName;
 
 // Some GraphQL services do not support subscriptions and fail an introspection
 // query which includes the `subscriptionType` field as the stock introspection


### PR DESCRIPTION
this should be all we need for introspection queries, especially as they are becoming increasingly dynamic with GraphQL 15

would be nice to allow users to pass settings to `getIntrospectionQuery()` via props or plugins eventually