### PR TITLE
feat: onSchemaChange callback

### DIFF
--- a/.changeset/seven-ties-march.md
+++ b/.changeset/seven-ties-march.md
@@ -1,0 +1,13 @@
+---
+'graphiql': minor
+---
+
+New callback property `onSchemaChange` for `GraphiQL`.
+
+The callback is invoked with the successfully fetched schema from the remote.
+
+**Usage example:**
+
+```tsx
+<GraphiQL onSchemaChange={schema => console.log(schema)} />
+```

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -284,6 +284,10 @@ export type GraphiQLProps = {
    * default: 20
    */
   maxHistoryLength?: number;
+  /**
+   * Callback that is invoked once a remote schema has been fetched.
+   */
+  onSchemaChange?: (schema: GraphQLSchema) => void;
 };
 
 export type GraphiQLState = {
@@ -1120,6 +1124,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
               ...queryFacts,
               schemaErrors: undefined,
             });
+            this.props.onSchemaChange?.(schema);
           }
         } else {
           // handle as if it were an error if the fetcher response is not a string or response.data is not present


### PR DESCRIPTION
This is a proposal for starting the discussion on such an API.

Currently, the only way of having the schema information outside of GraphiQL is to move the logic higher up in the tree and then pass the `GraphQLSchema` instance to `GraphiQL` via the `schema` property.

Having this convenient callback simplifies accessing the schema outside the `GraphiQL` component.