### PR TITLE
fix(variable editor): limit height of editor

### DIFF
--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -106,6 +106,7 @@
   display: flex;
   flex-direction: row;
   flex: 1;
+  max-height: 100%;
 }
 
 .graphiql-container .queryWrap {


### PR DESCRIPTION
Added max height 100% to editor bar component

Relevant issue: https://github.com/graphql/graphiql/issues/2074