### PR TITLE
feat: interfaces implementing interfaces for the LSP

### DIFF
--- a/packages/graphql-language-service-interface/src/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service-interface/src/__tests__/__schema__/StarWarsSchema.graphql
@@ -51,8 +51,16 @@ input InputType {
   value: Int = 42
 }
 
-type TestType {
-  testField: String
+interface TestInterface {
+  testField: String!
+}
+
+interface AnotherInterface implements TestInterface {
+  testField: String!
+}
+
+type TestType implements TestInterface & AnotherInterface {
+  testField: String!
 }
 
 type Query {

--- a/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
@@ -365,6 +365,26 @@ query name {
       { label: 'Character' },
       { label: 'TestInterface' },
     ]));
+
+  it('provides filtered interface suggestions when extending an interface', () =>
+    expect(
+      testSuggestions(
+        'interface Type implements TestInterface & Ch',
+        new Position(0, 44),
+      ),
+    ).toEqual([
+      {
+        label: 'Character',
+      },
+    ]));
+
+  it('provides no interface suggestions when extending an interface and an & or { is required', () =>
+    expect(
+      testSuggestions(
+        'interface Type implements TestInterface ',
+        new Position(0, 40),
+      ),
+    ).toEqual([]));
   it('provides correct interface suggestions when extending an interface with an inline interface', () =>
     expect(
       testSuggestions(

--- a/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
@@ -217,10 +217,12 @@ query name {
   it('provides correct typeCondition suggestions on fragment', () => {
     const result = testSuggestions('fragment Foo on {}', new Position(0, 16));
     expect(result.filter(({ label }) => !label.startsWith('__'))).toEqual([
+      { label: 'AnotherInterface' },
       { label: 'Character' },
       { label: 'Droid' },
       { label: 'Human' },
       { label: 'Query' },
+      { label: 'TestInterface' },
       { label: 'TestType' },
     ]);
   });
@@ -330,5 +332,49 @@ query name {
       { label: 'deprecated' },
       { label: 'onAllDefs' },
       { label: 'onArg' },
+    ]));
+
+  it('provides correct interface suggestions when extending with an interface', () =>
+    expect(
+      testSuggestions('type Type implements ', new Position(0, 20)),
+    ).toEqual([
+      { label: 'AnotherInterface' },
+      { label: 'Character' },
+      { label: 'TestInterface' },
+    ]));
+
+  it('provides correct interface suggestions when extending a type with multiple interfaces', () =>
+    expect(
+      testSuggestions(
+        'type Type implements TestInterface & ',
+        new Position(0, 37),
+      ),
+    ).toEqual([
+      { label: 'AnotherInterface' },
+      { label: 'Character' },
+      { label: 'TestInterface' },
+    ]));
+  it('provides correct interface suggestions when extending an interface with multiple interfaces', () =>
+    expect(
+      testSuggestions(
+        'interface Type implements TestInterface & ',
+        new Position(0, 44),
+      ),
+    ).toEqual([
+      { label: 'AnotherInterface' },
+      { label: 'Character' },
+      { label: 'TestInterface' },
+    ]));
+  it('provides correct interface suggestions when extending an interface with an inline interface', () =>
+    expect(
+      testSuggestions(
+        'interface A { id: String }\ninterface MyInterface implements ',
+        new Position(1, 33),
+      ),
+    ).toEqual([
+      { label: 'A' },
+      { label: 'AnotherInterface' },
+      { label: 'Character' },
+      { label: 'TestInterface' },
     ]));
 });

--- a/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
@@ -38,12 +38,13 @@ describe('getAutocompleteSuggestions', () => {
       )
       .sort((a, b) => a.label.localeCompare(b.label))
       .map(suggestion => {
-        const response = { label: suggestion.label };
+        const response = { label: suggestion.label } as CompletionItem;
         if (suggestion.detail) {
-          Object.assign(response, {
-            detail: String(suggestion.detail),
-          });
+          response.detail = String(suggestion.detail);
         }
+        // if(suggestion.documentation) {
+        //   response.documentation = String(suggestion.documentation)
+        // }
         return response;
       });
   }
@@ -357,34 +358,39 @@ query name {
   it('provides correct interface suggestions when extending an interface with multiple interfaces', () =>
     expect(
       testSuggestions(
-        'interface Type implements TestInterface & ',
-        new Position(0, 44),
+        'interface IExample implements TestInterface & ',
+        new Position(0, 46),
       ),
     ).toEqual([
       { label: 'AnotherInterface' },
       { label: 'Character' },
       { label: 'TestInterface' },
     ]));
-
-  it('provides filtered interface suggestions when extending an interface', () =>
+  it('provides filtered interface suggestions when extending an interface with multiple interfaces', () =>
+    expect(
+      testSuggestions('interface IExample implements I', new Position(0, 48)),
+    ).toEqual([
+      { label: 'AnotherInterface' },
+      // TODO: this shouldn't be here - must find way to
+      // track base interface name so we can filter it from inline suggestions
+      // on NamedType kind
+      { label: 'IExample' },
+      { label: 'TestInterface' },
+    ]));
+  it('provides no interface suggestions when using implements and there are no & or { characters present', () =>
     expect(
       testSuggestions(
-        'interface Type implements TestInterface & Ch',
+        'interface IExample implements TestInterface ',
         new Position(0, 44),
       ),
-    ).toEqual([
-      {
-        label: 'Character',
-      },
-    ]));
-
-  it('provides no interface suggestions when extending an interface and an & or { is required', () =>
+    ).toEqual([]));
+  it('provides fragment completion after a list of interfaces to extend', () =>
     expect(
       testSuggestions(
-        'interface Type implements TestInterface ',
-        new Position(0, 40),
+        'interface IExample implements TestInterface & AnotherInterface @f',
+        new Position(0, 65),
       ),
-    ).toEqual([]));
+    ).toEqual([{ label: 'onAllDefs' }]));
   it('provides correct interface suggestions when extending an interface with an inline interface', () =>
     expect(
       testSuggestions(

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -99,7 +99,11 @@ export function getAutocompleteSuggestions(
     ]);
   }
 
-  if (kind === RuleKinds.IMPLEMENTS) {
+  if (
+    kind === RuleKinds.IMPLEMENTS ||
+    (kind === RuleKinds.NAMED_TYPE &&
+      state?.prevState?.kind === RuleKinds.IMPLEMENTS)
+  ) {
     return getSuggestionsForImplements(token, state, schema, queryText);
   }
 

--- a/packages/graphql-language-service-parser/src/CharacterStream.ts
+++ b/packages/graphql-language-service-parser/src/CharacterStream.ts
@@ -20,9 +20,9 @@
 import { TokenPattern, CharacterStreamInterface } from './types';
 
 export default class CharacterStream implements CharacterStreamInterface {
-  _start: number;
-  _pos: number;
-  _sourceText: string;
+  private _start: number;
+  private _pos: number;
+  private _sourceText: string;
 
   constructor(sourceText: string) {
     this._start = 0;
@@ -30,11 +30,11 @@ export default class CharacterStream implements CharacterStreamInterface {
     this._sourceText = sourceText;
   }
 
-  getStartOfToken = (): number => this._start;
+  public getStartOfToken = (): number => this._start;
 
-  getCurrentPosition = (): number => this._pos;
+  public getCurrentPosition = (): number => this._pos;
 
-  _testNextCharacter(pattern: TokenPattern): boolean {
+  private _testNextCharacter(pattern: TokenPattern): boolean {
     const character = this._sourceText.charAt(this._pos);
     let isMatched = false;
     if (typeof pattern === 'string') {
@@ -48,23 +48,23 @@ export default class CharacterStream implements CharacterStreamInterface {
     return isMatched;
   }
 
-  eol = (): boolean => this._sourceText.length === this._pos;
+  public eol = (): boolean => this._sourceText.length === this._pos;
 
-  sol = (): boolean => this._pos === 0;
+  public sol = (): boolean => this._pos === 0;
 
-  peek = (): string | null => {
+  public peek = (): string | null => {
     return this._sourceText.charAt(this._pos)
       ? this._sourceText.charAt(this._pos)
       : null;
   };
 
-  next = (): string => {
+  public next = (): string => {
     const char = this._sourceText.charAt(this._pos);
     this._pos++;
     return char;
   };
 
-  eat = (pattern: TokenPattern): string | undefined => {
+  public eat = (pattern: TokenPattern): string | undefined => {
     const isMatched = this._testNextCharacter(pattern);
     if (isMatched) {
       this._start = this._pos;
@@ -74,7 +74,7 @@ export default class CharacterStream implements CharacterStreamInterface {
     return undefined;
   };
 
-  eatWhile = (match: TokenPattern): boolean => {
+  public eatWhile = (match: TokenPattern): boolean => {
     let isMatched = this._testNextCharacter(match);
     let didEat = false;
 
@@ -93,17 +93,17 @@ export default class CharacterStream implements CharacterStreamInterface {
     return didEat;
   };
 
-  eatSpace = (): boolean => this.eatWhile(/[\s\u00a0]/);
+  public eatSpace = (): boolean => this.eatWhile(/[\s\u00a0]/);
 
-  skipToEnd = (): void => {
+  public skipToEnd = (): void => {
     this._pos = this._sourceText.length;
   };
 
-  skipTo = (position: number): void => {
+  public skipTo = (position: number): void => {
     this._pos = position;
   };
 
-  match = (
+  public match = (
     pattern: TokenPattern,
     consume: boolean | null | undefined = true,
     caseFold: boolean | null | undefined = false,
@@ -143,13 +143,13 @@ export default class CharacterStream implements CharacterStreamInterface {
     return false;
   };
 
-  backUp = (num: number): void => {
+  public backUp = (num: number): void => {
     this._pos -= num;
   };
 
-  column = (): number => this._pos;
+  public column = (): number => this._pos;
 
-  indentation = (): number => {
+  public indentation = (): number => {
     const match = this._sourceText.match(/\s*/);
     let indent = 0;
     if (match && match.length !== 0) {
@@ -168,5 +168,5 @@ export default class CharacterStream implements CharacterStreamInterface {
     return indent;
   };
 
-  current = (): string => this._sourceText.slice(this._start, this._pos);
+  public current = (): string => this._sourceText.slice(this._start, this._pos);
 }

--- a/packages/graphql-language-service-parser/src/Rules.ts
+++ b/packages/graphql-language-service-parser/src/Rules.ts
@@ -31,7 +31,7 @@ export const LexRules = {
   Name: /^[_A-Za-z][_0-9A-Za-z]*/,
 
   // All Punctuation used in GraphQL
-  Punctuation: /^(?:!|\$|\(|\)|\.\.\.|:|=|@|\[|]|\{|\||\})/,
+  Punctuation: /^(?:!|\$|\(|\)|\.\.\.|:|=|&|@|\[|]|\{|\||\})/,
 
   // Combines the IntValue and FloatValue tokens.
   Number: /^-?(?:0|(?:[1-9][0-9]*))(?:\.[0-9]*)?(?:[eE][+-]?[0-9]+)?/,
@@ -173,6 +173,8 @@ export const ParseRules: { [name: string]: ParseRule } = {
             return 'ObjectValue';
           case '$':
             return 'Variable';
+          case '&':
+            return 'NamedType';
         }
 
         return null;
@@ -205,6 +207,25 @@ export const ParseRules: { [name: string]: ParseRule } = {
   NonNullType: ['NamedType', opt(p('!'))],
   NamedType: [type('atom')],
   Directive: [p('@', 'meta'), name('meta'), opt('Arguments')],
+  DirectiveDef: [
+    word('directive'),
+    p('@', 'meta'),
+    name('meta'),
+    opt('ArgumentsDef'),
+    word('on'),
+    list('DirectiveLocation', p('|')),
+  ],
+  InterfaceDef: [
+    word('interface'),
+    name('atom'),
+    opt('Implements'),
+    list('Directive'),
+    p('{'),
+    list('FieldDef'),
+    p('}'),
+  ],
+  Implements: [word('implements'), list('NamedType', p('&'))],
+  DirectiveLocation: [name('string-2')],
   // GraphQL schema language
   SchemaDef: [
     word('schema'),
@@ -226,7 +247,6 @@ export const ParseRules: { [name: string]: ParseRule } = {
     p('}'),
   ],
 
-  Implements: [word('implements'), list('NamedType')],
   FieldDef: [
     name('property'),
     opt('ArgumentsDef'),
@@ -242,15 +262,6 @@ export const ParseRules: { [name: string]: ParseRule } = {
     'Type',
     opt('DefaultValue'),
     list('Directive'),
-  ],
-
-  InterfaceDef: [
-    word('interface'),
-    name('atom'),
-    list('Directive'),
-    p('{'),
-    list('FieldDef'),
-    p('}'),
   ],
 
   UnionDef: [
@@ -281,16 +292,6 @@ export const ParseRules: { [name: string]: ParseRule } = {
     p('}'),
   ],
   ExtendDef: [word('extend'), 'ObjectTypeDef'],
-  DirectiveDef: [
-    word('directive'),
-    p('@', 'meta'),
-    name('meta'),
-    opt('ArgumentsDef'),
-    word('on'),
-    list('DirectiveLocation', p('|')),
-  ],
-
-  DirectiveLocation: [name('string-2')],
 };
 
 // A keyword Token.

--- a/packages/graphql-language-service-parser/src/__tests__/OnlineParser-test.ts
+++ b/packages/graphql-language-service-parser/src/__tests__/OnlineParser-test.ts
@@ -11,7 +11,7 @@ import {
 describe('onlineParser', () => {
   describe('.startState', () => {
     it('initializes state correctly', () => {
-      const parser = new OnlineParser();
+      const parser = OnlineParser();
 
       expect(parser.startState()).toEqual({
         level: 0,
@@ -336,7 +336,7 @@ describe('onlineParser', () => {
     });
 
     it('parses query with inline fragment', () => {
-      const { t, stream } = getUtils(`
+      const { t } = getUtils(`
         query SomeQuery {
           someField {
             ... on SomeType {
@@ -370,7 +370,7 @@ describe('onlineParser', () => {
     });
 
     it('parses query with fragment spread', () => {
-      const { t, stream } = getUtils(`
+      const { t } = getUtils(`
         query SomeQuery {
           someField {
             ...SomeFragment @someDirective
@@ -580,7 +580,7 @@ describe('onlineParser', () => {
     });
 
     it('parses mutation with inline fragment', () => {
-      const { t, stream } = getUtils(`
+      const { t } = getUtils(`
         mutation SomeMutation {
           someMutation {
             ... on SomeType {
@@ -614,7 +614,7 @@ describe('onlineParser', () => {
     });
 
     it('parses mutation with fragment spread', () => {
-      const { t, stream } = getUtils(`
+      const { t } = getUtils(`
         mutation SomeMutation {
           someMutation {
             ...SomeFragment @someDirective
@@ -905,7 +905,7 @@ describe('onlineParser', () => {
         t.eol();
       });
 
-      it('with implementing an interface', () => {
+      it('with an object implementing an interface', () => {
         const { t } = getUtils(`type SomeType implements SomeInterface`);
 
         t.keyword('type', { kind: 'ObjectTypeDef' });
@@ -913,6 +913,22 @@ describe('onlineParser', () => {
         t.keyword('implements', { kind: 'Implements' });
         t.name('SomeInterface', { kind: 'NamedType' });
 
+        t.eol();
+      });
+
+      it('with an object type implementing multiple interfaces', () => {
+        const { t } = getUtils(
+          `type SomeType implements SomeInterface & AnotherInterface & YetAnotherInterface`,
+        );
+
+        t.keyword('type', { kind: 'ObjectTypeDef' });
+        t.name('SomeType');
+        t.keyword('implements', { kind: 'Implements' });
+        t.name('SomeInterface', { kind: 'NamedType' });
+        t.punctuation('&', { kind: 'Implements' });
+        t.name('AnotherInterface', { kind: 'NamedType' });
+        t.punctuation('&', { kind: 'Implements' });
+        t.name('YetAnotherInterface', { kind: 'NamedType' });
         t.eol();
       });
 
@@ -978,6 +994,22 @@ describe('onlineParser', () => {
         t.eol();
       });
 
+      it('implementing multiple interfaces', () => {
+        const { t } = getUtils(
+          `interface AnInterface implements SomeInterface & AnotherInterface & YetAnotherInterface`,
+        );
+
+        t.keyword('interface', { kind: 'InterfaceDef' });
+        t.name('AnInterface');
+        t.keyword('implements', { kind: 'Implements' });
+        t.name('SomeInterface', { kind: 'NamedType' });
+        t.punctuation('&', { kind: 'Implements' });
+        t.name('AnotherInterface', { kind: 'NamedType' });
+        t.punctuation('&', { kind: 'Implements' });
+        t.name('YetAnotherInterface', { kind: 'NamedType' });
+        t.eol();
+      });
+
       performForEachType(
         `interface SomeInterface @someDirective(someArg: __VALUE__)`,
         ({ t, stream }, fill) => {
@@ -1021,7 +1053,7 @@ describe('onlineParser', () => {
       });
 
       it('with an argument', () => {
-        const { t, streams } = getUtils(`
+        const { t } = getUtils(`
           type SomeType {
             someField(someArg: AnotherType): [SomeAnotherType!]!
           }

--- a/packages/graphql-language-service-parser/src/onlineParser.ts
+++ b/packages/graphql-language-service-parser/src/onlineParser.ts
@@ -162,7 +162,7 @@ function getToken(
 
     // Seperator between list elements if necessary.
     if (state.needsSeperator) {
-      expected = expected && expected.separator;
+      expected = expected && expected?.separator;
     }
 
     if (expected) {

--- a/packages/graphql-language-service-parser/src/types.ts
+++ b/packages/graphql-language-service-parser/src/types.ts
@@ -79,6 +79,7 @@ export const AdditionalRuleKinds: _AdditionalRuleKinds = {
   ARGUMENTS_DEF: 'ArgumentsDef',
   EXTEND_DEF: 'ExtendDef',
   DIRECTIVE_DEF: 'DirectiveDef',
+  IMPLEMENTS: 'Implements',
 };
 
 export type _AdditionalRuleKinds = {
@@ -106,6 +107,7 @@ export type _AdditionalRuleKinds = {
   ARGUMENTS_DEF: 'ArgumentsDef';
   EXTEND_DEF: 'ExtendDef';
   DIRECTIVE_DEF: 'DirectiveDef';
+  IMPLEMENTS: 'Implements';
 };
 
 export const RuleKinds = {


### PR DESCRIPTION
# Features

This introduces a few new language features for `implements` syntax, including the new(ish) `&` operator, both for interfaces & types.

## Parsing & Highlighting

This implements support for & in the parser, which means highlighting support for codemirror graphql

## Autocompletion

Previously there was no autocompletion for any of this

```graphql
type Interface implements So▌
```
and
```graphql
type Interface implements Something & So▌
```

![monaco-autocomplete-interfaces](https://user-images.githubusercontent.com/1368727/102928069-1daa8700-4466-11eb-971a-894bbb0be135.gif)

now we have 

## Inline Autocompletion

it will also autocomplete for inline interfaces that may not be in the schema yet, for writing SDL files for example.


```graphql
interface Example { id: String }
type Interface implements Ex▌
```

## Where this feature works

- parser & interface
- `graphql-language-service-server`
- `vscode-graphql`
- `monaco-graphql`
- `codemirror-graphql` highlighting for & syntax works because of the parser implementation in this PR


## HTD

(netlify)
1. open the monaco netlify demo linked in CI jobs below
5. provide github personal access token to demo (no scopes needed, delete when finished from localstorage! oauth demo coming soon)
6. begin building types and interfaces that implement the github interfaces and eachother
7. confirm autocompletion works everywhere between the keyword “implements” and the first directive or { bracket

(manual)
1. clone repo
2. yarn
3. yarn build
4. yarn start-monaco
5. follow from step 2 above to the end

To see how this will impact graphiql, run yarn start-graphiql, and you’ll see the highlighting/parsing work for & syntax now.

## What's Next
- `codemirror-graphql` has an additional step for implementing these new autocompletion features. @yoshiakis and I found that codemirror-graphql’s hint.js is mostly a dupe of `getAutocompleteSuggestions`. So in the next PR, we will be able to replace most of whats in hint.js for codemirror with `getAutocompleteSuggestions`. This will make feature parity between monaco-graphql and codemirror-graphql much easier to maintain
- autocompletion for interface fields when extending an interface
- consider adding more validation rules for interfaces or object types (spec decision)