### PR TITLE
feat: export ToolbarSelectOption and ToolbarMenuItem

### DIFF
--- a/.changeset/strange-pugs-brush.md
+++ b/.changeset/strange-pugs-brush.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+feat: export ToolbarSelectOption and ToolbarMenuItem

--- a/packages/graphiql/src/index.ts
+++ b/packages/graphiql/src/index.ts
@@ -38,10 +38,10 @@ export { DocExplorer } from './components/DocExplorer';
 /**
  * Toolbar
  */
-export { ToolbarMenu } from './components/ToolbarMenu';
+export { ToolbarMenu, ToolbarMenuItem } from './components/ToolbarMenu';
 export { ToolbarButton } from './components/ToolbarButton';
 export { ToolbarGroup } from './components/ToolbarGroup';
-export { ToolbarSelect } from './components/ToolbarSelect';
+export { ToolbarSelect, ToolbarSelectOption } from './components/ToolbarSelect';
 
 /**
  * Utilities


### PR DESCRIPTION
It looks like `ToolbarSelect` is exported from the index module but `ToolbarSelectOption` isn't. We are upgrading from v0.14.2 to v1.4.2 and noticed that the `GraphiQL.Select` and `GraphiQL.SelectOption` properties are no longer available and appear to be [commented out](https://github.com/graphql/graphiql/blob/65aa64811ccd40c5e8ba99edec825a91115a3c8b/packages/graphiql/src/components/GraphiQL.tsx#L692-L694). When looking at moving over to `ToolbarSelect`  it seemed like it would be better if `ToolbarSelectOption` was also exported. `ToolbarMenu`/`ToolbarMenuItem` also appears to have the same issue. 

Thanks!