### PR TITLE
fix: fix Windows fileUri to resolve type definition

### DIFF
--- a/.changeset/rare-roses-give.md
+++ b/.changeset/rare-roses-give.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Fixed Windows fileUri when resolving type definition location

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -363,7 +363,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
               // the docs indicate that is what's there :shrug:
               const cacheEntry = globResult.statCache[filePath] as fs.Stats;
               return {
-                filePath: URI.parse(filePath).toString(),
+                filePath: URI.file(filePath).toString(),
                 mtime: Math.trunc(cacheEntry.mtime.getTime() / 1000),
                 size: cacheEntry.size,
               };

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -131,7 +131,7 @@ export class MessageProcessor {
     };
     this._tmpDir = tmpDir || tmpdir();
     this._tmpDirBase = path.join(this._tmpDir, 'graphql-language-service');
-    this._tmpUriBase = URI.parse(this._tmpDirBase).toString();
+    this._tmpUriBase = URI.file(this._tmpDirBase).toString();
     this._loadConfigOptions = loadConfigOptions;
     if (
       loadConfigOptions.extensions &&
@@ -833,7 +833,7 @@ export class MessageProcessor {
     const isFileUri = existsSync(uri);
     let version = 1;
     if (isFileUri) {
-      const schemaUri = URI.parse(path.join(project.dirpath, uri)).toString();
+      const schemaUri = URI.file(path.join(project.dirpath, uri)).toString();
       const schemaDocument = this._getCachedDocument(schemaUri);
 
       if (schemaDocument) {
@@ -859,7 +859,7 @@ export class MessageProcessor {
       projectTmpPath = path.join(projectTmpPath, appendPath);
     }
     if (prependWithProtocol) {
-      return URI.parse(path.resolve(projectTmpPath)).toString();
+      return URI.file(path.resolve(projectTmpPath)).toString();
     } else {
       return path.resolve(projectTmpPath);
     }
@@ -1014,7 +1014,7 @@ export class MessageProcessor {
           }
 
           // build full system URI path with protocol
-          const uri = URI.parse(filePath).toString();
+          const uri = URI.file(filePath).toString();
 
           // i would use the already existing graphql-config AST, but there are a few reasons we can't yet
           const contents = this._parser(document.rawSDL, uri);


### PR DESCRIPTION
Fixes #2212
Use `URI.file` instead of `URI.parse` to convert fs path to fileUri 

I found in some places there's the variable `filePath: Uri` which is a bit confusing because type says it's an Uri, but variable name says it's a path.
