### PR TITLE
chore: improve the way to print to stderr

### DIFF
--- a/packages/graphql-language-service/src/client.ts
+++ b/packages/graphql-language-service/src/client.ts
@@ -131,7 +131,7 @@ function _getDiagnostics(
     process.stdout.write(JSON.stringify(resultObject, null, 2));
     return GRAPHQL_SUCCESS_CODE;
   } catch (error) {
-    process.stderr.write(error.stack + '\n');
+    process.stderr.write((error?.stack ?? String(error)) + '\n');
     return GRAPHQL_FAILURE_CODE;
   }
 }
@@ -145,7 +145,7 @@ function _getOutline(queryText: string): EXIT_CODE {
       throw Error('Error parsing or no outline tree found');
     }
   } catch (error) {
-    process.stderr.write(error.stack + '\n');
+    process.stderr.write((error?.stack ?? String(error)) + '\n');
     return GRAPHQL_FAILURE_CODE;
   }
   return GRAPHQL_SUCCESS_CODE;


### PR DESCRIPTION
print to stderr even if falsy value is thrown or thrown error does not have property `stack`. it was intended to implement by #1381