### PR TITLE
chore: remove engine strict from utils, import() not used anymore

### DIFF
--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -23,10 +23,6 @@
   "main": "dist/index.js",
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
-  "engines": {
-    "node": ">= 9.7.3"
-  },
-  "engineStrict": true,
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"
   },


### PR DESCRIPTION
lol, oops this probably sucked on the install side. my bad i didnt remove this a while ago