### PR TITLE
feat: allow inserting content before the top bar

### DIFF
--- a/.changeset/blue-jeans-try.md
+++ b/.changeset/blue-jeans-try.md
@@ -1,0 +1,9 @@
+---
+'graphiql': minor
+---
+
+Allow inserting content before the topBar element via the `beforeTopBarContent` property.
+
+```ts
+<GraphiQL beforeTopBarContent={<SomeComponent />} />
+```

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -288,6 +288,10 @@ export type GraphiQLProps = {
    * Callback that is invoked once a remote schema has been fetched.
    */
   onSchemaChange?: (schema: GraphQLSchema) => void;
+  /**
+   * Content to place before the top bar (logo).
+   */
+  beforeTopBarContent?: React.ReactElement | null;
 };
 
 export type GraphiQLState = {
@@ -749,6 +753,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
         )}
         <div className="editorWrap">
           <div className="topBarWrap">
+            {this.props.beforeTopBarContent}
             <div className="topBar">
               {logo}
               <ExecuteButton


### PR DESCRIPTION
This allows inserting content such as the following:

![image](https://user-images.githubusercontent.com/14338007/155096226-2db679c3-eefe-49c8-9ad6-b3587637e888.png)
