### PR TITLE
improvement: server only LSP bugfix for config extensions

### DIFF
--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -194,9 +194,11 @@ export class GraphQLLanguageService {
 
     // Check if there are custom validation rules to be used
     let customRules: ValidationRule[] | null = null;
-    const customValidationRules = extensions.customValidationRules;
-    if (customValidationRules) {
-      customRules = customValidationRules(this._graphQLConfig);
+    if (
+      extensions?.customValidationRules &&
+      typeof extensions.customValidationRules === 'function'
+    ) {
+      customRules = extensions.customValidationRules(this._graphQLConfig);
 
       /* eslint-enable no-implicit-coercion */
     }


### PR DESCRIPTION
This LSP service class is only used by the LSP server currently, so this only effects the server

This actually prevents the server from running at all!