### PR TITLE
build: add missing include lists

### DIFF
--- a/packages/graphql-language-service-interface/tsconfig.esm.json
+++ b/packages/graphql-language-service-interface/tsconfig.esm.json
@@ -16,5 +16,6 @@
       "path": "../graphql-language-service-utils"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-interface/tsconfig.json
+++ b/packages/graphql-language-service-interface/tsconfig.json
@@ -16,5 +16,6 @@
       "path": "../graphql-language-service-utils"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-parser/tsconfig.esm.json
+++ b/packages/graphql-language-service-parser/tsconfig.esm.json
@@ -10,5 +10,6 @@
       "path": "../graphql-language-service-types"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-parser/tsconfig.json
+++ b/packages/graphql-language-service-parser/tsconfig.json
@@ -10,5 +10,6 @@
       "path": "../graphql-language-service-types"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-server/tsconfig.esm.json
+++ b/packages/graphql-language-service-server/tsconfig.esm.json
@@ -17,5 +17,6 @@
       "path": "../graphql-language-service-utils"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-server/tsconfig.json
+++ b/packages/graphql-language-service-server/tsconfig.json
@@ -17,5 +17,6 @@
       "path": "../graphql-language-service-utils"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-types/tsconfig.esm.json
+++ b/packages/graphql-language-service-types/tsconfig.esm.json
@@ -4,5 +4,6 @@
     "rootDir": "./src",
     "outDir": "./esm"
   },
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-types/tsconfig.json
+++ b/packages/graphql-language-service-types/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "outDir": "./dist"
   },
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-utils/tsconfig.esm.json
+++ b/packages/graphql-language-service-utils/tsconfig.esm.json
@@ -10,5 +10,6 @@
       "path": "../graphql-language-service-types"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service-utils/tsconfig.json
+++ b/packages/graphql-language-service-utils/tsconfig.json
@@ -10,5 +10,6 @@
       "path": "../graphql-language-service-types"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }

--- a/packages/graphql-language-service/tsconfig.json
+++ b/packages/graphql-language-service/tsconfig.json
@@ -19,5 +19,6 @@
       "path": "../graphql-language-service-types"
     }
   ],
+  "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]
 }


### PR DESCRIPTION
`rootDir` doesn't imply `include`, so output files were being incorrectly included as inputs.  Besides being less efficient, this made it necessary to clean before each TypeScript build.