### PR TITLE
LSP Server should parse more JS extensions

### DIFF
--- a/.changeset/short-fireants-shake.md
+++ b/.changeset/short-fireants-shake.md
@@ -1,0 +1,5 @@
+---
+"graphql-language-service-server": patch
+---
+
+Parse more JS extensions in the language server

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -4,7 +4,17 @@ import { Range, Position } from 'graphql-language-service-utils';
 
 import { findGraphQLTags, DEFAULT_TAGS } from './findGraphQLTags';
 
-export const DEFAULT_SUPPORTED_EXTENSIONS = ['.js', '.ts', '.jsx', '.tsx'];
+export const DEFAULT_SUPPORTED_EXTENSIONS = [
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.es',
+  '.esm',
+  '.es6',
+  '.ts',
+  '.jsx',
+  '.tsx',
+];
 
 /**
  * .graphql is the officially reccomended extension for graphql files


### PR DESCRIPTION
There are many more extensions people are using these days for javascript so it's time to honor all of them. This *should* fix #1955 when published to `vscode-graphql`, though graphql shouldn't be trying to parse those files anyways, so a bit more digging is in order