### PR TITLE
chore: cleanup test code for GraphQL cache

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -117,8 +117,7 @@ describe('GraphQLCache', () => {
         expect.objectContaining({
           args: [],
           description: undefined,
-          // TODO: failing now that tests are doing deep comparison
-          // isRepeatable: false,
+          isRepeatable: false,
           locations: ['FIELD'],
           name: 'customDirective',
         }),
@@ -133,8 +132,7 @@ describe('GraphQLCache', () => {
         expect.objectContaining({
           args: [],
           description: undefined,
-          // TODO: failing now that tests are doing deep comparison
-          // isRepeatable: false,
+          isRepeatable: false,
           locations: ['FRAGMENT_SPREAD'],
           name: 'customDirective',
         }),

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -111,9 +111,8 @@ describe('GraphQLCache', () => {
       const schema = (await cache.getSchema(
         'testWithCustomDirectives',
       )) as GraphQLSchema;
-      expect(
-        wihtoutASTNode(schema.getDirective('customDirective')),
-      ).toMatchObject(
+      expect(wihtoutASTNode(schema.getDirective('customDirective'))).toEqual(
+        // objectContaining is used to pass this test without changing the code if more properties are added in GraphQLDirective class in the new version of graphql module.
         expect.objectContaining({
           args: [],
           description: undefined,
@@ -126,9 +125,8 @@ describe('GraphQLCache', () => {
 
     it('extend the schema with appropriate custom directive 2', async () => {
       const schema = (await cache.getSchema('testWithSchema')) as GraphQLSchema;
-      expect(
-        wihtoutASTNode(schema.getDirective('customDirective')),
-      ).toMatchObject(
+      expect(wihtoutASTNode(schema.getDirective('customDirective'))).toEqual(
+        // objectContaining is used to pass this test without changing the code if more properties are added in GraphQLDirective class in the new version of graphql module.
         expect.objectContaining({
           args: [],
           description: undefined,


### PR DESCRIPTION
- check if directive contains `isRepeatable` property.
The reason why https://github.com/graphql/graphiql/pull/871#issuecomment-529152156 happened is probably because it had multiple versions of `graphql` module as a dependency and the one where `isRepeatable` property wasn't contained in `GraphQLDirective` class was used in this test. Currently it has only one version of `graphql` module where `isRepeatable` property is contained in the `GraphQLDirective` class.

- replase `toMatchObject` with `toEqual` since the meanings aren't changed in those tests
and toEqual is more offen used and easier to understand.
(If you aren't familiar with the difference between `toMatchObject` and `objectContaining`,
see this:
https://stackoverflow.com/questions/45692456/whats-the-difference-between-tomatchobject-and-objectcontaining
)