### PR TITLE
chore: netlify swapi schema urls are broken

### DIFF
--- a/examples/graphiql-webpack/src/index.jsx
+++ b/examples/graphiql-webpack/src/index.jsx
@@ -13,7 +13,7 @@ const App = () => (
     style={{ height: '100vh' }}
     fetcher={async graphQLParams => {
       const data = await fetch(
-        'https://swapi-graphql.netlify.com/.netlify/functions/index',
+        'https://swapi-graphql.netlify.app/.netlify/functions/index',
         {
           method: 'POST',
           headers: {

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -12,7 +12,7 @@ import JSONWorker from 'worker-loader!monaco-editor/esm/vs/language/json/json.wo
 // @ts-ignore
 import GraphQLWorker from 'worker-loader!monaco-graphql/esm/graphql.worker';
 
-const SCHEMA_URL = 'https://swapi-graphql.netlify.com/.netlify/functions/index';
+const SCHEMA_URL = 'https://swapi-graphql.netlify.app/.netlify/functions/index';
 
 // @ts-ignore
 window.MonacoEnvironment = {

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -13,7 +13,7 @@ var parameters = {};
 search
   .substr(1)
   .split('&')
-  .forEach(function(entry) {
+  .forEach(function (entry) {
     var eq = entry.indexOf('=');
     if (eq >= 0) {
       parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
@@ -57,10 +57,10 @@ function updateURL() {
   var newSearch =
     '?' +
     Object.keys(parameters)
-      .filter(function(key) {
+      .filter(function (key) {
         return Boolean(parameters[key]);
       })
-      .map(function(key) {
+      .map(function (key) {
         return (
           encodeURIComponent(key) + '=' + encodeURIComponent(parameters[key])
         );
@@ -79,7 +79,7 @@ function graphQLFetcher(graphQLParams) {
   const isDev = window.location.hostname.match(/localhost$/);
   const api = isDev
     ? '/graphql'
-    : 'https://swapi-graphql.netlify.com/.netlify/functions/index';
+    : 'https://swapi-graphql.netlify.app/.netlify/functions/index';
   return fetch(api, {
     method: 'post',
     headers: {
@@ -89,10 +89,10 @@ function graphQLFetcher(graphQLParams) {
     body: JSON.stringify(graphQLParams),
     credentials: 'omit',
   })
-    .then(function(response) {
+    .then(function (response) {
       return response.text();
     })
-    .then(function(responseBody) {
+    .then(function (responseBody) {
       try {
         return JSON.parse(responseBody);
       } catch (error) {

--- a/packages/monaco-graphql/src/defaults.ts
+++ b/packages/monaco-graphql/src/defaults.ts
@@ -68,7 +68,7 @@ export const diagnosticDefault: Required<monaco.languages.graphql.DiagnosticsOpt
   allowComments: true,
   schemas: [],
   enableSchemaRequest: true,
-  schemaUri: 'https://swapi-graphql.netlify.com/.netlify/functions/index',
+  schemaUri: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
 };
 
 export const modeConfigurationDefault: Required<monaco.languages.graphql.ModeConfiguration> = {


### PR DESCRIPTION
trying to figure out the situation with netlify support still, but the swapi netlify tld switched from .com to .app at some point and I can't switch it back?

this fixes our master build, but swapi itself is another matter.