### PR TITLE
feat: Add Headers Editor to GraphiQL

### DIFF
--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -199,6 +199,8 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `docExplorerOpen`: an optional boolean which when `true` will ensure the `DocExplorer` is open by default when the user first renders the component. If the user has toggled the doc explorer on/off following this, however, the persisted UI state will override this default flag.
 
+- `headerEditorEnabled`: an optional boolean which enables the header editor when `true`. Defaults to `false`.
+
 ### Children (dropped as of 1.0.0-rc.2)
 
 - `<GraphiQL.Logo>`: Replace the GraphiQL logo with your own.
@@ -259,6 +261,7 @@ class CustomGraphiQL extends React.Component {
       // Custom Event Handlers
       onEditQuery: null,
       onEditVariables: null,
+      onEditHeaders: null,
       onEditOperationName: null,
 
       // GraphiQL automatically fills in leaf nodes when the query

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -163,6 +163,8 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `variables`: an optional GraphQL string to use as the initial displayed query variables, if `undefined` is provided, the stored variables will be used.
 
+- `headers`: an optional GraphQL string to use as the initial displayed request headers, if `undefined` is provided, the stored headers will be used.
+
 - `operationName`: an optional name of which GraphQL operation should be executed.
 
 - `response`: an optional JSON string to use as the initial displayed response. If not provided, no response will be initially shown. You might provide this if illustrating the result of the initial query.
@@ -171,11 +173,15 @@ GraphiQL supports customization in UI and behavior by accepting React props and 
 
 - `defaultQuery`: an optional GraphQL string to use when no query is provided and no stored query exists from a previous session. If `undefined` is provided, GraphiQL will use its own default query.
 
-- `defaultVariableEditorOpen`: an optional boolean that sets whether or not to show the variables pane on startup. If not defined, it will be based off whether or not variables are present.
+- `defaultVariableEditorOpen`: an optional boolean that sets whether or not to show the variables pane on startup. If not defined, it will be based off whether or not variables are present. (**deprecated** in favor of `defaultSecondaryEditorOpen`)
+
+- `defaultSecondaryEditorOpen`: an optional boolean that sets whether or not to show the variables/headers pane on startup. If not defined, it will be based off whether or not variables and/or headers are present.
 
 - `onEditQuery`: an optional function which will be called when the Query editor changes. The argument to the function will be the query string.
 
 - `onEditVariables`: an optional function which will be called when the Query variable editor changes. The argument to the function will be the variables string.
+
+- `onEditHeaders`: an optional function which will be called when the request headers editor changes. The argument to the function will be the headers string.
 
 - `onEditOperationName`: an optional function which will be called when the operation name to be executed changes.
 
@@ -232,6 +238,7 @@ class CustomGraphiQL extends React.Component {
       // GraphQL artifacts
       query: '',
       variables: '',
+      headers: '',
       response: '',
 
       // GraphQL Schema

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -91,7 +91,7 @@ function updateURL() {
 // Defines a GraphQL fetcher using the fetch API. You're not required to
 // use fetch, and could instead implement graphQLFetcher however you like,
 // as long as it returns a Promise or Observable.
-function graphQLFetcher(graphQLParams, headers = {}) {
+function graphQLFetcher(graphQLParams, opts = { headers: {} }) {
   // When working locally, the example expects a GraphQL server at the path /graphql.
   // In a PR preview, it connects to the Star Wars API externally.
   // Change this to point wherever you host your GraphQL server.
@@ -101,16 +101,19 @@ function graphQLFetcher(graphQLParams, headers = {}) {
     : 'https://swapi-graphql.netlify.app/.netlify/functions/index';
 
   // Convert headers to an object.
-  if (typeof headers === 'string') {
-    headers = JSON.parse(headers);
+  if (typeof opts.headers === 'string') {
+    headers = JSON.parse(opts.headers);
   }
 
   return fetch(api, {
     method: 'post',
-    headers: Object.assign({
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    }, headers),
+    headers: Object.assign(
+      {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      headers,
+    ),
     body: JSON.stringify(graphQLParams),
     credentials: 'omit',
   })

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -146,6 +146,7 @@ ReactDOM.render(
     onEditHeaders: onEditHeaders,
     defaultVariableEditorOpen: true,
     onEditOperationName: onEditOperationName,
+    headerEditorEnabled: true,
   }),
   document.getElementById('graphiql'),
 );

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -100,8 +100,9 @@ function graphQLFetcher(graphQLParams, opts = { headers: {} }) {
     ? '/graphql'
     : 'https://swapi-graphql.netlify.app/.netlify/functions/index';
 
+  let headers = opts.headers;
   // Convert headers to an object.
-  if (typeof opts.headers === 'string') {
+  if (typeof headers === 'string') {
     headers = JSON.parse(opts.headers);
   }
 

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -36,6 +36,20 @@ if (parameters.variables) {
   }
 }
 
+// If headers was provided, try to format it.
+if (parameters.headers) {
+  try {
+    parameters.headers = JSON.stringify(
+      JSON.parse(parameters.headers),
+      null,
+      2,
+    );
+  } catch (e) {
+    // Do nothing, we want to display the invalid JSON as a string, rather
+    // than present an error.
+  }
+}
+
 // When the query and variables string is edited, update the URL bar so
 // that it can be easily shared.
 function onEditQuery(newQuery) {
@@ -45,6 +59,11 @@ function onEditQuery(newQuery) {
 
 function onEditVariables(newVariables) {
   parameters.variables = newVariables;
+  updateURL();
+}
+
+function onEditHeaders(newHeaders) {
+  parameters.headers = newHeaders;
   updateURL();
 }
 
@@ -72,7 +91,7 @@ function updateURL() {
 // Defines a GraphQL fetcher using the fetch API. You're not required to
 // use fetch, and could instead implement graphQLFetcher however you like,
 // as long as it returns a Promise or Observable.
-function graphQLFetcher(graphQLParams) {
+function graphQLFetcher(graphQLParams, headers = {}) {
   // When working locally, the example expects a GraphQL server at the path /graphql.
   // In a PR preview, it connects to the Star Wars API externally.
   // Change this to point wherever you host your GraphQL server.
@@ -80,12 +99,18 @@ function graphQLFetcher(graphQLParams) {
   const api = isDev
     ? '/graphql'
     : 'https://swapi-graphql.netlify.app/.netlify/functions/index';
+
+  // Convert headers to an object.
+  if (typeof headers === 'string') {
+    headers = JSON.parse(headers);
+  }
+
   return fetch(api, {
     method: 'post',
-    headers: {
+    headers: Object.assign({
       Accept: 'application/json',
       'Content-Type': 'application/json',
-    },
+    }, headers),
     body: JSON.stringify(graphQLParams),
     credentials: 'omit',
   })
@@ -110,9 +135,11 @@ ReactDOM.render(
     fetcher: graphQLFetcher,
     query: parameters.query,
     variables: parameters.variables,
+    headers: parameters.headers,
     operationName: parameters.operationName,
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
+    onEditHeaders: onEditHeaders,
     defaultVariableEditorOpen: true,
     onEditOperationName: onEditOperationName,
   }),

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -709,6 +709,18 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
   }
 
   /**
+   * Get the header editor CodeMirror instance.
+   *
+   * @public
+   */
+  public getHeaderEditor() {
+    if (this.headerEditorComponent) {
+      return this.headerEditorComponent.getCodeMirror();
+    }
+    return null;
+  }
+
+  /**
    * Refresh all CodeMirror instances.
    *
    * @public
@@ -954,7 +966,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       });
 
       if (this._queryHistory) {
-        this._queryHistory.updateHistory(editedQuery, variables, operationName);
+        this._queryHistory.updateHistory(editedQuery, variables, headers, operationName);
       }
 
       // _fetchQuery may return a subscription.
@@ -1045,6 +1057,22 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       );
       if (prettifiedVariableEditorContent !== variableEditorContent) {
         variableEditor?.setValue(prettifiedVariableEditorContent);
+      }
+    } catch {
+      /* Parsing JSON failed, skip prettification */
+    }
+
+    const headerEditor = this.getHeaderEditor();
+    const headerEditorContent = headerEditor?.getValue() ?? '';
+
+    try {
+      const prettifiedHeaderEditorContent = JSON.stringify(
+        JSON.parse(headerEditorContent),
+        null,
+        2,
+      );
+      if (prettifiedHeaderEditorContent !== headerEditorContent) {
+        headerEditor?.setValue(prettifiedHeaderEditorContent);
       }
     } catch {
       /* Parsing JSON failed, skip prettification */
@@ -1201,16 +1229,10 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     this.setState({ historyPaneOpen: !this.state.historyPaneOpen });
   };
 
-  handleToggleVariableEditor = () => {
-    if (typeof this.props.onToggleVariableEditor === 'function') {
-      this.props.onToggleVariableEditor(!this.state.variableEditorActive);
-    }
-    this.setState({ variableEditorActive: !this.state.variableEditorActive });
-  };
-
   handleSelectHistoryQuery = (
     query?: string,
     variables?: string,
+    headers?: string,
     operationName?: string,
   ) => {
     if (query) {
@@ -1218,6 +1240,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
     if (variables) {
       this.handleEditVariables(variables);
+    }
+    if (headers) {
+      this.handleEditHeaders(headers);
     }
     if (operationName) {
       this.handleEditOperationName(operationName);

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -73,8 +73,12 @@ export type FetcherParams = {
   query: string;
   operationName: string;
   variables?: string;
-  headers?: string;
 };
+
+export type FetcherOpts = {
+  headers?: { [key: string]: any };
+};
+
 export type FetcherResult =
   | {
       data: IntrospectionQuery;
@@ -84,7 +88,7 @@ export type FetcherResult =
 
 export type Fetcher = (
   graphQLParams: FetcherParams,
-  headers?: Object,
+  opts?: FetcherOpts,
 ) => Promise<FetcherResult> | Observable<FetcherResult>;
 
 type OnMouseMoveFn = Maybe<

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -102,6 +102,7 @@ export type GraphiQLProps = {
   response?: string;
   storage?: Storage;
   defaultQuery?: string;
+  defaultVariableEditorOpen?: boolean;
   defaultSecondaryEditorOpen?: boolean;
   onCopyQuery?: (query?: string) => void;
   onEditQuery?: (query?: string) => void;
@@ -233,10 +234,14 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
 
     // initial secondary editor pane open
-    const secondaryEditorOpen =
-      props.defaultSecondaryEditorOpen !== undefined
-        ? props.defaultSecondaryEditorOpen
-        : Boolean(variables || headers);
+    let secondaryEditorOpen;
+    if (props.defaultVariableEditorOpen !== undefined) {
+      secondaryEditorOpen = props.defaultVariableEditorOpen;
+    } else if (props.defaultSecondaryEditorOpen !== undefined) {
+      secondaryEditorOpen = props.defaultSecondaryEditorOpen;
+    } else {
+      secondaryEditorOpen = Boolean(variables || headers);
+    }
 
     // Initialize state
     this.state = {
@@ -549,14 +554,14 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 readOnly={this.props.readOnly}
               />
               <section
-                className="secondary-editor"
+                className="variable-editor secondary-editor"
                 style={secondaryEditorStyle}
                 aria-label={
                   variableEditorActive ? 'Query Variables' : 'Request Headers'
                 }>
                 <div
-                  className="secondary-editor-title"
-                  id="secondary-editor-title"
+                  className="secondary-editor-title variable-editor-title"
+                  id="secondary-editor-title variable-editor-title"
                   style={{
                     cursor: secondaryEditorOpen ? 'row-resize' : 'n-resize',
                   }}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -252,7 +252,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       secondaryEditorOpen = Boolean(variables || headers);
     }
 
-    const headerEditorEnabled = props.headerEditorEnabled ?? true;
+    const headerEditorEnabled = props.headerEditorEnabled ?? false;
 
     // Initialize state
     this.state = {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -110,8 +110,6 @@ export type GraphiQLProps = {
   onEditVariables?: (value: string) => void;
   onEditHeaders?: (value: string) => void;
   onEditOperationName?: (operationName: string) => void;
-  onToggleVariableEditor?: (variableEditorActive: boolean) => void;
-  onToggleHeaderEditor?: (headerEditorActive: boolean) => void;
   onToggleDocs?: (docExplorerOpen: boolean) => void;
   getDefaultFieldNames?: GetDefaultFieldNamesFn;
   editorTheme?: string;

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -597,7 +597,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   <div
                     style={{
                       cursor: 'pointer',
-                      color: this.state.variableEditorActive ? 'red' : '#000',
+                      color: this.state.variableEditorActive ? '#000' : 'gray',
                       display: 'inline-block',
                     }}
                     onClick={this.handleOpenVariableEditorTab}
@@ -608,7 +608,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                     <div
                       style={{
                         cursor: 'pointer',
-                        color: this.state.headerEditorActive ? 'red' : '#000',
+                        color: this.state.headerEditorActive ? '#000' : 'gray',
                         display: 'inline-block',
                         marginLeft: '20px',
                       }}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -1376,6 +1376,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     this.setState({
       headerEditorActive: true,
       variableEditorActive: false,
+      secondaryEditorOpen: true,
     });
   };
 
@@ -1385,6 +1386,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     this.setState({
       headerEditorActive: false,
       variableEditorActive: true,
+      secondaryEditorOpen: true,
     });
   };
 

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -84,6 +84,7 @@ export type FetcherResult =
 
 export type Fetcher = (
   graphQLParams: FetcherParams,
+  headers?: Object,
 ) => Promise<FetcherResult> | Observable<FetcherResult>;
 
 type OnMouseMoveFn = Maybe<
@@ -888,12 +889,14 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       throw new Error('Headers are not a JSON object.');
     }
 
-    const fetch = fetcher({
-      query,
-      variables: jsonVariables,
-      headers: jsonHeaders,
-      operationName,
-    });
+    const fetch = fetcher(
+      {
+        query,
+        variables: jsonVariables,
+        operationName,
+      },
+      jsonHeaders,
+    );
 
     if (isPromise(fetch)) {
       // If fetcher returned a Promise, then call the callback when the promise
@@ -966,7 +969,12 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       });
 
       if (this._queryHistory) {
-        this._queryHistory.updateHistory(editedQuery, variables, headers, operationName);
+        this._queryHistory.updateHistory(
+          editedQuery,
+          variables,
+          headers,
+          operationName,
+        );
       }
 
       // _fetchQuery may return a subscription.

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -102,7 +102,7 @@ export type GraphiQLProps = {
   response?: string;
   storage?: Storage;
   defaultQuery?: string;
-  defaultExtraEditorOpen?: boolean;
+  defaultSecondaryEditorOpen?: boolean;
   onCopyQuery?: (query?: string) => void;
   onEditQuery?: (query?: string) => void;
   onEditVariables?: (value: string) => void;
@@ -128,8 +128,8 @@ export type GraphiQLState = {
   docExplorerOpen: boolean;
   response?: string;
   editorFlex: number;
-  extraEditorOpen: boolean;
-  extraEditorHeight: number;
+  secondaryEditorOpen: boolean;
+  secondaryEditorHeight: number;
   variableEditorActive: boolean;
   headerEditorActive: boolean;
   historyPaneOpen: boolean;
@@ -232,10 +232,10 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       docExplorerOpen = this._storage.get('docExplorerOpen') === 'true';
     }
 
-    // initial extra editor pane open
-    const extraEditorOpen =
-      props.defaultExtraEditorOpen !== undefined
-        ? props.defaultExtraEditorOpen
+    // initial secondary editor pane open
+    const secondaryEditorOpen =
+      props.defaultSecondaryEditorOpen !== undefined
+        ? props.defaultSecondaryEditorOpen
         : Boolean(variables || headers);
 
     // Initialize state
@@ -247,8 +247,8 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       docExplorerOpen,
       response: props.response,
       editorFlex: Number(this._storage.get('editorFlex')) || 1,
-      extraEditorOpen,
-      extraEditorHeight: Number(this._storage.get('extraEditorHeight')) || 200,
+      secondaryEditorOpen,
+      secondaryEditorHeight: Number(this._storage.get('secondaryEditorHeight')) || 200,
       variableEditorActive:
         this._storage.get('variableEditorActive') === 'true',
       headerEditorActive: this._storage.get('headerEditorActive') === 'true',
@@ -388,8 +388,8 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
     this._storage.set('editorFlex', JSON.stringify(this.state.editorFlex));
     this._storage.set(
-      'extraEditorHeight',
-      JSON.stringify(this.state.extraEditorHeight),
+      'secondaryEditorHeight',
+      JSON.stringify(this.state.secondaryEditorHeight),
     );
     this._storage.set(
       'variableEditorActive',
@@ -470,9 +470,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       zIndex: 7,
     };
 
-    const extraEditorOpen = this.state.extraEditorOpen;
-    const extraEditorStyle = {
-      height: extraEditorOpen ? this.state.extraEditorHeight : undefined,
+    const secondaryEditorOpen = this.state.secondaryEditorOpen;
+    const secondaryEditorStyle = {
+      height: secondaryEditorOpen ? this.state.secondaryEditorHeight : undefined,
     };
 
     const variableEditorActive = this.state.variableEditorActive;
@@ -549,18 +549,18 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 readOnly={this.props.readOnly}
               />
               <section
-                className="extra-editor"
-                style={extraEditorStyle}
+                className="secondary-editor"
+                style={secondaryEditorStyle}
                 aria-label={
                   variableEditorActive ? 'Query Variables' : 'Request Headers'
                 }>
                 <div
-                  className="extra-editor-title"
-                  id="extra-editor-title"
+                  className="secondary-editor-title"
+                  id="secondary-editor-title"
                   style={{
-                    cursor: extraEditorOpen ? 'row-resize' : 'n-resize',
+                    cursor: secondaryEditorOpen ? 'row-resize' : 'n-resize',
                   }}
-                  onMouseDown={this.handleExtraEditorResizeStart}>
+                  onMouseDown={this.handleSecondaryEditorResizeStart}>
                   <div
                     style={{
                       cursor: 'pointer',
@@ -1388,14 +1388,14 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     });
   };
 
-  private handleExtraEditorResizeStart: MouseEventHandler<
+  private handleSecondaryEditorResizeStart: MouseEventHandler<
     HTMLDivElement
   > = downEvent => {
     downEvent.preventDefault();
 
     let didMove = false;
-    const wasOpen = this.state.extraEditorOpen;
-    const hadHeight = this.state.extraEditorHeight;
+    const wasOpen = this.state.secondaryEditorOpen;
+    const hadHeight = this.state.secondaryEditorHeight;
     const offset = downEvent.clientY - getTop(downEvent.target as HTMLElement);
 
     let onMouseMove: OnMouseMoveFn = moveEvent => {
@@ -1410,20 +1410,20 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       const bottomSize = editorBar.clientHeight - topSize;
       if (bottomSize < 60) {
         this.setState({
-          extraEditorOpen: false,
-          extraEditorHeight: hadHeight,
+          secondaryEditorOpen: false,
+          secondaryEditorHeight: hadHeight,
         });
       } else {
         this.setState({
-          extraEditorOpen: true,
-          extraEditorHeight: bottomSize,
+          secondaryEditorOpen: true,
+          secondaryEditorHeight: bottomSize,
         });
       }
     };
 
     let onMouseUp: OnMouseUpFn = () => {
       if (!didMove) {
-        this.setState({ extraEditorOpen: !wasOpen });
+        this.setState({ secondaryEditorOpen: !wasOpen });
       }
 
       document.removeEventListener('mousemove', onMouseMove!);

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -551,7 +551,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
               <section
                 className="extra-editor"
                 style={extraEditorStyle}
-                aria-label="Query Variables">
+                aria-label={
+                  variableEditorActive ? 'Query Variables' : 'Request Headers'
+                }>
                 <div
                   className="extra-editor-title"
                   id="extra-editor-title"
@@ -578,7 +580,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                     }}
                     onClick={this.handleOpenHeaderEditorTab}
                     onMouseDown={this.handleTabClickPropogation}>
-                    {'Query Headers'}
+                    {'Request Headers'}
                   </div>
                 </div>
                 {variableEditorActive && (

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -932,7 +932,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         variables: jsonVariables,
         operationName,
       },
-      jsonHeaders,
+      { headers: jsonHeaders },
     );
 
     if (isPromise(fetch)) {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -568,7 +568,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 }>
                 <div
                   className="secondary-editor-title variable-editor-title"
-                  id="secondary-editor-title variable-editor-title"
+                  id="secondary-editor-title"
                   style={{
                     cursor: secondaryEditorOpen ? 'row-resize' : 'n-resize',
                   }}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -480,9 +480,6 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       height: secondaryEditorOpen ? this.state.secondaryEditorHeight : undefined,
     };
 
-    const variableEditorActive = this.state.variableEditorActive;
-    const headerEditorActive = this.state.headerEditorActive;
-
     return (
       <div
         ref={n => {
@@ -557,7 +554,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 className="variable-editor secondary-editor"
                 style={secondaryEditorStyle}
                 aria-label={
-                  variableEditorActive ? 'Query Variables' : 'Request Headers'
+                  this.state.variableEditorActive ? 'Query Variables' : 'Request Headers'
                 }>
                 <div
                   className="secondary-editor-title variable-editor-title"
@@ -569,7 +566,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   <div
                     style={{
                       cursor: 'pointer',
-                      color: variableEditorActive ? 'red' : '#000',
+                      color: this.state.variableEditorActive ? 'red' : '#000',
                       display: 'inline-block',
                     }}
                     onClick={this.handleOpenVariableEditorTab}
@@ -579,7 +576,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   <div
                     style={{
                       cursor: 'pointer',
-                      color: headerEditorActive ? 'red' : '#000',
+                      color: this.state.headerEditorActive ? 'red' : '#000',
                       display: 'inline-block',
                       marginLeft: '20px',
                     }}
@@ -588,37 +585,35 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                     {'Request Headers'}
                   </div>
                 </div>
-                {variableEditorActive && (
-                  <VariableEditor
-                    ref={n => {
-                      this.variableEditorComponent = n;
-                    }}
-                    value={this.state.variables}
-                    variableToType={this.state.variableToType}
-                    onEdit={this.handleEditVariables}
-                    onHintInformationRender={this.handleHintInformationRender}
-                    onPrettifyQuery={this.handlePrettifyQuery}
-                    onMergeQuery={this.handleMergeQuery}
-                    onRunQuery={this.handleEditorRunQuery}
-                    editorTheme={this.props.editorTheme}
-                    readOnly={this.props.readOnly}
-                  />
-                )}
-                {headerEditorActive && (
-                  <HeaderEditor
-                    ref={n => {
-                      this.headerEditorComponent = n;
-                    }}
-                    value={this.state.headers}
-                    onEdit={this.handleEditHeaders}
-                    onHintInformationRender={this.handleHintInformationRender}
-                    onPrettifyQuery={this.handlePrettifyQuery}
-                    onMergeQuery={this.handleMergeQuery}
-                    onRunQuery={this.handleEditorRunQuery}
-                    editorTheme={this.props.editorTheme}
-                    readOnly={this.props.readOnly}
-                  />
-                )}
+                <VariableEditor
+                  ref={n => {
+                    this.variableEditorComponent = n;
+                  }}
+                  value={this.state.variables}
+                  variableToType={this.state.variableToType}
+                  onEdit={this.handleEditVariables}
+                  onHintInformationRender={this.handleHintInformationRender}
+                  onPrettifyQuery={this.handlePrettifyQuery}
+                  onMergeQuery={this.handleMergeQuery}
+                  onRunQuery={this.handleEditorRunQuery}
+                  editorTheme={this.props.editorTheme}
+                  readOnly={this.props.readOnly}
+                  active={this.state.variableEditorActive}
+                />
+                <HeaderEditor
+                  ref={n => {
+                    this.headerEditorComponent = n;
+                  }}
+                  value={this.state.headers}
+                  onEdit={this.handleEditHeaders}
+                  onHintInformationRender={this.handleHintInformationRender}
+                  onPrettifyQuery={this.handlePrettifyQuery}
+                  onMergeQuery={this.handleMergeQuery}
+                  onRunQuery={this.handleEditorRunQuery}
+                  editorTheme={this.props.editorTheme}
+                  readOnly={this.props.readOnly}
+                  active={this.state.headerEditorActive}
+                />
               </section>
             </div>
             <div className="resultWrap">

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -256,9 +256,11 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       response: props.response,
       editorFlex: Number(this._storage.get('editorFlex')) || 1,
       secondaryEditorOpen,
-      secondaryEditorHeight: Number(this._storage.get('secondaryEditorHeight')) || 200,
+      secondaryEditorHeight:
+        Number(this._storage.get('secondaryEditorHeight')) || 200,
       variableEditorActive:
-        this._storage.get('variableEditorActive') === 'true' || (this._storage.get('headerEditorActive') !== 'true'),
+        this._storage.get('variableEditorActive') === 'true' ||
+        this._storage.get('headerEditorActive') !== 'true',
       headerEditorActive: this._storage.get('headerEditorActive') === 'true',
       headerEditorEnabled,
       historyPaneOpen: this._storage.get('historyPaneOpen') === 'true' || false,
@@ -481,7 +483,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
 
     const secondaryEditorOpen = this.state.secondaryEditorOpen;
     const secondaryEditorStyle = {
-      height: secondaryEditorOpen ? this.state.secondaryEditorHeight : undefined,
+      height: secondaryEditorOpen
+        ? this.state.secondaryEditorHeight
+        : undefined,
     };
 
     return (
@@ -558,7 +562,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 className="variable-editor secondary-editor"
                 style={secondaryEditorStyle}
                 aria-label={
-                  this.state.variableEditorActive ? 'Query Variables' : 'Request Headers'
+                  this.state.variableEditorActive
+                    ? 'Query Variables'
+                    : 'Request Headers'
                 }>
                 <div
                   className="secondary-editor-title variable-editor-title"

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -258,7 +258,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       secondaryEditorOpen,
       secondaryEditorHeight: Number(this._storage.get('secondaryEditorHeight')) || 200,
       variableEditorActive:
-        this._storage.get('variableEditorActive') === 'true',
+        this._storage.get('variableEditorActive') === 'true' || (this._storage.get('headerEditorActive') !== 'true'),
       headerEditorActive: this._storage.get('headerEditorActive') === 'true',
       headerEditorEnabled,
       historyPaneOpen: this._storage.get('historyPaneOpen') === 'true' || false,

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -48,7 +48,7 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
   editor: (CM.Editor & { options: any }) | null = null;
   cachedValue: string;
   private _node: HTMLElement | null = null;
-  ignoreChangeEvent: boolean;
+  ignoreChangeEvent: boolean = false;
   constructor(props: HeaderEditorProps) {
     super(props);
 
@@ -56,7 +56,6 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
     // editor is updated, which can later be used to protect the editor from
     // unnecessary updates during the update lifecycle.
     this.cachedValue = props.value || '';
-    this.ignoreChangeEvent = true;
   }
 
   componentDidMount() {

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -175,8 +175,13 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
   render() {
     return (
       <div
-        style={{ display: this.props.active ? 'block' : 'none' }}
         className="codemirrorWrap"
+        // This horrible hack is necessary because a simple display none toggle
+        // causes one of the editors' gutters will break otherwise.
+        style={{
+          position: this.props.active ? 'relative' : 'absolute',
+          visibility: this.props.active ? 'visible' : 'hidden'
+        }}
         ref={node => {
           this._node = node as HTMLDivElement;
         }}

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -177,7 +177,7 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
       <div
         className="codemirrorWrap"
         // This horrible hack is necessary because a simple display none toggle
-        // causes one of the editors' gutters will break otherwise.
+        // causes one of the editors' gutters to break otherwise.
         style={{
           position: this.props.active ? 'relative' : 'absolute',
           visibility: this.props.active ? 'visible' : 'hidden'

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -180,7 +180,7 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
         // causes one of the editors' gutters to break otherwise.
         style={{
           position: this.props.active ? 'relative' : 'absolute',
-          visibility: this.props.active ? 'visible' : 'hidden'
+          visibility: this.props.active ? 'visible' : 'hidden',
         }}
         ref={node => {
           this._node = node as HTMLDivElement;

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -29,6 +29,7 @@ type HeaderEditorProps = {
   onMergeQuery: (value?: string) => void;
   onRunQuery: (value?: string) => void;
   editorTheme?: string;
+  active?: boolean;
 };
 
 /**
@@ -174,6 +175,7 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
   render() {
     return (
       <div
+        style={{ display: this.props.active ? 'block' : 'none' }}
         className="codemirrorWrap"
         ref={node => {
           this._node = node as HTMLDivElement;

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -1,0 +1,234 @@
+/**
+ *  Copyright (c) 2019 GraphQL Contributors.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+import * as CM from 'codemirror';
+import 'codemirror/addon/hint/show-hint';
+import React from 'react';
+
+import onHasCompletion from '../utility/onHasCompletion';
+import commonKeys from '../utility/commonKeys';
+
+declare module CodeMirror {
+  export interface Editor extends CM.Editor {}
+  export interface ShowHintOptions {
+    completeSingle: boolean;
+    hint: CM.HintFunction | CM.AsyncHintFunction;
+    container: HTMLElement | null;
+  }
+}
+
+type HeaderEditorProps = {
+  value?: string;
+  onEdit: (value: string) => void;
+  readOnly?: boolean;
+  onHintInformationRender: (value: HTMLDivElement) => void;
+  onPrettifyQuery: (value?: string) => void;
+  onMergeQuery: (value?: string) => void;
+  onRunQuery: (value?: string) => void;
+  editorTheme?: string;
+};
+
+/**
+ * HeaderEditor
+ *
+ * An instance of CodeMirror for editing headers to be passed with the GraphQL request.
+ *
+ * Props:
+ *
+ *   - value: The text of the editor.
+ *   - onEdit: A function called when the editor changes, given the edited text.
+ *   - readOnly: Turns the editor to read-only mode.
+ *
+ */
+export class HeaderEditor extends React.Component<HeaderEditorProps> {
+  CodeMirror: any;
+  editor: (CM.Editor & { options: any }) | null = null;
+  cachedValue: string;
+  private _node: HTMLElement | null = null;
+  ignoreChangeEvent: boolean;
+  constructor(props: HeaderEditorProps) {
+    super(props);
+
+    // Keep a cached version of the value, this cache will be updated when the
+    // editor is updated, which can later be used to protect the editor from
+    // unnecessary updates during the update lifecycle.
+    this.cachedValue = props.value || '';
+    this.ignoreChangeEvent = true;
+  }
+
+  componentDidMount() {
+    // Lazily require to ensure requiring GraphiQL outside of a Browser context
+    // does not produce an error.
+    this.CodeMirror = require('codemirror');
+    require('codemirror/addon/hint/show-hint');
+    require('codemirror/addon/edit/matchbrackets');
+    require('codemirror/addon/edit/closebrackets');
+    require('codemirror/addon/fold/brace-fold');
+    require('codemirror/addon/fold/foldgutter');
+    require('codemirror/addon/lint/lint');
+    require('codemirror/addon/search/searchcursor');
+    require('codemirror/addon/search/jump-to-line');
+    require('codemirror/addon/dialog/dialog');
+    require('codemirror/keymap/sublime');
+
+    const editor = (this.editor = this.CodeMirror(this._node, {
+      value: this.props.value || '',
+      lineNumbers: true,
+      tabSize: 2,
+      mode: 'graphql-headers',
+      theme: this.props.editorTheme || 'graphiql',
+      keyMap: 'sublime',
+      autoCloseBrackets: true,
+      matchBrackets: true,
+      showCursorWhenSelecting: true,
+      readOnly: this.props.readOnly ? 'nocursor' : false,
+      foldGutter: {
+        minFoldSize: 4,
+      },
+      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
+      extraKeys: {
+        'Cmd-Space': () =>
+          this.editor!.showHint({
+            completeSingle: false,
+            container: this._node,
+          } as CodeMirror.ShowHintOptions),
+        'Ctrl-Space': () =>
+          this.editor!.showHint({
+            completeSingle: false,
+            container: this._node,
+          } as CodeMirror.ShowHintOptions),
+        'Alt-Space': () =>
+          this.editor!.showHint({
+            completeSingle: false,
+            container: this._node,
+          } as CodeMirror.ShowHintOptions),
+        'Shift-Space': () =>
+          this.editor!.showHint({
+            completeSingle: false,
+            container: this._node,
+          } as CodeMirror.ShowHintOptions),
+        'Cmd-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
+        'Ctrl-Enter': () => {
+          if (this.props.onRunQuery) {
+            this.props.onRunQuery();
+          }
+        },
+        'Shift-Ctrl-P': () => {
+          if (this.props.onPrettifyQuery) {
+            this.props.onPrettifyQuery();
+          }
+        },
+
+        'Shift-Ctrl-M': () => {
+          if (this.props.onMergeQuery) {
+            this.props.onMergeQuery();
+          }
+        },
+
+        ...commonKeys,
+      },
+    }));
+
+    editor.on('change', this._onEdit);
+    editor.on('keyup', this._onKeyUp);
+    editor.on('hasCompletion', this._onHasCompletion);
+  }
+
+  componentDidUpdate(prevProps: HeaderEditorProps) {
+    this.CodeMirror = require('codemirror');
+    if (!this.editor) {
+      return;
+    }
+
+    // Ensure the changes caused by this update are not interpretted as
+    // user-input changes which could otherwise result in an infinite
+    // event loop.
+    this.ignoreChangeEvent = true;
+    if (
+      this.props.value !== prevProps.value &&
+      this.props.value !== this.cachedValue
+    ) {
+      const thisValue = this.props.value || '';
+      this.cachedValue = thisValue;
+      this.editor.setValue(thisValue);
+    }
+    this.ignoreChangeEvent = false;
+  }
+
+  componentWillUnmount() {
+    if (!this.editor) {
+      return;
+    }
+    this.editor.off('change', this._onEdit);
+    this.editor.off('keyup', this._onKeyUp);
+    this.editor.off('hasCompletion', this._onHasCompletion);
+    this.editor = null;
+  }
+
+  render() {
+    return (
+      <div
+        className="codemirrorWrap"
+        ref={node => {
+          this._node = node as HTMLDivElement;
+        }}
+      />
+    );
+  }
+
+  /**
+   * Public API for retrieving the CodeMirror instance from this
+   * React component.
+   */
+  getCodeMirror() {
+    return this.editor as CM.Editor;
+  }
+
+  /**
+   * Public API for retrieving the DOM client height for this component.
+   */
+  getClientHeight() {
+    return this._node && this._node.clientHeight;
+  }
+
+  private _onKeyUp = (_cm: CodeMirror.Editor, event: KeyboardEvent) => {
+    const code = event.keyCode;
+    if (!this.editor) {
+      return;
+    }
+    if (
+      (code >= 65 && code <= 90) || // letters
+      (!event.shiftKey && code >= 48 && code <= 57) || // numbers
+      (event.shiftKey && code === 189) || // underscore
+      (event.shiftKey && code === 222) // "
+    ) {
+      this.editor.execCommand('autocomplete');
+    }
+  };
+
+  private _onEdit = () => {
+    if (!this.editor) {
+      return;
+    }
+    if (!this.ignoreChangeEvent) {
+      this.cachedValue = this.editor.getValue();
+      if (this.props.onEdit) {
+        this.props.onEdit(this.cachedValue);
+      }
+    }
+  };
+
+  private _onHasCompletion = (
+    instance: CM.Editor,
+    changeObj?: CM.EditorChangeLinkedList,
+  ) => {
+    onHasCompletion(instance, changeObj, this.props.onHintInformationRender);
+  };
+}

--- a/packages/graphiql/src/components/HistoryQuery.tsx
+++ b/packages/graphiql/src/components/HistoryQuery.tsx
@@ -11,6 +11,7 @@ import { QueryStoreItem } from '../utility/QueryStore';
 export type HandleEditLabelFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
   favorite?: boolean,
@@ -19,6 +20,7 @@ export type HandleEditLabelFn = (
 export type HandleToggleFavoriteFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
   favorite?: boolean,
@@ -27,6 +29,7 @@ export type HandleToggleFavoriteFn = (
 export type HandleSelectQueryFn = (
   query?: string,
   variables?: string,
+  headers?: string,
   operationName?: string,
   label?: string,
 ) => void;
@@ -101,6 +104,7 @@ export default class HistoryQuery extends React.Component<
     this.props.onSelect(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       this.props.label,
     );
@@ -111,6 +115,7 @@ export default class HistoryQuery extends React.Component<
     this.props.handleToggleFavorite(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       this.props.label,
       this.props.favorite,
@@ -123,6 +128,7 @@ export default class HistoryQuery extends React.Component<
     this.props.handleEditLabel(
       this.props.query,
       this.props.variables,
+      this.props.headers,
       this.props.operationName,
       e.target.value,
       this.props.favorite,
@@ -136,6 +142,7 @@ export default class HistoryQuery extends React.Component<
       this.props.handleEditLabel(
         this.props.query,
         this.props.variables,
+        this.props.headers,
         this.props.operationName,
         e.currentTarget.value,
         this.props.favorite,

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -50,9 +50,7 @@ const shouldSaveQuery = (
     if (variables && !lastQuerySaved.variables) {
       return false;
     }
-    if (
-      JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)
-    ) {
+    if (JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)) {
       return false;
     }
     if (headers && !lastQuerySaved.headers) {
@@ -129,7 +127,14 @@ export class QueryHistory extends React.Component<
     headers?: string,
     operationName?: string,
   ) => {
-    if (shouldSaveQuery(query, variables, headers, this.historyStore.fetchRecent())) {
+    if (
+      shouldSaveQuery(
+        query,
+        variables,
+        headers,
+        this.historyStore.fetchRecent(),
+      )
+    ) {
       this.historyStore.push({
         query,
         variables,

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -21,6 +21,7 @@ const MAX_HISTORY_LENGTH = 20;
 const shouldSaveQuery = (
   query?: string,
   variables?: string,
+  headers?: string,
   lastQuerySaved?: QueryStoreItem,
 ) => {
   if (!query) {
@@ -49,6 +50,14 @@ const shouldSaveQuery = (
     if (variables && !lastQuerySaved.variables) {
       return false;
     }
+    if (
+      JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)
+    ) {
+      return false;
+    }
+    if (headers && !lastQuerySaved.headers) {
+      return false;
+    }
   }
   return true;
 };
@@ -56,6 +65,7 @@ const shouldSaveQuery = (
 type QueryHistoryProps = {
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   queryID?: number;
   onSelectQuery: HandleSelectQueryFn;
@@ -116,12 +126,14 @@ export class QueryHistory extends React.Component<
   updateHistory = (
     query?: string,
     variables?: string,
+    headers?: string,
     operationName?: string,
   ) => {
-    if (shouldSaveQuery(query, variables, this.historyStore.fetchRecent())) {
+    if (shouldSaveQuery(query, variables, headers, this.historyStore.fetchRecent())) {
       this.historyStore.push({
         query,
         variables,
+        headers,
         operationName,
       });
       const historyQueries = this.historyStore.items;
@@ -137,6 +149,7 @@ export class QueryHistory extends React.Component<
   toggleFavorite: HandleToggleFavoriteFn = (
     query,
     variables,
+    headers,
     operationName,
     label,
     favorite,
@@ -144,6 +157,7 @@ export class QueryHistory extends React.Component<
     const item: QueryStoreItem = {
       query,
       variables,
+      headers,
       operationName,
       label,
     };
@@ -163,6 +177,7 @@ export class QueryHistory extends React.Component<
   editLabel: HandleEditLabelFn = (
     query,
     variables,
+    headers,
     operationName,
     label,
     favorite,
@@ -170,6 +185,7 @@ export class QueryHistory extends React.Component<
     const item = {
       query,
       variables,
+      headers,
       operationName,
       label,
     };

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -45,15 +45,14 @@ const shouldSaveQuery = (
     if (
       JSON.stringify(variables) === JSON.stringify(lastQuerySaved.variables)
     ) {
-      return false;
+      if (JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)) {
+        return false;
+      }
+      if (headers && !lastQuerySaved.headers) {
+        return false;
+      }
     }
     if (variables && !lastQuerySaved.variables) {
-      return false;
-    }
-    if (JSON.stringify(headers) === JSON.stringify(lastQuerySaved.headers)) {
-      return false;
-    }
-    if (headers && !lastQuerySaved.headers) {
       return false;
     }
   }

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -198,7 +198,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
       <div
         className="codemirrorWrap"
         // This horrible hack is necessary because a simple display none toggle
-        // causes one of the editors' gutters will break otherwise.
+        // causes one of the editors' gutters to break otherwise.
         style={{
           position: this.props.active ? 'relative' : 'absolute',
           visibility: this.props.active ? 'visible' : 'hidden'

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -196,8 +196,13 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
   render() {
     return (
       <div
-        style={{ display: this.props.active ? 'block' : 'none' }}
         className="codemirrorWrap"
+        // This horrible hack is necessary because a simple display none toggle
+        // causes one of the editors' gutters will break otherwise.
+        style={{
+          position: this.props.active ? 'relative' : 'absolute',
+          visibility: this.props.active ? 'visible' : 'hidden'
+        }}
         ref={node => {
           this._node = node as HTMLDivElement;
         }}

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -201,7 +201,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
         // causes one of the editors' gutters to break otherwise.
         style={{
           position: this.props.active ? 'relative' : 'absolute',
-          visibility: this.props.active ? 'visible' : 'hidden'
+          visibility: this.props.active ? 'visible' : 'hidden',
         }}
         ref={node => {
           this._node = node as HTMLDivElement;

--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -31,6 +31,7 @@ type VariableEditorProps = {
   onMergeQuery: (value?: string) => void;
   onRunQuery: (value?: string) => void;
   editorTheme?: string;
+  active?: boolean;
 };
 
 /**
@@ -195,6 +196,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
   render() {
     return (
       <div
+        style={{ display: this.props.active ? 'block' : 'none' }}
         className="codemirrorWrap"
         ref={node => {
           this._node = node as HTMLDivElement;

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -19,6 +19,7 @@ import {
   mockQuery2,
   mockVariables2,
   mockHeaders1,
+  mockHeaders2,
 } from './fixtures';
 
 codeMirrorModules.forEach(m => jest.mock(m, () => {}));
@@ -271,6 +272,33 @@ describe('GraphiQL', () => {
       container.querySelector('[aria-label="Query Variables"] .mockCodeMirror'),
       {
         target: { value: mockVariables2 },
+      },
+    );
+
+    fireEvent.click(executeQueryButton);
+    expect(container.querySelectorAll('.history-label')).toHaveLength(2);
+  });
+
+  it('will save query if headers are different ', () => {
+    const { getByTitle, getByText, container } = render(
+      <GraphiQL
+        fetcher={noOpFetcher}
+        operationName={mockOperationName1}
+        query={mockQuery1}
+        variables={mockVariables1}
+        headers={mockHeaders1}
+      />,
+    );
+    const executeQueryButton = getByTitle('Execute Query (Ctrl-Enter)');
+    fireEvent.click(executeQueryButton);
+    expect(container.querySelectorAll('.history-label')).toHaveLength(1);
+
+    fireEvent.click(getByText("Request Headers"));
+
+    fireEvent.change(
+      container.querySelector('[aria-label="Request Headers"] .mockCodeMirror'),
+      {
+        target: { value: mockHeaders2 },
       },
     );
 

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -293,7 +293,7 @@ describe('GraphiQL', () => {
     fireEvent.click(executeQueryButton);
     expect(container.querySelectorAll('.history-label')).toHaveLength(1);
 
-    fireEvent.click(getByText("Request Headers"));
+    fireEvent.click(getByText('Request Headers'));
 
     fireEvent.change(
       container.querySelector('[aria-label="Request Headers"] .mockCodeMirror'),

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -147,11 +147,11 @@ describe('GraphiQL', () => {
 
     expect(queryVariables.style.height).toEqual('');
 
-    const variableEditorTitle = container1.querySelector(
-      '#variable-editor-title',
+    const secondaryEditorTitle = container1.querySelector(
+      '#secondary-editor-title',
     );
-    fireEvent.mouseDown(variableEditorTitle);
-    fireEvent.mouseMove(variableEditorTitle);
+    fireEvent.mouseDown(secondaryEditorTitle);
+    fireEvent.mouseMove(secondaryEditorTitle);
     expect(queryVariables.style.height).toEqual('200px');
 
     const { container: container2 } = render(

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -18,6 +18,7 @@ import {
   mockBadQuery,
   mockQuery2,
   mockVariables2,
+  mockHeaders1,
 } from './fixtures';
 
 codeMirrorModules.forEach(m => jest.mock(m, () => {}));
@@ -177,6 +178,7 @@ describe('GraphiQL', () => {
       <GraphiQL
         query={mockQuery1}
         variables={mockVariables1}
+        headers={mockHeaders1}
         operationName={mockOperationName1}
         fetcher={noOpFetcher}
       />,
@@ -200,6 +202,7 @@ describe('GraphiQL', () => {
         operationName={mockOperationName1}
         query={mockQuery1}
         variables={mockVariables1}
+        headers={mockHeaders1}
       />,
     );
     fireEvent.click(getByTitle('Execute Query (Ctrl-Enter)'));
@@ -213,6 +216,7 @@ describe('GraphiQL', () => {
         operationName={mockOperationName1}
         query={mockQuery1}
         variables={mockVariables1}
+        headers={mockHeaders1}
       />,
     );
     fireEvent.click(getByTitle('Execute Query (Ctrl-Enter)'));
@@ -228,6 +232,7 @@ describe('GraphiQL', () => {
         operationName={mockOperationName1}
         query={mockQuery1}
         variables={mockVariables1}
+        headers={mockHeaders1}
       />,
     );
     const executeQueryButton = getByTitle('Execute Query (Ctrl-Enter)');
@@ -255,6 +260,7 @@ describe('GraphiQL', () => {
         operationName={mockOperationName1}
         query={mockQuery1}
         variables={mockVariables1}
+        headers={mockHeaders1}
       />,
     );
     const executeQueryButton = getByTitle('Execute Query (Ctrl-Enter)');

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -287,6 +287,7 @@ describe('GraphiQL', () => {
         query={mockQuery1}
         variables={mockVariables1}
         headers={mockHeaders1}
+        headerEditorEnabled
       />,
     );
     const executeQueryButton = getByTitle('Execute Query (Ctrl-Enter)');

--- a/packages/graphiql/src/components/__tests__/HistoryQuery.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/HistoryQuery.spec.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import HistoryQuery, { HistoryQueryProps } from '../HistoryQuery';
-import { mockOperationName1, mockQuery1, mockVariables1 } from './fixtures';
+import { mockOperationName1, mockQuery1, mockVariables1, mockHeaders1 } from './fixtures';
 
 const noOp = () => {};
 
@@ -19,6 +19,7 @@ const baseMockProps = {
   onSelect: noOp,
   query: mockQuery1,
   variables: mockVariables1,
+  headers: mockHeaders1
 };
 
 function getMockProps(
@@ -62,6 +63,7 @@ describe('HistoryQuery', () => {
     expect(onSelectSpy).toHaveBeenCalledWith(
       mockQuery1,
       mockVariables1,
+      mockHeaders1,
       mockOperationName1,
       undefined,
     );

--- a/packages/graphiql/src/components/__tests__/HistoryQuery.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/HistoryQuery.spec.tsx
@@ -8,7 +8,12 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
 import HistoryQuery, { HistoryQueryProps } from '../HistoryQuery';
-import { mockOperationName1, mockQuery1, mockVariables1, mockHeaders1 } from './fixtures';
+import {
+  mockOperationName1,
+  mockQuery1,
+  mockVariables1,
+  mockHeaders1,
+} from './fixtures';
 
 const noOp = () => {};
 
@@ -19,7 +24,7 @@ const baseMockProps = {
   onSelect: noOp,
   query: mockQuery1,
   variables: mockVariables1,
-  headers: mockHeaders1
+  headers: mockHeaders1,
 };
 
 function getMockProps(

--- a/packages/graphiql/src/components/__tests__/fixtures.ts
+++ b/packages/graphiql/src/components/__tests__/fixtures.ts
@@ -19,6 +19,8 @@ export const mockQuery2 = /* GraphQL */ `
 export const mockVariables1 = JSON.stringify({ string: 'string' });
 export const mockVariables2 = JSON.stringify({ string: 'string2' });
 
+export const mockHeaders1 = JSON.stringify({ foo: 'bar' });
+
 export const mockOperationName1 = 'Test';
 export const mockOperationName2 = 'Test2';
 

--- a/packages/graphiql/src/components/__tests__/fixtures.ts
+++ b/packages/graphiql/src/components/__tests__/fixtures.ts
@@ -20,6 +20,7 @@ export const mockVariables1 = JSON.stringify({ string: 'string' });
 export const mockVariables2 = JSON.stringify({ string: 'string2' });
 
 export const mockHeaders1 = JSON.stringify({ foo: 'bar' });
+export const mockHeaders2 = JSON.stringify({ foo: 'baz' });
 
 export const mockOperationName1 = 'Test';
 export const mockOperationName2 = 'Test2';

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -161,14 +161,16 @@
   position: relative;
 }
 
-.graphiql-container .variable-editor {
+.graphiql-container .variable-editor,
+.graphiql-container .header-editor {
   display: flex;
   flex-direction: column;
   height: 30px;
   position: relative;
 }
 
-.graphiql-container .variable-editor-title {
+.graphiql-container .variable-editor-title,
+.graphiql-container .header-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;
   border-top: 1px solid #e0e0e0;

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -161,7 +161,6 @@
   position: relative;
 }
 
-.graphiql-container .variable-editor,
 .graphiql-container .secondary-editor {
   display: flex;
   flex-direction: column;
@@ -169,7 +168,6 @@
   position: relative;
 }
 
-.graphiql-container .variable-editor-title,
 .graphiql-container .secondary-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -161,6 +161,7 @@
   position: relative;
 }
 
+.graphiql-container .variable-editor,
 .graphiql-container .extra-editor {
   display: flex;
   flex-direction: column;
@@ -168,6 +169,7 @@
   position: relative;
 }
 
+.graphiql-container .variable-editor-title,
 .graphiql-container .extra-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -162,7 +162,7 @@
 }
 
 .graphiql-container .variable-editor,
-.graphiql-container .extra-editor {
+.graphiql-container .secondary-editor {
   display: flex;
   flex-direction: column;
   height: 30px;
@@ -170,7 +170,7 @@
 }
 
 .graphiql-container .variable-editor-title,
-.graphiql-container .extra-editor-title {
+.graphiql-container .secondary-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;
   border-top: 1px solid #e0e0e0;

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -161,16 +161,14 @@
   position: relative;
 }
 
-.graphiql-container .variable-editor,
-.graphiql-container .header-editor {
+.graphiql-container .extra-editor {
   display: flex;
   flex-direction: column;
   height: 30px;
   position: relative;
 }
 
-.graphiql-container .variable-editor-title,
-.graphiql-container .header-editor-title {
+.graphiql-container .extra-editor-title {
   background: #eeeeee;
   border-bottom: 1px solid #d6d6d6;
   border-top: 1px solid #e0e0e0;

--- a/packages/graphiql/src/utility/QueryStore.ts
+++ b/packages/graphiql/src/utility/QueryStore.ts
@@ -9,6 +9,7 @@ import StorageAPI from './StorageAPI';
 export type QueryStoreItem = {
   query?: string;
   variables?: string;
+  headers?: string;
   operationName?: string;
   label?: string;
   favorite?: boolean;
@@ -34,6 +35,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
   }
@@ -43,6 +45,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {
@@ -56,6 +59,7 @@ export default class QueryStore {
       x =>
         x.query === item.query &&
         x.variables === item.variables &&
+        x.headers === item.headers &&
         x.operationName === item.operationName,
     );
     if (itemIndex !== -1) {


### PR DESCRIPTION
This adds a header editor, for submitting HTTP headers when executing a query, as described in #59.

![image](https://user-images.githubusercontent.com/2977353/82621282-ea361000-9b97-11ea-9091-da277c30d9a2.png)

This is especially useful when you want to send an authentication token with your request, for example.

This adds an optional `headers` parameter to the `fetcher` which can then be merged into any other headers that the application sets itself.

```js
import React from 'react';
import ReactDOM from 'react-dom';
import GraphiQL from 'graphiql';
import fetch from 'isomorphic-fetch';

function graphQLFetcher(graphQLParams, headers) {
  return fetch(window.location.origin + '/graphql', {
    method: 'post',
    headers: Object.assign(headers, { 'Content-Type': 'application/json' }),
    body: JSON.stringify(graphQLParams),
  }).then(response => response.json());
}

ReactDOM.render(<GraphiQL fetcher={graphQLFetcher} />, document.body);
```

TODO:
- [x] Add tests.
- [x] Make sure this isn't a breaking change, or if it is we need to warn users and make sure upgrading is as easy as possible.
- [x] Add the ability to disable the headers editor entirely.
- [x] Make the tab selection style less ugly.
- [x] Rewrite my commit messages to pass the linter.
- [x] Figure out how to get the development application to handle the headers as headers (probably by modifying the fetcher it's rendered with).
- [x] Probably add some way to set a default value for the headers editor?