### PR TITLE
style: remove IE7 CSS star property hack

### DIFF
--- a/packages/graphiql/src/css/codemirror.css
+++ b/packages/graphiql/src/css/codemirror.css
@@ -277,9 +277,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
   margin-bottom: -30px;
   vertical-align: top;
   white-space: normal;
-  /* Hack to make IE7 behave */
-  *zoom: 1;
-  *display: inline;
 }
 .CodeMirror-gutter-wrapper {
   background: none !important;
@@ -412,11 +409,6 @@ div.CodeMirror-dragcursors {
 .cm-searching {
   background: #ffa;
   background: rgba(255, 255, 0, 0.4);
-}
-
-/* IE7 hack to prevent it from returning funny offsetTops on the spans */
-.CodeMirror span {
-  *vertical-align: text-bottom;
 }
 
 /* Used to force a border model for a node */


### PR DESCRIPTION
## WHAT
Remove the [star property hack](https://stackoverflow.com/a/14927670/808699) that was for IE 5.5 to 7 from CSS of graphiql.

## WHY
My project uses [`esbuild`](https://esbuild.github.io/). When I build my codes that includes the CSS of graphiql, the following warning occurs.

```
➜ cat node_modules/graphiql/graphiql.css | npx esbuild --loader=css --minify > /dev/null
▲ [WARNING] Expected identifier but found "*"

    <stdin>:844:2:
      844 │   *zoom:1;
          ╵   ^

▲ [WARNING] Expected identifier but found "*"

    <stdin>:845:2:
      845 │   *display:inline;
          ╵   ^

▲ [WARNING] Expected identifier but found "*"

    <stdin>:972:19:
      972 │ .CodeMirror span { *vertical-align: text-bottom; }
          ╵                    ^

3 warnings
```

I think these warnings make sense because this hack is invalid in current browsers.

And I checked `.browserslistrc` of graphiql.
https://github.com/graphql/graphiql/blob/d3e00052cdfbca4912713e9287aa7d636d947c2f/.browserslistrc
It doesn't include IE5.5 ~ IE7, so I thought graphiql claims to not support IE5.5  ~ IE7. 

That's why I opened this PR.
