### PR TITLE
remove dependency on `global`

### DIFF
--- a/.changeset/funny-jokes-divide.md
+++ b/.changeset/funny-jokes-divide.md
@@ -1,0 +1,5 @@
+---
+"graphiql": patch
+---
+
+remove dependency on `global` for esbuild/etc users!

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -89,7 +89,7 @@ if (majorVersion < 16) {
   );
 }
 
-declare namespace global {
+declare namespace window {
   export let g: GraphiQL;
 }
 
@@ -640,8 +640,8 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
     // Utility for keeping CodeMirror correctly sized.
     this.codeMirrorSizer = new CodeMirrorSizer();
 
-    if (typeof global !== undefined) {
-      global.g = this;
+    if (typeof window !== 'undefined') {
+      window.g = this;
     }
   }
   UNSAFE_componentWillMount() {


### PR DESCRIPTION
a proper working fix for #2155
this use of `global` will be removed for 2.0.x, it only remains for legacy support