### PR TITLE
fix: hover log

### DIFF
--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -243,7 +243,9 @@ export class GraphQLLanguageService {
     const projectConfig = this.getConfigForURI(filePath);
     const schema = await this._graphQLCache
       .getSchema(projectConfig.name)
-      .catch(() => null);
+      .catch(e => {
+        throw e;
+      });
 
     if (schema) {
       return getHoverInformation(schema, query, position);

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -412,11 +412,17 @@ export class MessageProcessor {
     if (range) {
       position.line -= range.start.line;
     }
-    const result = await this._languageService.getHoverInformation(
-      query,
-      position,
-      textDocument.uri,
-    );
+
+    let result: Hover['contents'] = '';
+    try {
+      result = await this._languageService.getHoverInformation(
+        query,
+        position,
+        textDocument.uri,
+      );
+    } catch (e) {
+      throw new Error(`Error parsing the schema, ${e}`);
+    }
 
     return {
       contents: result,


### PR DESCRIPTION
If there was an error in schema parsing, the hover handler silently
fails.

The aim of this PR is to raise the issue, the fix might be added at
another level (and maybe even needed at other places).

For this PR, we re-throw the error.

After this PR, invalid schema yields: 
<img width="1153" alt="CleanShot 2020-04-11 at 03 14 10@2x" src="https://user-images.githubusercontent.com/746482/79025519-a49f2400-7ba3-11ea-930a-296678249b2b.png">

P.S. the tests are much faster now! All of them took like 18s on my machine 🙌