### PR TITLE
style: remove IE7 CSS star property hack

### DIFF
--- a/.changeset/swift-pumpkins-sort.md
+++ b/.changeset/swift-pumpkins-sort.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+remove IE7 CSS star property hack

--- a/packages/graphiql/src/css/codemirror.css
+++ b/packages/graphiql/src/css/codemirror.css
@@ -277,9 +277,6 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
   margin-bottom: -30px;
   vertical-align: top;
   white-space: normal;
-  /* Hack to make IE7 behave */
-  *zoom: 1;
-  *display: inline;
 }
 .CodeMirror-gutter-wrapper {
   background: none !important;
@@ -412,11 +409,6 @@ div.CodeMirror-dragcursors {
 .cm-searching {
   background: #ffa;
   background: rgba(255, 255, 0, 0.4);
-}
-
-/* IE7 hack to prevent it from returning funny offsetTops on the spans */
-.CodeMirror span {
-  *vertical-align: text-bottom;
 }
 
 /* Used to force a border model for a node */


### PR DESCRIPTION
## WHAT
Remove the [star property hack](https://stackoverflow.com/a/14927670/808699) that was for IE 5.5 to 7 from CSS of graphiql.

## WHY
solve https://github.com/graphql/graphiql/issues/2211