### PR TITLE
Docs: Fixing a dead link for graphiql-cdn

### DIFF
--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -115,7 +115,7 @@ Read more about using [`createGraphiQLFetcher`](https://github.com/graphql/graph
 
 Don't forget to include the CSS file on the page! If you're using `npm` or `yarn`, you can find it in `node_modules/graphiql/graphiql.css`, or you can download it from the [releases page](https://github.com/graphql/graphiql/releases).
 
-For an example of setting up a GraphiQL, check out the [example](../examples/graphiql-cdn/) in this repository which also includes a few useful features highlighting GraphiQL's API.
+For an example of setting up a GraphiQL, check out the [example](../../examples/graphiql-cdn/) in this repository which also includes a few useful features highlighting GraphiQL's API.
 
 The most minimal way to set up GraphiQL is a single index.html file:
 


### PR DESCRIPTION
I found a dead link on [this README](https://github.com/graphql/graphiql/tree/main/packages/graphiql). It should be pointed one additional directory up to [here](https://github.com/graphql/graphiql/tree/main/examples/graphiql-cdn).

It's a small fix, but I figured I'd post it for others that are looking for it 👍 .