### PR TITLE
fix: highlightNode xxx in xxx syntax to revert back to simple dot notation for checking of existence

### DIFF
--- a/packages/graphql-language-service-interface/src/__tests__/getDiagnostics-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getDiagnostics-test.ts
@@ -44,22 +44,7 @@ describe('getDiagnostics', () => {
         return {
           Document(node) {
             for (const definition of node.definitions) {
-              // console.log(`definition:`, definition) //this is what the definition looks like:
-              // as you can see, the definition.name === undefined
-              // definition: {
-              //         kind: 'OperationDefinition',
-              //           operation: 'query',
-              //             name: undefined,
-              //               variableDefinitions: [],
-              //                 directives: [],
-              //                   selectionSet:
-              //         {
-              //           kind: 'SelectionSet',
-              //             selections: [[Object]],
-              //               loc: { start: 0, end: 17 }
-              //         },
-              //   loc: { start: 0, end: 17 }
-              // }
+              // add a custom error to every definition
               validationContext.reportError(
                 new GraphQLError(`This is a custom error.`, definition),
               );

--- a/packages/graphql-language-service-interface/src/__tests__/getDiagnostics-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getDiagnostics-test.ts
@@ -9,7 +9,7 @@
  */
 
 import fs from 'fs';
-import { buildSchema, parse, GraphQLSchema } from 'graphql';
+import { buildSchema, parse, GraphQLSchema, GraphQLError } from 'graphql';
 import path from 'path';
 
 import {
@@ -34,6 +34,42 @@ describe('getDiagnostics', () => {
     expect(error.message).toEqual(
       'Cannot query field "title" on type "Query".',
     );
+    expect(error.severity).toEqual(DIAGNOSTIC_SEVERITY.Error);
+    expect(error.source).toEqual('GraphQL: Validation');
+  });
+
+  it('catches multi root validation errors without breaking (with a custom validation function that always throws errors)', () => {
+    const error = validateQuery(parse('{ hero { name } } { seq }'), schema, [
+      validationContext => {
+        return {
+          Document(node) {
+            for (const definition of node.definitions) {
+              // console.log(`definition:`, definition) //this is what the definition looks like:
+              // as you can see, the definition.name === undefined
+              // definition: {
+              //         kind: 'OperationDefinition',
+              //           operation: 'query',
+              //             name: undefined,
+              //               variableDefinitions: [],
+              //                 directives: [],
+              //                   selectionSet:
+              //         {
+              //           kind: 'SelectionSet',
+              //             selections: [[Object]],
+              //               loc: { start: 0, end: 17 }
+              //         },
+              //   loc: { start: 0, end: 17 }
+              // }
+              validationContext.reportError(
+                new GraphQLError(`This is a custom error.`, definition),
+              );
+            }
+            return false;
+          },
+        };
+      },
+    ])[0];
+    expect(error.message).toEqual('This is a custom error.');
     expect(error.severity).toEqual(DIAGNOSTIC_SEVERITY.Error);
     expect(error.source).toEqual('GraphQL: Validation');
   });

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -120,9 +120,9 @@ function annotations(
   const highlightedNodes: Diagnostic[] = [];
   error.nodes.forEach(node => {
     const highlightNode =
-      node.kind !== 'Variable' && 'name' in node
+      node.kind !== 'Variable' && node.name
         ? node.name
-        : 'variable' in node
+        : node.variable
         ? node.variable
         : node;
     if (highlightNode) {

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -120,9 +120,9 @@ function annotations(
   const highlightedNodes: Diagnostic[] = [];
   error.nodes.forEach(node => {
     const highlightNode =
-      node.kind !== 'Variable' && node.name
+      node.kind !== 'Variable' && 'name' in node && node.name !== undefined
         ? node.name
-        : node.variable
+        : 'variable' in node && node.variable !== undefined
         ? node.variable
         : node;
     if (highlightNode) {


### PR DESCRIPTION
Connects https://github.com/graphql/graphiql/issues/1565

fixes highlightNode `xxx in xxx` syntax to revert back to simple dot notation for checking of existence