### PR TITLE
feat: typescript, tsx, jsx support for LSP server using babel

### DIFF
--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -80,8 +80,9 @@ For each transport, there is a slight difference in JSON message format, especia
 | ---------------: | ---------------------------- | ------------------------------------------- |
 |      Diagnostics | `getDiagnostics`             | `textDocument/publishDiagnostics`           |
 |   Autocompletion | `getAutocompleteSuggestions` | `textDocument/completion`                   |
-|          Outline | `getOutline`                 | Not supported yet                           |
-| Go-to definition | `getDefinition`              | Not supported yet                           |
+|          Outline | `getOutline`                 | `textDocument/outline`                      |
+| Document Symbols | `getDocumentSymbols`         | `textDocument/symbols`                      |
+| Go-to definition | `getDefinition`              | `textDocument/definition`                   |
 |      File Events | Not supported yet            | `didOpen/didClose/didSave/didChange` events |
 
 #### startServer

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -87,7 +87,7 @@ For each transport, there is a slight difference in JSON message format, especia
 
 #### startServer
 
-The GraphQL Language Server can be started with the following function:
+Initialize the GraphQL Language Server with the `startServer` function:
 
 ```ts
 import { startServer } from 'graphql-language-service-server';
@@ -105,3 +105,4 @@ await startServer({
 | method     | `false`                                           | socket, streams, or node (ipc)                                                    |
 | configDir  | `false`                                           | the directory where graphql-config is found                                       |
 | extensions | `false`                                           | array of functions to transform the graphql-config and add extensions dynamically |
+| parser     | `false`                                           | Customize _all_ file parsing by overriding the default `parseDocument` function   |

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -59,7 +59,7 @@ export async function getGraphQLCache(
 ): Promise<GraphQLCacheInterface> {
   let graphQLConfig = config || (await loadConfig({ rootDir: configDir }));
   if (extensions && extensions.length > 0) {
-    for (const extension of extensions) {
+    for await (const extension of extensions) {
       graphQLConfig = await extension(graphQLConfig);
     }
   }
@@ -633,7 +633,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       schema = await projectConfig.getSchema();
     }
 
-    const customDirectives = projectConfig.extensions.customDirectives;
+    const customDirectives = projectConfig?.extensions?.customDirectives;
     if (customDirectives && schema) {
       const directivesSDL = customDirectives.join('\n\n');
       schema = extendSchema(

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -27,7 +27,7 @@ import {
   GraphQLConfig,
   GraphQLProjectConfig,
 } from 'graphql-config';
-import { getQueryAndRange } from './MessageProcessor';
+import { parseDocument } from './parseDocument';
 import stringToHash from './stringToHash';
 import glob from 'glob';
 
@@ -796,7 +796,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
         let queries: CachedContent[] = [];
         if (content.trim().length !== 0) {
           try {
-            queries = getQueryAndRange(content, filePath);
+            queries = parseDocument(content, filePath);
             if (queries.length === 0) {
               // still resolve with an empty ast
               resolve({

--- a/packages/graphql-language-service-server/src/Logger.ts
+++ b/packages/graphql-language-service-server/src/Logger.ts
@@ -69,8 +69,9 @@ export class Logger implements VSCodeLogger {
     const logMessage = `${timestamp} [${severity}] (pid: ${pid}) graphql-language-service-usage-logs: ${message}\n\n`;
     // write to the file in tmpdir
     fs.appendFile(this._logFilePath, logMessage, _error => {});
-    process.stderr.write(logMessage, err => {
-      console.error(err);
+    // const processSt = (severity === SEVERITY.ERROR) ? process.stderr : process.stdout
+    process.stderr.write(logMessage, _err => {
+      // console.error(err);
     });
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -67,6 +67,9 @@ type CachedDocumentType = {
 //   FragmentSpread: SymbolKind.Struct,
 // };
 
+const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
+const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(i => `.${i}`);
+
 export class MessageProcessor {
   _graphQLCache!: GraphQLCache;
   _graphQLConfig: GraphQLConfig | undefined;
@@ -699,7 +702,8 @@ export class MessageProcessor {
 export function getQueryAndRange(text: string, uri: string): CachedContent[] {
   // Check if the text content includes a GraphQLV query.
   // If the text doesn't include GraphQL queries, do not proceed.
-  if (extname(uri) === '.js') {
+  const ext = extname(uri);
+  if (SUPPORTED_EXTENSIONS_FORMATTED.some(e => e === ext)) {
     if (
       text.indexOf('graphql`') === -1 &&
       text.indexOf('graphql.experimental`') === -1 &&
@@ -707,7 +711,7 @@ export function getQueryAndRange(text: string, uri: string): CachedContent[] {
     ) {
       return [];
     }
-    const templates = findGraphQLTags(text);
+    const templates = findGraphQLTags(text, ext);
     return templates.map(({ template, range }) => ({ query: template, range }));
   } else {
     const query = text;

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -158,9 +158,10 @@ export class MessageProcessor {
       // textDocument/didSave does not pass in the text content.
       // Only run the below function if text is passed in.
       contents = parseDocument(textDocument.text, uri);
+
       this._invalidateCache(textDocument, uri, contents);
     } else {
-      const cachedDocument = this._getCachedDocument(uri);
+      const cachedDocument = this._getCachedDocument(textDocument.uri);
       if (cachedDocument) {
         contents = cachedDocument.contents;
       }
@@ -227,7 +228,6 @@ export class MessageProcessor {
     // If it's a .js file, try parsing the contents to see if GraphQL queries
     // exist. If not found, delete from the cache.
     const contents = parseDocument(contentChange.text, uri);
-
     // If it's a .graphql file, proceed normally and invalidate the cache.
     this._invalidateCache(textDocument, uri, contents);
 
@@ -653,7 +653,6 @@ export class MessageProcessor {
 
     return null;
   }
-
   _invalidateCache(
     textDocument: VersionedTextDocumentIdentifier,
     uri: Uri,

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -20,7 +20,7 @@ import {
   TypeDefinitionNode,
 } from 'graphql';
 import { GraphQLCache, getGraphQLCache } from '../GraphQLCache';
-import { getQueryAndRange } from '../MessageProcessor';
+import { parseDocument } from '../parseDocument';
 import { FragmentInfo, ObjectTypeInfo } from 'graphql-language-service-types';
 
 function wihtoutASTNode(definition: any) {
@@ -161,7 +161,7 @@ describe('GraphQLCache', () => {
         '    `,\n' +
         '  },\n' +
         '});';
-      const contents = getQueryAndRange(text, 'test.js');
+      const contents = parseDocument(text, 'test.js');
       const result = await cache.getFragmentDependenciesForAST(
         parse(contents[0].query),
         fragmentDefinitions,

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -310,6 +310,66 @@ query Test {
 `);
   });
 
+  it('getQueryAndRange finds queries in tagged templates using typescript', async () => {
+    const text = `
+import {gql} from 'react-apollo';
+import {B} from 'B';
+import A from './A';
+
+const QUERY: string = gql\`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+\${A.fragments.test}
+\`
+
+export function Example(arg: string) {}`;
+
+    const contents = getQueryAndRange(text, 'test.ts');
+    expect(contents[0].query).toEqual(`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+`);
+  });
+
+  it('getQueryAndRange finds queries in tagged templates using tsx', async () => {
+    const text = `
+import {gql} from 'react-apollo';
+import {B} from 'B';
+import A from './A';
+
+const QUERY: string = gql\`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+\${A.fragments.test}
+\`
+
+export function Example(arg: string) {
+  return <div>{QUERY}</div>
+}`;
+
+    const contents = getQueryAndRange(text, 'test.tsx');
+    expect(contents[0].query).toEqual(`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+`);
+  });
+
   it('getQueryAndRange ignores non gql tagged templates', async () => {
     const text = `
 // @flow

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -9,7 +9,8 @@
 import { SymbolKind } from 'vscode-languageserver';
 import { Position, Range } from 'graphql-language-service-utils';
 
-import { MessageProcessor, getQueryAndRange } from '../MessageProcessor';
+import { MessageProcessor } from '../MessageProcessor';
+import { parseDocument } from '../parseDocument';
 
 jest.mock('../Logger');
 
@@ -280,7 +281,7 @@ describe('MessageProcessor', () => {
     await expect(result[0].uri).toEqual(`file://${queryDir}/test3.graphql`);
   });
 
-  it('getQueryAndRange finds queries in tagged templates', async () => {
+  it('parseDocument finds queries in tagged templates', async () => {
     const text = `
 // @flow
 import {gql} from 'react-apollo';
@@ -299,7 +300,7 @@ query Test {
 
 export function Example(arg: string) {}`;
 
-    const contents = getQueryAndRange(text, 'test.js');
+    const contents = parseDocument(text, 'test.js');
     expect(contents[0].query).toEqual(`
 query Test {
   test {
@@ -310,7 +311,7 @@ query Test {
 `);
   });
 
-  it('getQueryAndRange finds queries in tagged templates using typescript', async () => {
+  it('parseDocument finds queries in tagged templates using typescript', async () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -328,7 +329,7 @@ query Test {
 
 export function Example(arg: string) {}`;
 
-    const contents = getQueryAndRange(text, 'test.ts');
+    const contents = parseDocument(text, 'test.ts');
     expect(contents[0].query).toEqual(`
 query Test {
   test {
@@ -339,7 +340,7 @@ query Test {
 `);
   });
 
-  it('getQueryAndRange finds queries in tagged templates using tsx', async () => {
+  it('parseDocument finds queries in tagged templates using tsx', async () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -359,7 +360,7 @@ export function Example(arg: string) {
   return <div>{QUERY}</div>
 }`;
 
-    const contents = getQueryAndRange(text, 'test.tsx');
+    const contents = parseDocument(text, 'test.tsx');
     expect(contents[0].query).toEqual(`
 query Test {
   test {
@@ -370,7 +371,7 @@ query Test {
 `);
   });
 
-  it('getQueryAndRange ignores non gql tagged templates', async () => {
+  it('parseDocument ignores non gql tagged templates', async () => {
     const text = `
 // @flow
 import randomthing from 'package';
@@ -389,7 +390,7 @@ query Test {
 
 export function Example(arg: string) {}`;
 
-    const contents = getQueryAndRange(text, 'test.js');
+    const contents = parseDocument(text, 'test.js');
     expect(contents.length).toEqual(0);
   });
 });

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -2,3 +2,5 @@ export const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
 export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
   i => `.${i}`,
 );
+export const DEFAULT_STABLE_TAGS = ['graphql', 'gql'];
+export const DEFAULT_TAGS = [...DEFAULT_STABLE_TAGS, 'graphql.experimental'];

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -1,6 +1,0 @@
-export const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
-export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
-  i => `.${i}`,
-);
-export const DEFAULT_STABLE_TAGS = ['graphql', 'gql'];
-export const DEFAULT_TAGS = [...DEFAULT_STABLE_TAGS, 'graphql.experimental'];

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -1,0 +1,4 @@
+export const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
+export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
+  i => `.${i}`,
+);

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -15,7 +15,6 @@ import {
 } from '@babel/types';
 
 import { Position, Range } from 'graphql-language-service-utils';
-import { DEFAULT_STABLE_TAGS } from './constants';
 
 import { parse, ParserOptions, ParserPlugin } from '@babel/parser';
 
@@ -34,37 +33,44 @@ const CREATE_CONTAINER_FUNCTIONS: { [key: string]: boolean } = {
   createRefetchContainer: true,
 };
 
+export const DEFAULT_STABLE_TAGS = ['graphql', 'gql'];
+export const DEFAULT_TAGS = [...DEFAULT_STABLE_TAGS, 'graphql.experimental'];
+
 type TagResult = { tag: string; template: string; range: Range };
 
 interface TagVisitiors {
   [type: string]: (node: any) => void;
 }
 
+const BABEL_PLUGINS: ParserPlugin[] = [
+  'jsx',
+  'doExpressions',
+  'objectRestSpread',
+  ['decorators', { decoratorsBeforeExport: false }],
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'exportDefaultFrom',
+  'exportNamespaceFrom',
+  'asyncGenerators',
+  'functionBind',
+  'functionSent',
+  'dynamicImport',
+  'numericSeparator',
+  'optionalChaining',
+  'importMeta',
+  'bigInt',
+  'optionalCatchBinding',
+  'throwExpressions',
+  ['pipelineOperator', { proposal: 'minimal' }],
+  'nullishCoalescingOperator',
+];
+
 export function findGraphQLTags(text: string, ext: string): TagResult[] {
   const result: TagResult[] = [];
-  const plugins: ParserPlugin[] = [
-    'jsx',
-    'doExpressions',
-    'objectRestSpread',
-    ['decorators', { decoratorsBeforeExport: false }],
-    'classProperties',
-    'classPrivateProperties',
-    'classPrivateMethods',
-    'exportDefaultFrom',
-    'exportNamespaceFrom',
-    'asyncGenerators',
-    'functionBind',
-    'functionSent',
-    'dynamicImport',
-    'numericSeparator',
-    'optionalChaining',
-    'importMeta',
-    'bigInt',
-    'optionalCatchBinding',
-    'throwExpressions',
-    ['pipelineOperator', { proposal: 'minimal' }],
-    'nullishCoalescingOperator',
-  ];
+
+  const plugins = BABEL_PLUGINS.slice(0, BABEL_PLUGINS.length);
+
   if (ext === '.ts' || ext === '.tsx') {
     plugins?.push('typescript');
   } else {

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -33,7 +33,7 @@ const CREATE_CONTAINER_FUNCTIONS: { [key: string]: boolean } = {
   createRefetchContainer: true,
 };
 
-export const DEFAULT_STABLE_TAGS = ['graphql', 'gql'];
+const DEFAULT_STABLE_TAGS = ['graphql', 'gql'];
 export const DEFAULT_TAGS = [...DEFAULT_STABLE_TAGS, 'graphql.experimental'];
 
 type TagResult = { tag: string; template: string; range: Range };

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -15,6 +15,7 @@ import {
 } from '@babel/types';
 
 import { Position, Range } from 'graphql-language-service-utils';
+import { DEFAULT_STABLE_TAGS } from './constants';
 
 import { parse, ParserOptions, ParserPlugin } from '@babel/parser';
 
@@ -163,8 +164,6 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
   return result;
 }
 
-const IDENTIFIERS = { graphql: true, gql: true };
-
 const IGNORED_KEYS: { [key: string]: boolean } = {
   comments: true,
   end: true,
@@ -177,7 +176,10 @@ const IGNORED_KEYS: { [key: string]: boolean } = {
 };
 
 function getGraphQLTagName(tag: Expression): string | null {
-  if (tag.type === 'Identifier' && IDENTIFIERS.hasOwnProperty(tag.name)) {
+  if (
+    tag.type === 'Identifier' &&
+    DEFAULT_STABLE_TAGS.some(t => t === tag.name)
+  ) {
     return tag.name;
   } else if (
     tag.type === 'MemberExpression' &&

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -4,9 +4,9 @@ import { Range, Position } from 'graphql-language-service-utils';
 
 import { findGraphQLTags, DEFAULT_TAGS } from './findGraphQLTags';
 
-export const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
+const DEFAULT_SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
 
-export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
+const DEFAULT_SUPPORTED_EXTENSIONS_FORMATTED = DEFAULT_SUPPORTED_EXTENSIONS.map(
   i => `.${i}`,
 );
 
@@ -17,11 +17,15 @@ export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
 // Check the uri to determine the file type (JavaScript/GraphQL).
 // If .js file, either return the parsed query/range or null if GraphQL queries
 // are not found.
-export function parseDocument(text: string, uri: string): CachedContent[] {
+export function parseDocument(
+  text: string,
+  uri: string,
+  fileExtensions: string[] = DEFAULT_SUPPORTED_EXTENSIONS_FORMATTED,
+): CachedContent[] {
   // Check if the text content includes a GraphQLV query.
   // If the text doesn't include GraphQL queries, do not proceed.
   const ext = extname(uri);
-  if (SUPPORTED_EXTENSIONS_FORMATTED.some(e => e === ext)) {
+  if (fileExtensions.some(e => e === ext)) {
     if (DEFAULT_TAGS.some(t => t === text)) {
       return [];
     }

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -1,0 +1,37 @@
+import { extname } from 'path';
+import { CachedContent } from 'graphql-language-service-types';
+import { Range, Position } from 'graphql-language-service-utils';
+
+import { SUPPORTED_EXTENSIONS_FORMATTED, DEFAULT_TAGS } from './constants';
+import { findGraphQLTags } from './findGraphQLTags';
+
+/**
+ * Helper functions to perform requested services from client/server.
+ */
+
+// Check the uri to determine the file type (JavaScript/GraphQL).
+// If .js file, either return the parsed query/range or null if GraphQL queries
+// are not found.
+export function parseDocument(text: string, uri: string): CachedContent[] {
+  // Check if the text content includes a GraphQLV query.
+  // If the text doesn't include GraphQL queries, do not proceed.
+  const ext = extname(uri);
+  if (SUPPORTED_EXTENSIONS_FORMATTED.some(e => e === ext)) {
+    if (DEFAULT_TAGS.some(t => t === text)) {
+      return [];
+    }
+    const templates = findGraphQLTags(text, ext);
+    return templates.map(({ template, range }) => ({ query: template, range }));
+  } else {
+    const query = text;
+    if (!query && query !== '') {
+      return [];
+    }
+    const lines = query.split('\n');
+    const range = new Range(
+      new Position(0, 0),
+      new Position(lines.length - 1, lines[lines.length - 1].length - 1),
+    );
+    return [{ query, range }];
+  }
+}

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -2,8 +2,13 @@ import { extname } from 'path';
 import { CachedContent } from 'graphql-language-service-types';
 import { Range, Position } from 'graphql-language-service-utils';
 
-import { SUPPORTED_EXTENSIONS_FORMATTED, DEFAULT_TAGS } from './constants';
-import { findGraphQLTags } from './findGraphQLTags';
+import { findGraphQLTags, DEFAULT_TAGS } from './findGraphQLTags';
+
+export const SUPPORTED_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
+
+export const SUPPORTED_EXTENSIONS_FORMATTED = SUPPORTED_EXTENSIONS.map(
+  i => `.${i}`,
+);
 
 /**
  * Helper functions to perform requested services from client/server.

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -53,6 +53,7 @@ type Options = {
   configDir?: string;
   // array of functions to transform the graphql-config and add extensions dynamically
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>;
+  fileExtensions?: string[];
   // pre-existing GraphQLConfig
   config?: GraphQLConfig;
   parser?: typeof parseDocument;
@@ -122,6 +123,8 @@ export default async function startServer(options: Options): Promise<void> {
       options.configDir,
       options?.extensions ?? [],
       options.config,
+      options.parser,
+      options.fileExtensions,
     );
     connection.listen();
   }
@@ -133,8 +136,16 @@ function addHandlers(
   configDir?: string,
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>,
   config?: GraphQLConfig,
+  parser?: typeof parseDocument,
+  fileExtensions?: string[],
 ): void {
-  const messageProcessor = new MessageProcessor(logger, extensions, config);
+  const messageProcessor = new MessageProcessor(
+    logger,
+    extensions,
+    config,
+    parser,
+    fileExtensions,
+  );
   connection.onNotification(
     DidOpenTextDocumentNotification.type,
     async params => {

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -66,72 +66,64 @@ type Options = {
  * @returns {Promise<void>}
  */
 export default async function startServer(options: Options): Promise<void> {
-  try {
-    const logger = new Logger();
+  const logger = new Logger();
 
-    if (options && options.method) {
-      let reader;
-      let writer;
-      switch (options.method) {
-        case 'socket':
-          // For socket connection, the message connection needs to be
-          // established before the server socket starts listening.
-          // Do that, and return at the end of this block.
-          if (!options.port) {
-            process.stderr.write(
-              '--port is required to establish socket connection.',
+  if (options && options.method) {
+    let reader;
+    let writer;
+    switch (options.method) {
+      case 'socket':
+        // For socket connection, the message connection needs to be
+        // established before the server socket starts listening.
+        // Do that, and return at the end of this block.
+        if (!options.port) {
+          process.stderr.write(
+            '--port is required to establish socket connection.',
+          );
+          process.exit(1);
+        }
+
+        const port = options.port;
+        const socket = net
+          .createServer(client => {
+            client.setEncoding('utf8');
+            reader = new SocketMessageReader(client);
+            writer = new SocketMessageWriter(client);
+            client.on('end', () => {
+              socket.close();
+              process.exit(0);
+            });
+            const connection = createMessageConnection(reader, writer, logger);
+            addHandlers(
+              connection,
+              logger,
+              options.configDir,
+              options?.extensions ?? [],
+              options.config,
             );
-            process.exit(1);
-          }
-
-          const port = options.port;
-          const socket = net
-            .createServer(client => {
-              client.setEncoding('utf8');
-              reader = new SocketMessageReader(client);
-              writer = new SocketMessageWriter(client);
-              client.on('end', () => {
-                socket.close();
-                process.exit(0);
-              });
-              const connection = createMessageConnection(
-                reader,
-                writer,
-                logger,
-              );
-              addHandlers(
-                connection,
-                logger,
-                options.configDir,
-                options.extensions,
-                options.config,
-              );
-              connection.listen();
-            })
-            .listen(port);
-          return;
-        case 'stream':
-          reader = new StreamMessageReader(process.stdin);
-          writer = new StreamMessageWriter(process.stdout);
-          break;
-        case 'node':
-        default:
-          reader = new IPCMessageReader(process);
-          writer = new IPCMessageWriter(process);
-          break;
-      }
-      const connection = createMessageConnection(reader, writer, logger);
-      addHandlers(
-        connection,
-        logger,
-        options.configDir,
-        options.extensions,
-        options.config,
-      );
-      connection.listen();
+            connection.listen();
+          })
+          .listen(port);
+        return;
+      case 'stream':
+        reader = new StreamMessageReader(process.stdin);
+        writer = new StreamMessageWriter(process.stdout);
+        break;
+      case 'node':
+      default:
+        reader = new IPCMessageReader(process);
+        writer = new IPCMessageWriter(process);
+        break;
     }
-  } catch (err) {
-    process.stderr.write(err.message);
+    const connection = createMessageConnection(reader, writer, logger);
+    addHandlers(
+      connection,
+      logger,
+      options.configDir,
+      options?.extensions ?? [],
+      options.config,
+    );
+    connection.listen();
   }
 }
 

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -42,6 +42,7 @@ import {
 } from 'vscode-languageserver';
 
 import { Logger } from './Logger';
+import { parseDocument } from './parseDocument';
 
 type Options = {
   // port for the LSP server to run on
@@ -54,6 +55,7 @@ type Options = {
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>;
   // pre-existing GraphQLConfig
   config?: GraphQLConfig;
+  parser?: typeof parseDocument;
 };
 ('graphql-language-service-types');
 


### PR DESCRIPTION
- introduces typescript, tsx and jsx support via babel parser plugins
- #1263 by @zth is an alternative to solving this problem which also supports reasonml, and potentially other  a non-ast branch by @zth using regular expressions should  be reconsidered.
-tests for typecript and tsx added
- `getQueryAndRange` changed to `parseDocument`, and made override-able as `parse` by `startServer`.