### PR TITLE
fix: type check

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -14,10 +14,14 @@ import { GraphQLSchema } from 'graphql/type';
 import { parse } from 'graphql/language';
 import { loadConfig } from 'graphql-config';
 import fetchMock from 'fetch-mock';
-import { introspectionFromSchema } from 'graphql';
-
+import {
+  introspectionFromSchema,
+  FragmentDefinitionNode,
+  TypeDefinitionNode,
+} from 'graphql';
 import { GraphQLCache } from '../GraphQLCache';
 import { getQueryAndRange } from '../MessageProcessor';
+import { FragmentInfo, ObjectTypeInfo } from 'graphql-language-service-types';
 
 function wihtoutASTNode(definition: any) {
   const result = { ...definition };
@@ -119,17 +123,17 @@ describe('GraphQLCache', () => {
 
     const catDefinition = parse(catContent).definitions[0];
 
-    const fragmentDefinitions = new Map();
+    const fragmentDefinitions = new Map<string, FragmentInfo>();
     fragmentDefinitions.set('Duck', {
       file: 'someFilePath',
       content: duckContent,
       definition: duckDefinition,
-    });
+    } as FragmentInfo);
     fragmentDefinitions.set('Cat', {
       file: 'someOtherFilePath',
       content: catContent,
-      definition: catDefinition,
-    });
+      definition: catDefinition as FragmentDefinitionNode,
+    } as FragmentInfo);
 
     it('finds fragments referenced in Relay queries', async () => {
       const text =
@@ -197,7 +201,7 @@ describe('GraphQLCache', () => {
       `;
     const parsedQuery = parse(query);
 
-    const namedTypeDefinitions = new Map();
+    const namedTypeDefinitions = new Map<string, ObjectTypeInfo>();
     namedTypeDefinitions.set('Character', {
       file: 'someOtherFilePath',
       content: query,
@@ -211,8 +215,8 @@ describe('GraphQLCache', () => {
           start: 0,
           end: 0,
         },
-      },
-    });
+      } as TypeDefinitionNode,
+    } as ObjectTypeInfo);
 
     it('finds named types referenced from the SDL', async () => {
       const result = await cache.getObjectTypeDependenciesForAST(


### PR DESCRIPTION
I got the following errors in packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
```
Argument of type 'Map<unknown, unknown>' is not assignable to parameter of type 'Map<string, ObjectTypeInfo>'.
  Type 'unknown' is not assignable to type 'string'
```

So added types to receive benefits of typescript