### PR TITLE
build(deps): bump markdown-it from 12.2.0 to 12.3.2

### DIFF
--- a/.changeset/wild-oranges-learn.md
+++ b/.changeset/wild-oranges-learn.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix for a potential ReDOS in newlines in markdown-it package

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -54,7 +54,7 @@
     "entities": "^2.0.0",
     "escape-html": "^1.0.3",
     "graphql-language-service": "^4.1.4",
-    "markdown-it": "^12.2.0"
+    "markdown-it": "^12.3.2"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11257,7 +11257,7 @@ grapheme-splitter@^1.0.4:
     entities "^2.0.0"
     escape-html "^1.0.3"
     graphql-language-service "^4.1.4"
-    markdown-it "^12.2.0"
+    markdown-it "^12.3.2"
 
 graphql-config@^4.1.0:
   version "4.1.0"
@@ -14511,10 +14511,10 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-markdown-it@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.2.0.tgz#091f720fd5db206f80de7a8d1f1a7035fd0d38db"
-  integrity sha512-Wjws+uCrVQRqOoJvze4HCqkKl1AsSh95iFAeQDwnyfxM09divCBSXlDR1uTvyUP3Grzpn4Ru8GeCxYPM8vkCQg==
+markdown-it@^12.3.2:
+  version "12.3.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.3.2.tgz#bf92ac92283fe983fe4de8ff8abfb5ad72cd0c90"
+  integrity sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==
   dependencies:
     argparse "^2.0.1"
     entities "~2.1.0"


### PR DESCRIPTION
Up until version 12.3.2 markdown-it had a possible ReDOS in the newlinerule. This was fixed in this commit markdown-it/markdown-it@ffc49ab.

This updates the minimum version for graphiql to avoid this issue.