### PR TITLE
Update the header editor to work in the 2.0 version of GraphiQL

### DIFF
--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -104,7 +104,7 @@ function graphQLFetcher(graphQLParams, opts = { headers: {} }) {
   let headers = opts.headers;
   // Convert headers to an object.
   if (typeof headers === 'string') {
-    headers = JSON.parse(opts.headers);
+    headers = JSON.parse(headers);
   }
 
   return fetch(api, {

--- a/packages/graphiql/src/api/actions/sessionActions.ts
+++ b/packages/graphiql/src/api/actions/sessionActions.ts
@@ -5,6 +5,7 @@ export enum SessionActionTypes {
   EditorLoaded = 'EditorLoaded',
   OperationChanged = 'OperationChanged',
   VariablesChanged = 'VariablesChanged',
+  HeadersChanged = 'HeadersChanged',
   OperationSucceeded = 'OperationSucceeded',
   OperationErrored = 'OperationErrored',
   TabChanged = 'TabChanged',
@@ -19,6 +20,7 @@ export type SessionAction =
   | EditorLoadedAction
   | OperationChangedAction
   | VariablesChangedAction
+  | HeadersChangedAction
   | OperationSucceededAction
   | OperationErroredAction
   | TabChangedAction;
@@ -61,6 +63,14 @@ export const variableChangedAction = (value: string, sessionId: number) =>
   } as const);
 
 export type VariablesChangedAction = ReturnType<typeof variableChangedAction>;
+
+export const headerChangedAction = (value: string, sessionId: number) =>
+  ({
+    type: SessionActionTypes.HeadersChanged,
+    payload: { value, sessionId },
+  } as const);
+
+export type HeadersChangedAction = ReturnType<typeof headerChangedAction>;
 
 export const operationSucceededAction = (result: string, sessionId: number) =>
   ({

--- a/packages/graphiql/src/api/types.ts
+++ b/packages/graphiql/src/api/types.ts
@@ -21,6 +21,7 @@ export type SessionState = {
   sessionId: number;
   operation: File;
   variables: File;
+  headers: File;
   results: File;
   operationLoading: boolean;
   operationErrors: Error[] | null;

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -4,38 +4,33 @@
  *  This source code is licensed under the MIT license found in the
  *  LICENSE file in the root directory of this source tree.
  */
-import type * as CM from 'codemirror';
-import 'codemirror/addon/hint/show-hint';
+
+/** @jsx jsx */
+import { jsx } from 'theme-ui';
+
 import React from 'react';
 
-import onHasCompletion from '../utility/onHasCompletion';
-import commonKeys from '../utility/commonKeys';
+import EditorWrapper from '../components/common/EditorWrapper';
 
-declare module CodeMirror {
-  export interface Editor extends CM.Editor {}
-  export interface ShowHintOptions {
-    completeSingle: boolean;
-    hint: CM.HintFunction | CM.AsyncHintFunction;
-    container: HTMLElement | null;
-  }
-}
+import { useEditorsContext } from '../api/providers/GraphiQLEditorsProvider';
+import { useSessionContext } from '../api/providers/GraphiQLSessionProvider';
 
-type HeaderEditorProps = {
+import type { EditorOptions } from '../types';
+
+export type HeaderEditorProps = {
   value?: string;
-  onEdit: (value: string) => void;
   readOnly?: boolean;
   onHintInformationRender: (value: HTMLDivElement) => void;
   onPrettifyQuery: (value?: string) => void;
   onMergeQuery: (value?: string) => void;
-  onRunQuery: (value?: string) => void;
   editorTheme?: string;
-  active?: boolean;
+  editorOptions?: EditorOptions;
 };
 
 /**
  * HeaderEditor
  *
- * An instance of CodeMirror for editing headers to be passed with the GraphQL request.
+ * An instance of Monaco for editing headers.
  *
  * Props:
  *
@@ -44,197 +39,68 @@ type HeaderEditorProps = {
  *   - readOnly: Turns the editor to read-only mode.
  *
  */
-export class HeaderEditor extends React.Component<HeaderEditorProps> {
-  CodeMirror: any;
-  editor: (CM.Editor & { options: any }) | null = null;
-  cachedValue: string;
-  private _node: HTMLElement | null = null;
-  ignoreChangeEvent: boolean = false;
-  constructor(props: HeaderEditorProps) {
-    super(props);
+export function HeaderEditor(props: HeaderEditorProps) {
+  const session = useSessionContext();
+  const [ignoreChangeEvent, setIgnoreChangeEvent] = React.useState(false);
+  const editorRef = React.useRef<monaco.editor.IStandaloneCodeEditor>();
+  const cachedValueRef = React.useRef<string>(props.value ?? '');
+  const divRef = React.useRef<HTMLDivElement>(null);
+  const { loadEditor } = useEditorsContext();
 
-    // Keep a cached version of the value, this cache will be updated when the
-    // editor is updated, which can later be used to protect the editor from
-    // unnecessary updates during the update lifecycle.
-    this.cachedValue = props.value || '';
-  }
-
-  componentDidMount() {
+  React.useEffect(() => {
     // Lazily require to ensure requiring GraphiQL outside of a Browser context
     // does not produce an error.
-    this.CodeMirror = require('codemirror');
-    require('codemirror/addon/hint/show-hint');
-    require('codemirror/addon/edit/matchbrackets');
-    require('codemirror/addon/edit/closebrackets');
-    require('codemirror/addon/fold/brace-fold');
-    require('codemirror/addon/fold/foldgutter');
-    require('codemirror/addon/lint/lint');
-    require('codemirror/addon/search/searchcursor');
-    require('codemirror/addon/search/jump-to-line');
-    require('codemirror/addon/dialog/dialog');
-    require('codemirror/keymap/sublime');
 
-    const editor = (this.editor = this.CodeMirror(this._node, {
-      value: this.props.value || '',
-      lineNumbers: true,
-      tabSize: 2,
-      mode: 'graphql-headers',
-      theme: this.props.editorTheme || 'graphiql',
-      keyMap: 'sublime',
-      autoCloseBrackets: true,
-      matchBrackets: true,
-      showCursorWhenSelecting: true,
-      readOnly: this.props.readOnly ? 'nocursor' : false,
-      foldGutter: {
-        minFoldSize: 4,
+    const editor = (editorRef.current = monaco.editor.create(
+      divRef.current as HTMLDivElement,
+      {
+        value: session?.headers?.text || '',
+        language: 'json',
+        theme: props?.editorTheme,
+        readOnly: props?.readOnly ?? false,
+        automaticLayout: true,
+        ...props.editorOptions,
       },
-      gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      extraKeys: {
-        'Cmd-Space': () =>
-          this.editor!.showHint({
-            completeSingle: false,
-            container: this._node,
-          } as CodeMirror.ShowHintOptions),
-        'Ctrl-Space': () =>
-          this.editor!.showHint({
-            completeSingle: false,
-            container: this._node,
-          } as CodeMirror.ShowHintOptions),
-        'Alt-Space': () =>
-          this.editor!.showHint({
-            completeSingle: false,
-            container: this._node,
-          } as CodeMirror.ShowHintOptions),
-        'Shift-Space': () =>
-          this.editor!.showHint({
-            completeSingle: false,
-            container: this._node,
-          } as CodeMirror.ShowHintOptions),
-        'Cmd-Enter': () => {
-          if (this.props.onRunQuery) {
-            this.props.onRunQuery();
-          }
-        },
-        'Ctrl-Enter': () => {
-          if (this.props.onRunQuery) {
-            this.props.onRunQuery();
-          }
-        },
-        'Shift-Ctrl-P': () => {
-          if (this.props.onPrettifyQuery) {
-            this.props.onPrettifyQuery();
-          }
-        },
+    ));
+    loadEditor('headers', editor);
 
-        'Shift-Ctrl-M': () => {
-          if (this.props.onMergeQuery) {
-            this.props.onMergeQuery();
-          }
-        },
+    editor.onDidChangeModelContent(() => {
+      if (!ignoreChangeEvent) {
+        cachedValueRef.current = editor.getValue();
+        session.changeHeaders(cachedValueRef.current);
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-        ...commonKeys,
-      },
-    }));
-
-    editor.on('change', this._onEdit);
-    editor.on('keyup', this._onKeyUp);
-    editor.on('hasCompletion', this._onHasCompletion);
-  }
-
-  componentDidUpdate(prevProps: HeaderEditorProps) {
-    this.CodeMirror = require('codemirror');
-    if (!this.editor) {
+  React.useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
       return;
     }
 
     // Ensure the changes caused by this update are not interpretted as
     // user-input changes which could otherwise result in an infinite
     // event loop.
-    this.ignoreChangeEvent = true;
-    if (
-      this.props.value !== prevProps.value &&
-      this.props.value !== this.cachedValue
-    ) {
-      const thisValue = this.props.value || '';
-      this.cachedValue = thisValue;
-      this.editor.setValue(thisValue);
+    setIgnoreChangeEvent(true);
+    if (session.headers.text !== cachedValueRef.current) {
+      const thisValue = session.headers.text || '';
+      cachedValueRef.current = thisValue;
+      editor.setValue(thisValue);
     }
-    this.ignoreChangeEvent = false;
-  }
 
-  componentWillUnmount() {
-    if (!this.editor) {
+    setIgnoreChangeEvent(false);
+  }, [session.headers.text]);
+
+  React.useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
       return;
     }
-    this.editor.off('change', this._onEdit);
-    this.editor.off('keyup', this._onKeyUp);
-    this.editor.off('hasCompletion', this._onHasCompletion);
-    this.editor = null;
-  }
-
-  render() {
-    return (
-      <div
-        className="codemirrorWrap"
-        // This horrible hack is necessary because a simple display none toggle
-        // causes one of the editors' gutters to break otherwise.
-        style={{
-          position: this.props.active ? 'relative' : 'absolute',
-          visibility: this.props.active ? 'visible' : 'hidden',
-        }}
-        ref={node => {
-          this._node = node as HTMLDivElement;
-        }}
-      />
-    );
-  }
-
-  /**
-   * Public API for retrieving the CodeMirror instance from this
-   * React component.
-   */
-  getCodeMirror() {
-    return this.editor as CM.Editor;
-  }
-
-  /**
-   * Public API for retrieving the DOM client height for this component.
-   */
-  getClientHeight() {
-    return this._node && this._node.clientHeight;
-  }
-
-  private _onKeyUp = (_cm: CodeMirror.Editor, event: KeyboardEvent) => {
-    const code = event.keyCode;
-    if (!this.editor) {
-      return;
+    if (props.editorOptions) {
+      editor.updateOptions(props.editorOptions);
     }
-    if (
-      (code >= 65 && code <= 90) || // letters
-      (!event.shiftKey && code >= 48 && code <= 57) || // numbers
-      (event.shiftKey && code === 189) || // underscore
-      (event.shiftKey && code === 222) // "
-    ) {
-      this.editor.execCommand('autocomplete');
-    }
-  };
+  }, [props.editorOptions]);
 
-  private _onEdit = () => {
-    if (!this.editor) {
-      return;
-    }
-    if (!this.ignoreChangeEvent) {
-      this.cachedValue = this.editor.getValue();
-      if (this.props.onEdit) {
-        this.props.onEdit(this.cachedValue);
-      }
-    }
-  };
-
-  private _onHasCompletion = (
-    instance: CM.Editor,
-    changeObj?: CM.EditorChangeLinkedList,
-  ) => {
-    onHasCompletion(instance, changeObj, this.props.onHintInformationRender);
-  };
+  return <EditorWrapper className="headers-editor" innerRef={divRef} />;
 }

--- a/packages/graphiql/src/types/index.ts
+++ b/packages/graphiql/src/types/index.ts
@@ -61,6 +61,8 @@ export type EditorOptions = monaco.editor.IEditorOptions &
 
 export type Fetcher = (
   graphQLParams: FetcherParams,
+  // TODO: Define this as an object with a `headers` property.
+  opts: any,
 ) => Promise<FetcherResult> | Observable<FetcherResult>;
 
 export type ReactNodeLike =


### PR DESCRIPTION
Surprisingly, I think this mostly works. I originally intended to just try this because I wanted to mess with the 2.0 editor, but this actually seems to work surprisingly well.

I'm not sure if we wanted the headers editor as a plugin for 2.0, or something else?

I didn't spend that long on this, so if this isn't the route we want to go down that's fine by me. Like I said, I didn't originally intend for this to end up becoming anything.

![image](https://user-images.githubusercontent.com/2977353/85237977-0374eb00-b3e8-11ea-9bb1-bd47218f94ff.png)