### PR TITLE
chore: add working group landing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,4 @@ Eventually we hope to move these to a repo that serves this purpose.
 - **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/RfY2dvr) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
 - **Twitter** - [@GraphiQL](https://twitter.com/@GraphiQL) and [#GraphiQL](https://twitter.com/hashtag/GraphiQL)
 - **GitHub** - Create feature requests, discussions issues and bugs above
+- **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.]('working-group#readme')

--- a/working-group/README.md
+++ b/working-group/README.md
@@ -1,0 +1,36 @@
+# GraphiQL & GraphQL LSP Working Group
+
+The GraphiQL and GraphQL Working Group focuses on fielding and fostering proposals and specifications for plugin interfaces and other user/developer-facing interfaces, as well as overall features, decisions about lifecycle, etc. This doesn't mean we will make decisions about every PR we merge, but it's a chance to have stake in the roadmap and how commonly used interfaces change.
+
+All users of GraphiQL, the LSP, GraphQL IDE extensions, developer users, all GraphQL community members are welcome. There is no official list of members, though you can add yourself to the monthly meeting agends (see below)
+
+This working group is focused on usage of the entire monorepo - GraphiQL and plugins, codemirror-graphql, to the new monaco mode, the LSP service interface, the LSP server and the LSP server CLI.
+
+## Monthly Working Group Meeting
+
+> **Second Tuesday of Every month at 16GMT/12EST** > [Google Calendar Event](https://calendar.google.com/event?action=TEMPLATE&tmeid=NHN2YjJwcGc5bGxvb3MycW1xbXA1aTU3bzRfMjAyMDA0MTRUMTYwMDAwWiByaWtraS5zY2h1bHRlQG0&tmsrc=rikki.schulte%40gmail.com&scp=ALL)
+
+These are monthly sessions designed to work similarly to the official `graphql/graphql-wg` working group. The goal is decision making, setting specifications and navigating feature proposals for our shared graphql web and desktop IDE experiences as a community.
+
+Many of the underlying packages used for graphql web/desktop IDE tooling are in this very monorepo!
+
+In the [`'agendas'`]('/agendas') directory you can introduce PRs to add yourself as an atendee to each agenda, and optionally add an agenda item or two.
+
+## Rotating Working Sessions/Office Hours
+
+> **First and third saturday of the month at 16GMT/12EST** [Google Calendar Event](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXYxZnEzdHBvcHNqaTNrZHA5cm1obmFldm1fMjAyMDA0MThUMTYwMDAwWiByaWtraS5zY2h1bHRlQG0&tmsrc=rikki.schulte%40gmail.com&scp=ALL)
+
+For now just twice a month on saturdays, we will have a group working session where we collaborate on API and feature proposals, demonstrate contributions to the monorepo we're working on, improve documentation, or even pair on actual PRs whilst sharing the session on the zoom link.
+
+It will be informal, with no set agenda, and no official decisions made about the spec (though we may collaborate on proposals brought to the monthly meeting above).
+
+As far as office hours, during these sessions @acao and others can field support and setup issues for all users of all skills as we always do.
+It might be a good time to get discussions going that can be turned into discussion Issues, Feature/Plugin Proposals, RFCs, etc.
+
+## Get Involved
+
+You can also find us on [discord](https://discord.gg/8J65QW), in github via issues or PRs!
+
+See the Community section at the bottom of [the root level readme](../README.md) for more information.
+
+Aside from these two recurring zoom sessions, those two places in public (discord & github) are where the working group activity happens.


### PR DESCRIPTION
- add a landing readme for the working group directory
- add a reference in the Community section in the root readme