### PR TITLE
Feat: Add URI Prop

### DIFF
--- a/packages/graphiql/src/components/ExecuteButton.tsx
+++ b/packages/graphiql/src/components/ExecuteButton.tsx
@@ -55,24 +55,22 @@ export function ExecuteButton(props: ExecuteButtonProps) {
     );
   }
 
-  // Allow click event if there is a running query or if there are not options
-  // for which operation to run.
-  let onClick;
-  if (props.isRunning || !hasOptions) {
-    onClick = () => {
+  const onClick = () => {
+    // Allow click event if there is a running query or if there are not options
+    // for which operation to run.
+    if (props.isRunning || !hasOptions) {
       if (props.isRunning) {
         props.onStop();
       } else {
         session.executeOperation();
       }
-    };
-  }
+    }
+  };
 
-  // Allow mouse down if there is no running query, there are options for
-  // which operation to run, and the dropdown is currently closed.
-  let onMouseDown: MouseEventHandler<HTMLButtonElement> = () => {};
-  if (!props.isRunning && hasOptions && !optionsOpen) {
-    onMouseDown = downEvent => {
+  const onMouseDown: MouseEventHandler<HTMLButtonElement> = downEvent => {
+    // Allow mouse down if there is no running query, there are options for
+    // which operation to run, and the dropdown is currently closed.
+    if (!props.isRunning && hasOptions && !optionsOpen) {
       let initialPress = true;
       const downTarget = downEvent.currentTarget;
       setHighlight(null);
@@ -99,8 +97,8 @@ export function ExecuteButton(props: ExecuteButtonProps) {
       };
 
       document.addEventListener('mouseup', onMouseUp);
-    };
-  }
+    }
+  };
 
   const pathJSX = props.isRunning ? (
     <path d="M 10 10 L 23 10 L 23 23 L 10 23 z" />

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -36,6 +36,7 @@ import {
   SessionContext,
 } from '../state/GraphiQLSessionProvider';
 import { Fetcher, Unsubscribable } from '../state/types';
+import { getFetcher } from '../state/common';
 
 const DEFAULT_DOC_EXPLORER_WIDTH = 350;
 
@@ -71,6 +72,7 @@ type GraphiQLProps = {
   fetcher: Fetcher;
   schema: GraphQLSchema | null;
   query?: string;
+  uri?: string;
   variables?: string;
   operationName?: string;
   response?: string;
@@ -114,9 +116,10 @@ type GraphiQLState = {
  * @see https://github.com/graphql/graphiql#usage
  */
 export const GraphiQL: React.FC<GraphiQLProps> = props => {
+  const fetcher = getFetcher(props.fetcher, props.uri);
   return (
-    <SchemaProvider {...props}>
-      <SessionProvider sessionId={0} {...props}>
+    <SchemaProvider fetcher={fetcher} {...props}>
+      <SessionProvider fetcher={fetcher} sessionId={0} {...props}>
         <GraphiQLInternals
           {...{
             formatResult,

--- a/packages/graphiql/src/components/QueryEditor.tsx
+++ b/packages/graphiql/src/components/QueryEditor.tsx
@@ -253,7 +253,7 @@ export function QueryEditor(props: QueryEditorProps) {
       editor.setValue(session?.operation?.text ?? '');
     }
     ignoreChangeEventRef.current = false;
-  }, [schema, session.operation.text]);
+  }, [schema, session]);
 
   return (
     <section className="query-editor" aria-label="Query Editor" ref={nodeRef} />

--- a/packages/graphiql/src/components/ResultViewer.tsx
+++ b/packages/graphiql/src/components/ResultViewer.tsx
@@ -85,7 +85,7 @@ export function ResultViewer(props: ResultViewerProps) {
 
   useEffect(() => {
     if (session.results && viewerRef.current) {
-      viewerRef.current.setValue(session.results.formattedText || '');
+      viewerRef.current.setValue(session.results.text || '');
     }
   }, [session.results.text]);
 

--- a/packages/graphiql/src/components/ResultViewer.tsx
+++ b/packages/graphiql/src/components/ResultViewer.tsx
@@ -84,10 +84,14 @@ export function ResultViewer(props: ResultViewerProps) {
   }, []);
 
   useEffect(() => {
-    if (session.results && viewerRef.current) {
+    if (session.results.text && viewerRef.current) {
       viewerRef.current.setValue(session.results.text || '');
     }
-  }, [session.results.text]);
+
+    if (session.operationErrors && viewerRef.current) {
+      viewerRef.current.setValue(session.operationErrors.toString());
+    }
+  }, [session.results, session.operationErrors]);
 
   return (
     <section

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -58,7 +58,7 @@ export function VariableEditor(props: VariableEditorProps) {
   React.useEffect(() => {
     // Lazily require to ensure requiring GraphiQL outside of a Browser context
     // does not produce an error.
-    const _CodeMirror = require('codemirror');
+    const CodeMirror = require('codemirror');
     require('codemirror/addon/hint/show-hint');
     require('codemirror/addon/edit/matchbrackets');
     require('codemirror/addon/edit/closebrackets');
@@ -106,7 +106,7 @@ export function VariableEditor(props: VariableEditorProps) {
       onHasCompletion(instance, changeObj, props.onHintInformationRender);
     };
 
-    const editor = (editorRef.current = _CodeMirror(divRef.current, {
+    const editor = (editorRef.current = CodeMirror(divRef.current, {
       value: session.variables.text || '',
       lineNumbers: true,
       tabSize: 2,

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 import onHasCompletion from '../utility/onHasCompletion';
 import commonKeys from '../utility/commonKeys';
 import { useSessionContext } from '../state/GraphiQLSessionProvider';
-import { useSchemaContext } from '../state/GraphiQLSchemaProvider';
 import useQueryFacts from '../hooks/useQueryFacts';
 
 declare module CodeMirror {
@@ -51,7 +50,6 @@ type VariableEditorProps = {
 export function VariableEditor(props: VariableEditorProps) {
   const session = useSessionContext();
   const queryFacts = useQueryFacts();
-  const { schema } = useSchemaContext();
   const [ignoreChangeEvent, setIgnoreChangeEvent] = React.useState(false);
   const editorRef = React.useRef<(CM.Editor & { options: any }) | null>(null);
   const cachedValueRef = React.useRef<string>(props.value ?? '');
@@ -60,7 +58,7 @@ export function VariableEditor(props: VariableEditorProps) {
   React.useEffect(() => {
     // Lazily require to ensure requiring GraphiQL outside of a Browser context
     // does not produce an error.
-    const CodeMirror = require('codemirror');
+    const _CodeMirror = require('codemirror');
     require('codemirror/addon/hint/show-hint');
     require('codemirror/addon/edit/matchbrackets');
     require('codemirror/addon/edit/closebrackets');
@@ -108,7 +106,7 @@ export function VariableEditor(props: VariableEditorProps) {
       onHasCompletion(instance, changeObj, props.onHintInformationRender);
     };
 
-    const editor = (editorRef.current = CodeMirror(divRef.current, {
+    const editor = (editorRef.current = _CodeMirror(divRef.current, {
       value: session.variables.text || '',
       lineNumbers: true,
       tabSize: 2,

--- a/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { GraphQLSchema } from 'graphql';
 import { DispatchWithEffects, useReducers, Reducer } from './useReducers';
 import { defaultSchemaLoader } from './common';
@@ -145,30 +145,28 @@ export function SchemaProvider({
     }),
   });
 
-  const loadCurrentSchema = async (currentState: SchemaState) => {
-    const { config } = currentState;
+  const loadCurrentSchema = useCallback(async () => {
     dispatch(schemaRequestedAction());
     try {
-      const schema = await schemaLoader(config);
+      const schema = await schemaLoader(state.config);
       if (schema) {
         dispatch(schemaSucceededAction(schema));
       }
     } catch (error) {
       dispatch(schemaErroredAction(error));
     }
-  };
+  }, [dispatch, schemaLoader, state.config]);
 
-  const loadSchema = async (
-    currentState: SchemaState,
-    config: SchemaConfig,
-  ) => {
-    dispatch(schemaChangedAction(config));
-    await loadCurrentSchema(currentState);
-  };
+  const loadSchema = useCallback(
+    (config: SchemaConfig) => {
+      dispatch(schemaChangedAction(config));
+    },
+    [dispatch],
+  );
 
-  React.useEffect(() => {
-    (async () => loadCurrentSchema(state))();
-  }, []);
+  useEffect(() => {
+    loadCurrentSchema();
+  }, [loadCurrentSchema]);
 
   return (
     <SchemaContext.Provider

--- a/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
@@ -9,7 +9,6 @@ import {
   schemaRequestedAction,
   schemaSucceededAction,
   schemaErroredAction,
-  schemaChangedAction,
 } from './schemaActions';
 
 /**
@@ -46,10 +45,8 @@ export type SchemaContextValue = SchemaState & ProjectHandlers;
 
 export const SchemaContext = React.createContext<SchemaContextValue>({
   ...getInitialState(),
-  loadCurrentSchema: async () => undefined,
   loadSchema: async () => undefined,
   dispatch: async () => undefined,
-  // schemaLoader: defaultSchemaLoader,
 });
 
 export const useSchemaContext = () => React.useContext(SchemaContext);
@@ -109,8 +106,6 @@ export type SchemaProviderProps = {
 
 export type ProjectHandlers = {
   loadSchema: (state: SchemaState, config: SchemaConfig) => Promise<void>;
-  loadCurrentSchema: (state: SchemaState) => Promise<void>;
-  // schemaLoader: typeof defaultSchemaLoader;
   dispatch: DispatchWithEffects<SchemaActionTypes, SchemaAction>;
 };
 
@@ -119,12 +114,7 @@ export function SchemaProvider({
   config: userSchemaConfig = initialReducerState.config,
   ...props
 }: SchemaProviderProps) {
-  const [state, dispatch] = useReducers<
-    SchemaState,
-    SchemaAction,
-    SchemaReducer
-  >({
-    // @ts-ignore
+  const [state, dispatch] = useReducers({
     reducers: [schemaReducer],
     init: args => ({
       ...getInitialState({ config: userSchemaConfig }),
@@ -132,7 +122,7 @@ export function SchemaProvider({
     }),
   });
 
-  const loadCurrentSchema = useCallback(async () => {
+  const loadSchema = useCallback(async () => {
     dispatch(schemaRequestedAction());
     try {
       const schema = await fetchSchema(fetcher);
@@ -145,22 +135,14 @@ export function SchemaProvider({
     }
   }, [dispatch, fetcher]);
 
-  const loadSchema = useCallback(
-    (config: SchemaConfig) => {
-      dispatch(schemaChangedAction(config));
-    },
-    [dispatch],
-  );
-
   useEffect(() => {
-    loadCurrentSchema();
-  }, [loadCurrentSchema]);
+    loadSchema();
+  }, [loadSchema]);
 
   return (
     <SchemaContext.Provider
       value={{
         ...state,
-        loadCurrentSchema,
         loadSchema,
         dispatch,
       }}>

--- a/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSchemaProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
 import { GraphQLSchema } from 'graphql';
 import { DispatchWithEffects, useReducers, Reducer } from './useReducers';
-import { getDefaultFetcher, fetchSchema } from './common';
+import { fetchSchema } from './common';
 import { SchemaConfig, Fetcher } from './types';
 import {
   SchemaAction,

--- a/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
@@ -4,7 +4,6 @@ import { Fetcher } from './types';
 
 import { GraphQLParams, SessionState, EditorContexts } from './types';
 
-import { SchemaContext } from './GraphiQLSchemaProvider';
 import {
   SessionAction,
   SessionActionTypes,
@@ -189,11 +188,12 @@ export function SessionProvider({
           fetchValues.operationName = operationName as string;
         }
         const result = await observableToPromise(fetcher(fetchValues));
-        console.log(result);
         if (result && result.data) {
-          console.log('here');
           dispatch(
-            operationSucceededAction(JSON.stringify(result.data), sessionId),
+            operationSucceededAction(
+              JSON.stringify(result.data, null, 2),
+              sessionId,
+            ),
           );
         }
       } catch (err) {

--- a/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/state/GraphiQLSessionProvider.tsx
@@ -4,7 +4,6 @@ import { Fetcher } from './types';
 
 import { GraphQLParams, SessionState, EditorContexts } from './types';
 
-import { defaultFetcher } from './common';
 import { SchemaContext } from './GraphiQLSchemaProvider';
 import {
   SessionAction,
@@ -130,18 +129,18 @@ function sessionReducer(
 
 export type SessionProviderProps = {
   sessionId: number;
-  fetcher?: Fetcher;
+  fetcher: Fetcher;
   session?: SessionState;
   children: React.ReactNode;
 };
 
 export function SessionProvider({
   sessionId,
-  fetcher = defaultFetcher,
+  fetcher,
   session,
   children,
 }: SessionProviderProps) {
-  const schemaState = React.useContext(SchemaContext);
+  // const schemaState = React.useContext(SchemaContext);
 
   const [state, dispatch] = useReducers<
     SessionState,
@@ -189,10 +188,14 @@ export function SessionProvider({
         if (operationName) {
           fetchValues.operationName = operationName as string;
         }
-        const result = await observableToPromise(
-          fetcher(fetchValues, schemaState.config),
-        );
-        dispatch(operationSucceededAction(result, sessionId));
+        const result = await observableToPromise(fetcher(fetchValues));
+        console.log(result);
+        if (result && result.data) {
+          console.log('here');
+          dispatch(
+            operationSucceededAction(JSON.stringify(result.data), sessionId),
+          );
+        }
       } catch (err) {
         console.error(err.name, err.stack);
         operationError(err);
@@ -202,7 +205,6 @@ export function SessionProvider({
       dispatch,
       fetcher,
       operationError,
-      schemaState.config,
       sessionId,
       state.operation,
       state.variables,

--- a/packages/graphiql/src/state/common.ts
+++ b/packages/graphiql/src/state/common.ts
@@ -1,47 +1,56 @@
-import { GraphQLSchema, buildClientSchema } from 'graphql';
+import {
+  buildClientSchema,
+  ExecutionResult,
+  IntrospectionQuery,
+} from 'graphql';
 
 import {
   introspectionQuery,
   introspectionQueryName,
 } from '../utility/introspectionQueries';
 
-import { SchemaConfig, GraphQLParams } from './types';
+import { SchemaConfig, GraphQLParams, Fetcher } from './types';
+import { observableToPromise } from '../utility/observableToPromise';
 
-export const defaultSchemaLoader = async (
-  schemaConfig: SchemaConfig,
-): Promise<GraphQLSchema | void> => {
-  const rawResult = await fetch(schemaConfig.uri, {
-    method: 'post',
-    body: JSON.stringify({
-      query: introspectionQuery,
-      operationName: introspectionQueryName,
-    }),
-    headers: { 'Content-Type': 'application/json', credentials: 'omit' },
+export async function fetchSchema(fetcher: Fetcher) {
+  const rawResult = fetcher({
+    query: introspectionQuery,
+    operationName: introspectionQueryName,
   });
-
-  const introspectionResponse = await rawResult.json();
+  const introspectionResponse = await observableToPromise(rawResult);
 
   if (!introspectionResponse || !introspectionResponse.data) {
     throw Error('error fetching introspection schema');
   }
-  return buildClientSchema(introspectionResponse.data, {
+  return buildClientSchema(introspectionResponse.data as IntrospectionQuery, {
     assumeValid: true,
   });
-};
+}
 
-export const defaultFetcher = async (
-  graphqlParams: GraphQLParams,
-  schemaConfig: SchemaConfig,
-): Promise<string> => {
-  try {
-    const rawResult = await fetch(schemaConfig.uri, {
-      method: 'post',
-      body: JSON.stringify(graphqlParams),
-      headers: { 'Content-Type': 'application/json', credentials: 'omit' },
-    });
-    return rawResult.text();
-  } catch (err) {
-    console.error(err);
-    throw err;
+export function getDefaultFetcher(schemaConfig: SchemaConfig): Fetcher {
+  return async function defaultFetcher(graphqlParams: GraphQLParams) {
+    try {
+      const rawResult = await fetch(schemaConfig.uri!, {
+        method: 'post',
+        body: JSON.stringify(graphqlParams),
+        headers: { 'Content-Type': 'application/json', credentials: 'omit' },
+      });
+      return rawResult.json() as ExecutionResult;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  };
+}
+
+export function getFetcher(fetcher?: Fetcher, uri?: string): Fetcher {
+  if (fetcher) {
+    return fetcher;
   }
-};
+
+  if (uri) {
+    return getDefaultFetcher({ uri });
+  }
+
+  throw new Error('Must provide either a fetcher or a uri');
+}

--- a/packages/graphiql/src/state/types.ts
+++ b/packages/graphiql/src/state/types.ts
@@ -1,5 +1,4 @@
-import { OperationDefinitionNode } from 'graphql';
-import { QueryFacts } from '../utility/getQueryFacts';
+import { OperationDefinitionNode, ExecutionResult } from 'graphql';
 
 export type FetcherParams = {
   query: string;
@@ -7,11 +6,10 @@ export type FetcherParams = {
   variables?: string;
 };
 
-export type FetcherResult = string;
+export type FetcherResult = ExecutionResult;
 
 export type Fetcher = (
   graphQLParams: FetcherParams,
-  schemaConfig: SchemaConfig,
 ) => Promise<FetcherResult> | Observable<FetcherResult>;
 
 // These type just taken from https://github.com/ReactiveX/rxjs/blob/master/src/internal/types.ts#L41
@@ -51,7 +49,7 @@ export type GraphQLParams = {
 };
 
 export type SchemaConfig = {
-  uri: string;
+  uri?: string;
   assumeValid?: boolean;
 };
 


### PR DESCRIPTION
This PR adds a `uri` prop to `GraphiQL`. The user can now either pass just a string URI, in which case GraphiQL will use the default fetcher, or they can provide their own fetcher if they want more control. If neither are provided GraphiQL will throw

This PR also gets rid of the `schemaLoader` function an just uses the fetcher now instead