### PR TITLE
improvement: history icon size, add title

### DIFF
--- a/packages/graphiql/src/components/HistoryQuery.tsx
+++ b/packages/graphiql/src/components/HistoryQuery.tsx
@@ -62,6 +62,7 @@ export default class HistoryQuery extends React.Component<
         .filter(line => line.indexOf('#') !== 0)
         .join('');
     const starIcon = this.props.favorite ? '\u2605' : '\u2606';
+    const editIcon = '\u270e';
     return (
       <li className={this.state.editable ? 'editable' : undefined}>
         {this.state.editable ? (
@@ -83,13 +84,17 @@ export default class HistoryQuery extends React.Component<
           </button>
         )}
         <button
+          style={{ fontSize: '1.25rem' }}
           onClick={this.handleEditClick.bind(this)}
+          title="Edit label"
           aria-label="Edit label">
-          {'\u270e'}
+          {editIcon}
         </button>
         <button
+          style={{ fontSize: '1.25rem' }}
           className={this.props.favorite ? 'favorited' : undefined}
           onClick={this.handleStarClick.bind(this)}
+          title="Favorite"
           aria-label={this.props.favorite ? 'Remove favorite' : 'Add favorite'}>
           {starIcon}
         </button>


### PR DESCRIPTION
- fixed history icon size: `edit icon` and `favorite icon`
- when hover icon, description pop up.

### before
<img width="947" alt="Screen Shot 2020-02-24 at 10 34 28 AM" src="https://user-images.githubusercontent.com/34010665/75166068-50bea580-56f1-11ea-9f91-45856835dbba.png">

### after
<img width="888" alt="Screen Shot 2020-02-24 at 10 40 04 AM" src="https://user-images.githubusercontent.com/34010665/75166606-173a6a00-56f2-11ea-8007-7b426455572e.png">
