### PR TITLE
Update tsconfig.esm.json to not target ESNext

### DIFF
--- a/.changeset/chilled-pillows-warn.md
+++ b/.changeset/chilled-pillows-warn.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service': patch
+'graphql-language-service-cli': patch
+---
+
+Target es6 for the languages services

--- a/packages/graphql-language-service/tsconfig.esm.json
+++ b/packages/graphql-language-service/tsconfig.esm.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./esm",
-    "composite": true,
-    "target": "ESNext"
+    "composite": true
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]


### PR DESCRIPTION
I believe #2247 was supposed to fix this, but that change does not seem to be in the main branch.

Closes #2240