### PR TITLE
use graphql-lang-service in codemirror-graphql

### DIFF
--- a/.changeset/red-laws-argue.md
+++ b/.changeset/red-laws-argue.md
@@ -1,0 +1,5 @@
+---
+'codemirror-graphql': patch
+---
+
+Resolves #1944, replaces graphql-language-service-utils with graphql-language-service in codemirror-graphql

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -44,8 +44,7 @@
   },
   "dependencies": {
     "@codemirror/stream-parser": "^0.19.2",
-    "graphql-language-service-interface": "^2.9.0",
-    "graphql-language-service-parser": "^1.10.0"
+    "graphql-language-service": "^3.2.1"
   },
   "devDependencies": {
     "codemirror": "^5.58.2",

--- a/packages/codemirror-graphql/src/hint.ts
+++ b/packages/codemirror-graphql/src/hint.ts
@@ -13,9 +13,8 @@ import CodeMirror, { Hints, Hint } from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
 
 import { FragmentDefinitionNode, GraphQLSchema, GraphQLType } from 'graphql';
-import { getAutocompleteSuggestions } from 'graphql-language-service-interface';
-import { Maybe } from 'graphql-language-service-types';
-import { Position } from 'graphql-language-service-utils';
+import type { Maybe } from 'graphql-language-service';
+import { getAutocompleteSuggestions, Position } from 'graphql-language-service';
 
 export interface GraphQLHintOptions {
   schema?: GraphQLSchema;

--- a/packages/codemirror-graphql/src/info.ts
+++ b/packages/codemirror-graphql/src/info.ts
@@ -31,7 +31,7 @@ import {
   SchemaReference,
 } from './utils/SchemaReference';
 import './utils/info-addon';
-import { Maybe } from 'graphql-language-service-types';
+import type { Maybe } from 'graphql-language-service';
 
 export interface GraphQLInfoOptions {
   schema?: GraphQLSchema;

--- a/packages/codemirror-graphql/src/jump.ts
+++ b/packages/codemirror-graphql/src/jump.ts
@@ -22,7 +22,7 @@ import {
 } from './utils/SchemaReference';
 import './utils/jump-addon';
 import { GraphQLSchema } from 'graphql';
-import { State } from 'graphql-language-service-parser';
+import type { State } from 'graphql-language-service';
 
 export interface GraphQLJumpOptions {
   schema?: GraphQLSchema;

--- a/packages/codemirror-graphql/src/lint.ts
+++ b/packages/codemirror-graphql/src/lint.ts
@@ -9,7 +9,7 @@
 
 import CodeMirror from 'codemirror';
 import { FragmentDefinitionNode, GraphQLSchema, ValidationRule } from 'graphql';
-import { getDiagnostics } from 'graphql-language-service-interface';
+import { getDiagnostics } from 'graphql-language-service';
 
 const SEVERITY = ['error', 'warning', 'information', 'hint'];
 const TYPE: Record<string, string> = {

--- a/packages/codemirror-graphql/src/results/mode.ts
+++ b/packages/codemirror-graphql/src/results/mode.ts
@@ -16,7 +16,7 @@ import {
   p,
   State,
   Token,
-} from 'graphql-language-service-parser';
+} from 'graphql-language-service';
 
 /**
  * This mode defines JSON, but provides a data-laden parser state to enable

--- a/packages/codemirror-graphql/src/utils/forEachState.ts
+++ b/packages/codemirror-graphql/src/utils/forEachState.ts
@@ -7,8 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import { State } from 'graphql-language-service-parser';
-import { Maybe } from 'graphql-language-service-types';
+import type { State, Maybe } from 'graphql-language-service';
 
 // Utility for iterating through a CodeMirror parse state stack bottom-up.
 export default function forEachState(stack: State, fn: (state: State) => void) {

--- a/packages/codemirror-graphql/src/utils/getTypeInfo.ts
+++ b/packages/codemirror-graphql/src/utils/getTypeInfo.ts
@@ -24,8 +24,8 @@ import {
   GraphQLEnumValue,
   GraphQLInputFieldMap,
 } from 'graphql';
-import { State } from 'graphql-language-service-parser';
-import { Maybe } from 'graphql-language-service-types';
+import type { State, Maybe } from 'graphql-language-service';
+
 import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,

--- a/packages/codemirror-graphql/src/utils/runParser.ts
+++ b/packages/codemirror-graphql/src/utils/runParser.ts
@@ -12,7 +12,7 @@ import {
   onlineParser,
   ParserOptions,
   State,
-} from 'graphql-language-service-parser';
+} from 'graphql-language-service';
 
 export default function runParser(
   sourceText: string,

--- a/packages/codemirror-graphql/src/variables/__tests__/lint-test.ts
+++ b/packages/codemirror-graphql/src/variables/__tests__/lint-test.ts
@@ -10,7 +10,7 @@
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/lint/lint';
 import { parse } from 'graphql';
-import { Maybe } from 'graphql-language-service-types';
+import { Maybe } from 'graphql-language-service';
 import collectVariables from '../../utils/collectVariables';
 import { TestSchema } from '../../__tests__/testSchema';
 import '../lint';

--- a/packages/codemirror-graphql/src/variables/hint.ts
+++ b/packages/codemirror-graphql/src/variables/hint.ts
@@ -18,8 +18,7 @@ import {
   GraphQLInputType,
   GraphQLInputFieldMap,
 } from 'graphql';
-import { State } from 'graphql-language-service-parser';
-import { Maybe } from 'graphql-language-service-types';
+import type { State, Maybe } from 'graphql-language-service';
 import { IHints } from 'src/hint';
 
 import forEachState from '../utils/forEachState';

--- a/packages/codemirror-graphql/src/variables/mode.ts
+++ b/packages/codemirror-graphql/src/variables/mode.ts
@@ -17,7 +17,7 @@ import {
   p,
   State,
   Token,
-} from 'graphql-language-service-parser';
+} from 'graphql-language-service';
 
 /**
  * This mode defines JSON, but provides a data-laden parser state to enable

--- a/packages/codemirror-graphql/tsconfig.esm.json
+++ b/packages/codemirror-graphql/tsconfig.esm.json
@@ -22,10 +22,7 @@
   ],
   "references": [
     {
-      "path": "../graphql-language-service-interface"
-    },
-    {
-      "path": "../graphql-language-service-parser"
+      "path": "../graphql-language-service"
     }
   ]
 }

--- a/packages/codemirror-graphql/tsconfig.json
+++ b/packages/codemirror-graphql/tsconfig.json
@@ -25,10 +25,7 @@
 
   "references": [
     {
-      "path": "../graphql-language-service-parser"
-    },
-    {
-      "path": "../graphql-language-service-interface"
+      "path": "../graphql-language-service"
     }
   ]
 }


### PR DESCRIPTION
use `graphql-language-service` instead of `graphql-language-service-utils`, etc - towards eventually combining them.

it makes it easier to manage dependency versions as well