### PR TITLE
docs: lint command is not available

### DIFF
--- a/packages/graphql-language-service/README.md
+++ b/packages/graphql-language-service/README.md
@@ -49,7 +49,7 @@ The graphql features we support are:
 
 ### Using the command-line interface
 
-The node executable contains several commands: `server` and a command-line language service methods (`lint`, `autocomplete`, `outline`).
+The node executable contains several commands: `server` and a command-line language service methods (`validate`, `autocomplete`, `outline`).
 
 Improving this list is a work-in-progress.
 


### PR DESCRIPTION
> The node executable contains several commands: server and a command-line language service methods (lint, autocomplete, outline).

https://github.com/graphql/graphiql/blob/master/packages/graphql-language-service/README.md#using-the-command-line-interface

![Screenshot from 2020-02-26 19-33-47](https://user-images.githubusercontent.com/32242596/75353081-c765c980-58d0-11ea-928d-ad69efd2cae2.png)

@IvanGoncharov the current `help` command does not list the required options 
````
At least one command is required.
Commands: "server, validate, autocomplete, outline"
```
What about adding them to the help flag.