### PR TITLE
fix `codemirror` import for `onHasCompletion`

### DIFF
--- a/packages/graphiql/src/utility/onHasCompletion.ts
+++ b/packages/graphiql/src/utility/onHasCompletion.ts
@@ -26,7 +26,7 @@ export default function onHasCompletion(
   data: CM.EditorChange | undefined,
   onHintInformationRender: (el: HTMLDivElement) => void,
 ) {
-  import('codemirror').then(CodeMirror => {
+  import('codemirror').then(({ default: CodeMirror }) => {
     let information: HTMLDivElement | null;
     let deprecation: HTMLDivElement | null;
     CodeMirror.on(


### PR DESCRIPTION
Not seeing this in the umd build for whatever reason
https://graphiql-test.netlify.app

however #2263 seems to be occuring for some webpack users, and I suspect this might be a fix?