### PR TITLE
fix: regression for variable def completion #1622

### DIFF
--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -186,7 +186,8 @@ export function getAutocompleteSuggestions(
     (kind === RuleKinds.NAMED_TYPE &&
       state.prevState &&
       (state.prevState.kind === RuleKinds.VARIABLE_DEFINITION ||
-        state.prevState.kind === RuleKinds.LIST_TYPE))
+        state.prevState.kind === RuleKinds.LIST_TYPE ||
+        state.prevState.kind === RuleKinds.NON_NULL_TYPE))
   ) {
     return getSuggestionsForVariableDefinition(token, schema, kind);
   }


### PR DESCRIPTION
fixes #1622

Restores completion for variable definitions. When we fixed a bug that broke non-null lists in the parser, we did not update the completions for this change to the parser. this impacts monaco-graphql, graphiql, etc

![image](https://user-images.githubusercontent.com/1368727/88808467-ec60b000-d180-11ea-9582-2d37e8a0d73b.png)


