### PR TITLE
chore: make deploys less selective

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, synchronize]
     paths-ignore:
       - '**.md'
-      - 'examples'
-      - '!examples/monaco-graphql-webpack/**'
   
 jobs:
   graphiql-preview:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths-ignore:
       - '**.md'
-      - 'examples'
-      - '!examples/monaco-graphql-webpack/**'
 
 jobs:
   deploy:


### PR DESCRIPTION
For now, we will avoid running CI *only* if there are changes to markdown

Too difficult to decide what else can change but won't impact CI