### PR TITLE
Adds support for #graphql in the language server

### DIFF
--- a/.changeset/slow-books-repeat.md
+++ b/.changeset/slow-books-repeat.md
@@ -1,6 +1,6 @@
 ---
-"graphql-language-service-server": minor
-"graphql-language-service": minor
+'graphql-language-service-server': patch
+'graphql-language-service': patch
 ---
 
 Adds support for `#graphql` and `/* GraphQL */` in the language server

--- a/.changeset/slow-books-repeat.md
+++ b/.changeset/slow-books-repeat.md
@@ -1,0 +1,6 @@
+---
+"graphql-language-service-server": minor
+"graphql-language-service": minor
+---
+
+Adds support for `#graphql` and `/* GraphQL */` in the language server

--- a/.eslintignore
+++ b/.eslintignore
@@ -60,3 +60,5 @@ packages/graphiql/*.html
 
 # Vendored files
 /packages/graphiql/test/vendor
+
+.changeset

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 js-green-licenses.json
+.changeset

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -400,6 +400,64 @@ query Test {
 `);
   });
 
+  it('parseDocument finds queries in #graphql-annotated templates', async () => {
+    const text = `
+import {gql} from 'react-apollo';
+import {B} from 'B';
+import A from './A';
+
+const QUERY: string = \`#graphql
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+\${A.fragments.test}
+\`
+
+export function Example(arg: string) {}`;
+
+    const contents = parseDocument(text, 'test.ts');
+    expect(contents[0].query).toEqual(`#graphql
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+`);
+  });
+
+  it('parseDocument finds queries in /*GraphQL*/-annotated templates', async () => {
+    const text = `
+import {gql} from 'react-apollo';
+import {B} from 'B';
+import A from './A';
+
+const QUERY: string = /* GraphQL */ \`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+\${A.fragments.test}
+\`
+
+export function Example(arg: string) {}`;
+
+    const contents = parseDocument(text, 'test.ts');
+    expect(contents[0].query).toEqual(`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+`);
+  });
+
   it('parseDocument ignores non gql tagged templates', async () => {
     const text = `
 // @flow

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -169,7 +169,9 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
       }
     },
     TemplateLiteral: (node: TemplateExpression) => {
-      if (node.quasis[0].value.raw.startsWith('#graphql\n')) {
+      const hasGraphQLPrefix = node.quasis[0].value.raw.startsWith('#graphql\n');
+      const hasGraphQLComment = !!node.leadingComments[0]?.value.match(/^\s*GraphQL\s*$/);
+      if (hasGraphQLPrefix || hasGraphQLComment) {
         const loc = node.quasis[0].loc;
         if (loc) {
           const range = new Range(
@@ -180,8 +182,8 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
             tag: '',
             template: node.quasis[0].value.raw,
             range,
-          }
           });
+        }
       }
     }
   };

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -11,7 +11,6 @@ import {
   Expression,
   TaggedTemplateExpression,
   ObjectExpression,
-  TemplateExpression,
   TemplateLiteral,
 } from '@babel/types';
 
@@ -168,9 +167,13 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
         }
       }
     },
-    TemplateLiteral: (node: TemplateExpression) => {
-      const hasGraphQLPrefix = node.quasis[0].value.raw.startsWith('#graphql\n');
-      const hasGraphQLComment = !!node.leadingComments[0]?.value.match(/^\s*GraphQL\s*$/);
+    TemplateLiteral: (node: TemplateLiteral) => {
+      const hasGraphQLPrefix = node.quasis[0].value.raw.startsWith(
+        '#graphql\n',
+      );
+      const hasGraphQLComment = Boolean(
+        node.leadingComments?.[0]?.value.match(/^\s*GraphQL\s*$/),
+      );
       if (hasGraphQLPrefix || hasGraphQLComment) {
         const loc = node.quasis[0].loc;
         if (loc) {
@@ -185,7 +188,7 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
           });
         }
       }
-    }
+    },
   };
   visit(ast, visitors);
   return result;

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -11,6 +11,7 @@ import {
   Expression,
   TaggedTemplateExpression,
   ObjectExpression,
+  TemplateExpression,
   TemplateLiteral,
 } from '@babel/types';
 
@@ -167,6 +168,22 @@ export function findGraphQLTags(text: string, ext: string): TagResult[] {
         }
       }
     },
+    TemplateLiteral: (node: TemplateExpression) => {
+      if (node.quasis[0].value.raw.startsWith('#graphql\n')) {
+        const loc = node.quasis[0].loc;
+        if (loc) {
+          const range = new Range(
+            new Position(loc.start.line - 1, loc.start.column),
+            new Position(loc.end.line - 1, loc.end.column),
+          );
+          result.push({
+            tag: '',
+            template: node.quasis[0].value.raw,
+            range,
+          }
+          });
+      }
+    }
   };
   visit(ast, visitors);
   return result;


### PR DESCRIPTION
The `#graphql`-annotated strings weren't properly detected by the language server:

![image](https://user-images.githubusercontent.com/1037931/130155354-1587ce68-9dbc-4809-93f4-55c2f9a5c0fe.png)

Fixes https://github.com/graphql/vscode-graphql/issues/294