### PR TITLE
[RFC, Not ready for merge] Refactored Language Service API to be transport agnostic

### DIFF
--- a/packages/graphql-languageservice/src/http/HttpLanguageService.ts
+++ b/packages/graphql-languageservice/src/http/HttpLanguageService.ts
@@ -1,0 +1,67 @@
+import { LanguageService, GraphQLLspConfig } from 'LanguageService';
+import { createHttpSchemaLoader } from './schema-loader';
+import { createHttpQueryExecutor } from './query-executor';
+
+type EndpointConfig = { uri: string; requestOpts?: RequestInit };
+type SeparateIntrospectionAndExecutionConfig = {
+  introspection: EndpointConfig;
+  execution?: EndpointConfig;
+};
+
+type UnifiedConfig = EndpointConfig & { disableExecution?: boolean };
+
+export type HttpGraphQLLanguageServiceConfig = Omit<
+  GraphQLLspConfig,
+  'schemaLoader' | 'queryExecutor'
+> &
+  (UnifiedConfig | SeparateIntrospectionAndExecutionConfig);
+
+function createSchemaLoaderFromHttpGraphQLLanguageServiceConfig(
+  config: HttpGraphQLLanguageServiceConfig,
+) {
+  let endpointConfig: undefined | EndpointConfig = undefined;
+  if ((config as UnifiedConfig).uri) {
+    endpointConfig = config as UnifiedConfig;
+  } else {
+    endpointConfig = (config as SeparateIntrospectionAndExecutionConfig)
+      .introspection;
+  }
+  return createHttpSchemaLoader({
+    introspectionOptions: config.introspectionOptions,
+    uri: endpointConfig.uri,
+    requestOpts: endpointConfig.requestOpts,
+  });
+}
+
+function createQueryExecutorFromHttpGraphQLLanguageServiceConfig(
+  config: HttpGraphQLLanguageServiceConfig,
+) {
+  let endpointConfig: undefined | EndpointConfig = undefined;
+  if ((config as EndpointConfig).uri) {
+    const unified = config as UnifiedConfig;
+    endpointConfig = unified.disableExecution ? undefined : unified;
+  } else {
+    endpointConfig = (config as SeparateIntrospectionAndExecutionConfig)
+      .execution;
+  }
+  if (endpointConfig) {
+    return createHttpQueryExecutor({
+      uri: endpointConfig.uri,
+      requestOpts: endpointConfig.requestOpts,
+    });
+  }
+}
+
+export class HttpFetcherLanguageService extends LanguageService {
+  constructor(config: HttpGraphQLLanguageServiceConfig) {
+    super({
+      ...config,
+      schemaLoader: createSchemaLoaderFromHttpGraphQLLanguageServiceConfig(
+        config,
+      ),
+      queryExecutor: createQueryExecutorFromHttpGraphQLLanguageServiceConfig(
+        config,
+      ),
+    });
+  }
+}

--- a/packages/graphql-languageservice/src/http/fetcher.ts
+++ b/packages/graphql-languageservice/src/http/fetcher.ts
@@ -1,0 +1,34 @@
+import { Json } from 'queryExecutor';
+
+type FetcherArgs = {
+  uri: string;
+  query: string;
+  operationName?: string;
+  variables?: unknown;
+  requestOpts?: RequestInit;
+};
+
+export async function graphQLHttpFetcher<T extends Json>({
+  requestOpts,
+  uri,
+  query,
+  operationName,
+  variables,
+}: FetcherArgs): Promise<T> {
+  const rawResult = await fetch(uri, {
+    method: 'post',
+    body: JSON.stringify({
+      query,
+      operationName,
+      variables,
+    }),
+    credentials: 'omit',
+    headers: requestOpts?.headers || {
+      'Content-Type': 'application/json',
+    },
+    ...requestOpts,
+  });
+
+  const response: T = (await rawResult.json()) as T;
+  return response;
+}

--- a/packages/graphql-languageservice/src/http/queryExecutor.ts
+++ b/packages/graphql-languageservice/src/http/queryExecutor.ts
@@ -1,0 +1,23 @@
+import { QueryExecutor, QueryExecutorArgs } from 'queryExecutor';
+import { graphQLHttpFetcher } from './fetcher';
+
+export type HttpQueryExecutorConfig = {
+  requestOpts?: RequestInit;
+  uri: string;
+};
+
+export function createHttpQueryExecutor(
+  config: HttpQueryExecutorConfig,
+): QueryExecutor {
+  const { uri, requestOpts } = config;
+  return (args: QueryExecutorArgs) => {
+    const { query, operationName, variables } = args;
+    return graphQLHttpFetcher({
+      requestOpts,
+      uri,
+      operationName,
+      query,
+      variables,
+    });
+  };
+}

--- a/packages/graphql-languageservice/src/http/schemaLoader.ts
+++ b/packages/graphql-languageservice/src/http/schemaLoader.ts
@@ -1,0 +1,32 @@
+import { graphQLHttpFetcher } from './fetcher';
+import {
+  IntrospectionOptions,
+  getIntrospectionQuery,
+  IntrospectionQuery,
+} from 'graphql';
+import { SchemaLoader } from 'schemaLoader';
+import { Json } from 'queryExecutor';
+
+export type HttpSchemaLoaderConfig = {
+  uri: string;
+  requestOpts?: RequestInit;
+  introspectionOptions?: IntrospectionOptions;
+};
+
+export function createHttpSchemaLoader(
+  config: HttpSchemaLoaderConfig,
+): SchemaLoader {
+  const { requestOpts, uri, introspectionOptions } = config;
+  return async () => {
+    const introspectionResponse = await graphQLHttpFetcher<
+      { data: IntrospectionQuery } & Json
+    >({
+      requestOpts,
+      uri,
+      operationName: 'IntrospectionQuery',
+      query: getIntrospectionQuery(introspectionOptions),
+    });
+
+    return introspectionResponse?.data;
+  };
+}

--- a/packages/graphql-languageservice/src/index.ts
+++ b/packages/graphql-languageservice/src/index.ts
@@ -7,7 +7,11 @@
  *
  */
 export * from './schemaLoader';
+export * from './queryExecutor';
 export * from './LanguageService';
+export * from './http/queryExecutor';
+export * from './http/schemaLoader';
+// export * from './http/HttpLanguageService';
 export * from 'graphql-language-service-interface';
 export * from 'graphql-language-service-parser';
 export * from 'graphql-language-service-types';

--- a/packages/graphql-languageservice/src/queryExecutor.ts
+++ b/packages/graphql-languageservice/src/queryExecutor.ts
@@ -1,0 +1,15 @@
+export type QueryExecutorArgs = {
+  query: string;
+  operationName?: string;
+  variables?: unknown;
+};
+
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [prop: string]: Json };
+
+export type QueryExecutor = (args: QueryExecutorArgs) => Promise<Json>;

--- a/packages/graphql-languageservice/src/schemaLoader.ts
+++ b/packages/graphql-languageservice/src/schemaLoader.ts
@@ -1,6 +1,4 @@
 import {
-  getIntrospectionQuery,
-  IntrospectionOptions,
   IntrospectionQuery,
   DocumentNode,
   BuildSchemaOptions,
@@ -8,44 +6,16 @@ import {
   buildASTSchema,
 } from 'graphql';
 
-export type SchemaConfig = {
-  uri: string;
-  requestOpts?: RequestInit;
-  introspectionOptions?: IntrospectionOptions;
-  buildSchemaOptions?: BuildSchemaOptions;
-};
-
 export type SchemaResponse = IntrospectionQuery | DocumentNode;
 
-export type SchemaLoader = (config: SchemaConfig) => Promise<SchemaResponse>;
+export type SchemaLoader = () => Promise<SchemaResponse>;
 
-export const defaultSchemaLoader: SchemaLoader = async (
-  schemaConfig: SchemaConfig,
-): Promise<SchemaResponse> => {
-  const { requestOpts, uri, introspectionOptions } = schemaConfig;
-  const fetchResult = await fetch(uri, {
-    method: requestOpts?.method ?? 'post',
-    body: JSON.stringify({
-      query: getIntrospectionQuery(introspectionOptions),
-      operationName: 'IntrospectionQuery',
-    }),
-    credentials: 'omit',
-    headers: requestOpts?.headers || {
-      'Content-Type': 'application/json',
-    },
-    ...requestOpts,
-  });
-  const introspectionResponse: {
-    data: IntrospectionQuery;
-  } = await fetchResult.json();
-  return introspectionResponse?.data;
-};
 /**
  *
  * @param response {DocumentNode | IntrospectionQuery} response from retrieving schema
  * @param buildSchemaOptions {BuildSchemaOptions} options for building schema
  */
-export function defaultSchemaBuilder(
+export function buildSchemaFromResponse(
   response: SchemaResponse,
   buildSchemaOptions?: BuildSchemaOptions,
 ) {


### PR DESCRIPTION
This is a first pass at improving the LanguageService API. 

My main intention here was to:
- Add the ability to execute queries from within the language service
- Improve type safety 
- Remove conflating concerns from the Language Service. For example the URI and request options were baked into the Language Server config but would only apply to a subset of possible schema fetchers. 

Configuration here is performed on the schema fetcher and executors using a closure, instead of passing the config each time. 

This PR is not ready for merge as it'd break the GraphQL worker. Additional work will be required to bring the above benefits to configuration of the worker.

Would love to get some feedback on these preliminary changes.