### PR TITLE
fix: restore error handling for server #1306

### DIFF
--- a/packages/graphql-language-service-interface/src/getDefinition.ts
+++ b/packages/graphql-language-service-interface/src/getDefinition.ts
@@ -55,8 +55,7 @@ export async function getDefinitionQueryResultForNamedType(
   );
 
   if (defNodes.length === 0) {
-    process.stderr.write(`Definition not found for GraphQL type ${name}`);
-    return { queryRange: [], definitions: [] };
+    throw Error(`Definition not found for GraphQL type ${name}`);
   }
   const definitions: Array<Definition> = defNodes.map(
     ({ filePath, content, definition }) =>
@@ -80,8 +79,7 @@ export async function getDefinitionQueryResultForFragmentSpread(
   );
 
   if (defNodes.length === 0) {
-    process.stderr.write(`Definition not found for GraphQL fragment ${name}`);
-    return { queryRange: [], definitions: [] };
+    throw Error(`Definition not found for GraphQL fragment ${name}`);
   }
   const definitions: Array<Definition> = defNodes.map(
     ({ filePath, content, definition }) =>

--- a/packages/graphql-language-service-server/src/Logger.ts
+++ b/packages/graphql-language-service-server/src/Logger.ts
@@ -69,6 +69,9 @@ export class Logger implements VSCodeLogger {
     const logMessage = `${timestamp} [${severity}] (pid: ${pid}) graphql-language-service-usage-logs: ${message}\n\n`;
     // write to the file in tmpdir
     fs.appendFile(this._logFilePath, logMessage, _error => {});
+    process.stderr.write(logMessage, err => {
+      console.error(err);
+    });
   }
 }
 

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -62,57 +62,65 @@ type Options = {
  * @returns {Promise<void>}
  */
 export default async function startServer(options: Options): Promise<void> {
-  const logger = new Logger();
+  try {
+    const logger = new Logger();
 
-  if (options && options.method) {
-    let reader;
-    let writer;
-    switch (options.method) {
-      case 'socket':
-        // For socket connection, the message connection needs to be
-        // established before the server socket starts listening.
-        // Do that, and return at the end of this block.
-        if (!options.port) {
-          process.stderr.write(
-            '--port is required to establish socket connection.',
-          );
-          process.exit(1);
-        }
-
-        const port = options.port;
-        const socket = net
-          .createServer(client => {
-            client.setEncoding('utf8');
-            reader = new SocketMessageReader(client);
-            writer = new SocketMessageWriter(client);
-            client.on('end', () => {
-              socket.close();
-              process.exit(0);
-            });
-            const connection = createMessageConnection(reader, writer, logger);
-            addHandlers(
-              connection,
-              logger,
-              options.configDir,
-              options.extensions,
+    if (options && options.method) {
+      let reader;
+      let writer;
+      switch (options.method) {
+        case 'socket':
+          // For socket connection, the message connection needs to be
+          // established before the server socket starts listening.
+          // Do that, and return at the end of this block.
+          if (!options.port) {
+            process.stderr.write(
+              '--port is required to establish socket connection.',
             );
-            connection.listen();
-          })
-          .listen(port);
-        return;
-      case 'stream':
-        reader = new StreamMessageReader(process.stdin);
-        writer = new StreamMessageWriter(process.stdout);
-        break;
-      case 'node':
-      default:
-        reader = new IPCMessageReader(process);
-        writer = new IPCMessageWriter(process);
-        break;
+            process.exit(1);
+          }
+
+          const port = options.port;
+          const socket = net
+            .createServer(client => {
+              client.setEncoding('utf8');
+              reader = new SocketMessageReader(client);
+              writer = new SocketMessageWriter(client);
+              client.on('end', () => {
+                socket.close();
+                process.exit(0);
+              });
+              const connection = createMessageConnection(
+                reader,
+                writer,
+                logger,
+              );
+              addHandlers(
+                connection,
+                logger,
+                options.configDir,
+                options.extensions,
+              );
+              connection.listen();
+            })
+            .listen(port);
+          return;
+        case 'stream':
+          reader = new StreamMessageReader(process.stdin);
+          writer = new StreamMessageWriter(process.stdout);
+          break;
+        case 'node':
+        default:
+          reader = new IPCMessageReader(process);
+          writer = new IPCMessageWriter(process);
+          break;
+      }
+      const connection = createMessageConnection(reader, writer, logger);
+      addHandlers(connection, logger, options.configDir, options.extensions);
+      connection.listen();
     }
-    const connection = createMessageConnection(reader, writer, logger);
-    addHandlers(connection, logger, options.configDir, options.extensions);
-    connection.listen();
+  } catch (err) {
+    process.stderr.write(err.message);
   }
 }
 


### PR DESCRIPTION
seems that vscode-languageserver deprecated writing to stderr by default

also removing direct calls to process in the underlying language service so that it's compatible with non-node runtimes. trapping the exceptions in startServer should handle exceptions, but we should make sure that the editor events that we don't return from in those cases continue firing as normal?

CC: @divyenduz , @zth