### PR TITLE
Update GitHub Actions workflow image to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name: License Check
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
 
   build:
     name: Typescript Build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit:
     name: Unit Tests
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node: ['10', '12', '14', '16']
@@ -33,7 +33,7 @@ jobs:
 
   e2e:
     name: Cypress E2E Suite
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
At the moment we are using `ubuntu-16.04` which is no longer supported (https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/#:~:text=April%2029%2C%202021-,GitHub%20Actions%20%3A%20Ubuntu%2016.04%20LTS%20virtual%20environment%20will%20be%20removed,Actions%20on%20September%2020%2C%202021.)