### PR TITLE
fix: lsp server paths for windows, special chars, fragment/object cache

### DIFF
--- a/.changeset/fifty-actors-sleep.md
+++ b/.changeset/fifty-actors-sleep.md
@@ -1,0 +1,17 @@
+---
+'graphql-language-service-server': patch
+---
+
+this fixes the parsing of file URIs by `graphql-language-service-server` in cases such as:
+
+- windows without WSL
+- special characters in filenames
+- likely other cases
+
+previously we were using the old approach of `URL(uri).pathname` which was not working! now using the standard `vscode-uri` approach of `URI.parse(uri).fsName`.
+
+this should fix issues with object and fragment type completion as well I think
+
+also for #2066 made it so that graphql config is not loaded into the file cache unnecessarily, and that it's only loaded on editor save events rather than on file changed events
+
+fixes #1644 and #2066

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -40,7 +40,9 @@
     "nullthrows": "^1.0.0",
     "vscode-jsonrpc": "^5.0.1",
     "vscode-languageserver": "^6.1.1",
-    "fast-glob": "^3.2.7"
+    "fast-glob": "^3.2.7",
+    "vscode-uri": "^3.0.2",
+    "glob": "^7.2.0"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.1",

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -31,7 +31,8 @@ import { parseDocument } from './parseDocument';
 import stringToHash from './stringToHash';
 import glob from 'glob';
 import { LoadConfigOptions } from './types';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { pathToFileURL } from 'url';
+import { URI } from 'vscode-uri';
 
 // Maximum files to read when processing GraphQL files.
 const MAX_READS = 200;
@@ -106,7 +107,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;
 
   getProjectForFile = (uri: string): GraphQLProjectConfig => {
-    return this._graphQLConfig.getProjectForFile(new URL(uri).pathname);
+    return this._graphQLConfig.getProjectForFile(URI.parse(uri).fsPath);
   };
 
   getFragmentDependencies = async (
@@ -776,7 +777,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
    */
   promiseToReadGraphQLFile = (filePath: Uri): Promise<GraphQLFileInfo> => {
     return new Promise((resolve, reject) =>
-      fs.readFile(fileURLToPath(filePath), 'utf8', (error, content) => {
+      fs.readFile(URI.parse(filePath).fsPath, 'utf8', (error, content) => {
         if (error) {
           reject(error);
           return;

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -31,7 +31,6 @@ import { parseDocument } from './parseDocument';
 import stringToHash from './stringToHash';
 import glob from 'glob';
 import { LoadConfigOptions } from './types';
-import { pathToFileURL } from 'url';
 import { URI } from 'vscode-uri';
 
 // Maximum files to read when processing GraphQL files.
@@ -366,7 +365,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
               // the docs indicate that is what's there :shrug:
               const cacheEntry = globResult.statCache[filePath] as fs.Stats;
               return {
-                filePath: pathToFileURL(filePath).toString(),
+                filePath: URI.parse(filePath).toString(),
                 mtime: Math.trunc(cacheEntry.mtime.getTime() / 1000),
                 size: cacheEntry.size,
               };

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -9,7 +9,6 @@
 
 import mkdirp from 'mkdirp';
 import { readFileSync, existsSync, writeFileSync, writeFile } from 'fs';
-import { pathToFileURL } from 'url';
 import * as path from 'path';
 import glob from 'fast-glob';
 import { URI } from 'vscode-uri';
@@ -132,7 +131,7 @@ export class MessageProcessor {
     };
     this._tmpDir = tmpDir || tmpdir();
     this._tmpDirBase = path.join(this._tmpDir, 'graphql-language-service');
-    this._tmpUriBase = pathToFileURL(this._tmpDirBase).toString();
+    this._tmpUriBase = URI.parse(this._tmpDirBase).toString();
     this._loadConfigOptions = loadConfigOptions;
     if (
       loadConfigOptions.extensions &&
@@ -832,9 +831,7 @@ export class MessageProcessor {
     const isFileUri = existsSync(uri);
     let version = 1;
     if (isFileUri) {
-      const schemaUri = pathToFileURL(
-        path.join(project.dirpath, uri),
-      ).toString();
+      const schemaUri = URI.parse(path.join(project.dirpath, uri)).toString();
       const schemaDocument = this._getCachedDocument(schemaUri);
 
       if (schemaDocument) {
@@ -860,7 +857,7 @@ export class MessageProcessor {
       projectTmpPath = path.join(projectTmpPath, appendPath);
     }
     if (prependWithProtocol) {
-      return pathToFileURL(path.resolve(projectTmpPath)).toString();
+      return URI.parse(path.resolve(projectTmpPath)).toString();
     } else {
       return path.resolve(projectTmpPath);
     }
@@ -1015,7 +1012,7 @@ export class MessageProcessor {
           }
 
           // build full system URI path with protocol
-          const uri = pathToFileURL(filePath).toString();
+          const uri = URI.parse(filePath).toString();
 
           // i would use the already existing graphql-config AST, but there are a few reasons we can't yet
           const contents = this._parser(document.rawSDL, uri);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,10 +5102,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mkdirp@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.1.tgz#0930b948914a78587de35458b86c907b6e98bbf6"
-  integrity sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==
+"@types/mkdirp@^1.0.`1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
+  integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
   dependencies:
     "@types/node" "*"
 
@@ -10784,6 +10784,18 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, gl
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 global-dirs@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.1.0.tgz#e9046a49c806ff04d6c1825e196c8f0091e8df4d"
@@ -11003,16 +11015,16 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.5.5"
+  version "1.5.7"
   dependencies:
     "@graphiql/toolkit" "^0.4.2"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.3"
+    codemirror-graphql "^1.2.4"
     copy-to-clipboard "^3.2.0"
     dset "^3.1.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^3.2.3"
+    graphql-language-service "^3.2.4"
     markdown-it "^12.2.0"
 
 graphql-config@^4.1.0:
@@ -19948,6 +19960,11 @@ vscode-languageserver@^6.1.1:
   integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
   dependencies:
     vscode-languageserver-protocol "^3.15.3"
+
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA==
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## fixing windows and unicode-containing file paths
using the standard `vscode-uri` package, this should fix the parsing of file URIs by `graphql-language-service-server` in cases such as:

- windows without WSL
- special/unicode characters in filenames 
- likely other cases

previously we were using the old approach of `URL(uri).pathname` which was not working! it was url-encoding these characters which is not helping anyone haha

## fixing object and fragment definition cache across OSes

also, when switching back from `fileURLToPath`, we left one case in `GraphQLCache` which may impact how the fragment and object type cache are being loaded with a global file glob. this existing feature has led users to expect fragments and objects to load magically from config without configuration and we will need to change it, but for now we will keep the magic glob from rootDir. this is set from the graphql config rootDir so if that is overridden, it breaks how this cache works. we need in the future for users to specify the files or globs where fragments or object type definitions are contained.

also for #2066 made it so that graphql config is not loaded into the file cache unnecessarily, and that it's only loaded on editor save events rather than on file changed events

fixes #1644 and #2066 and I think also #2071