### PR TITLE
fix: append insertText instead of variable labels

### DIFF
--- a/.changeset/early-clouds-speak.md
+++ b/.changeset/early-clouds-speak.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-interface': patch
+---
+
+fix a potential issue where field(arg: $| in codemirror-graphql might have autocompletion insert of $\$variable because of recent changes to completion for monaco-graphql/vscode-graphql

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "release:canary": "(node scripts/canary-release.js && yarn build && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",
     "repo:fix": "manypkg fix",
-    "start-graphiql": "yarn build:clean && npm-run-all -l -p build dev-graphiql",
+    "start-graphiql": "yarn workspace graphiql dev",
     "start-monaco": "yarn workspace example-monaco-graphql-webpack start",
     "t": "yarn run testonly",
     "test": "yarn jest",

--- a/packages/codemirror-graphql/src/__tests__/hint-test.ts
+++ b/packages/codemirror-graphql/src/__tests__/hint-test.ts
@@ -1087,11 +1087,42 @@ describe('graphql-hint', () => {
       ch: 18,
     });
     expect(suggestions6?.list).toEqual(expectedSuggestions);
+
     const suggestions7 = await getHintSuggestions(
       '{ hasArgs(object: { string ',
       { line: 0, ch: 27 },
     );
     expect(suggestions7?.list).toEqual(expectedSuggestions);
+  });
+  it('provides variable completion for argments', async () => {
+    const expectedSuggestions = getExpectedSuggestions([
+      { text: 'string', type: GraphQLString },
+      { text: 'listString', type: new GraphQLList(GraphQLString) },
+    ]);
+    // kind is Argument, step is 2, and input type isn't GraphQLEnumType or GraphQLBoolean
+    const suggestions9 = await getHintSuggestions(
+      'query myQuery($arg: String){ hasArgs(string: ',
+      {
+        line: 0,
+        ch: 42,
+      },
+    );
+    expect(suggestions9?.list).toEqual(expectedSuggestions);
+  });
+  it('provides variable completion for argments with $', async () => {
+    const expectedSuggestions = getExpectedSuggestions([
+      { text: 'string', type: GraphQLString },
+      { text: 'listString', type: new GraphQLList(GraphQLString) },
+    ]);
+    // kind is Argument, step is 2, and input type isn't GraphQLEnumType or GraphQLBoolean
+    const suggestions9 = await getHintSuggestions(
+      'query myQuery($arg: String){ hasArgs(string: $',
+      {
+        line: 0,
+        ch: 42,
+      },
+    );
+    expect(suggestions9?.list).toEqual(expectedSuggestions);
   });
   it('provides correct field name suggestions for an interface type', async () => {
     const suggestions = await getHintSuggestions(

--- a/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service-interface/src/getAutocompleteSuggestions.ts
@@ -612,10 +612,11 @@ export function getVariableCompletions(
     if (variableName && variableType) {
       if (!definitions[variableName]) {
         // append `$` if the `token.string` is not already `$`
-        const label = token.string === '$' ? variableName : '$' + variableName;
+
         definitions[variableName] = {
           detail: variableType.toString(),
-          label,
+          insertText: token.string === '$' ? variableName : '$' + variableName,
+          label: variableName, // keep label the same for `codemirror-graphql`
           type: variableType,
           kind: CompletionItemKind.Variable,
         } as CompletionItem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,7 +5102,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/mkdirp@^1.0.`1":
+"@types/mkdirp@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.2.tgz#8d0bad7aa793abe551860be1f7ae7f3198c16666"
   integrity sha512-o0K1tSO0Dx5X6xlU5F1D6625FawhC3dU3iqr25lluNv/+/QIVH8RLNEiVokgIZo+mz+87w/3Mkg/VvQS+J51fQ==
@@ -11015,16 +11015,16 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.5.7"
+  version "1.5.8"
   dependencies:
     "@graphiql/toolkit" "^0.4.2"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.4"
+    codemirror-graphql "^1.2.5"
     copy-to-clipboard "^3.2.0"
     dset "^3.1.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^3.2.4"
+    graphql-language-service "^3.2.5"
     markdown-it "^12.2.0"
 
 graphql-config@^4.1.0:


### PR DESCRIPTION
fix a potential issue where field(arg: $| in codemirror-graphql might have autocompletion insert of $\$variable because of recent changes to completion for monaco-graphql/vscode-graphql