### PR TITLE
use temporary fork of picomatch based on browser support PR

### DIFF
--- a/.changeset/short-toes-whisper.md
+++ b/.changeset/short-toes-whisper.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Fix picomatch bug by using a browser compatible fork

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -35,7 +35,7 @@
     "graphql-language-service-parser": "^1.10.4",
     "graphql-language-service-types": "^1.8.7",
     "graphql-language-service-utils": "^2.7.1",
-    "picomatch": "^2.3.0"
+    "picomatch-browser": "^2.2.5"
   },
   "devDependencies": {
     "@types/picomatch": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11047,16 +11047,16 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.5.11"
+  version "1.5.13"
   dependencies:
     "@graphiql/toolkit" "^0.4.2"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.7"
+    codemirror-graphql "^1.2.8"
     copy-to-clipboard "^3.2.0"
     dset "^3.1.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^4.1.0"
+    graphql-language-service "^4.1.1"
     markdown-it "^12.2.0"
 
 graphql-config@^4.1.0:
@@ -15753,12 +15753,17 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
+picomatch-browser@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/picomatch-browser/-/picomatch-browser-2.2.5.tgz#dde032340731d069289e86164e0e143c7249ff78"
+  integrity sha512-Da/xnHhOtbSVhkayCPL9jcQ1nZBAm0Ylu5KAChEIr3xV/3jqQIAHoIqIEbEB9TKmgbLbV3PsRQ8VC6m74YVoEw==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
-picomatch@^2.2.3, picomatch@^2.3.0:
+picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==


### PR DESCRIPTION
This PR:
https://github.com/micromatch/picomatch/pull/73

introduces browser support for `picomatch`

I created a temporary npm package as a fork of `picomatch` that includes the changes in this PR

`picomatch` works fine with CRA and other common webpack configs, but not so well with vite and some other bunders.

I can confirm that this fixes the issue in vite:

https://stackblitz.com/edit/vitejs-vite-nsepqi?file=src%2Fmain.tsx