### PR TITLE
Mark prop-types peerDependency as optional

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -58,6 +58,11 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
+  "peerDependenciesMeta": {
+    "prop-types": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@storybook/addon-storyshots": "^5.2.8",
     "@storybook/react": "^5.2.8",


### PR DESCRIPTION
This avoids the log spam of unmet peer dependency warnings by yarn on every install for users that don't use prop-types.