### PR TITLE
docs: remove copy/paste artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 ![LGTM Grade](https://img.shields.io/lgtm/grade/javascript/github/graphql/graphiql)
 ![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/graphql/graphiql)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3887/badge)](https://bestpractices.coreinfrastructure.org/projects/3887)
-or by embedding this in your HTML:
 
 ## Overview
 


### PR DESCRIPTION
This was likely some instructions on markdown & html image; but with the info text still there