### PR TITLE
Fix css theme override on result window

### DIFF
--- a/.changeset/three-ligers-tie.md
+++ b/.changeset/three-ligers-tie.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix result window theme

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -213,7 +213,7 @@
 }
 
 /* No `.graphiql-container` here so themes can overwrite */
-.result-window .CodeMirror {
+.result-window .CodeMirror.cm-s-graphiql {
   background: #f6f7f8;
 }
 


### PR DESCRIPTION
close #1919 

`editorTheme` option apply theme uniformly on all the codemirror instances so we can considerate that this background is specific to the graphiql theme. Other theme should be able to override correctly this color.