### PR TITLE
fix: eslint warining fixes

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -31,7 +31,6 @@ describe('GraphQLCache', () => {
   let cache = new GraphQLCache(configDir, graphQLRC);
 
   beforeEach(async () => {
-    const configDir = __dirname;
     graphQLRC = await loadConfig({ rootDir: configDir });
     cache = new GraphQLCache(configDir, graphQLRC);
   });

--- a/resources/test.config.js
+++ b/resources/test.config.js
@@ -1,4 +1,3 @@
-/* global jsdom */
 /**
  *  Copyright (c) 2019 GraphQL Contributors.
  *


### PR DESCRIPTION
```
/Users/keita/Desktop/starPlatinum/graphQL/graphiql/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
  34:11  warning  'configDir' is already declared in the upper scope  no-shadow

/Users/keita/Desktop/starPlatinum/graphQL/graphiql/resources/test.config.js
  1:11  warning  'jsdom' is defined but never used  no-unused-vars

✖ 2 problems (0 errors, 2 warnings)
```

fixed this warning