### PR TITLE
fix: dont use initial query on every re-render

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -320,13 +320,19 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     if (nextProps.schema !== undefined) {
       nextSchema = nextProps.schema;
     }
-    if (nextProps.query !== undefined) {
+    if (nextProps.query !== undefined && this.props.query !== nextProps.query) {
       nextQuery = nextProps.query;
     }
-    if (nextProps.variables !== undefined) {
+    if (
+      nextProps.variables !== undefined &&
+      this.props.variables !== nextProps.variables
+    ) {
       nextVariables = nextProps.variables;
     }
-    if (nextProps.headers !== undefined) {
+    if (
+      nextProps.headers !== undefined &&
+      this.props.headers !== nextProps.headers
+    ) {
       nextHeaders = nextProps.headers;
     }
     if (nextProps.operationName !== undefined) {


### PR DESCRIPTION
this fix is a recreation of #987 by @jimmybergman

