### PR TITLE
fix: warn with no graphql config, instead of error

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -236,7 +236,7 @@ export class MessageProcessor {
         }
       }
     } catch (err) {
-      this._logger.error(err);
+      this._logger.warn(err);
     }
 
     // Here, we set the workspace settings in memory,


### PR DESCRIPTION
when the server is initialized without a graphql config present, we should warn instead of erroring. ideally, the language server should just quit, since the vast majority of features don't work without the configuration.