### PR TITLE
ci: force build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,6 +24,18 @@
    yarn run build
    ```
 
+   you can also use
+
+   ```sh
+   yarn run watch
+   ```
+
+   if you are focused on GraphiQL development, you can run
+
+   ```sh
+   yarn run start-graphiql
+   ```
+
 5. Get coding! If you've added code, add tests. If you've changed APIs, update
    any relevant documentation or tests. Ensure your work is committed within a
    feature branch.
@@ -54,10 +66,12 @@ to run tests for GraphiQL:
 
 1. `yarn` - install and link all packages
 2. `yarn build` - cleans first, then builds everything but webpack bundles - `tsc --build`, `babel` etc
-3. `yarn build-bundles` - builds webpack bundles that are used for releases
-4. `yarn build-demo` - builds demo projects for netlify; we run this on CI to make sure webpack can consume our project in a standalone project.
-5. `yarn test` - runs `jest`. so `yarn t --watch`
-6. `yarn format` - autoformats with eslint --fix and prettier
-7. `yarn lint` - checks for linting issues
-8. `yarn e2e` - runs cypress headlessly against the minified bundle and a local schema server, like in CI.
-9. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn test --watch` or `yarn jtest DocExplorer` for example :D
+3. `yarn build-ts` - builds typescript using `--build` and `--force` flag.
+4. `yarn watch` - runs `tsc --build --watch`, for when you make cross-repository changes
+5. `yarn build-bundles` - builds webpack bundles that are used for releases
+6. `yarn build-demo` - builds demo projects for netlify; we run this on CI to make sure webpack can consume our project in a standalone project.
+7. `yarn test` - runs `jest`. so `yarn t --watch`
+8. `yarn format` - autoformats with eslint --fix and prettier
+9. `yarn lint` - checks for linting issues
+10. `yarn e2e` - runs cypress headlessly against the minified bundle and a local schema server, like in CI.
+11. `yarn jest` - runs global jest commands across the entire monorepo; try `yarn test --watch` or `yarn jtest DocExplorer` for example :D

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "pretty": "node resources/pretty.js",
     "pretty-check": "node resources/pretty.js --check",
     "format": "yarn eslint --fix && yarn pretty",
-    "lerna-publish": "lerna publish",
-    "prepublish": "./resources/prepublish.sh"
+    "lerna-publish": "lerna publish"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "yarn run build-clean && yarn build-ts && yarn build-babel",
     "build-babel": "yarn workspace codemirror-graphql run build",
-    "build-ts": "yarn run tsc",
+    "build-ts": "yarn run tsc --force",
     "build-ts-cjs": "yarn run tsc resources/tsconfig.build.cjs.json",
     "build-ts-esm": "yarn run tsc resources/tsconfig.build.esm.json",
     "build-clean": "lerna run build-clean",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "pretty": "node resources/pretty.js",
     "pretty-check": "node resources/pretty.js --check",
     "format": "yarn eslint --fix && yarn pretty",
-    "lerna-publish": "lerna publish"
+    "lerna-publish": "lerna publish",
+    "watch": "yarn tsc --watch",
+    "start-graphiql": "yarn workspace graphiql dev"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -8,7 +8,6 @@
     "baseUrl": ".",
     "strictPropertyInitialization": false,
     "types": ["node", "jest"],
-    "typeRoots": ["../../node_modules/@types", "node_modules/@types"],
     "lib": ["dom"]
   },
   "include": ["src"],

--- a/resources/README.md
+++ b/resources/README.md
@@ -10,10 +10,11 @@ For each `.js` file under `src`, creates a corresponding `.js.flow` file under `
 
 Compiles `.js` files under `src` using Babel, writing the output to `dist`. This script is invoked via `yarn run build-js` (and also `yarn run build`).
 
-### `prepublish.js`
-
-This script is invoked via `yarn run prepublish`.
-
 ### `pretty.js`
 
 Prettifies the code base, or tests that it is already prettified. This script is invoked for these two purposes respectively via `yarn run pretty` and `yarn run pretty-check` (and also `npm test`).
+
+## Typescript Configs
+
+`.build.*` - used for project references
+`.base.*` - used for extends for downstream tsconfigs

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,7 @@
     "@babel/helper-remap-async-to-generator" "^7.8.3"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@^7.7.0", "@babel/plugin-proposal-class-properties@^7.8.3", "@babel/plugin-proposal-class-properties@^7.8.34":
+"@babel/plugin-proposal-class-properties@^7.7.0", "@babel/plugin-proposal-class-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz#5e06654af5cd04b608915aada9b2a6788004464e"
   integrity sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==


### PR DESCRIPTION
Especially locally, `tsc --build` without `--force` flag seems to give us some issues after removing `tsc --build --clean` as a prelminary step.

For example, for the last GraphiQL alpha, the index.js file didn't publish, despite my running `yarn build-ts` beforehand!