### PR TITLE
fix worker creation problem when changing config

### DIFF
--- a/.changeset/brown-eggs-tulip.md
+++ b/.changeset/brown-eggs-tulip.md
@@ -1,0 +1,5 @@
+---
+"monaco-graphql": patch
+---
+
+fix worker + n problem when changing config (schema, etc) in `monaco-graphql`

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -64,7 +64,7 @@ export class WorkerManager {
 
   private async _getClient(): Promise<GraphQLWorker> {
     this._lastUsedTime = Date.now();
-    if (!this._client) {
+    if (!this._client && !this._worker) {
       try {
         this._worker = monacoEditor.createWebWorker<GraphQLWorker>({
           // module that exports the create() method and returns a `GraphQLWorker` instance


### PR DESCRIPTION
In `monaco-graphql`, the language worker is creating a new instance of itself every time the config changes (schema, etc), which isn't how it should be working.

for reference, `monaco-json`'s `workerManager` does not do this, so I wonder if there is something wrong somewhere else.
I checked and made sure that the demos still worked on config changes

CC @cshaver