### PR TITLE
Add CII best practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 [![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/graphql/graphiql)](https://snyk.io/test/github/graphql/graphiql)
 ![LGTM Grade](https://img.shields.io/lgtm/grade/javascript/github/graphql/graphiql)
 ![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/graphql/graphiql)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3887/badge)](https://bestpractices.coreinfrastructure.org/projects/3887)
+or by embedding this in your HTML:
 
 ## Overview
 


### PR DESCRIPTION
Add a badge for our coreinfrastructure.org entry, as per #1500. All Linux Foundation projects adhere to these best practices. We will be updating this report as we improve our repository

[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3887/badge)](https://bestpractices.coreinfrastructure.org/projects/3887)