### PR TITLE
chore: update github action v1 to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     name: Lint & Test
     runs-on: ubuntu-16.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1
       - run: yarn ci && node_modules/.bin/codecov
 
@@ -13,6 +13,6 @@ jobs:
     name: Cypress
     runs-on: ubuntu-16.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1
       - run: yarn ci-e2e


### PR DESCRIPTION
- update github action v1 to v2
  - v2 is faster than v1 
  - https://github.com/actions/checkout#whats-new
