### PR TITLE
chore(docs): discord links in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Looking for the [GraphiQL Docs?](packages/graphiql/README.md)**: This is the root of the monorepo! The full GraphiQL docs are located at [`packages/graphiql`](packages/graphiql)
 
 [![Build Status](https://travis-ci.org/graphql/graphiql.svg?branch=master)](https://travis-ci.org/graphql/graphiql)
-[![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/RfY2dvr)
+[![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG)
 [![Code Coverage](https://img.shields.io/codecov/c/github/graphql/graphiql)](https://codecov.io/gh/graphql/graphiql)
 ![GitHub top language](https://img.shields.io/github/languages/top/graphql/graphiql)
 ![GitHub language count](https://img.shields.io/github/languages/count/graphql/graphiql)
@@ -140,7 +140,7 @@ Eventually we hope to move these to a repo that serves this purpose.
 
 ## Community
 
-- **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/RfY2dvr) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
+- **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
 - **Twitter** - [@GraphiQL](https://twitter.com/@GraphiQL) and [#GraphiQL](https://twitter.com/hashtag/GraphiQL)
 - **GitHub** - Create feature requests, discussions issues and bugs above
 - **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.]('working-group#readme')


### PR DESCRIPTION
these were old and sending folks to the wrong channel