### PR TITLE
fix: run onToggleDocs when setting docExplorerOpen to false

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -1472,6 +1472,10 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         if (typeof this.props.onToggleDocs === 'function') {
           this.props.onToggleDocs(!this.state.docExplorerOpen);
         }
+        this._storage.set(
+          'docExplorerOpen',
+          JSON.stringify(this.state.docExplorerOpen),
+        );
         this.setState({ docExplorerOpen: false });
       } else {
         this.setState({

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -1469,6 +1469,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       const docsSize = app.clientWidth - cursorPos;
 
       if (docsSize < 100) {
+        if (typeof this.props.onToggleDocs === 'function') {
+          this.props.onToggleDocs(!this.state.docExplorerOpen);
+        }
         this.setState({ docExplorerOpen: false });
       } else {
         this.setState({


### PR DESCRIPTION
Fix for issue #1717 

Fire onToggleDocs, when resizing the doc explorer to a small size and finally the docExplorerOpen state is set to false.