### PR TITLE
fix: @graphiql/toolkit dependencies

### DIFF
--- a/.changeset/nine-days-pretend.md
+++ b/.changeset/nine-days-pretend.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/toolkit': minor
+'graphiql': patch
+---
+
+Remove `optionalDependencies` entirely, remove `subscriptions-transport-ws` which introduces vulnerabilities, upgrade `@n1ru4l/push-pull-async-iterable-iterator` to 3.0.0, upgrade `graphql-ws` several minor versions - the `graphql-ws@5.x` upgrade will come in a later minor release.

--- a/packages/graphiql-toolkit/README.md
+++ b/packages/graphiql-toolkit/README.md
@@ -4,7 +4,7 @@
 
 General purpose library as a dependency of GraphiQL.
 
-Part of the GraphiQL 2.0.0 initiative.
+A core dependency of the GraphiQL 2.0.0 initiative.
 
 ## Docs
 
@@ -14,6 +14,6 @@ Part of the GraphiQL 2.0.0 initiative.
 ## Todo
 
 - [x] Begin porting common type definitions used by GraphiQL and it's dependencies
-- [ ] `createFetcher` utility for an easier `fetcher`
+- [x] `createGraphiQLFetcher` utility for an easier `fetcher`
 - [ ] Migrate over general purpose `graphiql/src/utilities`
 - [ ] Utility to generate json schema spec from `getQueryFacts` for monaco, vscode, etc

--- a/packages/graphiql-toolkit/package.json
+++ b/packages/graphiql-toolkit/package.json
@@ -21,7 +21,7 @@
   "scripts": {},
   "dependencies": {
     "@n1ru4l/push-pull-async-iterable-iterator": "^3.0.0",
-    "graphql-ws": "^5.5.0",
+    "graphql-ws": "^4.9.0",
     "meros": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -90,7 +90,7 @@ GraphiQL provides a React component responsible for rendering the UI, which shou
 
 For HTTP transport implementations, we recommend using the [fetch](https://fetch.spec.whatwg.org/) standard API, but you can use anything that matches [the type signature](https://graphiql-test.netlify.app/typedoc/modules/graphiql-toolkit.html#fetcher), including async iterables and observables.
 
-You can also install `@graphiql/create-fetcher` to make it easier to create a simple fetcher for conventional http and websockets transports.
+You can also install `@graphiql/create-fetcher` to make it easier to create a simple fetcher for conventional http and websockets transports. It uses `graphql-ws@4.x` protocol by default.
 
 ```js
 import React from 'react';
@@ -109,7 +109,7 @@ ReactDOM.render(
 );
 ```
 
-Read more about using [`createGraphiQLFetcher`](https://github.com/graphql/graphiql/tree/main/packages/graphiql-toolkit/docs/create-fetcher.md) in the readme to learn how to add headers and more.
+[Read more about using `createGraphiQLFetcher` in the readme](https://github.com/graphql/graphiql/tree/main/packages/graphiql-toolkit/docs/create-fetcher.md) to learn how to add headers, support the legacy `subsriptions-transport-ws` protocol, and more.
 
 ### Usage: UMD Bundle over CDN (Unpkg, JSDelivr, etc)
 
@@ -259,5 +259,3 @@ In order to theme the editor portions of the interface, you can supply a `editor
   editorTheme="solarized light"
 />
 ```
-
-### Running Operations

--- a/yarn.lock
+++ b/yarn.lock
@@ -9431,10 +9431,10 @@ graphql-config@^3.0.2:
     string-env-interpolation "1.0.1"
     tslib "^2.0.0"
 
-graphql-ws@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.0.tgz#79f10248d23d104369eaef93acb9f887276a2c42"
-  integrity sha512-WQepPMGQQoqS2VsrI2I3RMLCVz3CW4/6ZqGV6ABDOwH4R62DzjxwMlwZbj6vhSI/7IM3/C911yITwgs77iO/hw==
+graphql-ws@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-4.9.0.tgz#5cfd8bb490b35e86583d8322f5d5d099c26e365c"
+  integrity sha512-sHkK9+lUm20/BGawNEWNtVAeJzhZeBg21VmvmLoT5NdGVeZWv5PdIhkcayQIAgjSyyQ17WMKmbDijIPG2On+Ag==
 
 graphql@experimental-stream-defer:
   version "15.4.0-experimental-stream-defer.1"


### PR DESCRIPTION
Made the mistake of adding `optionalDependencies` to `@graphiql/toolkit`, some of which are vulnerable.

This reverts that, and increments versions to the latest of graphql-ws, meros, and @n1ru4l/push-pull-async-iterable-iterator

Question: should these be `peerDependencies` and documentation updated to reflect this?