### PR TITLE
chore: fix graphql-js peer dependencies

### DIFF
--- a/.changeset/few-numbers-check.md
+++ b/.changeset/few-numbers-check.md
@@ -1,0 +1,16 @@
+---
+'codemirror-graphql': patch
+'graphiql': patch
+'graphiql-2-rfc-context': patch
+'@graphiql/toolkit': patch
+'graphql-language-service': patch
+'graphql-language-service-cli': patch
+'graphql-language-service-interface': patch
+'graphql-language-service-parser': patch
+'graphql-language-service-server': patch
+'graphql-language-service-types': patch
+'graphql-language-service-utils': patch
+'monaco-graphql': patch
+---
+
+Fix peer resolution warnings for graphql@16 stabler versions

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "codemirror": "^5.58.2",
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "graphql-language-service-interface": "^2.9.0",

--- a/packages/graphiql-2-rfc-context/package.json
+++ b/packages/graphiql-2-rfc-context/package.json
@@ -57,7 +57,7 @@
     "theme-ui": "^0.3.1"
   },
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5",
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0",
     "prop-types": ">=15.5.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"

--- a/packages/graphiql-toolkit/package.json
+++ b/packages/graphiql-toolkit/package.json
@@ -30,7 +30,7 @@
     "graphql-ws": "^5.5.5"
   },
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5",
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0",
     "graphql-ws": ">= 4.5.0"
   },
   "keywords": [

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -54,7 +54,7 @@
     "markdown-it": "^12.2.0"
   },
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5",
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -27,7 +27,7 @@
     "LSP"
   ],
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.8.7",

--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -24,7 +24,7 @@
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "graphql-language-service-parser": "^1.10.0",

--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -24,7 +24,7 @@
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.33",

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -26,7 +26,7 @@
   "module": "esm/index.js",
   "typings": "esm/index.d.ts",
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "@babel/parser": "^7.13.13",

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -24,7 +24,7 @@
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "devDependencies": {
     "graphql": "16.0.0-experimental-stream-defer.5",

--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -24,7 +24,7 @@
   "module": "esm/index.js",
   "typings": "dist/index.d.ts",
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "graphql-language-service-types": "^1.8.3",

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -27,7 +27,7 @@
     "graphql": "./dist/temp-bin.js"
   },
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5"
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0"
   },
   "dependencies": {
     "graphql-language-service-interface": "^2.9.1",

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -31,7 +31,7 @@
     "vscode-languageserver-types": "^3.15.1"
   },
   "peerDependencies": {
-    "graphql": ">= 15.5.0 <= 16.0.0-experimental-stream-defer.5",
+    "graphql": "^15.5.0 || ^16.0.0-experimental-stream-defer.5 || ^16.0.0",
     "monaco-editor": "^0.20.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18063,15 +18063,6 @@ react-textarea-autosize@^7.1.0:
     "@babel/runtime" "^7.1.2"
     prop-types "^15.6.0"
 
-react@16.13.1, react@^16.12.0, react@^16.8.3:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -18079,6 +18070,15 @@ react@17.0.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+react@^16.12.0, react@^16.8.3:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 react@^16.13.1:
   version "16.14.0"


### PR DESCRIPTION
This should fix peer dependency issues with resolving stable 16.0.1 and beyond