### PR TITLE
feat: render markdown content urls as links

### DIFF
--- a/packages/graphiql/src/components/DocExplorer/MarkdownContent.tsx
+++ b/packages/graphiql/src/components/DocExplorer/MarkdownContent.tsx
@@ -9,7 +9,10 @@ import React from 'react';
 import MD from 'markdown-it';
 import { Maybe } from '../../types';
 
-const md = new MD();
+const md = new MD({
+  // render urls as links, à la github-flavored markdown
+  linkify: true,
+});
 
 type MarkdownContentProps = {
   markdown?: Maybe<string>;

--- a/packages/graphiql/test/schema.js
+++ b/packages/graphiql/test/schema.js
@@ -321,7 +321,8 @@ const TestMutationType = new GraphQLObjectType({
 
 const TestSubscriptionType = new GraphQLObjectType({
   name: 'SubscriptionType',
-  description: 'This is a simple subscription type',
+  description:
+    'This is a simple subscription type. Learn more at https://graphql.org/blog/subscriptions-in-graphql-and-relay/',
   fields: {
     subscribeToTest: {
       type: TestType,


### PR DESCRIPTION
This PR allows url content to be rendered as clickable links in the MarkdownContent used by the DocExplorer. I updated `packages/graphiql/test/schema.js` as well to provide an example

| Before | After |
|--------|------|
|<img width="349" alt="Screen Shot 2021-06-07 at 5 31 26 PM" src="https://user-images.githubusercontent.com/14367599/121234459-b80a5580-c861-11eb-9ad0-3e0c51a0e0fd.png">|<img width="351" alt="Screen Shot 2021-06-07 at 5 30 59 PM" src="https://user-images.githubusercontent.com/14367599/121234423-ade85700-c861-11eb-99cc-0756684d3fee.png">|

@cshaver @acao 