### PR TITLE
add discord invite links to the community graphql server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > **Looking for the [GraphiQL Docs?](packages/graphiql/README.md)**: This is the root of the monorepo! The full GraphiQL docs are located at [`packages/graphiql`](packages/graphiql)
 
 [![Build Status](https://github.com/graphql/graphiql/workflows/Node.JS%20CI/badge.svg)](https://github.com/graphql/graphiql/actions?query=workflow%3A%22Node.JS+CI%22)
-[![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG)
+[![Discord](https://img.shields.io/discord/625400653321076807.svg)](https://discord.gg/NP5vbPeUFp)
 [![Code Coverage](https://img.shields.io/codecov/c/github/graphql/graphiql)](https://codecov.io/gh/graphql/graphiql)
 ![GitHub top language](https://img.shields.io/github/languages/top/graphql/graphiql)
 ![GitHub language count](https://img.shields.io/github/languages/count/graphql/graphiql)
@@ -212,7 +212,7 @@ Eventually we hope to move these to a repo that serves this purpose.
 
 ## Community
 
-- **Discord** [![Discord](https://img.shields.io/discord/586999333447270440.svg)](https://discord.gg/fHje6QG) - Most discussion outside of github happens on our [Discord Server](https://discord.gg/eNuu9Cb)
+- **Discord** [![Discord](https://img.shields.io/discord/625400653321076807.svg)](https://discord.gg/NP5vbPeUFp) - Most discussion outside of github happens on the GraphQL [Discord Server](https://discord.gg/NP5vbPeUFp)
 - **Twitter** - [@GraphiQL](https://twitter.com/@GraphiQL) and [#GraphiQL](https://twitter.com/hashtag/GraphiQL)
 - **GitHub** - Create feature requests, discussions issues and bugs above
 - **Working Group** - Yes, you're invited! Monthly planning/decision making meetings, and working sessions every two weeks on zoom! [Learn more.](working-group#readme)

--- a/packages/codemirror-graphql/README.md
+++ b/packages/codemirror-graphql/README.md
@@ -3,6 +3,7 @@
 [![NPM](https://img.shields.io/npm/v/codemirror-graphql.svg?style=flat-square)](https://npmjs.com/codemirror-graphql)
 ![npm downloads](https://img.shields.io/npm/dm/codemirror-graphql?label=npm%20downloads)
 [![License](https://img.shields.io/npm/l/codemirror-graphql.svg?style=flat-square)](LICENSE)
+[Discord Channel](https://discord.gg/cffZwk8NJW)
 
 Provides CodeMirror with a parser mode for GraphQL along with a live linter and
 typeahead hinter powered by your GraphQL Schema.

--- a/packages/graphiql-2-rfc-context/README.md
+++ b/packages/graphiql-2-rfc-context/README.md
@@ -1,3 +1,5 @@
+[Discord Channel](https://discord.gg/NP5vbPeUFp)
+
 # GraphiQL 2.x - React Context RFC Proposal
 
 This effort was merge to master in spring of 2020, and then moved to this workspace for the time being until we address some of the issues

--- a/packages/graphiql-toolkit/README.md
+++ b/packages/graphiql-toolkit/README.md
@@ -1,3 +1,5 @@
+[Discord Channel](https://discord.gg/NP5vbPeUFp)
+
 # `@graphiql/toolkit`
 
 General purpose library as a dependency of GraphiQL.

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -13,7 +13,7 @@
 ![npm bundle size (version)](https://img.shields.io/bundlephobia/min/graphiql/latest)
 ![npm bundle size (version)](https://img.shields.io/bundlephobia/minzip/graphiql/latest)
 [![License](https://img.shields.io/npm/l/graphiql.svg?style=flat-square)](LICENSE)
-
+[Discord Channel](https://discord.gg/NP5vbPeUFp)
 _/ˈɡrafək(ə)l/_ A graphical interactive in-browser GraphQL IDE. [Try the live demo](http://graphql.org/swapi-graphql).
 
 [![](https://raw.githubusercontent.com/graphql/graphiql/master/packages/graphiql/resources/graphiql.jpg)](http://graphql.org/swapi-graphql)

--- a/packages/graphql-language-service-interface/README.md
+++ b/packages/graphql-language-service-interface/README.md
@@ -5,6 +5,7 @@
 ![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-interface?label=npm%20downloads)
 ![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/codemirror-graphql)
 [![License](https://img.shields.io/npm/l/graphql-language-service-interface.svg?style=flat-square)](LICENSE)
+[Discord Channel](https://discord.gg/wkQCKwazxj)
 
 [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_interface.html)
 

--- a/packages/graphql-language-service-parser/README.md
+++ b/packages/graphql-language-service-parser/README.md
@@ -3,7 +3,7 @@
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-parser.svg?style=flat-square)](https://npmjs.com/graphql-language-service-parser)
 ![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-parser?label=npm%20downloads)
 [![License](https://img.shields.io/npm/l/graphql-language-service-parser.svg?style=flat-square)](LICENSE)
-
 [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_parser.html)
+[Discord Channel](https://discord.gg/wkQCKwazxj)
 
 An online immutable parser for [GraphQL](http://graphql.org/), designed to be used as part of syntax-highlighting and code intelligence tools such as for the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service) and [codemirror-graphql](https://github.com/graphql/graphiql/tree/main/packages/codemirror-graphql).

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/npm/l/graphql-language-service-server.svg?style=flat-square)](LICENSE)
 
 [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_server.html)
+[Discord Channel](https://discord.gg/PXaRYrpgK4)
 
 Server process backing the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service).
 

--- a/packages/graphql-language-service-utils/README.md
+++ b/packages/graphql-language-service-utils/README.md
@@ -2,8 +2,6 @@
 
 [![NPM](https://img.shields.io/npm/v/graphql-language-service-utils.svg?style=flat-square)](https://npmjs.com/graphql-language-service-utils)
 ![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-utils?label=npm%20downloads)
-[![License](https://img.shields.io/npm/l/graphql-language-service-utils.svg?style=flat-square)](LICENSE)
-
-[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_utils.html)
+[![License](https://img.shields.io/npm/l/graphql-language-service-utils.svg?style=flat-square)](LICENSE)[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_utils.html)[Discord Channel](https://discord.gg/wkQCKwazxj)
 
 Utilities to support the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service) and the rest of the language ecosystem.

--- a/packages/graphql-language-service/README.md
+++ b/packages/graphql-language-service/README.md
@@ -1,6 +1,7 @@
 # `graphql-language-service`
 
 [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service.html)
+[Discord Channel](https://discord.gg/wkQCKwazxj)
 
 > **Note**: Still mostly experimental, however it depends mostly on stable libraries.
 > **Migration Note**: As of 3.0.0, the LSP command line interface has been moved to [`graphql-language-service-cli`](../graphql-language-service-cli)

--- a/packages/monaco-graphql/README.md
+++ b/packages/monaco-graphql/README.md
@@ -1,3 +1,5 @@
+[Discord Channel](https://discord.gg/r4BxrAG6fN)
+
 # Monaco GraphQL
 
 GraphQL language plugin for the Monaco Editor. You can use it to build vscode/codespaces-like web or desktop IDEs using whatever frontend javascript libraries or frameworks you want, or none!

--- a/working-group/README.md
+++ b/working-group/README.md
@@ -1,5 +1,7 @@
 # GraphiQL & GraphQL LSP Working Group
 
+> **NOTE:** Working Group is on hiatus. For now, reach out in discord, create RFCs or discussions on github!
+
 The GraphiQL and GraphQL Working Group focuses on fielding and fostering proposals and specifications for plugin interfaces and other user/developer-facing interfaces, as well as overall features, decisions about lifecycle, etc. This doesn't mean we will make decisions about every PR we merge, but it's a chance to have stake in the roadmap and how commonly used interfaces change.
 
 All users of GraphiQL, the LSP, GraphQL IDE extensions, developer users, all GraphQL community members are welcome. There is no official list of members, though you can add yourself to the monthly meeting agends (see below)
@@ -16,20 +18,9 @@ Many of the underlying packages used for graphql web/desktop IDE tooling are in 
 
 In the [`'agendas'`]('/agendas') directory you can introduce PRs to add yourself as an atendee to each agenda, and optionally add an agenda item or two.
 
-## Rotating Working Sessions/Office Hours
-
-> **First and third saturday of the month at 16GMT/12EST** [(Google Calendar Event)](https://calendar.google.com/event?action=TEMPLATE&tmeid=NXYxZnEzdHBvcHNqaTNrZHA5cm1obmFldm1fMjAyMDA0MThUMTYwMDAwWiByaWtraS5zY2h1bHRlQG0&tmsrc=rikki.schulte%40gmail.com&scp=ALL)
-
-For now just twice a month on saturdays, we will have a group working session where we collaborate on API and feature proposals, demonstrate contributions to the monorepo we're working on, improve documentation, or even pair on actual PRs whilst sharing the session on the zoom link.
-
-It will be informal, with no set agenda, and no official decisions made about the spec (though we may collaborate on proposals brought to the monthly meeting above).
-
-As far as office hours, during these sessions @acao and others can field support and setup issues for all users of all skills as we always do.
-It might be a good time to get discussions going that can be turned into discussion Issues, Feature/Plugin Proposals, RFCs, etc.
-
 ## Get Involved
 
-You can also find us on [discord](https://discord.gg/8J65QW), in github via issues or PRs!
+You can also find us on [discord](https://discord.gg/NP5vbPeUFp), in github via issues or PRs!
 
 See the Community section at the bottom of [the root level readme](../README.md) for more information.
 


### PR DESCRIPTION
thank you to @urigo and @benjie for leading the initiative for getting us moved over to a community graphql discord! one discord server to unite us all!

this adds links to graphiql at the root, and then to appropriate rooms for each nested readme, which will be helpful on npmjs