### PR TITLE
improvement: add resizer component

### DIFF
--- a/packages/graphiql/src/components/common/Resizer/ResizeHandler.tsx
+++ b/packages/graphiql/src/components/common/Resizer/ResizeHandler.tsx
@@ -1,0 +1,84 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ResizeHandlerData, ResizeHandlerProps } from './types';
+
+export const ResizeHandler: React.FC<ResizeHandlerProps> = props => {
+  const { dir, onStart, onEnd, onUpdate, className, style, children } = props;
+
+  const [isDragging, setIsDragging] = useState(false);
+  const listenersRef = useRef<ResizeHandlerData['listenersRef']>(null);
+
+  const handleMouseMove = useCallback(
+    e => {
+      onUpdate(e);
+    },
+    [onUpdate],
+  );
+
+  const cleanMouseListeners = useCallback(() => {
+    const oldRef = listenersRef.current;
+    if (oldRef) {
+      window.removeEventListener('mousemove', oldRef.handleMouseMove);
+      window.removeEventListener('touchmove', oldRef.handleMouseMove);
+      window.removeEventListener('mouseup', oldRef.handleMouseUp);
+      window.removeEventListener('touchend', oldRef.handleMouseUp);
+    }
+  }, []);
+
+  const handleMouseUp = useCallback(
+    e => {
+      setIsDragging(false);
+      cleanMouseListeners();
+      onEnd(e);
+    },
+    [cleanMouseListeners, onEnd],
+  );
+
+  const handleMouseDown = useCallback(
+    e => {
+      setIsDragging(true);
+      cleanMouseListeners();
+
+      listenersRef.current = {
+        handleMouseMove,
+        handleMouseUp,
+      };
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('touchmove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+      window.addEventListener('touchend', handleMouseUp);
+
+      onStart(e);
+    },
+    [cleanMouseListeners, handleMouseMove, handleMouseUp, onStart],
+  );
+
+  useEffect(() => {
+    return () => {
+      cleanMouseListeners();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      onMouseDown={handleMouseDown}
+      onTouchStart={handleMouseDown}
+      className={className}
+      style={{
+        cursor: `${dir}-resize`,
+        ...style,
+      }}>
+      {isDragging && (
+        <style>{`
+        * {
+          cursor: ${dir}-resize !important;
+          -webkit-user-select: none !important;
+        }
+        `}</style>
+      )}
+      {children}
+    </div>
+  );
+};

--- a/packages/graphiql/src/components/common/Resizer/Resizer.stories.tsx
+++ b/packages/graphiql/src/components/common/Resizer/Resizer.stories.tsx
@@ -1,0 +1,13 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+import { Resizer } from './Resizer';
+
+export default { title: 'Resizer' };
+
+export const resizer = () => (
+  <Resizer
+    border="bottom"
+    handlerStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.2)' }}>
+    <main>{`Main content`}</main>
+  </Resizer>
+);

--- a/packages/graphiql/src/components/common/Resizer/Resizer.tsx
+++ b/packages/graphiql/src/components/common/Resizer/Resizer.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { ResizeHandler } from './ResizeHandler';
+import { ResizingData, ResizeProps, MEvent } from './types';
+import {
+  getContainerInfo,
+  getContainerMeta,
+  getHandlerInfo,
+  isNil,
+  normalizeMEvent,
+} from './util';
+
+export const Resizer: React.FC<ResizeProps> = props => {
+  const {
+    border,
+    onStart,
+    onEnd,
+    onUpdate,
+    id,
+    className,
+    style,
+    handlerClassName,
+    handlerStyle: _handlerStyle,
+    handlerWidth: _handlerWidth,
+    handlerOffset: _handlerOffset,
+    handlerZIndex: _handlerZIndex,
+    children,
+  } = props;
+
+  const handlerWidth = isNil(_handlerWidth) ? 16 : (_handlerWidth as number);
+  const handlerOffset = (isNil(_handlerOffset)
+    ? -handlerWidth / 2
+    : _handlerOffset) as number;
+  const handlerZIndex = (isNil(_handlerZIndex) ? 10 : _handlerZIndex) as number;
+
+  const [diffCoord, setDiffCoord] = useState<ResizingData['diffCoord']>(0);
+  const [oldSize, setOldSize] = useState<ResizingData['oldSize']>(null);
+  const oldCoordRef = useRef<ResizingData['oldCorrd']>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  const containerMeta = getContainerMeta({ border });
+
+  const { style: containerStyle } = getContainerInfo({
+    style,
+    containerMeta,
+    diffCoord,
+    oldSize,
+  });
+
+  const { dir, style: handlerStyle } = getHandlerInfo({
+    border,
+    handlerWidth,
+    handlerOffset,
+    handlerStyle: _handlerStyle,
+  });
+
+  const handleStart = useCallback(
+    (_e: MEvent) => {
+      const e = normalizeMEvent(_e);
+
+      const { wh, xy } = containerMeta;
+      const el = boxRef.current;
+      if (!el) {
+        return;
+      }
+
+      const px = window.getComputedStyle(el)[wh] as string;
+
+      setDiffCoord(0);
+      setOldSize(parseInt(px, 10));
+      oldCoordRef.current = e[xy];
+
+      if (onStart) {
+        onStart(e);
+      }
+    },
+    [containerMeta, onStart],
+  );
+
+  const handleEnd = useCallback(
+    (_e: MEvent) => {
+      const e = normalizeMEvent(_e);
+      if (onEnd) {
+        onEnd(e);
+      }
+    },
+    [onEnd],
+  );
+
+  const handleUpdate = useCallback(
+    (_e: MEvent) => {
+      const e = normalizeMEvent(_e);
+
+      const { xy } = containerMeta;
+      if (oldCoordRef.current === null) {
+        return;
+      }
+
+      setDiffCoord(e[xy] - oldCoordRef.current);
+
+      if (onUpdate) {
+        onUpdate(e);
+      }
+    },
+    [containerMeta, onUpdate],
+  );
+
+  return (
+    <div
+      ref={boxRef}
+      id={id}
+      className={className}
+      style={{
+        position: 'relative',
+        ...containerStyle,
+      }}>
+      <ResizeHandler
+        dir={dir}
+        className={handlerClassName}
+        style={{
+          position: 'absolute',
+          zIndex: handlerZIndex,
+          ...handlerStyle,
+        }}
+        onStart={handleStart}
+        onEnd={handleEnd}
+        onUpdate={handleUpdate}
+      />
+      {children}
+    </div>
+  );
+};

--- a/packages/graphiql/src/components/common/Resizer/index.ts
+++ b/packages/graphiql/src/components/common/Resizer/index.ts
@@ -1,0 +1,1 @@
+export * from './Resizer';

--- a/packages/graphiql/src/components/common/Resizer/types.ts
+++ b/packages/graphiql/src/components/common/Resizer/types.ts
@@ -1,0 +1,45 @@
+export type MEvent = MouseEvent | TouchEvent;
+
+export type RdsMEvent =
+  | MouseEvent
+  | (TouchEvent & {
+      clientX: number;
+      clientY: number;
+    });
+
+export interface ResizeHandlerProps {
+  dir: 'ew' | 'ns';
+  onStart: (e: MEvent) => void;
+  onEnd: (e: MEvent) => void;
+  onUpdate: (e: MEvent) => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export interface ResizeHandlerData {
+  listenersRef: {
+    handleMouseMove: (e: MEvent) => void;
+    handleMouseUp: (e: MEvent) => void;
+  } | null;
+}
+
+export interface ResizeProps {
+  border: 'top' | 'bottom' | 'left' | 'right';
+  onStart?: ResizeHandlerProps['onStart'];
+  onEnd?: ResizeHandlerProps['onEnd'];
+  onUpdate?: ResizeHandlerProps['onUpdate'];
+  id?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  handlerClassName?: string;
+  handlerStyle?: React.CSSProperties;
+  handlerWidth?: number;
+  handlerOffset?: number;
+  handlerZIndex?: number;
+}
+
+export interface ResizingData {
+  diffCoord: number;
+  oldCorrd: number | null;
+  oldSize: number | null;
+}

--- a/packages/graphiql/src/components/common/Resizer/util.ts
+++ b/packages/graphiql/src/components/common/Resizer/util.ts
@@ -1,0 +1,96 @@
+import {
+  ResizeHandlerProps,
+  ResizingData,
+  ResizeProps,
+  MEvent,
+  RdsMEvent,
+} from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isNil = (v: any) => v === null || v === undefined;
+
+export const normalizeMEvent = (e: MEvent): RdsMEvent => {
+  if ((e as TouchEvent).touches && (e as TouchEvent).touches[0]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (e as any).clientX = Math.round((e as TouchEvent).touches[0].clientX);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (e as any).clientY = Math.round((e as TouchEvent).touches[0].clientY);
+  }
+  return e as RdsMEvent;
+};
+
+export const getContainerMeta = ({
+  border,
+}: {
+  border: ResizeProps['border'];
+}) => {
+  let wh: 'width' | 'height';
+  let xy: 'clientX' | 'clientY';
+  let sn: 1 | -1;
+
+  if (/^(left|right)$/.test(border)) {
+    wh = 'width';
+    xy = 'clientX';
+    sn = border === 'right' ? 1 : -1;
+  } else {
+    wh = 'height';
+    xy = 'clientY';
+    sn = border === 'bottom' ? 1 : -1;
+  }
+  return { wh, xy, sn };
+};
+
+export const getContainerInfo = ({
+  style,
+  containerMeta,
+  diffCoord,
+  oldSize,
+}: {
+  style: ResizeProps['style'];
+  containerMeta: ReturnType<typeof getContainerMeta>;
+  diffCoord: ResizingData['diffCoord'];
+  oldSize: ResizingData['oldSize'];
+}) => {
+  const { wh, sn } = containerMeta;
+  let retStyle: React.CSSProperties = {};
+
+  if (oldSize != null) {
+    retStyle[wh] = oldSize + diffCoord * sn;
+  }
+  retStyle = {
+    ...style,
+    ...retStyle,
+  };
+  return { style: retStyle };
+};
+
+export const getHandlerInfo = ({
+  border,
+  handlerWidth,
+  handlerOffset,
+  handlerStyle,
+}: {
+  border: ResizeProps['border'];
+  handlerWidth: ResizeProps['handlerWidth'];
+  handlerOffset: ResizeProps['handlerOffset'];
+  handlerStyle: ResizeProps['handlerStyle'];
+}) => {
+  let dir: ResizeHandlerProps['dir'];
+  let style: React.CSSProperties = {};
+
+  if (/^(left|right)$/.test(border)) {
+    dir = 'ew';
+    style.width = handlerWidth;
+    style.top = 0;
+    style.bottom = 0;
+  } else {
+    dir = 'ns';
+    style.height = handlerWidth;
+    style.left = 0;
+    style.right = 0;
+  }
+  style[border] = handlerOffset;
+
+  style = { ...style, ...handlerStyle };
+  return { dir, style };
+};


### PR DESCRIPTION
This PR adds a new Resizer component. So we will be able to resize the editors. We can simply wrap the editor with resizer component like this

```ts
<Resizer
  border="bottom"
  handlerStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.2)' }}
>
  <main>{`Main content`}</main>
</Resizer>
```

This above example will add a resizer option below the `main` tag and we can also pass the required styles to it.

@acao can you review this