### PR TITLE
fix: add missing nullthrows dependency to utils

### DIFF
--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -27,7 +27,8 @@
     "graphql": "^14.0.0 || ^15.0.0"
   },
   "dependencies": {
-    "graphql-language-service-types": "^1.8.0"
+    "graphql-language-service-types": "^1.8.0",
+    "nullthrows": "^1.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1"


### PR DESCRIPTION
Fixes the issue seen in https://github.com/backstage/backstage/issues/3961

Projects that don't use `graphql-language-service-server` may run into this issue, since that's the only package that declares the existing `nullthrows` dependency.