### PR TITLE
graphiql: refactor unit-tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -26,7 +26,16 @@ module.exports = {
   ],
   env: {
     test: {
-      plugins: [require.resolve('babel-plugin-macros')],
+      presets: [require.resolve('@babel/preset-react')],
+      plugins: [
+        require.resolve('babel-plugin-macros'),
+        [
+          require.resolve('@babel/plugin-transform-typescript'),
+          {
+            allowNamespaces: true,
+          },
+        ],
+      ],
     },
     development: {
       compact: false,

--- a/jest.config.js
+++ b/jest.config.js
@@ -29,12 +29,7 @@ module.exports = {
     '!**/cypress/**',
   ],
   testEnvironment: require.resolve('jest-environment-jsdom'),
-  testPathIgnorePatterns: [
-    'node_modules',
-    'dist',
-    'codemirror-graphql',
-    'packages/graphiql',
-  ],
+  testPathIgnorePatterns: ['node_modules', 'dist', 'codemirror-graphql'],
   collectCoverageFrom: [
     '**/src/**/*.{js,jsx,ts,tsx}',
     '!**/src/**/*.stories.js*',

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "start-graphiql": "yarn workspace graphiql dev"
   },
   "devDependencies": {
+    "@babel/plugin-transform-typescript": "7.9.6",
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/node": "^7.8.7",

--- a/packages/graphiql/.storybook/babel.config.js
+++ b/packages/graphiql/.storybook/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react'],
+};

--- a/packages/graphiql/src/api/providers/__tests__/GraphiQLSchemaProvider.spec.tsx
+++ b/packages/graphiql/src/api/providers/__tests__/GraphiQLSchemaProvider.spec.tsx
@@ -42,6 +42,7 @@ describe('GraphiQLSchemaProvider', () => {
     });
     const provider = await renderSchemaProvider({
       config: { uri: 'https://example' },
+      fetcher: async () => '',
     });
     await wait(1000);
     const { schema, isLoading, error } = getProviderData(provider);
@@ -64,8 +65,9 @@ describe('GraphiQLSchemaProvider', () => {
     );
     const provider = await renderSchemaProvider({
       config: { uri: 'https://bad' },
+      fetcher: async () => '',
     });
-    const { schema, isLoading } = getProviderData(provider);
+    const { schema } = getProviderData(provider);
     expect(schema).toBeFalsy();
     const { hasError, error } = getProviderData(provider);
     expect(hasError).toBeTruthy();

--- a/packages/graphiql/src/components/common/__tests__/stories.spec.js
+++ b/packages/graphiql/src/components/common/__tests__/stories.spec.js
@@ -1,6 +1,5 @@
 import initStoryshots from '@storybook/addon-storyshots';
 import path from 'path';
-
 initStoryshots({
-  configPath: path.resolve(__dirname, '../../../.storybook'),
+  configPath: path.resolve(__dirname, '../../../../.storybook'),
 });


### PR DESCRIPTION
- added @babel/plugin-transform-typescript to allow exporting namespaces.
- fixed directory of storybooks
