### PR TITLE
use cheap invariant

### DIFF
--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -52,7 +52,7 @@ export const DIAGNOSTIC_SEVERITY = {
 const invariant = (
   condition: any,
   message: string,
-): asserts condition => {
+) => {
   if (!condition) {
     throw new Error(message);
   }

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -51,7 +51,7 @@ export const DIAGNOSTIC_SEVERITY = {
 
 const invariant = (
   condition: any,
-  message: string | number,
+  message: string,
 ): asserts condition => {
   if (!condition) {
     throw new Error(message);

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -17,7 +17,6 @@ import {
   ValidationRule,
 } from 'graphql';
 
-import invariant from 'assert';
 import { findDeprecatedUsages, parse } from 'graphql';
 
 import { CharacterStream, onlineParser } from 'graphql-language-service-parser';
@@ -49,6 +48,15 @@ export const DIAGNOSTIC_SEVERITY = {
   [SEVERITY.Information]: 3 as DiagnosticSeverity,
   [SEVERITY.Hint]: 4 as DiagnosticSeverity,
 };
+
+const invariant = (
+  condition: any,
+  message: string | number,
+): asserts condition => {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
 
 export function getDiagnostics(
   query: string,

--- a/packages/graphql-language-service-interface/src/getDiagnostics.ts
+++ b/packages/graphql-language-service-interface/src/getDiagnostics.ts
@@ -49,14 +49,11 @@ export const DIAGNOSTIC_SEVERITY = {
   [SEVERITY.Hint]: 4 as DiagnosticSeverity,
 };
 
-const invariant = (
-  condition: any,
-  message: string,
-) => {
+const invariant = (condition: any, message: string) => {
   if (!condition) {
     throw new Error(message);
   }
-}
+};
 
 export function getDiagnostics(
   query: string,


### PR DESCRIPTION
Fix #1740 

assert is a node package that webpack 4 included automatically. 
Webpack 5 does not, so any dependency on it will bork the package.

With only a handful of uses, it doesn't make sense to add the invariant package that would minify away the messages, so we just do a quick & dirty to get it working again. can test this out by building it with webpack 5.

@acao let me know if this is what you had in mind.