### PR TITLE
Improve the document cache miss error message

### DIFF
--- a/.changeset/chilly-birds-poke.md
+++ b/.changeset/chilly-birds-poke.md
@@ -1,0 +1,6 @@
+---
+"graphql-language-service-server": patch
+"graphql-language-service": patch
+---
+
+Do not log errors when a JS/TS file has no embedded graphql tags

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -485,7 +485,7 @@ export class MessageProcessor {
 
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument) {
-      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
+      return [];
     }
 
     const found = cachedDocument.contents.find(content => {
@@ -537,7 +537,7 @@ export class MessageProcessor {
 
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument) {
-      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
+      return { contents: [] };
     }
 
     const found = cachedDocument.contents.find(content => {
@@ -749,26 +749,13 @@ export class MessageProcessor {
     const textDocument = params.textDocument;
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument || !cachedDocument.contents[0]) {
-      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
+      return [];
     }
 
     return this._languageService.getDocumentSymbols(
       cachedDocument.contents[0].query,
       textDocument.uri,
     );
-  }
-
-  _errorMessageForMissingDocument(uri: string): string {
-    const allURIs = Object.keys(this._textDocumentCache);
-    if (allURIs.length === 0) {
-      return `A cached document cannot be found for ${uri}. There are no documents in the cache.`;
-    } else if (allURIs.length > 5) {
-      return `A cached document cannot be found for ${uri}. There are ${
-        allURIs.length
-      } documents in the cache: ${allURIs.join(', ')}`;
-    } else {
-      return `A cached document cannot be found for ${uri}. There are ${allURIs.length} documents in the cache.`;
-    }
   }
 
   // async handleReferencesRequest(params: ReferenceParams): Promise<Location[]> {

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -485,7 +485,7 @@ export class MessageProcessor {
 
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument) {
-      throw new Error('A cached document cannot be found.');
+      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
     }
 
     const found = cachedDocument.contents.find(content => {
@@ -537,7 +537,7 @@ export class MessageProcessor {
 
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument) {
-      throw new Error('A cached document cannot be found.');
+      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
     }
 
     const found = cachedDocument.contents.find(content => {
@@ -749,12 +749,26 @@ export class MessageProcessor {
     const textDocument = params.textDocument;
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument || !cachedDocument.contents[0]) {
-      throw new Error('A cached document cannot be found.');
+      throw new Error(this._errorMessageForMissingDocument(textDocument.uri));
     }
+
     return this._languageService.getDocumentSymbols(
       cachedDocument.contents[0].query,
       textDocument.uri,
     );
+  }
+
+  _errorMessageForMissingDocument(uri: string): string {
+    const allURIs = Object.keys(this._textDocumentCache);
+    if (allURIs.length === 0) {
+      return `A cached document cannot be found for ${uri}. There are no documents in the cache.`;
+    } else if (allURIs.length > 5) {
+      return `A cached document cannot be found for ${uri}. There are ${
+        allURIs.length
+      } documents in the cache: ${allURIs.join(', ')}`;
+    } else {
+      return `A cached document cannot be found for ${uri}. There are ${allURIs.length} documents in the cache.`;
+    }
   }
 
   // async handleReferencesRequest(params: ReferenceParams): Promise<Location[]> {


### PR DESCRIPTION
Helps folks get a bit more insight into what's going on when this error is thrown:

<img width="1053" alt="Screen Shot 2022-02-08 at 1 36 37 PM" src="https://user-images.githubusercontent.com/49038/152998008-ecb496e5-ad87-4e13-9f72-6efee165cb61.png">
 