### PR TITLE
Add hover syntax highlighting for types

### DIFF
--- a/.changeset/real-boxes-clap.md
+++ b/.changeset/real-boxes-clap.md
@@ -1,0 +1,7 @@
+---
+'graphql-language-service': patch
+'graphql-language-service-interface': patch
+'graphql-language-service-server': patch
+---
+
+Add an opt-in feature to generate markdown in hover elements, starting with highlighting type information. Enabled for the language server and also the language service and thus `monaco-graphql` as well.

--- a/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-interface/src/GraphQLLanguageService.ts
@@ -35,7 +35,7 @@ import {
 
 import { Kind, parse, print } from 'graphql';
 import { getAutocompleteSuggestions } from './getAutocompleteSuggestions';
-import { getHoverInformation } from './getHoverInformation';
+import { getHoverInformation, HoverConfig } from './getHoverInformation';
 import { validateQuery, getRange, DIAGNOSTIC_SEVERITY } from './getDiagnostics';
 import {
   getDefinitionQueryResultForFragmentSpread,
@@ -250,12 +250,13 @@ export class GraphQLLanguageService {
     query: string,
     position: IPosition,
     filePath: Uri,
+    options?: HoverConfig,
   ): Promise<Hover['contents']> {
     const projectConfig = this.getConfigForURI(filePath);
     const schema = await this._graphQLCache.getSchema(projectConfig.name);
 
     if (schema) {
-      return getHoverInformation(schema, query, position);
+      return getHoverInformation(schema, query, position, undefined, options);
     }
     return '';
   }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -549,6 +549,7 @@ export class MessageProcessor {
       query,
       toPosition(position),
       textDocument.uri,
+      { useMarkdown: true },
     );
 
     return {

--- a/packages/graphql-language-service/src/LanguageService.ts
+++ b/packages/graphql-language-service/src/LanguageService.ts
@@ -25,6 +25,7 @@ import {
   SchemaResponse,
   defaultSchemaBuilder,
 } from './schemaLoader';
+import { HoverConfig } from 'graphql-language-service-interface/src/getHoverInformation';
 
 export type GraphQLLanguageConfig = {
   parser?: typeof parse;
@@ -203,10 +204,13 @@ export class LanguageService {
     _uri: string,
     documentText: string,
     position: IPosition,
+    options?: HoverConfig,
   ) =>
     getHoverInformation(
       (await this.getSchema()) as GraphQLSchema,
       documentText,
       position,
+      undefined,
+      { useMarkdown: true, ...options },
     );
 }


### PR DESCRIPTION
This applies to all implementations essentially. because it's opt-in for direct usage with `getAutocompleteSuggestions`, `codemirror-graphql` will be unaffected.

the lsp server, monaco-graphql and others will be able to use the markdown output
this is just the start!

![Screenshot 2021-11-28 at 01 23 07](https://user-images.githubusercontent.com/1368727/143724298-25a87664-391d-463b-945a-39efcb62478b.png)

where to test:

1. `monaco-graphql`
2. `graphql-language-service-server`