### PR TITLE
fix: a warning caused by an infinity value

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -1130,7 +1130,11 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       const editorBar = this.editorBarComponent as HTMLElement;
       const leftSize = moveEvent.clientX - getLeft(editorBar) - offset;
       const rightSize = editorBar.clientWidth - leftSize;
-      this.setState({ editorFlex: leftSize / rightSize });
+      if (rightSize === 0) {
+        this.setState({ editorFlex: 10000 });
+      } else {
+        this.setState({ editorFlex: leftSize / rightSize });
+      }
     };
 
     let onMouseUp: OnMouseUpFn = () => {


### PR DESCRIPTION
Reproduce:
Start the GraphiQL dev server, go to the localhost:8080, drag the divide bar to the right-most position, if the position `rightSize === 0`, the React State `EditorFlex` will be `Infinity`, and when the state dispatched to the CSS style property, CSS doesn't recognize `Infinity` and will throw a warning in the console.

My Solution:
Set a very big number (10000), if `rightSize === 0`, we should return the big number and avoid producing `Infinity` value in Javascript.

Safari Console Error:
<img width="998" alt="Screen Shot 2020-02-24 at 19 49 19" src="https://user-images.githubusercontent.com/9049783/75151196-0c5af600-5741-11ea-9310-80f7e10b87ce.png">

Chrome Console Error:
<img width="988" alt="Screen Shot 2020-02-24 at 19 59 00" src="https://user-images.githubusercontent.com/9049783/75151203-1250d700-5741-11ea-8234-246098e52886.png">
