### PR TITLE
fix: schema prop type fix

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -110,7 +110,7 @@ export type GenericError =
 
 export type GraphiQLProps = {
   fetcher: Fetcher;
-  schema?: GraphQLSchema;
+  schema?: GraphQLSchema | null;
   validationRules?: ValidationRule[];
   query?: string;
   variables?: string;
@@ -145,7 +145,7 @@ export type GraphiQLProps = {
 };
 
 export type GraphiQLState = {
-  schema?: GraphQLSchema;
+  schema?: GraphQLSchema | null;
   query?: string;
   variables?: string;
   headers?: string;
@@ -1399,7 +1399,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     query: string,
     operationName?: string,
     prevOperations?: OperationDefinitionNode[],
-    schema?: GraphQLSchema,
+    schema?: GraphQLSchema | null,
   ) => {
     const queryFacts = getOperationFacts(schema, query);
     if (queryFacts) {

--- a/packages/graphiql/src/components/QueryEditor.tsx
+++ b/packages/graphiql/src/components/QueryEditor.tsx
@@ -23,7 +23,7 @@ const md = new MD();
 const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
 
 type QueryEditorProps = {
-  schema?: GraphQLSchema;
+  schema?: GraphQLSchema | null;
   validationRules?: ValidationRule[];
   value?: string;
   onEdit?: (value: string) => void;

--- a/packages/graphiql/src/utility/fillLeafs.ts
+++ b/packages/graphiql/src/utility/fillLeafs.ts
@@ -40,7 +40,7 @@ export type GetDefaultFieldNamesFn = (type: GraphQLType) => string[];
  * utility represents a "best effort" which may be useful within IDE tools.
  */
 export function fillLeafs(
-  schema?: GraphQLSchema,
+  schema?: GraphQLSchema | null,
   docString?: string,
   getDefaultFieldNames?: GetDefaultFieldNamesFn,
 ) {

--- a/packages/graphiql/src/utility/getQueryFacts.ts
+++ b/packages/graphiql/src/utility/getQueryFacts.ts
@@ -33,7 +33,7 @@ export type QueryFacts = {
  * If the query cannot be parsed, returns undefined.
  */
 export default function getOperationFacts(
-  schema?: GraphQLSchema,
+  schema?: GraphQLSchema | null,
   documentStr?: string | null,
 ): QueryFacts | undefined {
   if (!documentStr) {

--- a/packages/graphiql/src/utility/mergeAst.ts
+++ b/packages/graphiql/src/utility/mergeAst.ts
@@ -117,7 +117,7 @@ export function inlineRelevantFragmentSpreads(
  */
 export default function mergeAST(
   documentAST: DocumentNode,
-  schema?: GraphQLSchema,
+  schema?: GraphQLSchema | null,
 ): DocumentNode {
   // If we're given the schema, we can simplify even further by resolving object
   // types vs unions/interfaces


### PR DESCRIPTION
Fixes https://github.com/graphql/graphiql/issues/2028

### Summary

The `schema` prop of the GraphiQL component currently has the type `GraphQLSchema | undefined`. The correct type is `GraphQLSchema | null | undefined` because `null` is an accepted value. This PR fixes the type in the props, state and other functions that use the prop/state. 