### PR TITLE
fix: Trigger editor update when externalFragments change

### DIFF
--- a/packages/graphiql/src/components/QueryEditor.tsx
+++ b/packages/graphiql/src/components/QueryEditor.tsx
@@ -215,11 +215,23 @@ export class QueryEditor extends React.Component<QueryEditorProps, {}>
     // user-input changes which could otherwise result in an infinite
     // event loop.
     this.ignoreChangeEvent = true;
+    let signalChange = false;
     if (this.props.schema !== prevProps.schema && this.editor) {
       this.editor.options.lint.schema = this.props.schema;
       this.editor.options.hintOptions.schema = this.props.schema;
       this.editor.options.info.schema = this.props.schema;
       this.editor.options.jump.schema = this.props.schema;
+      signalChange = true;
+    }
+    if (
+      this.props.externalFragments !== prevProps.externalFragments &&
+      this.editor
+    ) {
+      this.editor.options.lint.externalFragments = this.props.externalFragments;
+      this.editor.options.hintOptions.externalFragments = this.props.externalFragments;
+      signalChange = true;
+    }
+    if (signalChange) {
       CodeMirror.signal(this.editor, 'change', this.editor);
     }
     if (


### PR DESCRIPTION
Updates codemirror when the `externalFragments` prop changes.

Without this change, GraphiQL must be remounted for any changes to `externalFragments` to take effect.