### PR TITLE
feat: deeper fragment merging

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -1121,7 +1121,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     }
 
     const ast = parse(query);
-    editor.setValue(print(mergeAST(ast)));
+    editor.setValue(print(mergeAST(ast, this.state.schema)));
   };
 
   handleEditQuery = debounce(100, (value: string) => {


### PR DESCRIPTION
Follow up to #1542; this passes the schema through to mergeAST so that the query can be further simplified in a type-aware way (i.e. spreading a fragment of type `Test` inside a scope that can only be type `Test` will result in the fragment being fully inlined).

Given this query:

```graphql
{
  test {
    id
    ...T
  }
}

fragment T on Test {
  isTest
}
```

Pressing "Merge" previously simplified to:

```graphql
{
  test {
    id
    ... on Test {
      isTest
    }
  }
}
```

But with this change, it now simplifies to:

```graphql
{
  test {
    id
    isTest
  }
}
```