### PR TITLE
default to es6 target for language service, fix #2240

### DIFF
--- a/packages/graphql-language-service/tsconfig.esm.json
+++ b/packages/graphql-language-service/tsconfig.esm.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./esm",
-    "composite": true,
-    "target": "ESNext"
+    "composite": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]


### PR DESCRIPTION
set `es6` as tsc `target`, instead of `esnext`