### PR TITLE
fix: remove reducer dispatcher from useCallback dependencies

### DIFF
--- a/packages/graphiql/src/api/providers/GraphiQLEditorsProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLEditorsProvider.tsx
@@ -70,12 +70,12 @@ export function EditorsProvider(props: { children?: any }) {
     editors: {},
   });
 
-  const loadEditor = useCallback(
-    (editorKey: string, editor: monaco.editor.IStandaloneCodeEditor) => {
-      dispatch(editorLoadedAction(editorKey, editor));
-    },
-    [dispatch],
-  );
+  const loadEditor = (
+    editorKey: string,
+    editor: monaco.editor.IStandaloneCodeEditor,
+  ) => {
+    dispatch(editorLoadedAction(editorKey, editor));
+  };
 
   return (
     <EditorContext.Provider

--- a/packages/graphiql/src/api/providers/GraphiQLEditorsProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLEditorsProvider.tsx
@@ -70,12 +70,12 @@ export function EditorsProvider(props: { children?: any }) {
     editors: {},
   });
 
-  const loadEditor = (
-    editorKey: string,
-    editor: monaco.editor.IStandaloneCodeEditor,
-  ) => {
-    dispatch(editorLoadedAction(editorKey, editor));
-  };
+  const loadEditor = useCallback(
+    (editorKey: string, editor: monaco.editor.IStandaloneCodeEditor) => {
+      dispatch(editorLoadedAction(editorKey, editor));
+    },
+    [],
+  );
 
   return (
     <EditorContext.Provider

--- a/packages/graphiql/src/api/providers/GraphiQLSchemaProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLSchemaProvider.tsx
@@ -115,7 +115,7 @@ export function SchemaProvider({
     getInitialState({ config: userSchemaConfig }),
   );
 
-  const loadCurrentSchema = useCallback(async () => {
+  const loadCurrentSchema = async () => {
     dispatch(schemaRequestedAction());
     try {
       // @ts-ignore
@@ -130,7 +130,7 @@ export function SchemaProvider({
       console.error(error);
       dispatch(schemaErroredAction(error));
     }
-  }, [dispatch]);
+  };
 
   React.useEffect(() => {
     if (state.config) {

--- a/packages/graphiql/src/api/providers/GraphiQLSchemaProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLSchemaProvider.tsx
@@ -115,7 +115,7 @@ export function SchemaProvider({
     getInitialState({ config: userSchemaConfig }),
   );
 
-  const loadCurrentSchema = async () => {
+  const loadCurrentSchema = useCallback(async () => {
     dispatch(schemaRequestedAction());
     try {
       // @ts-ignore
@@ -130,7 +130,7 @@ export function SchemaProvider({
       console.error(error);
       dispatch(schemaErroredAction(error));
     }
-  };
+  }, []);
 
   React.useEffect(() => {
     if (state.config) {

--- a/packages/graphiql/src/api/providers/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLSessionProvider.tsx
@@ -149,24 +149,24 @@ export function SessionProvider({
 
   const operationError = React.useCallback(
     (error: Error) => dispatch(operationErroredAction(error, sessionId)),
-    [dispatch, sessionId],
+    [sessionId],
   );
 
   const changeOperation = React.useCallback(
     (operationText: string) =>
       dispatch(operationChangedAction(operationText, sessionId)),
-    [dispatch, sessionId],
+    [sessionId],
   );
 
   const changeVariables = React.useCallback(
     (variablesText: string) =>
       dispatch(variableChangedAction(variablesText, sessionId)),
-    [dispatch, sessionId],
+    [sessionId],
   );
 
   const changeTab = React.useCallback(
     (pane: string, tabId: number) => dispatch(tabChangedAction(pane, tabId)),
-    [dispatch],
+    [],
   );
 
   const executeOperation = React.useCallback(

--- a/packages/graphiql/src/api/providers/GraphiQLSessionProvider.tsx
+++ b/packages/graphiql/src/api/providers/GraphiQLSessionProvider.tsx
@@ -197,7 +197,6 @@ export function SessionProvider({
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      dispatch,
       fetcher,
       operationError,
       schemaState.config,


### PR DESCRIPTION
It's referenced here that the returned dispatcher from useReducer doesn't need to be passed as a dependency to useCallback because the reducer is evaluated directly in the render phase.
https://github.com/facebook/react/issues/14099#issuecomment-436647120