### PR TITLE
variables in FetcherParams

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -72,7 +72,7 @@ export type Maybe<T> = T | null | undefined;
 export type FetcherParams = {
   query: string;
   operationName: string;
-  variables?: string;
+  variables?: any;
 };
 
 export type FetcherOpts = {


### PR DESCRIPTION
need to make sure `variables` is typed as any, since it comes in as an object literal, not a string. resolves #1632