### PR TITLE
fix: prevent npm usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },
+  "engines": {
+    "npm": "please_use_yarn_instead"
+  },
   "scripts": {
     "build": "yarn run build-clean && yarn build-ts && yarn build-babel",
     "build-babel": "yarn workspace codemirror-graphql run build",


### PR DESCRIPTION
- prevent npm command for safety
- in this repo, yarn is used. Sometimes ppl accidentally use npm instead of yarn. In order to prevent it, this PR is created.
