### PR TITLE
feat: make sure @ triggers directive completion automatically

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -102,7 +102,10 @@ export class MessageProcessor {
       capabilities: {
         workspaceSymbolProvider: true,
         documentSymbolProvider: true,
-        completionProvider: { resolveProvider: true },
+        completionProvider: {
+          resolveProvider: true,
+          triggerCharacters: ['@'],
+        },
         definitionProvider: true,
         textDocumentSync: 1,
         hoverProvider: true,


### PR DESCRIPTION
This adds `@` as an explicit trigger character for code completion in the LS. What this does is that it brings up the autocomplete list as soon as you type "@", rather than you needing to manually activate autocomplete (ctrl+space) to autocomplete directives.