### PR TITLE
improvement: Show directives inside of FieldDoc.

### DIFF
--- a/packages/graphiql/src/components/DocExplorer/Directive.tsx
+++ b/packages/graphiql/src/components/DocExplorer/Directive.tsx
@@ -1,0 +1,22 @@
+/**
+ *  Copyright (c) 2020 GraphQL Contributors.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { DirectiveNode } from 'graphql';
+
+type DirectiveProps = {
+  directive: DirectiveNode;
+};
+
+export default function Directive({ directive }: DirectiveProps) {
+  return (
+    <span className="doc-category-item" id={directive.name.value}>
+      {'@'}
+      {directive.name.value}
+    </span>
+  );
+}

--- a/packages/graphiql/src/components/DocExplorer/FieldDoc.tsx
+++ b/packages/graphiql/src/components/DocExplorer/FieldDoc.tsx
@@ -7,9 +7,10 @@
 
 import React from 'react';
 import Argument from './Argument';
+import Directive from './Directive';
 import MarkdownContent from './MarkdownContent';
 import TypeLink from './TypeLink';
-import { GraphQLArgument } from 'graphql';
+import { GraphQLArgument, DirectiveNode } from 'graphql';
 import { OnClickTypeFunction, FieldType } from './types';
 
 type FieldDocProps = {
@@ -38,6 +39,27 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
     );
   }
 
+  let directivesDef;
+  if (
+    field &&
+    field.astNode &&
+    field.astNode.directives &&
+    field.astNode.directives.length > 0
+  ) {
+    directivesDef = (
+      <div className="doc-category">
+        <div className="doc-category-title">{'directives'}</div>
+        {field.astNode.directives.map((directive: DirectiveNode) => (
+          <div key={directive.name.value} className="doc-category-item">
+            <div>
+              <Directive directive={directive} />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div>
       <MarkdownContent
@@ -55,6 +77,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
         <TypeLink type={field?.type} onClick={onClickType} />
       </div>
       {argsDef}
+      {directivesDef}
     </div>
   );
 }

--- a/packages/graphiql/src/components/DocExplorer/__tests__/FieldDoc.spec.tsx
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/FieldDoc.spec.tsx
@@ -30,6 +30,33 @@ const exampleObject = new GraphQLObjectType({
         },
       },
     },
+    stringWithDirective: {
+      name: 'stringWithDirective',
+      type: GraphQLString,
+      astNode: {
+        kind: 'FieldDefinition',
+        name: {
+          kind: 'Name',
+          value: 'stringWithDirective',
+        },
+        type: {
+          kind: 'NamedType',
+          name: {
+            kind: 'Name',
+            value: 'GraphQLString',
+          },
+        },
+        directives: [
+          {
+            kind: 'Directive',
+            name: {
+              kind: 'Name',
+              value: 'development',
+            },
+          },
+        ],
+      },
+    },
   },
 });
 
@@ -87,6 +114,19 @@ describe('FieldDoc', () => {
     expect(container.querySelectorAll('.arg')).toHaveLength(1);
     expect(container.querySelector('.arg')).toHaveTextContent(
       'stringArg: String',
+    );
+  });
+
+  it('should render a string field with directives', () => {
+    const { container } = render(
+      <FieldDoc
+        field={exampleObject.getFields().stringWithDirective}
+        onClickType={jest.fn()}
+      />,
+    );
+    expect(container.querySelector('.type-name')).toHaveTextContent('String');
+    expect(container.querySelector('#development')).toHaveTextContent(
+      '@development',
     );
   });
 });


### PR DESCRIPTION
Directives are not exposed in the introspection schema (discussion here: https://github.com/graphql/graphql-spec/issues/300). Nevertheless, if GraphiQL is supplied with an SDL schema, it can access AST directives for fields. It would be useful to show field directives in Doc Explorer for that case.