### PR TITLE
Add missing changesets

### DIFF
--- a/.changeset/large-points-add.md
+++ b/.changeset/large-points-add.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-utils': minor
+---
+
+upgrade to `graphql@16.0.0-experimental-stream-defer.5`

--- a/.changeset/slow-cooks-hear.md
+++ b/.changeset/slow-cooks-hear.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-types': patch
+---
+
+Add graphql 16 in peerDependencies

--- a/.changeset/thirty-doors-trade.md
+++ b/.changeset/thirty-doors-trade.md
@@ -1,0 +1,10 @@
+---
+'graphiql': patch
+'graphql-language-service': patch
+'graphql-language-service-cli': patch
+'graphql-language-service-interface': patch
+'graphql-language-service-server': patch
+'monaco-graphql': patch
+---
+
+Update utils


### PR DESCRIPTION
As mentioned in https://github.com/graphql/graphiql/pull/2010#issuecomment-962743181

- Added missing changeset for graphql-language-service-utils
- Added patch changeset for graphql-language-service-utils dependants

I also found that graphql-language-service-types was not published with the only change it had, which is adding graphql 16 in the peer dependencies:

- Added patch changeset for graphql-language-service-types


@acao 