### PR TITLE
fix: graphiql introspection bug with <graphql@16 servers

### DIFF
--- a/.changeset/silver-trainers-double.md
+++ b/.changeset/silver-trainers-double.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix issue with introspection in servers which don't support `inputValueDeprecation`. make `inputValueDeprecation` an opt-in prop for DocExplorer features

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -126,6 +126,7 @@ ReactDOM.render(
     onEditOperationName: onEditOperationName,
     headerEditorEnabled: true,
     shouldPersistHeaders: true,
+    inputValueDeprecation: true,
   }),
   document.getElementById('graphiql'),
 );

--- a/packages/graphiql/src/utility/introspectionQueries.ts
+++ b/packages/graphiql/src/utility/introspectionQueries.ts
@@ -5,22 +5,6 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { getIntrospectionQuery } from 'graphql';
-
-export const introspectionQuery = getIntrospectionQuery({
-  schemaDescription: true,
-  inputValueDeprecation: true,
-  specifiedByUrl: true,
-});
-
 export const staticName = 'IntrospectionQuery';
 
 export const introspectionQueryName = staticName;
-
-// Some GraphQL services do not support subscriptions and fail an introspection
-// query which includes the `subscriptionType` field as the stock introspection
-// query does. This backup query removes that field.
-export const introspectionQuerySansSubscriptions = introspectionQuery.replace(
-  'subscriptionType { name }',
-  '',
-);


### PR DESCRIPTION
I think this will fix #2085 

provides a prop for `inputValueDeprecation` when invoking `getIntrospectionQuery()` to avoid causing issues with graphql servers who do not yet support this introspection option