### PR TITLE
chore: improved the CLI's help output

### DIFF
--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -32,6 +32,6 @@
     "graphql-language-service-interface": "^2.4.0-alpha.1",
     "graphql-language-service-server": "^2.4.0-alpha.1",
     "graphql-language-service-utils": "^2.4.0-alpha.1",
-    "yargs": "^3.32.0 || ^7.0.0"
+    "yargs": "^15.2.0"
   }
 }

--- a/packages/graphql-language-service/src/cli.ts
+++ b/packages/graphql-language-service/src/cli.ts
@@ -22,15 +22,20 @@ const { argv } = yargs
       '    [-f | --file] {filePath}\n' +
       '    [-s | --schema] {schemaPath}\n' +
       '    [-m | --method] {method}\n' +
-      '    [-p | --port] {port}\n',
+      '    [-p | --port] {port}\n' +
+      '\n    At least one command is required.\n',
   )
   .help('h')
   .alias('h', 'help')
-  .demand(
+  .demandCommand(
     1,
     'At least one command is required.\n' +
       'Commands: "server, validate, autocomplete, outline"\n',
   )
+  .command('server', 'GraphQL language server service')
+  .command('validate', 'Validates the query')
+  .command('autocomplete', 'Get autocomplete suggestions')
+  .command('outline', 'Get outline')
   .option('t', {
     alias: 'text',
     describe:


### PR DESCRIPTION
The current `--help` output of the `graphql-language-service` CLI misses the possible <commands>.
