### PR TITLE
improvement: default import for codemirror

### DIFF
--- a/packages/graphiql/src/components/QueryEditor.tsx
+++ b/packages/graphiql/src/components/QueryEditor.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import * as CM from 'codemirror';
+import CM from 'codemirror';
 import { GraphQLSchema, GraphQLType } from 'graphql';
 import MD from 'markdown-it';
 import { normalizeWhitespace } from '../utility/normalizeWhitespace';

--- a/packages/graphiql/src/components/ResultViewer.tsx
+++ b/packages/graphiql/src/components/ResultViewer.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { Component, FunctionComponent } from 'react';
-import * as CM from 'codemirror';
+import CM from 'codemirror';
 import ReactDOM from 'react-dom';
 import commonKeys from '../utility/commonKeys';
 import { SizerComponent } from 'src/utility/CodeMirrorSizer';

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 import { GraphQLType } from 'graphql';
-import * as CM from 'codemirror';
+import CM from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
 import React from 'react';
 

--- a/packages/graphiql/src/utility/onHasCompletion.ts
+++ b/packages/graphiql/src/utility/onHasCompletion.ts
@@ -4,7 +4,7 @@
  *  This source code is licensed under the MIT license found in the
  *  LICENSE file in the root directory of this source tree.
  */
-import * as CodeMirror from 'codemirror';
+import CodeMirror from 'codemirror';
 
 import {
   GraphQLNonNull,


### PR DESCRIPTION
Since the "codemirror" package have a default export, we can use it without using the `import * as CM from 'codemirror'`, we have a better, tidier way to import it.