### PR TITLE
Adds better error messages for unparsable babel files:

### DIFF
--- a/.changeset/ten-pianos-report.md
+++ b/.changeset/ten-pianos-report.md
@@ -1,0 +1,6 @@
+---
+"graphql-language-service-server": patch
+"graphql-language-service": patch
+---
+
+Better handling of unparsable babel JS/TS files

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -127,7 +127,7 @@ export class MessageProcessor {
     this._graphQLConfig = config;
     this._parser = (text, uri) => {
       const p = parser ?? parseDocument;
-      return p(text, uri, fileExtensions, graphqlFileExtensions);
+      return p(text, uri, fileExtensions, graphqlFileExtensions, this._logger);
     };
     this._tmpDir = tmpDir || tmpdir();
     this._tmpDirBase = path.join(this._tmpDir, 'graphql-language-service');

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -623,6 +623,26 @@ export function Example(arg: string) {}`;
     expect(contents.length).toEqual(0);
   });
 
+  it('an unparsable JS/TS file does not throw and bring down the server', async () => {
+    const text = `
+// @flow
+import type randomthing fro 'package';
+import type {B} from 'B';
+im port A from './A';
+
+con  QUERY = randomthing\`
+query Test {
+  test {
+    value
+    ...FragmentsComment
+  }
+}
+\${A.frag`;
+
+    const contents = parseDocument(text, 'test.js');
+    expect(contents.length).toEqual(0);
+  });
+
   describe('handleWatchedFilesChangedNotification', () => {
     const mockReadFileSync: jest.Mock = jest.requireMock('fs').readFileSync;
 

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -3,6 +3,7 @@ import type { CachedContent } from 'graphql-language-service';
 import { Range, Position } from 'graphql-language-service-utils';
 
 import { findGraphQLTags, DEFAULT_TAGS } from './findGraphQLTags';
+import { Logger } from './Logger';
 
 export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.js',
@@ -17,7 +18,7 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
 ];
 
 /**
- * .graphql is the officially reccomended extension for graphql files
+ * .graphql is the officially recommended extension for graphql files
  *
  * .gql and .graphqls are included for compatibility for commonly used extensions
  *
@@ -43,6 +44,7 @@ export function parseDocument(
   uri: string,
   fileExtensions: string[] = DEFAULT_SUPPORTED_EXTENSIONS,
   graphQLFileExtensions: string[] = DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
+  logger: Logger = new Logger(),
 ): CachedContent[] {
   // Check if the text content includes a GraphQLV query.
   // If the text doesn't include GraphQL queries, do not proceed.
@@ -51,7 +53,7 @@ export function parseDocument(
     if (DEFAULT_TAGS.some(t => t === text)) {
       return [];
     }
-    const templates = findGraphQLTags(text, ext);
+    const templates = findGraphQLTags(text, ext, uri, logger);
     return templates.map(({ template, range }) => ({ query: template, range }));
   }
   if (graphQLFileExtensions.some(e => e === ext)) {


### PR DESCRIPTION
I've had vscode-graphql be un-usable for a few days because I have no idea which file is doing this on load:

```sh
[Info  - 4:06:51 PM] Connection to server got closed. Server will restart.
[Info  - 4:06:51 PM] The graphql server has stopped running
[Info  - 4:06:51 PM] The graphql server has stopped running
2/16/2022, 4:06:51 PM [3] (pid: 57218) graphql-language-service-usage-logs: {"type":"usage","messageType":"initialize"}
/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:99551
        const err = new SyntaxError(message);
                    ^

SyntaxError: Unexpected token, expected "," (21:7)
    at Object._raise (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:99551:21)
    at Object.raiseWithData (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:99545:21)
    at Object.raise (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:99512:21)
    at Object.unexpected (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:102147:20)
    at Object.expect (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:102124:32)
    at Object.parseObjectLike (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:109414:18)
    at Object.parseExprAtom (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:108971:25)
    at Object.parseExprAtom (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:105392:24)
    at Object.parseExprSubscripts (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:108718:27)
    at Object.parseUpdate (/Users/ortatherox/.vscode-insiders/extensions/graphql.vscode-graphql-0.3.50/out/server/server.js:108700:25) {
  loc: Position { line: 21, column: 7 },
  pos: 716,
  code: 'BABEL_PARSER_SYNTAX_ERROR',
  reasonCode: 'UnexpectedToken'
}
[Error - 4:06:51 PM] Connection to server got closed. Server will not be restarted.
[Info  - 4:06:51 PM] The graphql server has stopped running
```

Now it would load up, give a few logger error messages and not throw 👍🏻 