### PR TITLE
Add Working Group 9 agenda

### DIFF
--- a/working-group/agendas/2022-03-08.md
+++ b/working-group/agendas/2022-03-08.md
@@ -1,0 +1,29 @@
+# 9th GraphiQL Working Group
+
+- **Video Conference Link:** https://zoom.us/j/760146252
+- **Live Notes:** https://docs.google.com/document/d/1Jz0STnSDiEjFTj6mGzvdjoQ2VR01o5it26GgiBC4j5I/edit?usp=sharing
+- **Date & Time:** [March 8th 2022 16:00 - 18:00 UTC](https://www.timeanddate.com/worldclock/meetingdetails.html?year=2021&month=10&day=12&hour=16&min=0&sec=0&p1=224&p2=179&p3=136&p4=37&p5=239&p6=101&p7=152)
+- **NOTE:** Meeting date and time may change up to a week before the meeting. Please check the agenda the week of the meeting to confirm.
+
+## Attendees
+
+<!-- NOTE: because we expect you to use github UI to do this, we ignore prettier for attendees and agenda section. this will prevent CI breakages. enjoy!-->
+<!-- prettier-ignore-start -->
+
+| Name                 | Organization      | Location            |
+| -------------------- | ----------------- | ------------------- |
+| Tim Suchanek         | GraphCDN          | Berlin, Germany     |
+| ...                  | ....              | ...                 |
+
+
+## Agenda
+
+1. Review v2 design
+2. Decide v2 minimal scope
+3. Plan implementation
+ - Schedule pair programming
+ - Distribute work
+ - What is needed missing from the toolkit?
+4. Plan communication to community
+
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
As the working group happens every month per the [GraphQL Foundation Calendar](https://calendar.google.com/calendar/embed?src=linuxfoundation.org_ik79t9uuj2p32i3r203dgv5mo8@group.calendar.google.com), the next meeting is set for March 8.

Here's a proposed agenda, but of course happy to shuffle things around.
We'd like to present the new GraphiQL v2 design and discuss next steps for the implementation.