### PR TITLE
more vscode-graphql migration

### DIFF
--- a/packages/vscode-graphql/.vscodeignore
+++ b/packages/vscode-graphql/.vscodeignore
@@ -1,0 +1,12 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+out/**/*.map
+src/**
+.gitignore
+tsconfig.json
+vsc-extension-quickstart.md
+tslint.json
+node_modules
+.github
+renovate.json

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -242,7 +242,7 @@
     "vsce:package": "vsce package --yarn",
     "env:source": "export $(cat .envrc | xargs)",
     "vsce:publish": "vsce publish --yarn --pat \"$PAT_TOKEN\"",
-    "open-vsx:publish": "ovsx publish -p \"$OPEN_VSX_ACCESS_TOKEN\"",
+    "open-vsx:publish": "ovsx publish --pat \"$OPEN_VSX_ACCESS_TOKEN\"",
     "release": "npm run vsce:publish && npm run open-vsx:publish"
   },
   "devDependencies": {


### PR DESCRIPTION
* we forgot `.vscodeignore` so the extension is publishing HUGE now
* open vsix requires full `--pat` argument now?