### PR TITLE
chore: move typescript to devDependencies

### DIFF
--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -32,11 +32,11 @@
     "lodash": "^4.17.15",
     "platform": "^1.3.5",
     "ts-node": "^8.10.2",
+    "typescript": "^3.9.5",
     "vscode-languageserver-types": "3.15.1"
   },
   "dependencies": {
-    "graphql-language-service-types": "^1.6.3",
-    "typescript": "^3.9.5"
+    "graphql-language-service-types": "^1.6.3"
   },
   "scripts": {
     "benchmark": "ts-node benchmark/index.ts"


### PR DESCRIPTION
This should reduce the size of node_modules when using graphiql by quite a bit!

<img src="https://user-images.githubusercontent.com/2136754/96955408-5a7bf100-14aa-11eb-8e0a-4327758b1b3f.png" width="315" alt="" />

