### PR TITLE
ci: deploy to netlify using github actions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,17 +1,15 @@
 # .github/workflows/netlify.yml
-name: Netlify Production Deploy
+name: Netlify Deploy Preview
 on:
   push:
-    branch:
-      only: main
     paths-ignore:
       - '**.md'
       - 'examples'
       - '!examples/monaco-graphql-webpack'
-
+  
 jobs:
-  deploy:
-    name: "Build & Deploy Production Demo & API Docs"
+  build:
+    name: "Build & Deploy"
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -20,7 +18,6 @@ jobs:
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
       # ( Build to ./dist or other directory... )
-
       - name: Build 
         run: yarn build
 
@@ -30,16 +27,18 @@ jobs:
       - name: Build Typedoc
         run: yarn build-docs
 
-      - name: Deploy Production Demo & Typedoc to Netlify
+      - name: Deploy Dev to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
           publish-dir: './packages/graphiql/'
           production-branch: main
-          production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "GraphiQL 1 Demo"
+          deploy-message: "Deploy Preview: ${{ github.event.pull_request.title }}. Use `/dev` for react debugging"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          overwrites-pull-request-comment: true
           functions-dir: functions
-          github-deployment-environment: "GraphiQL 1 Demo"
+          github-deployment-environment: "Deploy Preview"
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.SITE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+# .github/workflows/netlify.yml
+name: Build & Deploy to Netlify
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'examples'
+      - '!examples/monaco-graphql-webpack'
+  pull_request:
+  
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Yarn Install
+        uses: bahmutov/npm-install@v1
+      # ( Build to ./dist or other directory... )
+      - name: Build 
+        run: yarn build
+
+      - name: Build Bundles 
+        run: yarn build-bundles
+
+      - name: Build Typedoc
+        run: yarn build-docs
+
+      - name: Deploy Dev to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: './packages/graphiql/'
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy Preview: ${{ github.event.pull_request.title }}. Use `/dev` for react debugging"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          overwrites-pull-request-comment: true
+          functions-dir: functions
+          github-deployment-environment: "Deploy Preview"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@
 name: Netlify Production Deploy
 on:
   push:
-    branch:
-      only: main
+    branches:
+      - main
     paths-ignore:
       - '**.md'
       - 'examples'

--- a/.github/workflows/push-pr.yml
+++ b/.github/workflows/push-pr.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Yarn Install
         uses: bahmutov/npm-install@v1
 
-      - run: yarn test --coverage
+      - name: Run Unit Tests
+        run: yarn test --coverage
 
       - name: Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
This should be faster than netlify build, still get the benefits of netlify deploy, and it costs us less netlify resources, and potentially give us some more flexibility (to eventually create multiple deployments, etc)

based on example from:

https://github.com/marketplace/actions/netlify-actions#usage