### PR TITLE
chore: introduce more active maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Originally this was three seperate repositories
 - [@imolorhe](https://github.com/imolorhe)
 - [@yoshiakis](https://github.com/yoshiakis)
 - [@dotansimha](https://github.com/dotansimha)
+- [@urigo](https://github.com/urigo)
+- [@timsuchanek](https://github.com/timsuchanek)
 
 ### Fielding Proposals!
 


### PR DESCRIPTION
I've done this in the reverse and made an "executive decision" to add these co-maintainers. 

Usually the process would be to propose in a PR as such, and then once approved, add them, but I wanted folks to be able to hit the ground running here.

Moving forward, I would suggest giving new maintainer applicants "triage" privilege to start, and then promoting them to "write" once they've gained enough experience helping community members, assisting with building the roadmap, and helping to review or introduce PRs.