### PR TITLE
feat: optionally provide LSP an instantiated GraphQLConfig

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -55,8 +55,9 @@ const {
 export async function getGraphQLCache(
   configDir: Uri,
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>,
+  config?: GraphQLConfig,
 ): Promise<GraphQLCacheInterface> {
-  let graphQLConfig = await loadConfig({ rootDir: configDir });
+  let graphQLConfig = config || (await loadConfig({ rootDir: configDir }));
   if (extensions && extensions.length > 0) {
     for (const extension of extensions) {
       graphQLConfig = await extension(graphQLConfig);

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -69,6 +69,7 @@ type CachedDocumentType = {
 
 export class MessageProcessor {
   _graphQLCache!: GraphQLCache;
+  _graphQLConfig: GraphQLConfig | undefined;
   _languageService!: GraphQLLanguageService;
   _textDocumentCache: Map<string, CachedDocumentType>;
 
@@ -82,12 +83,14 @@ export class MessageProcessor {
   constructor(
     logger: Logger,
     extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>,
+    config?: GraphQLConfig,
   ) {
     this._textDocumentCache = new Map();
     this._isInitialized = false;
     this._willShutdown = false;
     this._logger = logger;
     this._extensions = extensions;
+    this._graphQLConfig = config;
   }
 
   async handleInitializeRequest(
@@ -117,7 +120,11 @@ export class MessageProcessor {
       );
     }
 
-    this._graphQLCache = await getGraphQLCache(rootPath, this._extensions);
+    this._graphQLCache = await getGraphQLCache(
+      rootPath,
+      this._extensions,
+      this._graphQLConfig,
+    );
     this._languageService = new GraphQLLanguageService(this._graphQLCache);
 
     if (!serverCapabilities) {

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -52,6 +52,8 @@ type Options = {
   configDir?: string;
   // array of functions to transform the graphql-config and add extensions dynamically
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>;
+  // pre-existing GraphQLConfig
+  config?: GraphQLConfig;
 };
 ('graphql-language-service-types');
 
@@ -100,6 +102,7 @@ export default async function startServer(options: Options): Promise<void> {
                 logger,
                 options.configDir,
                 options.extensions,
+                options.config,
               );
               connection.listen();
             })
@@ -116,7 +119,13 @@ export default async function startServer(options: Options): Promise<void> {
           break;
       }
       const connection = createMessageConnection(reader, writer, logger);
-      addHandlers(connection, logger, options.configDir, options.extensions);
+      addHandlers(
+        connection,
+        logger,
+        options.configDir,
+        options.extensions,
+        options.config,
+      );
       connection.listen();
     }
   } catch (err) {
@@ -129,8 +138,9 @@ function addHandlers(
   logger: Logger,
   configDir?: string,
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>,
+  config?: GraphQLConfig,
 ): void {
-  const messageProcessor = new MessageProcessor(logger, extensions);
+  const messageProcessor = new MessageProcessor(logger, extensions, config);
   connection.onNotification(
     DidOpenTextDocumentNotification.type,
     async params => {


### PR DESCRIPTION
This allows supplying a pre-existing graphql-config to the LS. The idea is that external consumers, like a vscode extension, should be able to provide defaults and extensions of the existing config (or generate it programatically all together) in a way that can be supplied directly to the LS.

It's basically https://github.com/graphql/graphiql/pull/1272 but rebased.