### PR TITLE
fix: enable variable editor when header editor is not enabled

### DIFF
--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -144,7 +144,7 @@ ReactDOM.render(
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
     onEditHeaders: onEditHeaders,
-    defaultVariableEditorOpen: true,
+    defaultSecondaryEditorOpen: true,
     onEditOperationName: onEditOperationName,
     headerEditorEnabled: true,
   }),

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -275,7 +275,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         this._storage.get('variableEditorActive') === 'true' ||
         props.headerEditorEnabled
           ? this._storage.get('headerEditorActive') !== 'true'
-          : secondaryEditorOpen && true,
+          : true,
       headerEditorActive: this._storage.get('headerEditorActive') === 'true',
       headerEditorEnabled,
       shouldPersistHeaders,


### PR DESCRIPTION
fixes #1677 
This PR is to enable variable editor when the header editor is not enabled