### PR TITLE
Configure changesets to automatically publish internal dependents

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["example-*", "graphiql-2-rfc-context*"]
+  "ignore": ["example-*", "graphiql-2-rfc-context*"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  }
 }


### PR DESCRIPTION
Configure changesets to automatically publish internal dependents, ala #2013 

it seems that lerna publish automatically handled this, whereas changesets allows you to change packages without publishing their changes. I think this option will *force* it, even if a user removes packages from the changeset