### PR TITLE
ci: cleanup labelling for ci

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,4 +1,4 @@
-name: Node.JS CI
+name: License Check
 on: 
   push:
     paths:
@@ -15,5 +15,5 @@ jobs:
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
 
-      - name: Eslint
+      - name: License Check
         run: yarn license-check

--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -1,4 +1,4 @@
-name: Node.JS CI
+name: CI
 on: [push]
       
 jobs:
@@ -22,7 +22,8 @@ jobs:
     name: Typescript Build
     runs-on: ubuntu-16.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
@@ -35,31 +36,30 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        node: ['12', '14']
+        node: ['10', '12', '14', '16']
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
 
       - run: yarn test --coverage
 
-      - uses: codecov/codecov-action@v1
+      - name: Codecov
+        uses: codecov/codecov-action@v1
         with:
           directory: coverage
 
   e2e:
-    name: Cypress
+    name: Cypress E2E Suite
     runs-on: ubuntu-16.04
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
 
       - name: Run E2E suite
         run: yarn e2e
-
-      - uses: codecov/codecov-action@v1
-        with:
-          directory: .nyc_output


### PR DESCRIPTION
fix the `name` properties on the workflows and some steps to even further improve visibility. 

remove codecov from cypress for now until we can instrument coverage from cypress

add a few more node versions to the unit test matrix for fun