### PR TITLE
feat: apply variable editor title text via CSS classes instead of inline styles

### DIFF
--- a/.changeset/orange-cups-dress.md
+++ b/.changeset/orange-cups-dress.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+Apply variable editor title text styles via class `variable-editor-title-text` instead of using inline-styles. This allows better customization of styles. An active element also has the class `active`. This allows overriding the inactive state color using the selector `.graphiql-container .variable-editor-title-text` and overriding the active state color using the selector `.graphiql-container .variable-editor-title-text.active`.

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -806,11 +806,9 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   }}
                   onMouseDown={this.handleSecondaryEditorResizeStart}>
                   <div
-                    style={{
-                      cursor: 'pointer',
-                      color: this.state.variableEditorActive ? '#000' : 'gray',
-                      display: 'inline-block',
-                    }}
+                    className={`variable-editor-title-text${
+                      this.state.variableEditorActive ? ' active' : ''
+                    }`}
                     onClick={this.handleOpenVariableEditorTab}
                     onMouseDown={this.handleTabClickPropogation}>
                     {'Query Variables'}
@@ -818,11 +816,11 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                   {this.state.headerEditorEnabled && (
                     <div
                       style={{
-                        cursor: 'pointer',
-                        color: this.state.headerEditorActive ? '#000' : 'gray',
-                        display: 'inline-block',
                         marginLeft: '20px',
                       }}
+                      className={`variable-editor-title-text${
+                        this.state.headerEditorActive ? ' active' : ''
+                      }`}
                       onClick={this.handleOpenHeaderEditorTab}
                       onMouseDown={this.handleTabClickPropogation}>
                       {'Request Headers'}

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -496,6 +496,16 @@ div.CodeMirror-lint-tooltip > * + * {
   margin-top: 12px;
 }
 
+.graphiql-container .variable-editor-title-text {
+  cursor: pointer;
+  display: inline-block;
+  color: gray;
+}
+
+.graphiql-container .variable-editor-title-text.active {
+  color: #000;
+}
+
 /* COLORS */
 
 .graphiql-container .CodeMirror-foldmarker {


### PR DESCRIPTION
Apply variable editor title text styles via class `variable-editor-title-text` instead of using inline-styles. This allows better customization of styles. An active element also has the class `active`. This allows overriding the inactive state color using the selector `.graphiql-container .variable-editor-title-text` and overriding the active state color using the selector `.graphiql-container .variable-editor-title-text.active`.