### PR TITLE
docs: fix working Group link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ Eventually we hope to move these to a repo that serves this purpose.
 - **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
 - **Twitter** - [@GraphiQL](https://twitter.com/@GraphiQL) and [#GraphiQL](https://twitter.com/hashtag/GraphiQL)
 - **GitHub** - Create feature requests, discussions issues and bugs above
-- **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.](/working-group/README.md)
+- **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.](working-group#readme)

--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ Eventually we hope to move these to a repo that serves this purpose.
 - **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
 - **Twitter** - [@GraphiQL](https://twitter.com/@GraphiQL) and [#GraphiQL](https://twitter.com/hashtag/GraphiQL)
 - **GitHub** - Create feature requests, discussions issues and bugs above
-- **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.]('working-group#readme')
+- **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.](/working-group/README.md)


### PR DESCRIPTION
The Working group link in the `Community` section was broken.