### PR TITLE
Declare graphql-language-service-utils dependency

### DIFF
--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -44,7 +44,8 @@
   },
   "dependencies": {
     "graphql-language-service-interface": "^2.9.0",
-    "graphql-language-service-parser": "^1.10.0"
+    "graphql-language-service-parser": "^1.10.0",
+    "graphql-language-service-utils": "^2.6.0"
   },
   "devDependencies": {
     "codemirror": "^5.58.2",


### PR DESCRIPTION
Fixes: #1944

I currently get this error when trying to build our react app with uses graphiql:

`Module not found: Error: Can't resolve 'graphql-language-service-utils' in '/home/wstott/repos/tritium/user_interfaces/tritium_graphql/node_modules/graphiql/node_modules/codemirror-graphql'`