### PR TITLE
fix: make sure that custom parser is used if passed to process

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -54,9 +54,9 @@ const {
 
 export async function getGraphQLCache(
   configDir: Uri,
+  parser: typeof parseDocument,
   extensions?: Array<(config: GraphQLConfig) => GraphQLConfig>,
   config?: GraphQLConfig,
-  parser?: typeof parseDocument,
 ): Promise<GraphQLCacheInterface> {
   let graphQLConfig =
     config ?? ((await loadConfig({ rootDir: configDir })) as GraphQLConfig);
@@ -81,7 +81,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   constructor(
     configDir: Uri,
     graphQLConfig: GraphQLConfig,
-    parser?: typeof parseDocument,
+    parser: typeof parseDocument,
   ) {
     this._configDir = configDir;
     this._graphQLConfig = graphQLConfig;
@@ -90,7 +90,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._fragmentDefinitionsCache = new Map();
     this._typeDefinitionsCache = new Map();
     this._typeExtensionMap = new Map();
-    this._parser = parser || parseDocument;
+    this._parser = parser;
   }
 
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -120,6 +120,7 @@ export class MessageProcessor {
       rootPath,
       this._extensions,
       this._graphQLConfig,
+      this._parser,
     );
     this._languageService = new GraphQLLanguageService(this._graphQLCache);
 
@@ -160,7 +161,7 @@ export class MessageProcessor {
     if ('text' in textDocument && textDocument.text) {
       // textDocument/didSave does not pass in the text content.
       // Only run the below function if text is passed in.
-      contents = parseDocument(textDocument.text, uri, this._fileExtensions);
+      contents = this._parser(textDocument.text, uri, this._fileExtensions);
 
       this._invalidateCache(textDocument, uri, contents);
     } else {
@@ -230,7 +231,7 @@ export class MessageProcessor {
 
     // If it's a .js file, try parsing the contents to see if GraphQL queries
     // exist. If not found, delete from the cache.
-    const contents = parseDocument(
+    const contents = this._parser(
       contentChange.text,
       uri,
       this._fileExtensions,
@@ -449,7 +450,7 @@ export class MessageProcessor {
         ) {
           const uri = change.uri;
           const text: string = readFileSync(new URL(uri).pathname).toString();
-          const contents = parseDocument(text, uri, this._fileExtensions);
+          const contents = this._parser(text, uri, this._fileExtensions);
 
           this._updateFragmentDefinition(uri, contents);
           this._updateObjectTypeDefinition(uri, contents);

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -86,7 +86,7 @@ export class MessageProcessor {
     this._extensions = extensions;
     this._fileExtensions = fileExtensions;
     this._graphQLConfig = config;
-    this._parser = parser || parseDocument;
+    this._parser = parser ?? parseDocument;
   }
 
   async handleInitializeRequest(
@@ -118,9 +118,9 @@ export class MessageProcessor {
 
     this._graphQLCache = await getGraphQLCache(
       rootPath,
+      this._parser,
       this._extensions,
       this._graphQLConfig,
-      this._parser,
     );
     this._languageService = new GraphQLLanguageService(this._graphQLCache);
 

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -32,11 +32,11 @@ function wihtoutASTNode(definition: any) {
 describe('GraphQLCache', () => {
   const configDir = __dirname;
   let graphQLRC;
-  let cache = new GraphQLCache(configDir, graphQLRC);
+  let cache = new GraphQLCache(configDir, graphQLRC, parseDocument);
 
   beforeEach(async () => {
     graphQLRC = await loadConfig({ rootDir: configDir });
-    cache = new GraphQLCache(configDir, graphQLRC);
+    cache = new GraphQLCache(configDir, graphQLRC, parseDocument);
   });
 
   afterEach(() => {
@@ -52,7 +52,11 @@ describe('GraphQLCache', () => {
         };
       };
       const extensions = [extension];
-      const cacheWithExtensions = await getGraphQLCache(configDir, extensions);
+      const cacheWithExtensions = await getGraphQLCache(
+        configDir,
+        parseDocument,
+        extensions,
+      );
       const config = cacheWithExtensions.getGraphQLConfig();
       expect('extension' in config).toBe(true);
       expect((config as any).extension).toBe('extension-used');


### PR DESCRIPTION
This ensures that a custom parser is used if passed to the server.