### PR TITLE
fix: trigger edit variables on first render

### DIFF
--- a/packages/graphiql/src/components/VariableEditor.tsx
+++ b/packages/graphiql/src/components/VariableEditor.tsx
@@ -51,7 +51,7 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
   editor: (CM.Editor & { options: any }) | null = null;
   cachedValue: string;
   private _node: HTMLElement | null = null;
-  ignoreChangeEvent: boolean;
+  ignoreChangeEvent: boolean = false;
   constructor(props: VariableEditorProps) {
     super(props);
 
@@ -59,7 +59,6 @@ export class VariableEditor extends React.Component<VariableEditorProps> {
     // editor is updated, which can later be used to protect the editor from
     // unnecessary updates during the update lifecycle.
     this.cachedValue = props.value || '';
-    this.ignoreChangeEvent = true;
   }
 
   componentDidMount() {


### PR DESCRIPTION
Closes #1532 

Initialised `ignoreChangeEvent` to `false` in Variables Editor

@acao can you review this