### PR TITLE
fix: update issue link

### DIFF
--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -1,6 +1,6 @@
 # GraphiQL
 
-> **Breaking Changes & Improvements:** several interfaces are being dropped for new ones for GraphiQL 1.0.0! Read more in [this issue](#1165)
+> **Breaking Changes & Improvements:** several interfaces are being dropped for new ones for GraphiQL 1.0.0! Read more in [this issue](https://github.com/graphql/graphiql/issues/1165)
 
 [![NPM](https://img.shields.io/npm/v/graphiql.svg)](https://npmjs.com/graphiql)
 ![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/npm/hm/graphiql)


### PR DESCRIPTION
previous link was directing to `https://github.com/graphql/graphiql/blob/master/packages/graphiql/README.md#1165`