### PR TITLE
feat: introduce proper vscode completion kinds

### DIFF
--- a/examples/graphiql-webpack/webpack.config.js
+++ b/examples/graphiql-webpack/webpack.config.js
@@ -66,5 +66,6 @@ module.exports = {
   },
   node: {
     fs: 'empty',
+    module: 'empty',
   },
 };

--- a/packages/graphiql/resources/webpack.config.js
+++ b/packages/graphiql/resources/webpack.config.js
@@ -40,6 +40,7 @@ const resultConfig = {
   devtool: isDev ? 'cheap-module-eval-source-map' : 'source-map',
   node: {
     fs: 'empty',
+    module: 'empty',
   },
   externals: {
     react: 'React',

--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -73,18 +73,19 @@ const {
 } = Kind;
 
 const KIND_TO_SYMBOL_KIND: { [key: string]: SymbolKind } = {
-  Field: SymbolKind.Field,
-  OperationDefinition: SymbolKind.Class,
-  FragmentDefinition: SymbolKind.Class,
-  FragmentSpread: SymbolKind.Struct,
-  ObjectTypeDefinition: SymbolKind.Class,
-  EnumTypeDefinition: SymbolKind.Enum,
-  EnumValueDefinition: SymbolKind.EnumMember,
-  InputObjectTypeDefinition: SymbolKind.Class,
-  InputValueDefinition: SymbolKind.Field,
-  FieldDefinition: SymbolKind.Field,
-  InterfaceTypeDefinition: SymbolKind.Interface,
-  Document: SymbolKind.File,
+  [Kind.FIELD]: SymbolKind.Field,
+  [Kind.OPERATION_DEFINITION]: SymbolKind.Class,
+  [Kind.FRAGMENT_DEFINITION]: SymbolKind.Class,
+  [Kind.FRAGMENT_SPREAD]: SymbolKind.Struct,
+  [Kind.OBJECT_TYPE_DEFINITION]: SymbolKind.Class,
+  [Kind.ENUM_TYPE_DEFINITION]: SymbolKind.Enum,
+  [Kind.ENUM_VALUE_DEFINITION]: SymbolKind.EnumMember,
+  [Kind.INPUT_OBJECT_TYPE_DEFINITION]: SymbolKind.Class,
+  [Kind.INPUT_VALUE_DEFINITION]: SymbolKind.Field,
+  [Kind.FIELD_DEFINITION]: SymbolKind.Field,
+  [Kind.INTERFACE_TYPE_DEFINITION]: SymbolKind.Interface,
+  [Kind.DOCUMENT]: SymbolKind.File,
+  // novel, for symbols only
   FieldWithArguments: SymbolKind.Method,
 };
 

--- a/packages/graphql-language-service-types/src/index.ts
+++ b/packages/graphql-language-service-types/src/index.ts
@@ -8,13 +8,11 @@
  */
 import {
   Diagnostic as DiagnosticType,
-  Position as PositionType,
   CompletionItem as CompletionItemType,
-} from 'vscode-languageserver-protocol';
-import { GraphQLSchema, KindEnum } from 'graphql';
+} from 'vscode-languageserver-types';
+import { Kind, ASTNode, GraphQLSchema } from 'graphql';
 
 import {
-  ASTNode,
   DocumentNode,
   FragmentDefinitionNode,
   NamedTypeNode,
@@ -32,8 +30,14 @@ import { GraphQLDirective } from 'graphql/type/directives';
 
 export type Maybe<T> = T | null | undefined;
 
-export { GraphQLConfig, GraphQLProjectConfig };
-import { GraphQLConfig, GraphQLProjectConfig } from 'graphql-config';
+import {
+  GraphQLConfig,
+  GraphQLProjectConfig,
+  GraphQLExtensionDeclaration,
+} from 'graphql-config';
+export { GraphQLConfig, GraphQLProjectConfig, GraphQLExtensionDeclaration };
+
+import { _Kind } from 'graphql/language/kinds';
 
 export type TokenPattern = string | ((char: string) => boolean) | RegExp;
 
@@ -59,33 +63,6 @@ export interface CharacterStreamInterface {
   indentation: () => number;
   current: () => string;
 }
-
-// Cache and config-related.
-export type GraphQLConfiguration = GraphQLProjectConfiguration & {
-  projects?: {
-    [projectName: string]: GraphQLProjectConfiguration;
-  };
-};
-
-export type GraphQLProjectConfiguration = {
-  // The name for this project configuration.
-  // If not supplied, the object key can be used for the project name.
-  name?: string;
-  schemaPath?: string; // a file with schema IDL
-
-  // For multiple applications with overlapping files,
-  // these configuration options may be helpful
-  includes?: string[];
-  excludes?: string[];
-
-  // If you'd like to specify any other configurations,
-  // we provide a reserved namespace for it
-  extensions?: GraphQLConfigurationExtension;
-};
-
-export type GraphQLConfigurationExtension = {
-  [name: string]: unknown;
-};
 
 export interface GraphQLCache {
   getGraphQLConfig: () => GraphQLConfig;
@@ -149,7 +126,7 @@ export interface GraphQLCache {
 }
 
 // online-parser related
-export type Position = PositionType & {
+export type Position = {
   line: number;
   character: number;
   lessThanOrEqualTo?: (position: Position) => boolean;
@@ -186,29 +163,63 @@ export type Rule = {
   ofRule?: Rule | string;
 };
 
-export type RuleKind =
-  | KindEnum
-  | 'AliasedField'
-  | 'Arguments'
-  | 'ShortQuery'
-  | 'Query'
-  | 'Mutation'
-  | 'Subscription'
-  | 'TypeCondition'
-  | 'Invalid'
-  | 'Comment'
-  | 'SchemaDef'
-  | 'ScalarDef'
-  | 'ObjectTypeDef'
-  | 'InterfaceDef'
-  | 'UnionDef'
-  | 'EnumDef'
-  | 'FieldDef'
-  | 'InputDef'
-  | 'InputValueDef'
-  | 'ArgumentsDef'
-  | 'ExtendDef'
-  | 'DirectiveDef';
+export const AdditionalRuleKinds: _AdditionalRuleKinds = {
+  ALIASED_FIELD: 'AliasedField',
+  ARGUMENTS: 'Arguments',
+  SHORT_QUERY: 'ShortQuery',
+  QUERY: 'Query',
+  MUTATION: 'Mutation',
+  SUBSCRIPTION: 'Subscription',
+  TYPE_CONDITION: 'TypeCondition',
+  INVALID: 'Invalid',
+  COMMENT: 'Comment',
+  SCHEMA_DEF: 'SchemaDef',
+  SCALAR_DEF: 'ScalarDef',
+  OBJECT_TYPE_DEF: 'ObjectTypeDef',
+  INTERFACE_DEF: 'InterfaceDef',
+  UNION_DEF: 'UnionDef',
+  ENUM_DEF: 'EnumDef',
+  FIELD_DEF: 'FieldDef',
+  INPUT_DEF: 'InputDef',
+  INPUT_VALUE_DEF: 'InputValueDef',
+  ARGUMENTS_DEF: 'ArgumentsDef',
+  EXTEND_DEF: 'ExtendDef',
+  DIRECTIVE_DEF: 'DirectiveDef',
+};
+
+export type _AdditionalRuleKinds = {
+  ALIASED_FIELD: 'AliasedField';
+  ARGUMENTS: 'Arguments';
+  SHORT_QUERY: 'ShortQuery';
+  QUERY: 'Query';
+  MUTATION: 'Mutation';
+  SUBSCRIPTION: 'Subscription';
+  TYPE_CONDITION: 'TypeCondition';
+  INVALID: 'Invalid';
+  COMMENT: 'Comment';
+  SCHEMA_DEF: 'SchemaDef';
+  SCALAR_DEF: 'ScalarDef';
+  OBJECT_TYPE_DEF: 'ObjectTypeDef';
+  INTERFACE_DEF: 'InterfaceDef';
+  UNION_DEF: 'UnionDef';
+  ENUM_DEF: 'EnumDef';
+  FIELD_DEF: 'FieldDef';
+  INPUT_DEF: 'InputDef';
+  INPUT_VALUE_DEF: 'InputValueDef';
+  ARGUMENTS_DEF: 'ArgumentsDef';
+  EXTEND_DEF: 'ExtendDef';
+  DIRECTIVE_DEF: 'DirectiveDef';
+};
+
+export const RuleKinds = {
+  ...Kind,
+  ...AdditionalRuleKinds,
+};
+
+export type _RuleKinds = _Kind & typeof AdditionalRuleKinds;
+
+export type RuleKind = _RuleKinds[keyof _RuleKinds];
+export type RuleKindEnum = RuleKind;
 
 export type State = {
   level: number;


### PR DESCRIPTION
this re-uses vscode's own CompletionItemKind to introduce completion kinds at the LSP interface level.  these will make different icons appear for different types on completion. currently kind values are not returned, so it's up to the user to specify them.

also, introduce a const for RuleKinds lookup that will be used by monaco. using these, monaco has slightly different kinds that we will configure in a simple lookup object in a later PR