### PR TITLE
fix monaco-graphql bug with `_cacheSchemas()`

### DIFF
--- a/.changeset/fuzzy-ants-float.md
+++ b/.changeset/fuzzy-ants-float.md
@@ -1,0 +1,5 @@
+---
+'monaco-graphql': patch
+---
+
+Fix a bug where `_cacheSchemas()` was not being called by the language service

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -64,10 +64,10 @@ export class LanguageService {
     this._schemaLoader = defaultSchemaLoader;
     if (schemas) {
       this._schemas = schemas;
+      this._cacheSchemas();
     }
     if (parser) {
       this._parser = parser;
-      this._cacheSchemas();
     }
 
     if (parseOptions) {


### PR DESCRIPTION
Introduced this slight bug with major impact to `monaco-graphql` last night whilst moving things around. 

**Actual Behavior:**

No language features appear. Schema request completes but the editor doesn't appear to load features.

**Expected behavior:**

Language features should appear

Followup:
Need a basic jest and/or cypress suite for `monaco-graphql` asap! Jest looks difficult with `monaco-editor` from what I've read