### PR TITLE
Fix typo in README.md

### DIFF
--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -82,7 +82,7 @@ Build for the web with [webpack](https://webpack.js.org/) or [browserify](http:/
 
 ### Usage: NPM module
 
-**Note**: If you are having webpack issues or questions about webpack, make sure you've cross-referenced your webpack configuration with our own [webpack example](../examples/graphiql-webpack) first. f you are having webpack issues or questions about webpack, make sure you've cross-referenced your webpack configuration with our own [webpack example](../examples/graphiql-webpack) first. We now have tests in CI that ensure this always builds, and we ensure it works end-to-end with every publish.
+**Note**: If you are having webpack issues or questions about webpack, make sure you've cross-referenced your webpack configuration with our own [webpack example](../examples/graphiql-webpack) first. We now have tests in CI that ensure this always builds, and we ensure it works end-to-end with every publish.
 
 Using another GraphQL service? Here's how to get GraphiQL set up:
 


### PR DESCRIPTION
Fix typo in README.md. A sentence was duplicated.