### PR TITLE
chore: relative paths for imports

### DIFF
--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -13,7 +13,7 @@ import HistoryQuery, {
   HandleToggleFavoriteFn,
   HandleSelectQueryFn,
 } from './HistoryQuery';
-import StorageAPI from 'src/utility/StorageAPI';
+import StorageAPI from '../utility/StorageAPI';
 
 const MAX_QUERY_SIZE = 100000;
 const MAX_HISTORY_LENGTH = 20;

--- a/packages/graphiql/src/components/ResultViewer.tsx
+++ b/packages/graphiql/src/components/ResultViewer.tsx
@@ -9,7 +9,7 @@ import React, { Component, FunctionComponent } from 'react';
 import * as CM from 'codemirror';
 import ReactDOM from 'react-dom';
 import commonKeys from '../utility/commonKeys';
-import { SizerComponent } from 'src/utility/CodeMirrorSizer';
+import { SizerComponent } from '../utility/CodeMirrorSizer';
 import { ImagePreview as ImagePreviewComponent } from './ImagePreview';
 
 type ResultViewerProps = {


### PR DESCRIPTION
these are auto-added by vscode because of the tsconfig somehow, and usually work for builds but sometimes break tests