### PR TITLE
fix: repair CLI, handle all schema and LSP errors

### DIFF
--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -125,6 +125,9 @@ export class GraphQLLanguageService {
     // schema/fragment definitions, even the project configuration.
     let queryHasExtensions = false;
     const projectConfig = this.getConfigForURI(uri);
+    if (!projectConfig) {
+      return [];
+    }
     const { schema: schemaPath, name: projectName, extensions } = projectConfig;
 
     try {

--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -208,9 +208,10 @@ export class GraphQLLanguageService {
       }
       /* eslint-enable no-implicit-coercion */
     }
-    const schema = await this._graphQLCache
-      .getSchema(projectName, queryHasExtensions)
-      .catch(() => null);
+    const schema = await this._graphQLCache.getSchema(
+      projectName,
+      queryHasExtensions,
+    );
 
     if (!schema) {
       return [];

--- a/packages/graphql-language-service/src/cli.ts
+++ b/packages/graphql-language-service/src/cli.ts
@@ -83,6 +83,7 @@ const { argv } = yargs
       'Can be one of: stream, node, socket.\n' +
       'Will default to use a node IPC channel for communication.\n',
     type: 'string',
+    default: 'node',
   })
   .option('p', {
     alias: 'port',

--- a/packages/graphql-language-service/tsconfig.json
+++ b/packages/graphql-language-service/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "./src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "target": "ES2017"
   },
   "references": [
     {


### PR DESCRIPTION
This should do what @divyenduz set out to do in #1481 more universally. Any exception in any of the handlers bubbles up to the GLS output channel now.

It also repairs the CLI. It was targeting `esnext` by default, thus a use of nullish coalescing was breaking the CLI (not supported natively in node yet). 

So, I set it to `target: es2017` for node 10 support.

Additionally, CLI should default method to `node` as advertised.

Tested with both the CLI using validate command, and `vscode-graphql` - the only issue there is the custom prisma extension is throwing an error. the extension works great if you remove that extension. I think it just needs to be upgraded for the new graphql-config?

