### PR TITLE
fix: Add graphql-language-service-utils to dependencies of codemirror-graphql

### DIFF
--- a/.changeset/beige-boxes-suffer.md
+++ b/.changeset/beige-boxes-suffer.md
@@ -1,0 +1,5 @@
+---
+'codemirror-graphql': patch
+---
+
+fix: Add graphql-language-service-utils to dependencies of codemirror-graphql

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -44,7 +44,8 @@
   },
   "dependencies": {
     "graphql-language-service-interface": "^2.9.0",
-    "graphql-language-service-parser": "^1.10.0"
+    "graphql-language-service-parser": "^1.10.0",
+    "graphql-language-service-utils": "^2.6.0"
   },
   "devDependencies": {
     "codemirror": "^5.58.2",


### PR DESCRIPTION
I made this change because it fixes codemirror-graphql with Yarn v2/3's plug-and-play.

Example error before this patch:

```js
./.yarn/__virtual__/codemirror-graphql-virtual-738f7121e6/0/cache/codemirror-graphql-npm-1.1.0-2d50dab87f-abfa711716.zip/node_modules/codemirror-graphql/hint.js
Module not found: codemirror-graphql tried to access graphql-language-service-utils, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

After, it should work just fine.  