### PR TITLE
fix: headers tab - highlighting and schema fetch

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -787,11 +787,24 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
   private fetchSchema() {
     const fetcher = this.props.fetcher;
 
+    const fetcherOpts: FetcherOpts = {
+      shouldPersistHeaders: Boolean(this.props.shouldPersistHeaders),
+    };
+    if (this.state.headers && this.state.headers.trim().length > 2) {
+      fetcherOpts.headers = JSON.parse(this.state.headers);
+      // if state is not present, but props are
+    } else if (this.props.headers) {
+      fetcherOpts.headers = JSON.parse(this.props.headers);
+    }
+
     const fetch = observableToPromise(
-      fetcher({
-        query: introspectionQuery,
-        operationName: introspectionQueryName,
-      }),
+      fetcher(
+        {
+          query: introspectionQuery,
+          operationName: introspectionQueryName,
+        },
+        fetcherOpts,
+      ),
     );
     if (!isPromise(fetch)) {
       this.setState({
@@ -809,10 +822,13 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         // Try the stock introspection query first, falling back on the
         // sans-subscriptions query for services which do not yet support it.
         const fetch2 = observableToPromise(
-          fetcher({
-            query: introspectionQuerySansSubscriptions,
-            operationName: introspectionQueryName,
-          }),
+          fetcher(
+            {
+              query: introspectionQuerySansSubscriptions,
+              operationName: introspectionQueryName,
+            },
+            fetcherOpts,
+          ),
         );
         if (!isPromise(fetch)) {
           throw new Error(

--- a/packages/graphiql/src/components/HeaderEditor.tsx
+++ b/packages/graphiql/src/components/HeaderEditor.tsx
@@ -71,13 +71,14 @@ export class HeaderEditor extends React.Component<HeaderEditorProps> {
     require('codemirror/addon/search/searchcursor');
     require('codemirror/addon/search/jump-to-line');
     require('codemirror/addon/dialog/dialog');
+    require('codemirror/mode/javascript/javascript');
     require('codemirror/keymap/sublime');
 
     const editor = (this.editor = this.CodeMirror(this._node, {
       value: this.props.value || '',
       lineNumbers: true,
       tabSize: 2,
-      mode: 'graphql-headers',
+      mode: { name: 'javascript', json: true },
       theme: this.props.editorTheme || 'graphiql',
       keyMap: 'sublime',
       autoCloseBrackets: true,


### PR DESCRIPTION
- headers tab does not re-fetch schema with same headers when fetcher prop changes
- codemirror mode for json, `graphql-headers` is a non-existant mode
- resolves #1592 