### PR TITLE
fix: patch versions only for graphiql package

### DIFF
--- a/.changeset/short-mirrors-occur.md
+++ b/.changeset/short-mirrors-occur.md
@@ -1,5 +1,5 @@
 ---
-'graphiql': minor
+'graphiql': patch
 ---
 
 fix: history can now be saved even when query history panel is not opened


### PR DESCRIPTION
for reasons that will soon be revealed, we can only perform patch increments of `graphiql` currently

it may be worth considering reverting this PR to introduce the `feat` seperately, because otherwise it's tricky for semver