### PR TITLE
fix: should not depend on 'global' global variable (#2155)

### DIFF
--- a/.changeset/tasty-pillows-compare.md
+++ b/.changeset/tasty-pillows-compare.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fixed problem where 'global' variable is referenced when it might not be present (#2155)

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -539,7 +539,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     // Utility for keeping CodeMirror correctly sized.
     this.codeMirrorSizer = new CodeMirrorSizer();
 
-    if (typeof global !== undefined) {
+    if (global !== undefined) {
       global.g = this;
     }
   }


### PR DESCRIPTION
This addresses issue: https://github.com/graphql/graphiql/issues/2155

It corrects the fixes made by https://github.com/graphql/graphiql/pull/2166 and https://github.com/graphql/graphiql/pull/2167.

Those PRs changed the code to compare `typeof global` to `undefined` which would always return true, negating the effects my original PR https://github.com/graphql/graphiql/pull/2156 and not resolving the issue (I tested version 1.6.0).