### PR TITLE
fix: autocompletion for argument values, more trigger characters

### DIFF
--- a/.changeset/green-ghosts-agree.md
+++ b/.changeset/green-ghosts-agree.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-interface': patch
+'monaco-graphql': patch
+---
+
+Fix a bug with variable completion with or without `$` across the ecosytem. Introduce more triggerCharacters for fun!

--- a/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service-interface/src/__tests__/getAutocompleteSuggestions-test.ts
@@ -279,7 +279,7 @@ query name {
     ]);
   });
 
-  it('provides correct suggestions when autocompleting for declared variable while typing', () => {
+  it('provides correct suggestions for declared variables upon typing $', () => {
     const result = testSuggestions(
       'query($id: String, $ep: Episode!){ hero(episode: $ }',
       new Position(0, 51),
@@ -287,7 +287,7 @@ query name {
     expect(result).toEqual([{ label: '$ep', detail: 'Episode' }]);
   });
 
-  it('provides correct suggestions when autocompleting for declared variable', () => {
+  it('provides correct suggestions for variables based on argument context', () => {
     const result = testSuggestions(
       'query($id: String!, $episode: Episode!){ hero(episode: ',
       new Position(0, 55),
@@ -297,6 +297,7 @@ query name {
       { label: 'EMPIRE', detail: 'Episode' },
       { label: 'JEDI', detail: 'Episode' },
       { label: 'NEWHOPE', detail: 'Episode' },
+      // no $id here, it's not compatible :P
     ]);
   });
 

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -156,8 +156,13 @@ export function getAutocompleteSuggestions(
     if (argDefs) {
       return hintList(
         token,
-        argDefs.map(argDef => ({
+        argDefs.map((argDef: GraphQLArgument): CompletionItem => ({
           label: argDef.name,
+          insertText: argDef.name + ': ',
+          command: {
+            command: 'editor.action.triggerSuggest',
+            title: 'Suggestions',
+          },
           detail: String(argDef.type),
           documentation: argDef.description ?? undefined,
           kind: CompletionItemKind.Variable,
@@ -585,15 +590,15 @@ export function getVariableCompletions(
   schema: GraphQLSchema,
   token: ContextToken,
 ): CompletionItem[] {
-  let variableName: null | string;
+  let variableName: null | string = null;
   let variableType: GraphQLInputObjectType | undefined | null;
   const definitions: Record<string, any> = Object.create({});
-  // TODO: gather this as part of `AllTypeInfo`, as I don't think it's optimal to re-run the parser like this
   runOnlineParser(queryText, (_, state: State) => {
-    if (state.kind === RuleKinds.VARIABLE && state.name) {
+    // TODO: gather this as part of `AllTypeInfo`, as I don't think it's optimal to re-run the parser like this
+    if (state?.kind === RuleKinds.VARIABLE && state.name) {
       variableName = state.name;
     }
-    if (state.kind === RuleKinds.NAMED_TYPE && variableName) {
+    if (state?.kind === RuleKinds.NAMED_TYPE && variableName) {
       const parentDefinition = getParentDefinition(state, RuleKinds.TYPE);
       if (parentDefinition?.type) {
         variableType = schema.getType(

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -156,18 +156,20 @@ export function getAutocompleteSuggestions(
     if (argDefs) {
       return hintList(
         token,
-        argDefs.map((argDef: GraphQLArgument): CompletionItem => ({
-          label: argDef.name,
-          insertText: argDef.name + ': ',
-          command: {
-            command: 'editor.action.triggerSuggest',
-            title: 'Suggestions',
-          },
-          detail: String(argDef.type),
-          documentation: argDef.description ?? undefined,
-          kind: CompletionItemKind.Variable,
-          type: argDef.type,
-        })),
+        argDefs.map(
+          (argDef: GraphQLArgument): CompletionItem => ({
+            label: argDef.name,
+            insertText: argDef.name + ': ',
+            command: {
+              command: 'editor.action.triggerSuggest',
+              title: 'Suggestions',
+            },
+            detail: String(argDef.type),
+            documentation: argDef.description ?? undefined,
+            kind: CompletionItemKind.Variable,
+            type: argDef.type,
+          }),
+        ),
       );
     }
   }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -166,7 +166,7 @@ export class MessageProcessor {
         documentSymbolProvider: true,
         completionProvider: {
           resolveProvider: true,
-          triggerCharacters: ['@'],
+          triggerCharacters: [' ', ':', '$', '\n', ' ', '(', '@'],
         },
         definitionProvider: true,
         textDocumentSync: 1,

--- a/packages/graphql-language-service-types/src/index.ts
+++ b/packages/graphql-language-service-types/src/index.ts
@@ -189,6 +189,7 @@ export type CompletionItem = CompletionItemType & {
   documentation?: string | null;
   deprecationReason?: string | null;
   type?: GraphQLType;
+  command?: CompletionItemType['command'];
 };
 // Below are basically a copy-paste from Nuclide rpc types for definitions.
 
@@ -246,6 +247,7 @@ export const FileChangeTypeKind = {
   Deleted: 3,
 };
 
+// eslint-disable-next-line no-redeclare
 export type FileChangeTypeKind = {
   Created: 1;
   Changed: 2;
@@ -255,3 +257,64 @@ export type FileChangeTypeKind = {
 export type FileChangeTypeKeys = keyof FileChangeTypeKind;
 
 export type FileChangeType = FileChangeTypeKind[FileChangeTypeKeys];
+
+// copied from `microsoft/vscode-languageserver-types` to prevent import issues
+
+/**
+ * The kind of a completion entry.
+ */
+export namespace CompletionItemKind {
+  export const Text: 1 = 1;
+  export const Method: 2 = 2;
+  export const Function: 3 = 3;
+  export const Constructor: 4 = 4;
+  export const Field: 5 = 5;
+  export const Variable: 6 = 6;
+  export const Class: 7 = 7;
+  export const Interface: 8 = 8;
+  export const Module: 9 = 9;
+  export const Property: 10 = 10;
+  export const Unit: 11 = 11;
+  export const Value: 12 = 12;
+  export const Enum: 13 = 13;
+  export const Keyword: 14 = 14;
+  export const Snippet: 15 = 15;
+  export const Color: 16 = 16;
+  export const File: 17 = 17;
+  export const Reference: 18 = 18;
+  export const Folder: 19 = 19;
+  export const EnumMember: 20 = 20;
+  export const Constant: 21 = 21;
+  export const Struct: 22 = 22;
+  export const Event: 23 = 23;
+  export const Operator: 24 = 24;
+  export const TypeParameter: 25 = 25;
+}
+
+// eslint-disable-next-line no-redeclare
+export type CompletionItemKind =
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25;

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -7,21 +7,19 @@
 
 import { FormattingOptions, ICreateData } from './typings';
 
-import type { worker, editor, Position, IRange } from 'monaco-editor';
+import type { worker, editor, Position } from 'monaco-editor';
 import * as monaco from 'monaco-editor';
 
 import { getRange, LanguageService } from 'graphql-language-service';
 
-import type {
-  SchemaResponse,
-  CompletionItem as GraphQLCompletionItem,
-} from 'graphql-language-service';
+import type { SchemaResponse } from 'graphql-language-service';
 
 import {
   toGraphQLPosition,
   toMonacoRange,
   toMarkerData,
   toCompletion,
+  GraphQLWorkerCompletionItem,
 } from './utils';
 
 import type { GraphQLSchema, DocumentNode } from 'graphql';
@@ -65,7 +63,7 @@ export class GraphQLWorker {
   async doComplete(
     uri: string,
     position: Position,
-  ): Promise<(GraphQLCompletionItem & { range: IRange })[]> {
+  ): Promise<GraphQLWorkerCompletionItem[]> {
     const document = this._getTextDocument(uri);
     const graphQLPosition = toGraphQLPosition(position);
 

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -14,14 +14,13 @@ import type {
   Thenable,
   CancellationToken,
   IDisposable,
-  IRange,
 } from 'monaco-editor';
 
 import * as monaco from 'monaco-editor';
 
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
-import { CompletionItemKind as lsCompletionItemKind } from 'vscode-languageserver-types';
-import { CompletionItem as GraphQLCompletionItem } from 'graphql-language-service';
+import { CompletionItemKind as lsCompletionItemKind } from 'graphql-language-service';
+import { GraphQLWorkerCompletionItem } from './utils';
 export interface WorkerAccessor {
   (...more: Uri[]): Thenable<GraphQLWorker>;
 }
@@ -174,17 +173,19 @@ export function toCompletionItemKind(kind: lsCompletionItemKind) {
 }
 
 export function toCompletion(
-  entry: GraphQLCompletionItem & { range: IRange },
+  entry: GraphQLWorkerCompletionItem,
 ): monaco.languages.CompletionItem {
   return {
+    // @ts-expect-error
+    range: entry.range,
+    kind: toCompletionItemKind(entry.kind as lsCompletionItemKind),
     label: entry.label,
     insertText: entry.insertText || (entry.label as string),
     sortText: entry.sortText,
     filterText: entry.filterText,
     documentation: entry.documentation,
     detail: entry.detail,
-    range: entry.range,
-    kind: toCompletionItemKind(entry.kind as lsCompletionItemKind),
+    command: entry.command,
   };
 }
 

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -195,7 +195,7 @@ export class CompletionAdapter
   }
 
   public get triggerCharacters(): string[] {
-    return [' ', ':'];
+    return [' ', ':', '$', '\n', ' ', '('];
   }
 
   async provideCompletionItems(

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -196,7 +196,7 @@ export class CompletionAdapter
   }
 
   public get triggerCharacters(): string[] {
-    return [' ', ':', '$', '\n', ' ', '('];
+    return [':', '$', '\n', ' ', '(', '@'];
   }
 
   async provideCompletionItems(

--- a/packages/monaco-graphql/src/utils.ts
+++ b/packages/monaco-graphql/src/utils.ts
@@ -14,12 +14,10 @@ import type {
 
 import { Position } from 'graphql-language-service';
 
-// @ts-ignore
 export type MonacoCompletionItem = monaco.languages.CompletionItem & {
   isDeprecated?: boolean;
   deprecationReason?: string | null;
 };
-// @ts-ignore
 export function toMonacoRange(range: GraphQLRange): monaco.IRange {
   return {
     startLineNumber: range.start.line + 1,
@@ -29,7 +27,6 @@ export function toMonacoRange(range: GraphQLRange): monaco.IRange {
   };
 }
 
-// @ts-ignore
 export function toGraphQLPosition(position: monaco.Position): GraphQLPosition {
   return new Position(position.lineNumber - 1, position.column - 1);
 }
@@ -37,20 +34,15 @@ export function toGraphQLPosition(position: monaco.Position): GraphQLPosition {
 export function toCompletion(
   entry: GraphQLCompletionItem,
   range?: GraphQLRange,
-  // @ts-ignore
 ): GraphQLCompletionItem & { range: monaco.IRange } {
   return {
     label: entry.label,
-    // TODO: when adding variables to getAutocompleteSuggestions, we appended the $.
-    // this appears to cause an issue in monaco, but not vscode
-    insertText:
-      entry.insertText ||
-      (!entry.label.startsWith('$') ? entry.label : entry.label.substring(1)),
+    insertText: entry.insertText ?? entry.label,
     sortText: entry.sortText,
     filterText: entry.filterText,
     documentation: entry.documentation,
     detail: entry.detail,
-    // @ts-ignore
+    // @ts-expect-error
     range: range ? toMonacoRange(range) : undefined,
     kind: entry.kind,
   };
@@ -84,7 +76,6 @@ export function toCompletion(
 
 export function toMarkerData(
   diagnostic: Diagnostic,
-  // @ts-ignore
 ): monaco.editor.IMarkerData {
   return {
     startLineNumber: diagnostic.range.start.line + 1,

--- a/packages/monaco-graphql/src/utils.ts
+++ b/packages/monaco-graphql/src/utils.ts
@@ -31,21 +31,31 @@ export function toGraphQLPosition(position: monaco.Position): GraphQLPosition {
   return new Position(position.lineNumber - 1, position.column - 1);
 }
 
+export type GraphQLWorkerCompletionItem = GraphQLCompletionItem & {
+  range?: monaco.IRange;
+  command?: monaco.languages.CompletionItem['command'];
+};
+
 export function toCompletion(
   entry: GraphQLCompletionItem,
   range?: GraphQLRange,
-): GraphQLCompletionItem & { range: monaco.IRange } {
-  return {
+): GraphQLWorkerCompletionItem {
+  const results: GraphQLWorkerCompletionItem = {
     label: entry.label,
     insertText: entry.insertText ?? entry.label,
     sortText: entry.sortText,
     filterText: entry.filterText,
     documentation: entry.documentation,
     detail: entry.detail,
-    // @ts-expect-error
     range: range ? toMonacoRange(range) : undefined,
     kind: entry.kind,
   };
+
+  if (entry.command) {
+    results.command = { ...entry.command, id: entry.command.command };
+  }
+
+  return results;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -11003,16 +11003,16 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.5.5"
+  version "1.5.7"
   dependencies:
     "@graphiql/toolkit" "^0.4.2"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.3"
+    codemirror-graphql "^1.2.4"
     copy-to-clipboard "^3.2.0"
     dset "^3.1.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^3.2.3"
+    graphql-language-service "^3.2.4"
     markdown-it "^12.2.0"
 
 graphql-config@^4.1.0:


### PR DESCRIPTION
fixes #2068 🎉  and #1894 (i think - @rchl do you agree?)

simplifies the code a bit. untangles a mess that I left when introducing argument value completion last year.

introduces more `triggerCharacters` to `monaco-graphql` as a precursor to #1997 

fixes this bug across the entire ecosystem by fixing the issue at the core `graphql-language-service-server` level