### PR TITLE
safelist argparser

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -1,6 +1,7 @@
 {
   "packageAllowlist": [
     // MIT, just lacking SPDX in manifest
-    "valid-url"
+    "valid-url",
+    "argparse"
   ]
 }


### PR DESCRIPTION
`argparser` which is used somewhere by `markdown-it` has a Python 2.0 License which is not in the default list https://github.com/google/js-green-licenses#configurations