### PR TITLE
fix(codemirror-graphql): give interface field name suggestions

### DIFF
--- a/packages/codemirror-graphql/src/__tests__/hint-test.js
+++ b/packages/codemirror-graphql/src/__tests__/hint-test.js
@@ -998,4 +998,22 @@ describe('graphql-hint', () => {
     );
     expect(suggestions7.list).to.deep.equal(expectedSuggestions);
   });
+  it('provides correct field name suggestions for an interface type', async () => {
+    const suggestions = await getHintSuggestions(
+      '{ first { ... on TestInterface { ',
+      {
+        line: 0,
+        ch: 33,
+      },
+    );
+    const list = [
+      {
+        text: 'scalar',
+        type: GraphQLString,
+        isDeprecated: false,
+      },
+    ];
+    const expectedSuggestions = getExpectedSuggestions(list);
+    expect(suggestions.list).to.deep.equal(expectedSuggestions);
+  });
 });

--- a/packages/codemirror-graphql/src/hint.js
+++ b/packages/codemirror-graphql/src/hint.js
@@ -34,6 +34,7 @@ import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
+  isInterfaceType,
 } from 'graphql';
 import type {
   GraphQLField,
@@ -225,7 +226,7 @@ function getSuggestionsForFieldNames(
   if (typeInfo.parentType) {
     const parentType = typeInfo.parentType;
     const fields: GraphQLField<*, *>[] =
-      isObjectType(parentType) && 'getFields' in parentType
+      isObjectType(parentType) || isInterfaceType(parentType)
         ? objectValues((parentType.getFields(): any))
         : [];
     if (isCompositeType(parentType)) {


### PR DESCRIPTION
Currently `codemirror-graphql` plugin ignores the fields of an interface type and doesn't give suggestions for those fields as hints because `getSuggestionsForFieldNames` uses `isObjectType` that returns `false` for interface types.