### PR TITLE
chore: _Kind is causing issues in graphql 15

### DIFF
--- a/packages/graphql-language-service-parser/src/types.ts
+++ b/packages/graphql-language-service-parser/src/types.ts
@@ -1,5 +1,4 @@
 import { Kind } from 'graphql';
-import { _Kind } from 'graphql/language/kinds';
 import { Maybe } from 'graphql-language-service-types';
 import CharacterStream from './CharacterStream';
 
@@ -114,7 +113,7 @@ export const RuleKinds = {
   ...AdditionalRuleKinds,
 };
 
-export type _RuleKinds = _Kind & typeof AdditionalRuleKinds;
+export type _RuleKinds = typeof Kind & typeof AdditionalRuleKinds;
 
 export type RuleKind = _RuleKinds[keyof _RuleKinds];
 export type RuleKindEnum = RuleKind;


### PR DESCRIPTION
was having this issue:
![image](https://user-images.githubusercontent.com/1368727/90066817-3dfa5600-dcbc-11ea-86ae-e76d3c0f53ea.png)

`_Kind` was not even needed to begin with! can just be inferred from `typeof Kind`. it must be that they dropped it in 15 sometime after `15.0.0`