### PR TITLE
use patched vsce

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prepublishOnly": "./scripts/prepublish.sh",
     "pretty": "node scripts/pretty.js",
     "pretty-check": "node scripts/pretty.js --check",
-    "release": "yarn build && yarn build-bundles && yarn changeset publish && wsrun publish",
+    "release": "yarn build && yarn build-bundles && yarn changeset publish && wsrun release",
     "release:canary": "(node scripts/canary-release.js && yarn build && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",
     "repo:fix": "manypkg fix",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -239,9 +239,9 @@
     "compile": "npm run compile:server && esbuild ./dist/extension.js --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "compile:server": "esbuild ./dist/server/index.js --bundle --outfile=out/server/server.js --external:vscode --format=cjs --platform=node",
     "build-bundles": "npm run compile -- --sourcemap",
-    "vsce:package": "vsce package",
+    "vsce:package": "vsce package --yarn",
     "env:source": "export $(cat .envrc | xargs)",
-    "vsce:publish": "vsce publish",
+    "vsce:publish": "vsce publish --yarn",
     "open-vsx:publish": "ovsx publish -p \"$OPEN_VSX_ACCESS_TOKEN\"",
     "release": "npm run vsce:publish && npm run open-vsx:publish"
   },
@@ -250,7 +250,7 @@
     "@types/vscode": "1.62.0",
     "esbuild": "0.13.15",
     "ovsx": "0.3.0",
-    "vsce": "2.6.7"
+    "vsce-yarn-patch": "^1.66.2"
   },
   "dependencies": {
     "graphql": "16.0.0-experimental-stream-defer.5",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -243,7 +243,7 @@
     "env:source": "export $(cat .envrc | xargs)",
     "vsce:publish": "vsce publish",
     "open-vsx:publish": "ovsx publish -p \"$OPEN_VSX_ACCESS_TOKEN\"",
-    "publish": "npm run vsce:publish && npm run open-vsx:publish"
+    "release": "npm run vsce:publish && npm run open-vsx:publish"
   },
   "devDependencies": {
     "@types/capitalize": "2.0.0",

--- a/packages/vscode-graphql/yarn.lock
+++ b/packages/vscode-graphql/yarn.lock
@@ -1,0 +1,2 @@
+// EMPTY ON PURPOSE, see
+// https://github.com/microsoft/vscode-vsce/issues/300


### PR DESCRIPTION
This sucks, we have to use an older and patched version of vsce because of yarn workspaces :/


https://github.com/microsoft/vscode-vsce/issues/300