### PR TITLE
feat(merge): make fragment merging type-aware

### DIFF
--- a/packages/graphiql/jest.config.js
+++ b/packages/graphiql/jest.config.js
@@ -3,6 +3,8 @@ const base = require('../../jest.config.base')(__dirname);
 module.exports = {
   ...base,
 
-  // All tests disabled currently
-  testMatch: ['nothing'],
+  testMatch: [
+    // All other tests disabled currently
+    '**/src/utility/__tests__/*[-.](spec|test).[jt]s?(x)',
+  ],
 };

--- a/packages/graphiql/src/utility/__tests__/mergeAst-fixture.ts
+++ b/packages/graphiql/src/utility/__tests__/mergeAst-fixture.ts
@@ -16,6 +16,10 @@ export const fixtures = [
       query Test {
         id
       }`,
+    mergedQueryWithSchema: `
+      query Test {
+        id
+      }`,
   },
   {
     desc: 'inlines simple nested fragment',
@@ -32,6 +36,10 @@ export const fixtures = [
         ...on Test {
           id
         }
+      }`,
+    mergedQueryWithSchema: `
+      query Test {
+        id
       }`,
   },
   {
@@ -61,6 +69,10 @@ export const fixtures = [
             }
           }
         }
+      }`,
+    mergedQueryWithSchema: `
+      query Test {
+        id
       }`,
   },
   {
@@ -95,6 +107,10 @@ export const fixtures = [
           id
         }
       }`,
+    mergedQueryWithSchema: `
+      query Test {
+        id
+      }`,
   },
   {
     desc: 'removes duplicate fragment spreads',
@@ -112,6 +128,10 @@ export const fixtures = [
         ...on Test {
           id
         }
+      }`,
+    mergedQueryWithSchema: `
+      query Test {
+        id
       }`,
   },
 ];

--- a/packages/graphiql/src/utility/__tests__/mergeAst.spec.ts
+++ b/packages/graphiql/src/utility/__tests__/mergeAst.spec.ts
@@ -5,17 +5,39 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { parse, print } from 'graphql';
+import {
+  parse,
+  print,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInt,
+} from 'graphql';
 
 import mergeAst from '../mergeAst';
 
 import { fixtures } from './mergeAst-fixture';
 
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Test',
+    fields: {
+      id: {
+        type: GraphQLInt,
+      },
+    },
+  }),
+});
+
 describe('MergeAst', () => {
   fixtures.forEach(fixture => {
     it(fixture.desc, () => {
       const result = print(mergeAst(parse(fixture.query))).replace(/\s/g, '');
+      const result2 = print(mergeAst(parse(fixture.query), schema)).replace(
+        /\s/g,
+        '',
+      );
       expect(result).toEqual(fixture.mergedQuery.replace(/\s/g, ''));
+      expect(result2).toEqual(fixture.mergedQueryWithSchema.replace(/\s/g, ''));
     });
   });
 });

--- a/packages/graphiql/src/utility/mergeAst.ts
+++ b/packages/graphiql/src/utility/mergeAst.ts
@@ -20,6 +20,7 @@ import {
   Visitor,
   ASTNode,
 } from 'graphql';
+import Maybe from 'graphql/tsutils/Maybe';
 
 export function uniqueBy<T>(
   array: readonly SelectionNode[],
@@ -58,7 +59,7 @@ export function inlineRelevantFragmentSpreads(
     [key: string]: FragmentDefinitionNode | undefined;
   },
   selections: readonly SelectionNode[],
-  selectionSetType?: GraphQLOutputType,
+  selectionSetType?: Maybe<GraphQLOutputType>,
 ): readonly SelectionNode[] {
   const selectionSetTypeName = selectionSetType
     ? getNamedType(selectionSetType).name

--- a/packages/graphiql/src/utility/mergeAst.ts
+++ b/packages/graphiql/src/utility/mergeAst.ts
@@ -64,8 +64,18 @@ export function inlineRelevantFragmentSpreads(
     ? getNamedType(selectionSetType).name
     : null;
   const outputSelections = [];
+  const seenSpreads = [];
   for (let selection of selections) {
     if (selection.kind === 'FragmentSpread') {
+      const fragmentName = selection.name.value;
+      if (!selection.directives || selection.directives.length === 0) {
+        if (seenSpreads.indexOf(fragmentName) >= 0) {
+          /* It's a duplicate - skip it! */
+          continue;
+        } else {
+          seenSpreads.push(fragmentName);
+        }
+      }
       const fragmentDefinition = fragmentDefinitions[selection.name.value];
       if (fragmentDefinition) {
         const { typeCondition, directives, selectionSet } = fragmentDefinition;


### PR DESCRIPTION
Some massive improvements to `mergeAsts`:

- Doesn't inline fields/fragments if they use directives
- Doesn't drop following selection sets using same field name (merges them instead)
- Factors in types if optional schema is provided, allowing for deeper merging (i.e. no more `... on User {...}` when you're already referring to the User type)
- Stronger types throughout
- Tighter conversion to `InlineFragment` (doesn't add extraneous attributes)
- Still manages this on a single `visit`