### PR TITLE
fix: correctly render new lines for doc explorer description fields

### DIFF
--- a/.changeset/little-glasses-sort.md
+++ b/.changeset/little-glasses-sort.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Correctly render line breaks for Descriptions in Doc Explorer - #2137 - @danielleletarte

--- a/packages/graphiql/src/components/DocExplorer/MarkdownContent.tsx
+++ b/packages/graphiql/src/components/DocExplorer/MarkdownContent.tsx
@@ -11,6 +11,7 @@ import { Maybe } from '../../types';
 
 const md = new MD({
   // render urls as links, à la github-flavored markdown
+  breaks: true,
   linkify: true,
 });
 

--- a/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
@@ -29,6 +29,12 @@ describe('TypeDoc', () => {
         onClickType={jest.fn()}
       />,
     );
+    const description = container.querySelectorAll('.doc-type-description');
+    expect(description).toHaveLength(1);
+    expect(description[0]).toHaveTextContent('Query description\nSecond line', {
+      normalizeWhitespace: false,
+    });
+
     const cats = container.querySelectorAll('.doc-category-item');
     expect(cats[0]).toHaveTextContent('string: String');
     expect(cats[1]).toHaveTextContent('union: exampleUnion');

--- a/packages/graphiql/src/components/__tests__/ExampleSchema.ts
+++ b/packages/graphiql/src/components/__tests__/ExampleSchema.ts
@@ -64,6 +64,7 @@ export const ExampleUnion = new GraphQLUnionType({
 
 export const ExampleQuery = new GraphQLObjectType({
   name: 'Query',
+  description: 'Query description\n Second line',
   fields: {
     string: {
       name: 'exampleString',

--- a/packages/graphiql/test/schema.js
+++ b/packages/graphiql/test/schema.js
@@ -200,7 +200,7 @@ const sleep = async timeout => new Promise(res => setTimeout(res, timeout));
 
 const TestType = new GraphQLObjectType({
   name: 'Test',
-  description: 'Test type for testing',
+  description: 'Test type for testing\n New line works',
   fields: () => ({
     test: {
       type: TestType,


### PR DESCRIPTION
Proposed fix to close #2137 

Issue: Line breaks do not render for descriptions in the Doc Explorer. 