### PR TITLE
improvement: dotenv, reload on config changes

### DIFF
--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -35,6 +35,7 @@
     "graphql-language-service": "^3.0.2",
     "graphql-language-service-utils": "^2.4.3",
     "mkdirp": "^1.0.4",
+    "dotenv": "8.2.0",
     "nullthrows": "^1.0.0",
     "vscode-jsonrpc": "^5.0.1",
     "vscode-languageserver": "^6.1.1"

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -364,7 +364,8 @@ async function addHandlers({
   connection.onRequest(WorkspaceSymbolRequest.type, params =>
     messageProcessor.handleWorkspaceSymbolRequest(params),
   );
-  // connection.onRequest(ReferencesRequest.type, params =>
-  //   messageProcessor.handleReferencesRequest(params),
-  // );
+
+  connection.onDidChangeConfiguration(
+    messageProcessor.handleDidChangeConfiguration,
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8475,15 +8475,15 @@ dotenv-webpack@^1.7.0:
   dependencies:
     dotenv-defaults "^1.0.2"
 
+dotenv@8.2.0, dotenv@^8.0.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
-
-dotenv@^8.0.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 duplexer@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
- require `dotenv` in the server runtime (for loading graphql config values), and allow a `graphql-config.dotEnvPath` configuration to specify specific paths
- reload server on workspace configuration changes
- reload severside `graphql-config` and language service on config file changes. definitions cache/etc will be rebuilt
  - note: client not configured to reload on graphql config changes yet (i.e endpoints)
- accept all `graphql-config.loadConfig()` options
- readme updates