### PR TITLE
ignore linting working-group directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -45,6 +45,8 @@ packages/graphiql/*.html
 **/coverage/
 .nyc_output/
 
+# ignore working-group dir markdown so it's easier for people to edit from the UI
+working-group/
 
 # codemirror's build artefacts are exported from the package root
 **/codemirror-graphql/variables


### PR DESCRIPTION
this makes it easier to add/edit markdown for contributors