### PR TITLE
build: remove codemirror dependency from lsp

### DIFF
--- a/.changeset/forty-apes-retire.md
+++ b/.changeset/forty-apes-retire.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-interface': patch
+---
+
+remove implicit codemirror dependency

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -7,7 +7,6 @@
  *
  */
 import { CompletionItemKind } from 'vscode-languageserver-types';
-import type CodeMirror from 'codemirror';
 
 import {
   FragmentDefinitionNode,
@@ -57,6 +56,7 @@ import {
   RuleKinds,
   RuleKind,
   _RuleKinds,
+  ContextTokenForCodeMirror,
 } from 'graphql-language-service-parser';
 
 import {
@@ -92,7 +92,7 @@ export function getAutocompleteSuggestions(
   schema: GraphQLSchema,
   queryText: string,
   cursor: IPosition,
-  contextToken?: CodeMirror.Token,
+  contextToken?: ContextTokenForCodeMirror,
   fragmentDefs?: FragmentDefinitionNode[] | string,
 ): Array<CompletionItem> {
   const token: ContextToken =


### PR DESCRIPTION
`CodeMirror.Token` is identical to `ContextTokenForCodeMirror`

see https://github.com/graphql/vscode-graphql/pull/335#issuecomment-957665844

---

this will allow updating the vscode-graphql to update to the latest packages from this project without having to add codemirror as a dependency