### PR TITLE
feat: custom config baseDir, embedded fragment def offsets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": true
-}

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -62,10 +62,8 @@ export async function getGraphQLCache({
   loadConfigOptions: LoadConfigOptions;
   config?: GraphQLConfig;
 }): Promise<GraphQLCacheInterface> {
-  let graphQLConfig;
-  if (config) {
-    graphQLConfig = config;
-  } else {
+  let graphQLConfig = config;
+  if (!graphQLConfig) {
     graphQLConfig = await loadConfig(loadConfigOptions);
   }
   return new GraphQLCache({

--- a/packages/graphql-language-service-server/src/Logger.ts
+++ b/packages/graphql-language-service-server/src/Logger.ts
@@ -67,9 +67,10 @@ export class Logger implements VSCodeLogger {
     const logMessage = `${timestamp} [${severity}] (pid: ${pid}) graphql-language-service-usage-logs: ${message}\n\n`;
     // write to the file in tmpdir
     fs.appendFile(this._logFilePath, logMessage, _error => {});
-    // const processSt = (severity === DIAGNOSTIC_SEVERITY.Error) ? process.stderr : process.stdout
-    process.stderr.write(logMessage, _err => {
-      // console.error(err);
+    const processSt =
+      severity === DIAGNOSTIC_SEVERITY.Error ? process.stderr : process.stdout;
+    processSt.write(logMessage, err => {
+      console.error(err);
     });
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -641,7 +641,7 @@ export class MessageProcessor {
       },
     );
     const formatted = result
-      ? result.definitions.map(res => {
+      ? result?.definitions?.map(res => {
           const defRange = res.range as Range;
 
           if (parentRange && res.name) {

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -640,8 +640,9 @@ export class MessageProcessor {
         },
       },
     );
+
     const formatted = result
-      ? result?.definitions?.map(res => {
+      ? result.definitions.map(res => {
           const defRange = res.range as Range;
 
           if (parentRange && res.name) {
@@ -650,13 +651,14 @@ export class MessageProcessor {
               path.extname(textDocument.uri),
             );
             if (isInline && isEmbedded) {
+              const vOffset = parentRange.start.line;
               defRange.setStart(
-                (defRange.start.line += parentRange.start.line),
-                parentRange.start.character,
+                (defRange.start.line += vOffset),
+                defRange.start.character,
               );
               defRange.setEnd(
-                (defRange.end.line += parentRange.end.line),
-                parentRange.end.character,
+                (defRange.end.line += vOffset),
+                defRange.end.character,
               );
             }
           }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -52,15 +52,16 @@ import type {
   DocumentSymbolParams,
   SymbolInformation,
   WorkspaceSymbolParams,
+  IConnection,
 } from 'vscode-languageserver';
 
 import type { UnnormalizedTypeDefPointer } from '@graphql-tools/load';
 
 import { getGraphQLCache } from './GraphQLCache';
-import { parseDocument } from './parseDocument';
+import { parseDocument, DEFAULT_SUPPORTED_EXTENSIONS } from './parseDocument';
 
 import { Logger } from './Logger';
-import { printSchema } from 'graphql';
+import { printSchema, visit, parse, FragmentDefinitionNode } from 'graphql';
 import { tmpdir } from 'os';
 import { GraphQLExtensionDeclaration } from 'graphql-config';
 import type { LoadConfigOptions } from './types';
@@ -74,6 +75,7 @@ type CachedDocumentType = {
 };
 
 export class MessageProcessor {
+  _connection: IConnection;
   _graphQLCache!: GraphQLCache;
   _graphQLConfig: GraphQLConfig | undefined;
   _languageService!: GraphQLLanguageService;
@@ -88,6 +90,7 @@ export class MessageProcessor {
   _tmpDirBase: string;
   _loadConfigOptions: LoadConfigOptions;
   _schemaCacheInit: boolean = false;
+  _rootPath: string = process.cwd();
 
   constructor({
     logger,
@@ -97,6 +100,7 @@ export class MessageProcessor {
     config,
     parser,
     tmpDir,
+    connection,
   }: {
     logger: Logger;
     fileExtensions: string[];
@@ -105,7 +109,9 @@ export class MessageProcessor {
     config?: GraphQLConfig;
     parser?: typeof parseDocument;
     tmpDir?: string;
+    connection: IConnection;
   }) {
+    this._connection = connection;
     this._textDocumentCache = new Map();
     this._isInitialized = false;
     this._willShutdown = false;
@@ -130,6 +136,12 @@ export class MessageProcessor {
       mkdirp(this._tmpDirBase);
     }
   }
+  get connection(): IConnection {
+    return this._connection;
+  }
+  set connection(connection: IConnection) {
+    this._connection = connection;
+  }
 
   async handleInitializeRequest(
     params: InitializeParams,
@@ -151,15 +163,25 @@ export class MessageProcessor {
         definitionProvider: true,
         textDocumentSync: 1,
         hoverProvider: true,
+        workspace: {
+          workspaceFolders: {
+            supported: true,
+            changeNotifications: true,
+          },
+        },
       },
     };
 
-    const rootPath = configDir ? configDir.trim() : params.rootPath;
-    if (!rootPath) {
-      throw new Error(
-        '`--configDir` option or `rootPath` argument is required.',
+    this._rootPath = configDir
+      ? configDir.trim()
+      : params.rootPath || this._rootPath;
+    if (!this._rootPath) {
+      this._logger.warn(
+        'no rootPath configured in extension or server, defaulting to cwd',
       );
     }
+    this._loadConfigOptions.rootDir = this._rootPath;
+
     this._graphQLCache = await getGraphQLCache({
       parser: this._parser,
       loadConfigOptions: this._loadConfigOptions,
@@ -190,6 +212,21 @@ export class MessageProcessor {
   ): Promise<PublishDiagnosticsParams | null> {
     if (!this._isInitialized || !this._graphQLCache) {
       return null;
+    }
+
+    const settings = await this._connection.workspace.getConfiguration({
+      section: 'graphql-config',
+    });
+    if (settings.rootDir && settings.rootDir !== this._rootPath) {
+      this._rootPath = settings.rootDir;
+      this._loadConfigOptions.rootDir = settings.rootDir;
+
+      this._graphQLCache = await getGraphQLCache({
+        parser: this._parser,
+        loadConfigOptions: this._loadConfigOptions,
+        config: this._graphQLConfig,
+      });
+      this._languageService = new GraphQLLanguageService(this._graphQLCache);
     }
 
     if (!params || !params.textDocument) {
@@ -579,9 +616,9 @@ export class MessageProcessor {
       return [];
     }
 
-    const { query, range } = found;
-    if (range) {
-      position.line -= range.start.line;
+    const { query, range: parentRange } = found;
+    if (parentRange) {
+      position.line -= parentRange.start.line;
     }
 
     const result = await this._languageService.getDefinition(
@@ -590,9 +627,40 @@ export class MessageProcessor {
       textDocument.uri,
     );
 
+    const inlineFragments: string[] = [];
+
+    visit(
+      parse(query, {
+        allowLegacySDLEmptyFields: true,
+        allowLegacySDLImplementsInterfaces: true,
+      }),
+      {
+        FragmentDefinition: (node: FragmentDefinitionNode) => {
+          inlineFragments.push(node.name.value);
+        },
+      },
+    );
     const formatted = result
       ? result.definitions.map(res => {
           const defRange = res.range as Range;
+
+          if (parentRange && res.name) {
+            const isInline = inlineFragments.includes(res.name);
+            const isEmbedded = DEFAULT_SUPPORTED_EXTENSIONS.includes(
+              path.extname(textDocument.uri),
+            );
+            if (isInline && isEmbedded) {
+              defRange.setStart(
+                (defRange.start.line += parentRange.start.line),
+                parentRange.start.character,
+              );
+              defRange.setEnd(
+                (defRange.end.line += parentRange.end.line),
+                parentRange.end.character,
+              );
+            }
+          }
+
           return {
             // TODO: fix this hack!
             // URI is being misused all over this library - there's a link that
@@ -605,7 +673,7 @@ export class MessageProcessor {
                 ? res.path
                 : `file://${path.resolve(res.path)}`,
             range: defRange,
-          };
+          } as Location;
         })
       : [];
 
@@ -693,6 +761,7 @@ export class MessageProcessor {
 
     return [];
   }
+
   _getTextDocuments() {
     return Array.from(this._textDocumentCache);
   }
@@ -734,8 +803,8 @@ export class MessageProcessor {
     appendPath?: string,
   ) {
     const baseDir = this._graphQLCache.getGraphQLConfig().dirpath;
-    const baseName = path.basename(baseDir);
-    const basePath = path.join(this._tmpDirBase, baseName);
+    const workspaceName = path.basename(baseDir);
+    const basePath = path.join(this._tmpDirBase, workspaceName);
     let projectTmpPath = path.join(basePath, 'projects', project.name);
     if (!existsSync(projectTmpPath)) {
       mkdirp(projectTmpPath);
@@ -744,9 +813,10 @@ export class MessageProcessor {
       projectTmpPath = path.join(projectTmpPath, appendPath);
     }
     if (prependWithProtocol) {
-      projectTmpPath = `file://${projectTmpPath}`;
+      return `file://${path.resolve(projectTmpPath)}`;
+    } else {
+      return path.resolve(projectTmpPath);
     }
-    return projectTmpPath;
   }
   async _cacheSchemaFilesForProject(project: GraphQLProjectConfig) {
     const schema = project?.schema;
@@ -789,23 +859,27 @@ export class MessageProcessor {
     try {
       const schema = await this._graphQLCache.getSchema(project.name);
       if (schema) {
-        const schemaText = printSchema(schema, {
+        let schemaText = printSchema(schema, {
           commentDescriptions: true,
         });
         // file:// protocol path
-        const uri = this._getTmpProjectPath(project, true, 'schema.graphql');
+        const uri = this._getTmpProjectPath(
+          project,
+          true,
+          'generated-schema.graphql',
+        );
 
         // no file:// protocol for fs.writeFileSync()
         const fsPath = this._getTmpProjectPath(
           project,
           false,
-          'schema.graphql',
+          'generated-schema.graphql',
         );
+        schemaText = `# This is an automatically generated representation of your schema.\n# Any changes to this file will be overwritten and will not be\n# reflected in the resulting GraphQL schema\n\n${schemaText}`;
 
         const cachedSchemaDoc = this._getCachedDocument(uri);
 
         if (!cachedSchemaDoc) {
-          console.log({ fsPath });
           await writeFileAsync(fsPath, schemaText, {
             encoding: 'utf-8',
           });

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -24,9 +24,12 @@ import type { DefinitionQueryResult, Outline } from 'graphql-language-service';
 import { Logger } from '../Logger';
 
 const baseConfig = { dirpath: __dirname };
+
 describe('MessageProcessor', () => {
   const logger = new Logger(tmpdir());
   const messageProcessor = new MessageProcessor({
+    // @ts-ignore
+    connection: {},
     logger,
     fileExtensions: ['js'],
     graphqlFileExtensions: ['graphql'],
@@ -103,6 +106,17 @@ describe('MessageProcessor', () => {
       },
     };
   });
+  // @ts-ignore
+  messageProcessor._connection = {
+    // @ts-ignore
+    get workspace() {
+      return {
+        getConfiguration: async () => {
+          return [{}];
+        },
+      };
+    },
+  };
 
   const initialDocument = {
     textDocument: {
@@ -247,6 +261,7 @@ describe('MessageProcessor', () => {
 
   // modified to work with jest.mock() of WatchmanClient
   it('runs definition requests', async () => {
+    jest.setTimeout(10000);
     const validQuery = `
   {
     hero(episode: EMPIRE){

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -289,7 +289,6 @@ async function addHandlers({
     loadConfigOptions,
     connection,
   });
-  messageProcessor.connection = connection;
 
   connection.onNotification(
     DidOpenTextDocumentNotification.type,


### PR DESCRIPTION
- requires using `createConnection()` strategy
- extension settings on server side for the first time
- allow graphql-config `loadConnfig()` `baseDir` to be configured
- properly calculate offsets for inline operation fragment defs