### PR TITLE
fix: a few major bugs with SDL and remote schema in the language server

### DIFF
--- a/.changeset/cuddly-games-protect.md
+++ b/.changeset/cuddly-games-protect.md
@@ -1,0 +1,11 @@
+---
+'graphql-language-service-cli': patch
+'graphql-language-service-server': patch
+---
+
+this fixes the URI scheme related bugs and make sure schema as sdl config works again.
+
+`fileURLToPath` had been introduced by a contributor and I didnt test properly, it broke sdl file loading!
+
+definitions, autocomplete, diagnostics, etc should work again
+also hides the more verbose logging output for now

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -117,7 +117,7 @@ await startServer({
     // rootDir is same as `configDir` before, the path where the graphql config file would be found by cosmic-config
     rootDir: 'config/',
     // or - the relative or absolute path to your file
-    filePath: 'exact/path/to/config.js (also supports yml, json)',
+      filePath: 'exact/path/to/config.js' // (also supports yml, json, ts, toml)
     // myPlatform.config.js/json/yaml works now!
     configName: 'myPlatform',
   },
@@ -134,8 +134,9 @@ module.exports = {
      // a function that returns rules array with parameter `ValidationContext` from `graphql/validation`
     "customValidationRules": require('./config/customValidationRules')
     "languageService": {
-      // should the language service read from source files? if false, it generates a schema from the project/config schema
-      useSchemaFileDefinitions: false
+      // should the language service read schema for lookups from a cached file based on graphql config output?
+      cacheSchemaFileForLookup: true
+     // NOTE: this will disable all definition lookup for local SDL files
     }
   }
 }
@@ -147,14 +148,14 @@ we also load `require('dotenv').config()`, so you can use process.env variables 
 
 The LSP Server reads config by sending `workspace/configuration` method when it initializes.
 
-| Parameter                                | Default                         | Description                                                                                            |
-| ---------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `graphql-config.load.baseDir`            | workspace root or process.cwd() | the path where graphql config looks for config files                                                   |
-| `graphql-config.load.filePath`           | `null`                          | exact filepath of the config file.                                                                     |
-| `graphql-config.load.configName`         | `graphql`                       | config name prefix instead of `graphql`                                                                |
-| `graphql-config.load.legacy`             | `true`                          | backwards compatibility with `graphql-config@2`                                                        |
-| `graphql-config.dotEnvPath`              | `null`                          | backwards compatibility with `graphql-config@2`                                                        |
-| `vsode-graphql.useSchemaFileDefinitions` | `false`                         | whether the LSP server will use source files, or generate an SDL from `config.schema`/`project.schema` |
+| Parameter                                | Default                         | Description                                                                                                                                                       |
+| ---------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `graphql-config.load.baseDir`            | workspace root or process.cwd() | the path where graphql config looks for config files                                                                                                              |
+| `graphql-config.load.filePath`           | `null`                          | exact filepath of the config file.                                                                                                                                |
+| `graphql-config.load.configName`         | `graphql`                       | config name prefix instead of `graphql`                                                                                                                           |
+| `graphql-config.load.legacy`             | `true`                          | backwards compatibility with `graphql-config@2`                                                                                                                   |
+| `graphql-config.dotEnvPath`              | `null`                          | backwards compatibility with `graphql-config@2`                                                                                                                   |
+| `vsode-graphql.cacheSchemaFileForLookup` | `false`                         | generate an SDL file based on your graphql-config schema configuration for schema definition lookup and other features. useful when your `schema` config are urls |
 
 all the `graphql-config.load.*` configuration values come from static `loadConfig()` options in graphql config.
 

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@babel/parser": "^7.13.13",
     "dotenv": "8.2.0",
-    "glob": "^7.1.2",
     "graphql-config": "^4.1.0",
     "graphql-language-service": "^3.2.3",
     "graphql-language-service-utils": "^2.6.2",
@@ -40,7 +39,8 @@
     "node-fetch": "^2.6.1",
     "nullthrows": "^1.0.0",
     "vscode-jsonrpc": "^5.0.1",
-    "vscode-languageserver": "^6.1.1"
+    "vscode-languageserver": "^6.1.1",
+    "fast-glob": "^3.2.7"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.1",

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -106,7 +106,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;
 
   getProjectForFile = (uri: string): GraphQLProjectConfig => {
-    return this._graphQLConfig.getProjectForFile(fileURLToPath(uri));
+    return this._graphQLConfig.getProjectForFile(new URL(uri).pathname);
   };
 
   getFragmentDependencies = async (

--- a/packages/graphql-language-service-server/src/Logger.ts
+++ b/packages/graphql-language-service-server/src/Logger.ts
@@ -71,9 +71,12 @@ export class Logger implements VSCodeLogger {
     const logMessage = `${timestamp} [${severity}] (pid: ${pid}) graphql-language-service-usage-logs: ${stringMessage}\n`;
     // write to the file in tmpdir
     fs.appendFile(this._logFilePath, logMessage, _error => {});
-    this._getOutputStream(severity).write(logMessage, err => {
-      err && console.error(err);
-    });
+    // @TODO: enable with debugging
+    if (severityKey !== SEVERITY.Hint) {
+      this._getOutputStream(severity).write(logMessage, err => {
+        err && console.error(err);
+      });
+    }
   }
 
   _getOutputStream(severity: DiagnosticSeverity): Socket {

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -9,7 +9,7 @@
 
 import mkdirp from 'mkdirp';
 import { readFileSync, existsSync, writeFileSync, writeFile } from 'fs';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { pathToFileURL } from 'url';
 import * as path from 'path';
 import {
   CachedContent,
@@ -191,7 +191,7 @@ export class MessageProcessor {
       throw new Error('GraphQL Language Server is not initialized.');
     }
 
-    this._logger.log(
+    this._logger.info(
       JSON.stringify({
         type: 'usage',
         messageType: 'initialize',
@@ -584,7 +584,7 @@ export class MessageProcessor {
         ) {
           const uri = change.uri;
 
-          const text = readFileSync(fileURLToPath(uri), { encoding: 'utf8' });
+          const text = readFileSync(new URL(uri).pathname).toString();
           const contents = this._parser(text, uri);
 
           await this._updateFragmentDefinition(uri, contents);
@@ -878,10 +878,10 @@ export class MessageProcessor {
      * The default temporary schema file seems preferrable until we have graphql source maps
      */
     const useSchemaFileDefinitions =
-      (config?.useSchemaFileDefinitions ??
-        this?._settings?.useSchemaFileDefinitions) ||
+      config?.useSchemaFileDefinitions ??
+      this?._settings?.useSchemaFileDefinitions ??
       false;
-    if (!useSchemaFileDefinitions) {
+    if (useSchemaFileDefinitions) {
       await this._cacheConfigSchema(project);
     } else {
       if (Array.isArray(schema)) {

--- a/packages/graphql-language-service-server/src/__tests__/.graphqlrc.yml
+++ b/packages/graphql-language-service-server/src/__tests__/.graphqlrc.yml
@@ -3,6 +3,10 @@ projects:
     schema:
       - __schema__/StarWarsSchema.graphql
       - 'directive @customDirective on FRAGMENT_SPREAD'
+  testWithGlobSchema:
+    schema:
+      - __schema__/*.graphql
+      - 'directive @customDirective on FRAGMENT_SPREAD'
   testWithEndpoint:
     schema: https://example.com/graphql
   testWithEndpointAndSchema:

--- a/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
@@ -30,7 +30,7 @@ describe('Logger', () => {
 
   it('logs to stdout', () => {
     const logger = new Logger(tmpdir());
-    logger.log('log test');
+    logger.info('log test');
 
     expect(mockedStdoutWrite.mock.calls.length).toBe(1);
     expect(mockedStdoutWrite.mock.calls[0][0]).toContain('log test');
@@ -51,14 +51,14 @@ describe('Logger', () => {
     const logger = new Logger(tmpdir(), stderrOnly);
     logger.info('info test');
     logger.warn('warn test');
+    // log is only logged to file now :)
     logger.log('log test');
     logger.error('error test');
 
     expect(mockedStdoutWrite.mock.calls.length).toBe(0);
-    expect(mockedStderrWrite.mock.calls.length).toBe(4);
+    expect(mockedStderrWrite.mock.calls.length).toBe(3);
     expect(mockedStderrWrite.mock.calls[0][0]).toContain('info test');
     expect(mockedStderrWrite.mock.calls[1][0]).toContain('warn test');
-    expect(mockedStderrWrite.mock.calls[2][0]).toContain('log test');
-    expect(mockedStderrWrite.mock.calls[3][0]).toContain('error test');
+    expect(mockedStderrWrite.mock.calls[2][0]).toContain('error test');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,7 +3270,7 @@
     tslib "^2"
 
 "@graphiql/toolkit@file:packages/graphiql-toolkit":
-  version "0.4.1"
+  version "0.4.2"
   dependencies:
     "@n1ru4l/push-pull-async-iterable-iterator" "^3.1.0"
     meros "^1.1.4"
@@ -10014,6 +10014,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -10744,7 +10755,7 @@ glob-parent@^5.0.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.0:
+glob-parent@^5.1.0, glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -10992,16 +11003,16 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.5.2"
+  version "1.5.5"
   dependencies:
-    "@graphiql/toolkit" "^0.4.1"
+    "@graphiql/toolkit" "^0.4.2"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.0"
+    codemirror-graphql "^1.2.3"
     copy-to-clipboard "^3.2.0"
     dset "^3.1.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^3.2.1"
+    graphql-language-service "^3.2.3"
     markdown-it "^12.2.0"
 
 graphql-config@^4.1.0:


### PR DESCRIPTION
this fixes the URI scheme related bugs and make sure config works
sdl first dev experience should work again

`fileURLToPath` had been introduced by a contributor and I didnt test properly, it broke sdl file loading!

i only tested with remote schemas before releasing my bad!

definitions, autocomplete, diagnostics, etc should work again
also hides the more verbose logging output for now
still the cache miss error will get that next

This should fix:
#2021 #2018 #1672 #1977 

and many others issues `vscode-graphql` repository