### PR TITLE
Correctly declare dependency on graphql-config

### DIFF
--- a/packages/graphql-language-service-interface/package.json
+++ b/packages/graphql-language-service-interface/package.json
@@ -28,6 +28,7 @@
     "graphql": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
+    "graphql-config": "^4.1.0",
     "graphql-language-service-parser": "^1.10.2",
     "graphql-language-service-types": "^1.8.5",
     "graphql-language-service-utils": "^2.6.2",
@@ -35,7 +36,6 @@
   },
   "devDependencies": {
     "graphql": "16.0.0-experimental-stream-defer.5",
-    "graphql-config": "^4.1.0",
     "vscode-languageserver-protocol": "^3.16.0"
   }
 }

--- a/packages/graphql-language-service-types/package.json
+++ b/packages/graphql-language-service-types/package.json
@@ -27,9 +27,11 @@
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0"
   },
+  "dependencies": {
+    "graphql-config": "^4.1.0"
+  },
   "devDependencies": {
     "graphql": "16.0.0-experimental-stream-defer.5",
-    "graphql-config": "^4.1.0",
     "vscode-languageserver-types": "^3.15.1"
   }
 }


### PR DESCRIPTION
`graphql-language-service-types` and `graphql-language-service-interface` are failing to compile in typescript right now because they're missing a prod dependency on `graphql-config`.

- `graphql-language-service-types` uses `graphql-config` here https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-types/src/index.ts#L39
- `graphql-language-service-interface` uses `graphql-config` here https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts#L29
