### PR TITLE
fix: crash on receiving an LSP message in "stream" mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Our commit messages are linted by `commitlint` following the angular changelog c
 
 You will need to include a type prefix for all commit messages. For example:
 
-`git commit -m 'fix: fix window undefined error in result viewer'
+`git commit -m 'fix: fix window undefined error in result viewer'`
 
 ### Type Prefixes
 

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -206,14 +206,14 @@ export class MessageProcessor {
     const vscodeSettings = await this._connection.workspace.getConfiguration({
       section: 'vscode-graphql',
     });
-    if (settings.dotEnvPath) {
+    if (settings?.dotEnvPath) {
       require('dotenv').config({ path: settings.dotEnvPath });
     }
     this._settings = { ...settings, ...vscodeSettings };
     const rootDir = this._settings?.load?.rootDir || this._rootPath;
     this._rootPath = rootDir;
     this._loadConfigOptions = {
-      ...Object.keys(this._settings?.load).reduce((agg, key) => {
+      ...Object.keys(this._settings.load || []).reduce((agg, key) => {
         const value = this._settings.load[key];
         if (value === undefined || value === null) {
           delete agg[key];

--- a/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
@@ -1,0 +1,64 @@
+/**
+ *  Copyright (c) 2020 GraphQL Contributors
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { tmpdir } from 'os';
+import { Logger } from '../Logger';
+
+describe('Logger', () => {
+  let mockedStdoutWrite: jest.SpyInstance = null;
+  let mockedStderrWrite: jest.SpyInstance = null;
+
+  beforeEach(async () => {
+    mockedStdoutWrite = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+    mockedStderrWrite = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    mockedStdoutWrite.mockReset();
+    mockedStderrWrite.mockReset();
+  });
+
+  it('logs to stdout', () => {
+    const logger = new Logger(tmpdir());
+    logger.log('log test');
+
+    expect(mockedStdoutWrite.mock.calls.length).toBe(1);
+    expect(mockedStdoutWrite.mock.calls[0][0]).toContain('log test');
+    expect(mockedStderrWrite.mock.calls.length).toBe(0);
+  });
+
+  it('logs to stderr', () => {
+    const logger = new Logger(tmpdir());
+    logger.error('error test');
+
+    expect(mockedStdoutWrite.mock.calls.length).toBe(0);
+    expect(mockedStderrWrite.mock.calls.length).toBe(1);
+    expect(mockedStderrWrite.mock.calls[0][0]).toContain('error test');
+  });
+
+  it('only writes to stderr with "stderrOnly" enabled', () => {
+    const stderrOnly = true;
+    const logger = new Logger(tmpdir(), stderrOnly);
+    logger.info('info test');
+    logger.warn('warn test');
+    logger.log('log test');
+    logger.error('error test');
+
+    expect(mockedStdoutWrite.mock.calls.length).toBe(0);
+    expect(mockedStderrWrite.mock.calls.length).toBe(4);
+    expect(mockedStderrWrite.mock.calls[0][0]).toContain('info test');
+    expect(mockedStderrWrite.mock.calls[1][0]).toContain('warn test');
+    expect(mockedStderrWrite.mock.calls[2][0]).toContain('log test');
+    expect(mockedStderrWrite.mock.calls[3][0]).toContain('error test');
+  });
+});

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -106,13 +106,15 @@ describe('MessageProcessor', () => {
       },
     };
   });
+
+  let getConfigurationReturnValue = {};
   // @ts-ignore
   messageProcessor._connection = {
     // @ts-ignore
     get workspace() {
       return {
         getConfiguration: async () => {
-          return [{}];
+          return [getConfigurationReturnValue];
         },
       };
     },
@@ -244,6 +246,15 @@ describe('MessageProcessor', () => {
     });
     // Query fixed, no more errors
     expect(result.diagnostics.length).toEqual(0);
+  });
+
+  it('does not crash on null value returned in response to workspace configuration', async () => {
+    const previousConfigurationValue = getConfigurationReturnValue;
+    getConfigurationReturnValue = null;
+    await expect(
+      messageProcessor.handleDidChangeConfiguration(),
+    ).resolves.toStrictEqual({});
+    getConfigurationReturnValue = previousConfigurationValue;
   });
 
   it('properly removes from the file cache with the didClose handler', async () => {

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -148,9 +148,10 @@ const buildOptions = (options: ServerOptions): MappedServerOptions => {
 export default async function startServer(
   options: ServerOptions,
 ): Promise<void> {
-  const logger = new Logger(options.tmpDir);
-
   if (options && options.method) {
+    const stderrOnly = options.method === 'stream';
+    const logger = new Logger(options.tmpDir, stderrOnly);
+
     const finalOptions = buildOptions(options);
     let reader;
     let writer;


### PR DESCRIPTION
Don't write log messages to stdout in "stream" mode. stdout is reserved
for communicating with the LSP client in the "stream" mode. Write all
types of log messages to stderr.

Fixes LSP server crashing on the first message it receives (or maybe
LSP client closing it because it received an invalid response).

Also:
 - the callback to socket.write() was always logging the "err" parameter
   even if there was undefined which caused spurious lines in the
   console. Only actually log that if "err" is truthy.
 - Avoid too many newlines at the end of the log message as that also
   causes spurious empty lines in the log and the console.
 - Gracefully handle the case when the response for "workspace/configuration"
   returns a null value. Those configuration options have sane defaults
   and don't need to be present.
 - The Logger._stream property was removed as it was unused.

Resolves #1708