### PR TITLE
enable `react/jsx-curly-brace-presence` rule and remove `react/jsx-no-literals` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,10 +34,10 @@ module.exports = {
   },
 
   extends: [
-    'prettier',
     'plugin:import/typescript',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
+    'prettier',
   ],
 
   globals: {
@@ -275,11 +275,11 @@ module.exports = {
     'prefer-object-spread/prefer-object-spread': 1,
 
     // react rules
+    'react/jsx-curly-brace-presence': 'error',
     'react/jsx-boolean-value': 'error',
     'react/jsx-handler-names': 'error',
     'react/jsx-key': 'error',
     'react/jsx-no-duplicate-props': 'error',
-    'react/jsx-no-literals': 'error',
     'react/jsx-no-undef': 'error',
     'react/jsx-pascal-case': 'error',
     'react/jsx-uses-react': 'error',

--- a/examples/graphiql-webpack/src/index.jsx
+++ b/examples/graphiql-webpack/src/index.jsx
@@ -3,7 +3,7 @@ import { render } from 'react-dom';
 import GraphiQL from 'graphiql';
 import 'graphiql/graphiql.css';
 
-const Logo = () => <span>{'My Corp'}</span>;
+const Logo = () => <span>My Corp</span>;
 
 // See GraphiQL Readme - Advanced Usage section for more examples like this
 GraphiQL.Logo = Logo;

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer.tsx
@@ -88,7 +88,7 @@ export class DocExplorer extends React.Component<
     } else if (!schema) {
       // Schema is null when it explicitly does not exist, typically due to
       // an error during introspection.
-      content = <div className="error-container">{'No Schema Available'}</div>;
+      content = <div className="error-container">No Schema Available</div>;
     } else if (navItem.search) {
       content = (
         <SearchResults

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer/FieldDoc.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer/FieldDoc.tsx
@@ -22,7 +22,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
   if (field && 'args' in field && field.args.length > 0) {
     argsDef = (
       <div className="doc-category">
-        <div className="doc-category-title">{'arguments'}</div>
+        <div className="doc-category-title">arguments</div>
         {field.args.map((arg: GraphQLArgument) => (
           <div key={arg.name} className="doc-category-item">
             <div>
@@ -51,7 +51,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
         />
       )}
       <div className="doc-category">
-        <div className="doc-category-title">{'type'}</div>
+        <div className="doc-category-title">type</div>
         <TypeLink type={field?.type} onClick={onClickType} />
       </div>
       {argsDef}

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer/SchemaDoc.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer/SchemaDoc.tsx
@@ -27,27 +27,25 @@ export default function SchemaDoc({ schema, onClickType }: SchemaDocProps) {
     <div>
       <MarkdownContent
         className="doc-type-description"
-        markdown={
-          'A GraphQL schema provides a root type for each kind of operation.'
-        }
+        markdown="A GraphQL schema provides a root type for each kind of operation."
       />
       <div className="doc-category">
-        <div className="doc-category-title">{'root types'}</div>
+        <div className="doc-category-title">root types</div>
         <div className="doc-category-item">
-          <span className="keyword">{'query'}</span>
+          <span className="keyword">query</span>
           {': '}
           <TypeLink type={queryType} onClick={onClickType} />
         </div>
         {mutationType && (
           <div className="doc-category-item">
-            <span className="keyword">{'mutation'}</span>
+            <span className="keyword">mutation</span>
             {': '}
             <TypeLink type={mutationType} onClick={onClickType} />
           </div>
         )}
         {subscriptionType && (
           <div className="doc-category-item">
-            <span className="keyword">{'subscription'}</span>
+            <span className="keyword">subscription</span>
             {': '}
             <TypeLink type={subscriptionType} onClick={onClickType} />
           </div>

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer/SearchResults.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer/SearchResults.tsx
@@ -128,7 +128,7 @@ export default class SearchResults extends React.Component<
       matchedWithin.length + matchedTypes.length + matchedFields.length ===
       0
     ) {
-      return <span className="doc-alert-text">{'No results found.'}</span>;
+      return <span className="doc-alert-text">No results found.</span>;
     }
 
     if (withinType && matchedTypes.length + matchedFields.length > 0) {
@@ -136,7 +136,7 @@ export default class SearchResults extends React.Component<
         <div>
           {matchedWithin}
           <div className="doc-category">
-            <div className="doc-category-title">{'other results'}</div>
+            <div className="doc-category-title">other results</div>
             {matchedTypes}
             {matchedFields}
           </div>

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer/TypeDoc.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer/TypeDoc.tsx
@@ -91,7 +91,7 @@ export default class TypeDoc extends React.Component<
       const fields = Object.keys(fieldMap).map(name => fieldMap[name]);
       fieldsDef = (
         <div className="doc-category">
-          <div className="doc-category-title">{'fields'}</div>
+          <div className="doc-category-title">fields</div>
           {fields
             .filter(field =>
               'isDeprecated' in field ? !field.isDeprecated : true,
@@ -114,10 +114,10 @@ export default class TypeDoc extends React.Component<
       if (deprecatedFields.length > 0) {
         deprecatedFieldsDef = (
           <div className="doc-category">
-            <div className="doc-category-title">{'deprecated fields'}</div>
+            <div className="doc-category-title">deprecated fields</div>
             {!this.state.showDeprecated ? (
               <button className="show-btn" onClick={this.handleShowDeprecated}>
-                {'Show deprecated fields...'}
+                Show deprecated fields...
               </button>
             ) : (
               deprecatedFields.map(field => (
@@ -141,7 +141,7 @@ export default class TypeDoc extends React.Component<
       const values = type.getValues();
       valuesDef = (
         <div className="doc-category">
-          <div className="doc-category-title">{'values'}</div>
+          <div className="doc-category-title">values</div>
           {values
             .filter(value => !value.isDeprecated)
             .map(value => (
@@ -154,10 +154,10 @@ export default class TypeDoc extends React.Component<
       if (deprecatedValues.length > 0) {
         deprecatedValuesDef = (
           <div className="doc-category">
-            <div className="doc-category-title">{'deprecated values'}</div>
+            <div className="doc-category-title">deprecated values</div>
             {!this.state.showDeprecated ? (
               <button className="show-btn" onClick={this.handleShowDeprecated}>
-                {'Show deprecated values...'}
+                Show deprecated values...
               </button>
             ) : (
               deprecatedValues.map(value => (

--- a/packages/graphiql-2-rfc-context/src/components/DocExplorer/TypeLink.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/DocExplorer/TypeLink.tsx
@@ -28,21 +28,10 @@ export default function TypeLink(props: TypeLinkProps) {
 
 function renderType(type: Maybe<GraphQLType>, onClick: OnClickTypeFunction) {
   if (type instanceof GraphQLNonNull) {
-    return (
-      <span>
-        {renderType(type.ofType, onClick)}
-        {'!'}
-      </span>
-    );
+    return <span>{renderType(type.ofType, onClick)}!</span>;
   }
   if (type instanceof GraphQLList) {
-    return (
-      <span>
-        {'['}
-        {renderType(type.ofType, onClick)}
-        {']'}
-      </span>
-    );
+    return <span>[{renderType(type.ofType, onClick)}]</span>;
   }
   return (
     <a

--- a/packages/graphiql-2-rfc-context/src/components/GraphiQL.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/GraphiQL.tsx
@@ -265,7 +265,7 @@ class GraphiQLInternals extends React.Component<
       //   onMouseDown={this.handleResizeStart}>
       //   <div className="queryWrap" style={queryWrapStyle}>
       <section aria-label="Operation Editor">
-        <SessionTabs tabs={[`Operation`, `Explorer`]} name={`operation`}>
+        <SessionTabs tabs={[`Operation`, `Explorer`]} name="operation">
           <QueryEditor
             onHintInformationRender={this.handleHintInformationRender}
             onClickReference={this.handleClickReference}
@@ -273,14 +273,14 @@ class GraphiQLInternals extends React.Component<
             readOnly={this.props.readOnly}
             editorOptions={this.props.operationEditorOptions}
           />
-          <div>{`Explorer`}</div>
+          <div>Explorer</div>
         </SessionTabs>
       </section>
     );
 
     const variables = (
       <section aria-label="Query Variables">
-        <SessionTabs tabs={[`Variables`, `Console`]} name={`variables`}>
+        <SessionTabs tabs={[`Variables`, `Console`]} name="variables">
           <VariableEditor
             onHintInformationRender={this.handleHintInformationRender}
             onPrettifyQuery={this.handlePrettifyQuery}
@@ -289,7 +289,7 @@ class GraphiQLInternals extends React.Component<
             readOnly={this.props.readOnly}
             editorOptions={this.props.variablesEditorOptions}
           />
-          <div>{`Console`}</div>
+          <div>Console</div>
         </SessionTabs>
       </section>
     );
@@ -298,7 +298,7 @@ class GraphiQLInternals extends React.Component<
       <section aria-label="Response Editor">
         <SessionTabs
           tabs={[`Response`, `Extensions`, `Playground`]}
-          name={`results`}>
+          name="results">
           <>
             {this.state.isWaitingForResponse && (
               <div className="spinner-container">
@@ -311,8 +311,8 @@ class GraphiQLInternals extends React.Component<
             />
             {footer}
           </>
-          <div>{`Extensions`}</div>
-          <div>{`Playground`}</div>
+          <div>Extensions</div>
+          <div>Playground</div>
         </SessionTabs>
       </section>
     );
@@ -747,9 +747,9 @@ function GraphiQLLogo<TProps>(props: PropsWithChildren<TProps>) {
     <div className="title">
       {props.children || (
         <span>
-          {'Graph'}
-          <em>{'i'}</em>
-          {'QL'}
+          Graph
+          <em>i</em>
+          QL
         </span>
       )}
     </div>

--- a/packages/graphiql-2-rfc-context/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/__tests__/GraphiQL.spec.tsx
@@ -366,7 +366,7 @@ describe('GraphiQL', () => {
       it('can be overridden using the exported type', () => {
         const { container } = render(
           <GraphiQL fetcher={noOpFetcher}>
-            <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>
+            <GraphiQL.Logo>My Great Logo</GraphiQL.Logo>
           </GraphiQL>,
         );
 
@@ -376,9 +376,7 @@ describe('GraphiQL', () => {
       });
 
       it('can be overridden using a named component', () => {
-        const WrappedLogo = wrap(
-          <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>,
-        );
+        const WrappedLogo = wrap(<GraphiQL.Logo>My Great Logo</GraphiQL.Logo>);
         WrappedLogo.displayName = 'GraphiQLLogo';
 
         const { getByText } = render(

--- a/packages/graphiql-2-rfc-context/src/components/common/Layout.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Layout.stories.tsx
@@ -17,17 +17,17 @@ import Logo from './Logo';
 const explorer = {
   input: (
     <List>
-      <ListRow>{'Input'}</ListRow>
+      <ListRow>Input</ListRow>
     </List>
   ),
   response: (
     <List>
-      <ListRow>{'Response'}</ListRow>
+      <ListRow>Response</ListRow>
     </List>
   ),
   console: (
     <List>
-      <ListRow>{'Console/Inspector'}</ListRow>
+      <ListRow>Console/Inspector</ListRow>
     </List>
   ),
 };
@@ -36,9 +36,9 @@ const nav = (
     <NavItem label="Schema">
       <Logo size="1em" />
     </NavItem>
-    <NavItem label="Pig’s nose">{'🐽'}</NavItem>
-    <NavItem label="Farmer">{'👨‍🌾'}</NavItem>
-    <NavItem label="Bee">{'🐝'}</NavItem>
+    <NavItem label="Pig’s nose">🐽</NavItem>
+    <NavItem label="Farmer">👨‍🌾</NavItem>
+    <NavItem label="Bee">🐝</NavItem>
   </Nav>
 );
 const slots = { nav, explorer };
@@ -61,7 +61,7 @@ export const WithManySidebars = () => {
           size: 'sidebar',
           component: (
             <List>
-              <ListRow>{'Sidebar'}</ListRow>
+              <ListRow>Sidebar</ListRow>
             </List>
           ),
         },
@@ -70,7 +70,7 @@ export const WithManySidebars = () => {
           size: 'aside',
           component: (
             <List>
-              <ListRow>{'aside'}</ListRow>
+              <ListRow>aside</ListRow>
             </List>
           ),
         },
@@ -79,7 +79,7 @@ export const WithManySidebars = () => {
           size: 'aside',
           component: (
             <List>
-              <ListRow>{'Another aside'}</ListRow>
+              <ListRow>Another aside</ListRow>
             </List>
           ),
         },
@@ -99,7 +99,7 @@ export const WithFullScreenPanel = () => {
           size: 'full-screen',
           component: (
             <List>
-              <ListRow>{'Woooo'}</ListRow>
+              <ListRow>Woooo</ListRow>
             </List>
           ),
         },

--- a/packages/graphiql-2-rfc-context/src/components/common/List/List.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/List/List.stories.tsx
@@ -22,15 +22,14 @@ export const WithFlexChild = () => (
     <List>
       <ListRow padding>
         <div>
-          {
-            'Lists are a vertical stack of components and form the basis of most modules. This one is very long'
-          }
+          Lists are a vertical stack of components and form the basis of most
+          modules. This one is very long
         </div>
       </ListRow>
       <ListRow padding flex>
-        {'You normally want 1 flex area that grows forever like this one'}
+        You normally want 1 flex area that grows forever like this one
         {longText}
-        {'the end'}
+        the end
       </ListRow>
     </List>
   </div>
@@ -39,17 +38,17 @@ export const WithFlexChild = () => (
 export const WithStackedRows = () => (
   <div style={{ height: '100vh', display: 'grid' }}>
     <List>
-      <ListRow padding>{'Title'}</ListRow>
-      <ListRow padding>{'Navigation'}</ListRow>
-      <ListRow padding>{'Search'}</ListRow>
-      <ListRow padding>{'Filter'}</ListRow>
+      <ListRow padding>Title</ListRow>
+      <ListRow padding>Navigation</ListRow>
+      <ListRow padding>Search</ListRow>
+      <ListRow padding>Filter</ListRow>
       <ListRow padding flex>
-        {'Actual content'}
+        Actual content
         {longText}
-        {'Actual content ends here'}
+        Actual content ends here
       </ListRow>
-      <ListRow padding>{'Footer'}</ListRow>
-      <ListRow padding>{'Footers footer'}</ListRow>
+      <ListRow padding>Footer</ListRow>
+      <ListRow padding>Footers footer</ListRow>
     </List>
   </div>
 );

--- a/packages/graphiql-2-rfc-context/src/components/common/Nav.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Nav.stories.tsx
@@ -21,8 +21,8 @@ export const NavBar = () => (
     <NavItem label="Schema">
       <Logo size="1em" />
     </NavItem>
-    <NavItem label="Pig’s nose">{'🐽'}</NavItem>
-    <NavItem label="Farmer">{'👨‍🌾'}</NavItem>
-    <NavItem label="Bee">{'🐝'}</NavItem>
+    <NavItem label="Pig’s nose">🐽</NavItem>
+    <NavItem label="Farmer">👨‍🌾</NavItem>
+    <NavItem label="Bee">🐝</NavItem>
   </Nav>
 );

--- a/packages/graphiql-2-rfc-context/src/components/common/Resizer/Resizer.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Resizer/Resizer.stories.tsx
@@ -17,6 +17,6 @@ export const resizer = () => (
   <Resizer
     border="bottom"
     handlerStyle={{ backgroundColor: 'rgba(0, 0, 0, 0.2)' }}>
-    <main>{`Main content`}</main>
+    <main>Main content</main>
   </Resizer>
 );

--- a/packages/graphiql-2-rfc-context/src/components/common/Toolbar/Tabs.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Toolbar/Tabs.stories.tsx
@@ -33,9 +33,9 @@ export const Tabbar = () => (
   <List>
     <ListRow>
       <ManagedTabs tabs={['One', 'Two', 'Three']}>
-        <p>{'One'}</p>
-        <p>{'Two'}</p>
-        <p>{'Three'}</p>
+        <p>One</p>
+        <p>Two</p>
+        <p>Three</p>
       </ManagedTabs>
     </ListRow>
     <ListRow>
@@ -46,20 +46,20 @@ export const Tabbar = () => (
           'nested',
           <>
             {'Component '}
-            <small style={{ background: 'yellow', padding: 3 }}>{'2'}</small>
+            <small style={{ background: 'yellow', padding: 3 }}>2</small>
           </>,
         ]}>
-        <p>{'With'}</p>
-        <p>{'a'}</p>
-        <p>{'nested'}</p>
-        <p>{'component'}</p>
+        <p>With</p>
+        <p>a</p>
+        <p>nested</p>
+        <p>component</p>
       </ManagedTabs>
     </ListRow>
     <ListRow flex>
       <div style={{ height: '100px', display: 'grid' }}>
         <ManagedTabs tabs={['Very tall', 'tabs']}>
-          <p>{'a'}</p>
-          <p>{'b'}</p>
+          <p>a</p>
+          <p>b</p>
         </ManagedTabs>
       </div>
     </ListRow>

--- a/packages/graphiql-2-rfc-context/src/components/common/Toolbar/Toolbar.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Toolbar/Toolbar.stories.tsx
@@ -18,36 +18,38 @@ export default { title: 'Toolbar', decorators: [layout] };
 export const Basic = () => (
   <List>
     <ListRow padding>
-      <p>{`Toolbars group together widgets in a flexbox. You can cutomize what type of
-      justification to use and if elements go together it'll add dividers
-      between them`}</p>
+      <p>
+        Toolbars group together widgets in a flexbox. You can customize what
+        type of justification to use and if elements go together it&apos;ll add
+        dividers between them
+      </p>
     </ListRow>
     <ListRow>
       <Toolbar justifyContent="center">
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
       </Toolbar>
     </ListRow>
     <ListRow>
       <Toolbar justifyContent="flex-start">
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
       </Toolbar>
     </ListRow>
     <ListRow>
       <Toolbar justifyContent="flex-end">
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
       </Toolbar>
     </ListRow>
     <ListRow>
       <Toolbar justifyContent="space-between">
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
-        <Content>{'Some text'}</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
+        <Content>Some text</Content>
       </Toolbar>
     </ListRow>
   </List>
@@ -57,7 +59,8 @@ export const ToolbarWithTabs = () => (
   <List>
     <ListRow padding>
       <p>
-        {`The dividers don't nest so if you have tabs inside a toolbar the tabs won't get dividers`}
+        The dividers don&apos;t nest so if you have tabs inside a toolbar the
+        tabs won&apos;t get dividers
       </p>
     </ListRow>
     <ListRow>

--- a/packages/graphiql-2-rfc-context/src/components/common/Type.stories.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/common/Type.stories.tsx
@@ -18,11 +18,11 @@ export default { title: 'Type', decorators: [layout] };
 export const type = () => (
   <List>
     <ListRow padding>
-      <SectionHeader>{'Title'}</SectionHeader>
+      <SectionHeader>Title</SectionHeader>
     </ListRow>
     <ListRow padding>
-      <Explainer>{'Small explainer text'}</Explainer>
+      <Explainer>Small explainer text</Explainer>
     </ListRow>
-    <ListRow padding>{'Normal text'}</ListRow>
+    <ListRow padding>Normal text</ListRow>
   </List>
 );

--- a/packages/graphiql/src/components/DocExplorer.tsx
+++ b/packages/graphiql/src/components/DocExplorer.tsx
@@ -81,9 +81,7 @@ export class DocExplorer extends React.Component<
 
     let content;
     if (schemaErrors) {
-      content = (
-        <div className="error-container">{'Error fetching schema'}</div>
-      );
+      content = <div className="error-container">Error fetching schema</div>;
     } else if (schema === undefined) {
       // Schema is undefined when it is being loaded via introspection.
       content = (
@@ -94,7 +92,7 @@ export class DocExplorer extends React.Component<
     } else if (!schema) {
       // Schema is null when it explicitly does not exist, typically due to
       // an error during introspection.
-      content = <div className="error-container">{'No Schema Available'}</div>;
+      content = <div className="error-container">No Schema Available</div>;
     } else if (navItem.search) {
       content = (
         <SearchResults

--- a/packages/graphiql/src/components/DocExplorer/Directive.tsx
+++ b/packages/graphiql/src/components/DocExplorer/Directive.tsx
@@ -15,8 +15,7 @@ type DirectiveProps = {
 export default function Directive({ directive }: DirectiveProps) {
   return (
     <span className="doc-category-item" id={directive.name.value}>
-      {'@'}
-      {directive.name.value}
+      @{directive.name.value}
     </span>
   );
 }

--- a/packages/graphiql/src/components/DocExplorer/FieldDoc.tsx
+++ b/packages/graphiql/src/components/DocExplorer/FieldDoc.tsx
@@ -25,7 +25,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
   if (field && 'args' in field && field.args.length > 0) {
     argsDef = (
       <div id="doc-args" className="doc-category">
-        <div className="doc-category-title">{'arguments'}</div>
+        <div className="doc-category-title">arguments</div>
         {field.args
           .filter(arg => !arg.deprecationReason)
           .map((arg: GraphQLArgument) => (
@@ -53,12 +53,12 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
     if (deprecatedArgs.length > 0) {
       deprecatedArgsDef = (
         <div id="doc-deprecated-args" className="doc-category">
-          <div className="doc-category-title">{'deprecated arguments'}</div>
+          <div className="doc-category-title">deprecated arguments</div>
           {!showDeprecated ? (
             <button
               className="show-btn"
               onClick={() => handleShowDeprecated(!showDeprecated)}>
-              {'Show deprecated arguments...'}
+              Show deprecated arguments...
             </button>
           ) : (
             deprecatedArgs.map((arg, i) => (
@@ -93,7 +93,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
   ) {
     directivesDef = (
       <div id="doc-directives" className="doc-category">
-        <div className="doc-category-title">{'directives'}</div>
+        <div className="doc-category-title">directives</div>
         {field.astNode.directives.map((directive: DirectiveNode) => (
           <div key={directive.name.value} className="doc-category-item">
             <div>
@@ -118,7 +118,7 @@ export default function FieldDoc({ field, onClickType }: FieldDocProps) {
         />
       )}
       <div className="doc-category">
-        <div className="doc-category-title">{'type'}</div>
+        <div className="doc-category-title">type</div>
         <TypeLink type={field?.type} onClick={onClickType} />
       </div>
       {argsDef}

--- a/packages/graphiql/src/components/DocExplorer/SchemaDoc.tsx
+++ b/packages/graphiql/src/components/DocExplorer/SchemaDoc.tsx
@@ -33,22 +33,22 @@ export default function SchemaDoc({ schema, onClickType }: SchemaDocProps) {
         }
       />
       <div className="doc-category">
-        <div className="doc-category-title">{'root types'}</div>
+        <div className="doc-category-title">root types</div>
         <div className="doc-category-item">
-          <span className="keyword">{'query'}</span>
+          <span className="keyword">query</span>
           {': '}
           <TypeLink type={queryType} onClick={onClickType} />
         </div>
         {mutationType && (
           <div className="doc-category-item">
-            <span className="keyword">{'mutation'}</span>
+            <span className="keyword">mutation</span>
             {': '}
             <TypeLink type={mutationType} onClick={onClickType} />
           </div>
         )}
         {subscriptionType && (
           <div className="doc-category-item">
-            <span className="keyword">{'subscription'}</span>
+            <span className="keyword">subscription</span>
             {': '}
             <TypeLink type={subscriptionType} onClick={onClickType} />
           </div>

--- a/packages/graphiql/src/components/DocExplorer/SearchResults.tsx
+++ b/packages/graphiql/src/components/DocExplorer/SearchResults.tsx
@@ -128,7 +128,7 @@ export default class SearchResults extends React.Component<
       matchedWithin.length + matchedTypes.length + matchedFields.length ===
       0
     ) {
-      return <span className="doc-alert-text">{'No results found.'}</span>;
+      return <span className="doc-alert-text">No results found.</span>;
     }
 
     if (withinType && matchedTypes.length + matchedFields.length > 0) {
@@ -136,7 +136,7 @@ export default class SearchResults extends React.Component<
         <div>
           {matchedWithin}
           <div className="doc-category">
-            <div className="doc-category-title">{'other results'}</div>
+            <div className="doc-category-title">other results</div>
             {matchedTypes}
             {matchedFields}
           </div>

--- a/packages/graphiql/src/components/DocExplorer/TypeDoc.tsx
+++ b/packages/graphiql/src/components/DocExplorer/TypeDoc.tsx
@@ -91,7 +91,7 @@ export default class TypeDoc extends React.Component<
       const fields = Object.keys(fieldMap).map(name => fieldMap[name]);
       fieldsDef = (
         <div id="doc-fields" className="doc-category">
-          <div className="doc-category-title">{'fields'}</div>
+          <div className="doc-category-title">fields</div>
           {fields
             .filter(field => !field.deprecationReason)
             .map(field => (
@@ -112,10 +112,10 @@ export default class TypeDoc extends React.Component<
       if (deprecatedFields.length > 0) {
         deprecatedFieldsDef = (
           <div id="doc-deprecated-fields" className="doc-category">
-            <div className="doc-category-title">{'deprecated fields'}</div>
+            <div className="doc-category-title">deprecated fields</div>
             {!this.state.showDeprecated ? (
               <button className="show-btn" onClick={this.handleShowDeprecated}>
-                {'Show deprecated fields...'}
+                Show deprecated fields...
               </button>
             ) : (
               deprecatedFields.map(field => (
@@ -139,7 +139,7 @@ export default class TypeDoc extends React.Component<
       const values = type.getValues();
       valuesDef = (
         <div className="doc-category">
-          <div className="doc-category-title">{'values'}</div>
+          <div className="doc-category-title">values</div>
           {values
             .filter(value => Boolean(!value.deprecationReason))
             .map(value => (
@@ -154,10 +154,10 @@ export default class TypeDoc extends React.Component<
       if (deprecatedValues.length > 0) {
         deprecatedValuesDef = (
           <div className="doc-category">
-            <div className="doc-category-title">{'deprecated values'}</div>
+            <div className="doc-category-title">deprecated values</div>
             {!this.state.showDeprecated ? (
               <button className="show-btn" onClick={this.handleShowDeprecated}>
-                {'Show deprecated values...'}
+                Show deprecated values...
               </button>
             ) : (
               deprecatedValues.map(value => (

--- a/packages/graphiql/src/components/DocExplorer/TypeLink.tsx
+++ b/packages/graphiql/src/components/DocExplorer/TypeLink.tsx
@@ -28,21 +28,10 @@ export default function TypeLink(props: TypeLinkProps) {
 
 function renderType(type: Maybe<GraphQLType>, onClick: OnClickTypeFunction) {
   if (type instanceof GraphQLNonNull) {
-    return (
-      <span>
-        {renderType(type.ofType, onClick)}
-        {'!'}
-      </span>
-    );
+    return <span>{renderType(type.ofType, onClick)}!</span>;
   }
   if (type instanceof GraphQLList) {
-    return (
-      <span>
-        {'['}
-        {renderType(type.ofType, onClick)}
-        {']'}
-      </span>
-    );
+    return <span>[{renderType(type.ofType, onClick)}]</span>;
   }
   return (
     <a

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -644,9 +644,11 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
       window.g = this;
     }
   }
+
   UNSAFE_componentWillMount() {
     this.componentIsMounted = false;
   }
+
   // TODO: these values should be updated in a reducer imo
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps: GraphiQLProps) {
@@ -911,7 +913,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                 className="docExplorerShow"
                 onClick={this.handleToggleDocs}
                 aria-label="Open Documentation Explorer">
-                {'Docs'}
+                Docs
               </button>
             )}
           </div>
@@ -987,7 +989,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                     }`}
                     onClick={this.handleOpenVariableEditorTab}
                     onMouseDown={this.handleTabClickPropogation}>
-                    {'Query Variables'}
+                    Query Variables
                   </div>
                   {this.state.headerEditorEnabled && (
                     <div
@@ -999,7 +1001,7 @@ export class GraphiQL extends React.Component<GraphiQLProps, GraphiQLState> {
                       }`}
                       onClick={this.handleOpenHeaderEditorTab}
                       onMouseDown={this.handleTabClickPropogation}>
-                      {'Request Headers'}
+                      Request Headers
                     </div>
                   )}
                 </div>
@@ -2144,14 +2146,15 @@ function GraphiQLLogo<TProps>(props: PropsWithChildren<TProps>) {
     <div className="title">
       {props.children || (
         <span>
-          {'Graph'}
-          <em>{'i'}</em>
-          {'QL'}
+          Graph
+          <em>i</em>
+          QL
         </span>
       )}
     </div>
   );
 }
+
 GraphiQLLogo.displayName = 'GraphiQLLogo';
 
 // Configure the UI by providing this Component as a child of GraphiQL.
@@ -2162,12 +2165,14 @@ function GraphiQLToolbar<TProps>(props: PropsWithChildren<TProps>) {
     </div>
   );
 }
+
 GraphiQLToolbar.displayName = 'GraphiQLToolbar';
 
 // Configure the UI by providing this Component as a child of GraphiQL.
 function GraphiQLFooter<TProps>(props: PropsWithChildren<TProps>) {
   return <div className="footer">{props.children}</div>;
 }
+
 GraphiQLFooter.displayName = 'GraphiQLFooter';
 
 const defaultQuery = `# Welcome to GraphiQL

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -110,7 +110,7 @@ export class QueryHistory extends React.Component<
     return (
       <section aria-label="History">
         <div className="history-title-bar">
-          <div className="history-title">{'History'}</div>
+          <div className="history-title">History</div>
           <div className="doc-explorer-rhs">{this.props.children}</div>
         </div>
         <ul className="history-contents">{queryNodes}</ul>

--- a/packages/graphiql/src/components/Tabs.tsx
+++ b/packages/graphiql/src/components/Tabs.tsx
@@ -53,7 +53,7 @@ export function Tab(props: TabProps): React.ReactElement {
 export function TabAddButton(props: { onClick: () => void }) {
   return (
     <button onClick={props.onClick} className="tab-add" title="Create new tab">
-      <span>{'+'}</span>
+      <span>+</span>
     </button>
   );
 }

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -76,12 +76,14 @@ describe('GraphiQL', () => {
 
   it('should refetch schema with new fetcher', async () => {
     let firstCalled = false;
+
     function firstFetcher() {
       firstCalled = true;
       return Promise.resolve(simpleIntrospection);
     }
 
     let secondCalled = false;
+
     function secondFetcher() {
       secondCalled = true;
       return Promise.resolve(simpleIntrospection);
@@ -399,7 +401,7 @@ describe('GraphiQL', () => {
       it('can be overridden using the exported type', () => {
         const { container } = render(
           <GraphiQL fetcher={noOpFetcher}>
-            <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>
+            <GraphiQL.Logo>My Great Logo</GraphiQL.Logo>
           </GraphiQL>,
         );
 
@@ -409,9 +411,7 @@ describe('GraphiQL', () => {
       });
 
       it('can be overridden using a named component', () => {
-        const WrappedLogo = wrap(
-          <GraphiQL.Logo>{'My Great Logo'}</GraphiQL.Logo>,
-        );
+        const WrappedLogo = wrap(<GraphiQL.Logo>My Great Logo</GraphiQL.Logo>);
         WrappedLogo.displayName = 'GraphiQLLogo';
 
         const { getByText } = render(


### PR DESCRIPTION
It's anti-practice in React as it's unnecessary JSX expressions and provokes confusing