### PR TITLE
Include source code in all packages to fix source maps.

### DIFF
--- a/.changeset/grumpy-dolphins-behave.md
+++ b/.changeset/grumpy-dolphins-behave.md
@@ -1,0 +1,14 @@
+---
+'codemirror-graphql': patch
+'graphiql': patch
+'graphiql-2-rfc-context': patch
+'graphql-language-service': patch
+'graphql-language-service-cli': patch
+'graphql-language-service-interface': patch
+'graphql-language-service-parser': patch
+'graphql-language-service-server': patch
+'graphql-language-service-types': patch
+'graphql-language-service-utils': patch
+---
+
+Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -16,7 +16,8 @@
   "main": "index.js",
   "module": "esm/index.js",
   "files": [
-    "dist",
+    "src",
+    "esm",
     "utils",
     "variables",
     "results",

--- a/packages/graphiql-2-rfc-context/package.json
+++ b/packages/graphiql-2-rfc-context/package.json
@@ -18,6 +18,7 @@
   "files": [
     "dist",
     "esm",
+    "src",
     "graphiql.js",
     "graphiql.min.js",
     "graphiql.css",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -18,6 +18,7 @@
   "files": [
     "dist",
     "esm",
+    "src",
     "graphiql.js",
     "graphiql.min.js",
     "graphiql.css",

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "src"
   ],
   "keywords": [
     "graphql",

--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql"

--- a/packages/graphql-language-service-parser/package.json
+++ b/packages/graphql-language-service-parser/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql"

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql",

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql"

--- a/packages/graphql-language-service-utils/package.json
+++ b/packages/graphql-language-service-utils/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql"

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "files": [
     "dist",
-    "esm"
+    "esm",
+    "src"
   ],
   "keywords": [
     "graphql",


### PR DESCRIPTION
Currently some build tools (**cough** react-scripts on webpack 5 **cough**) error out when trying to build source maps for the graphiql packages. This makes development much harder than it needs to be. By including the source code in the packages we build, the source maps are more likely to work...