### PR TITLE
fix: move @codemirror packages to peer deps, upgrade to 0.20.0

### DIFF
--- a/.changeset/sixty-squids-peel.md
+++ b/.changeset/sixty-squids-peel.md
@@ -1,0 +1,5 @@
+---
+'codemirror-graphql': minor
+---
+
+Moved @codemirror/language to peer dependencies and upgraded to 0.20.0

--- a/examples/cm6-graphql-parcel/package.json
+++ b/examples/cm6-graphql-parcel/package.json
@@ -22,8 +22,8 @@
     ]
   },
   "dependencies": {
-    "@codemirror/basic-setup": "^0.19.0",
-    "@codemirror/stream-parser": "^0.19.2",
+    "@codemirror/basic-setup": "^0.20.0",
+    "@codemirror/language": "^0.20.0",
     "codemirror-graphql": "file:../../packages/codemirror-graphql",
     "graphql": "16.0.0-experimental-stream-defer.5",
     "typescript": "^4.1.3"

--- a/examples/cm6-graphql-parcel/src/index.ts
+++ b/examples/cm6-graphql-parcel/src/index.ts
@@ -1,15 +1,11 @@
 import { EditorState, EditorView, basicSetup } from '@codemirror/basic-setup';
-import { StreamLanguage } from '@codemirror/stream-parser';
+import { StreamLanguage } from '@codemirror/language';
 import { graphql } from 'codemirror-graphql/cm6-legacy/mode';
 import query from './sample-query';
 
 const state = EditorState.create({
   doc: query,
-  extensions: [
-    basicSetup,
-    StreamLanguage.define(graphql),
-    // javascript(),
-  ],
+  extensions: [basicSetup, StreamLanguage.define(graphql)],
 });
 
 const view = new EditorView({

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -41,14 +41,15 @@
     "postbuild": "node ../../scripts/renameFileExtensions.js './esm/{**,!**/__tests__/}/*.js' . .esm.js"
   },
   "peerDependencies": {
+    "@codemirror/language": "^0.20.0",
     "codemirror": "^5.58.2",
     "graphql": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
-    "@codemirror/stream-parser": "^0.19.2",
     "graphql-language-service": "^5.0.3"
   },
   "devDependencies": {
+    "@codemirror/language": "^0.20.0",
     "codemirror": "^5.58.2",
     "cross-env": "^7.0.2",
     "graphql": "16.0.0-experimental-stream-defer.5",

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@codemirror/language": "^0.20.0",
-    "codemirror": "^5.58.2",
+    "codemirror": "^5.65.3",
     "graphql": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@codemirror/language": "^0.20.0",
-    "codemirror": "^5.58.2",
+    "codemirror": "^5.65.3",
     "cross-env": "^7.0.2",
     "graphql": "16.0.0-experimental-stream-defer.5",
     "jsdom": "^16.4.0",

--- a/packages/codemirror-graphql/src/cm6-legacy/mode.ts
+++ b/packages/codemirror-graphql/src/cm6-legacy/mode.ts
@@ -1,4 +1,4 @@
-import type { StreamParser } from '@codemirror/stream-parser';
+import type { StreamParser } from '@codemirror/language';
 import graphqlModeFactory from '../utils/mode-factory';
 
 // Types of property 'token' are incompatible.

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@graphiql/toolkit": "^0.4.3",
-    "codemirror": "^5.58.2",
+    "codemirror": "^5.65.3",
     "codemirror-graphql": "^1.2.17",
     "copy-to-clipboard": "^3.2.0",
     "set-value": "^4.1.0",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.4.0",
     "@testing-library/react": "9.4.1",
-    "@types/codemirror": "^5.58.2",
+    "@types/codemirror": "^5.60.5",
     "@types/escape-html": "^1.0.1",
     "@types/markdown-it": "^12.2.3",
     "@types/node": "^14.14.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3973,68 +3973,28 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@codemirror/highlight@^0.19.0":
-  version "0.19.6"
-  resolved "https://registry.yarnpkg.com/@codemirror/highlight/-/highlight-0.19.6.tgz#7f2e066f83f5649e8e0748a3abe0aaeaf64b8ac2"
-  integrity sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==
+"@codemirror/language@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-0.20.0.tgz#959967901e780c1612934cf5d6df3d7b7e5bf9f0"
+  integrity sha512-lPsF5Y2ZFd5lZ9+7HXTxu57Po3dms3+7q2iAffzrbis2wyJo0lzi/j2312EKStEzwd0pGGpvrUk2dEd333N2jw==
   dependencies:
-    "@codemirror/language" "^0.19.0"
-    "@codemirror/rangeset" "^0.19.0"
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/view" "^0.19.0"
-    "@lezer/common" "^0.15.0"
-    style-mod "^4.0.0"
+    "@codemirror/state" "^0.20.0"
+    "@codemirror/view" "^0.20.0"
+    "@lezer/common" "^0.16.0"
+    "@lezer/highlight" "^0.16.0"
+    "@lezer/lr" "^0.16.0"
 
-"@codemirror/language@^0.19.0":
-  version "0.19.5"
-  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-0.19.5.tgz#4d816ce3f72974ad443cbf1a18ff4fcd1e56f1d0"
-  integrity sha512-FnIST07vaM99mv1mJaMMLvxiHSDGgP3wdlcEZzmidndWdbxjrYYYnJzVUOEkeZJNGOfrtPRMF62UCyrTjQMR3g==
+"@codemirror/state@^0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.20.0.tgz#3343d209169813b0152b77361cd78bea01549a73"
+  integrity sha512-R3XrAWCS5Xm9lx+4pDET4EUPEg+8bDfAa5zoOFIhx+VChsfew9Vy33dAjCXS5ES4Q8UecW4WM4UudmUFpZ+86A==
+
+"@codemirror/view@^0.20.0":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.20.1.tgz#071f192b2586e3122f1b8b2a9edcd06709a31e9d"
+  integrity sha512-DpTtg/w4LxgYmEYq67LY4k7ZDRJ97ppeQVg0+VsUi7CqHjfedi3zmjiUq9gA9is5DKIpGARDKyHigslpw3cX5w==
   dependencies:
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/text" "^0.19.0"
-    "@codemirror/view" "^0.19.0"
-    "@lezer/common" "^0.15.5"
-    "@lezer/lr" "^0.15.0"
-
-"@codemirror/rangeset@^0.19.0":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/rangeset/-/rangeset-0.19.2.tgz#d7a999e4273c00fecef4aba8535a426073cdcddf"
-  integrity sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==
-  dependencies:
-    "@codemirror/state" "^0.19.0"
-
-"@codemirror/state@^0.19.0", "@codemirror/state@^0.19.3":
-  version "0.19.6"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-0.19.6.tgz#d631f041d39ce41b7891b099fca26cb1fdb9763e"
-  integrity sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==
-  dependencies:
-    "@codemirror/text" "^0.19.0"
-
-"@codemirror/stream-parser@^0.19.2":
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/@codemirror/stream-parser/-/stream-parser-0.19.2.tgz#793428e55aa7b9daa64cb733973e5d5e3d9a2306"
-  integrity sha512-hBKRQlyu8GUOrY33xZ6/1kAfNZ8ZUm6cX9a7mPx8zAAqnpz/fpksC/qJRrkg1mPMBwxm+JG4fqAwDGJ3gLVniQ==
-  dependencies:
-    "@codemirror/highlight" "^0.19.0"
-    "@codemirror/language" "^0.19.0"
-    "@codemirror/state" "^0.19.0"
-    "@codemirror/text" "^0.19.0"
-    "@lezer/common" "^0.15.0"
-    "@lezer/lr" "^0.15.0"
-
-"@codemirror/text@^0.19.0":
-  version "0.19.5"
-  resolved "https://registry.yarnpkg.com/@codemirror/text/-/text-0.19.5.tgz#75033af2476214e79eae22b81ada618815441c18"
-  integrity sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow==
-
-"@codemirror/view@^0.19.0":
-  version "0.19.20"
-  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-0.19.20.tgz#77969ff93cb097e3d4c9245b32e220efb80131be"
-  integrity sha512-j4cI/Egdhha77pMfKQQWZmpkcF7vhe21LqdZs8hsG09OtvsPVCHUXmfB0u7nMpcX1JR8aZ3ob9g6FMr+OVtjgA==
-  dependencies:
-    "@codemirror/rangeset" "^0.19.0"
-    "@codemirror/state" "^0.19.3"
-    "@codemirror/text" "^0.19.0"
+    "@codemirror/state" "^0.20.0"
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
@@ -4915,17 +4875,24 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lezer/common@^0.15.0", "@lezer/common@^0.15.5":
-  version "0.15.8"
-  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-0.15.8.tgz#e9d87b5f05c18feb51b7f04d74b124caea32a94b"
-  integrity sha512-zpS/xty48huX4uBidupmWDYCRBYpVtoTiFhzYhd6GsQwU67WsdSImdWzZJDrF/DhcQ462wyrZahHlo2grFB5ig==
+"@lezer/common@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-0.16.0.tgz#b6023a0a682b0b7676d0e7f0e0838f71bde39fcd"
+  integrity sha512-H6sPCku+asKWYaNjwfQ1Uvcay9UP1Pdzu4qpy8GtRZ0cKT2AAGnj9MQGiRtY18MDntvhYRJxNGv7FNWOSV/e8A==
 
-"@lezer/lr@^0.15.0":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-0.15.4.tgz#634670d7224040fddac1370af01211eecd9ac0a0"
-  integrity sha512-vwgG80sihEGJn6wJp6VijXrnzVai/KPva/OzYKaWvIx0IiXKjoMQ8UAwcgpSBwfS4Fbz3IKOX/cCNXU3r1FvpQ==
+"@lezer/highlight@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-0.16.0.tgz#95f7b7ee3c32c8a0f6ce499c085e8b1f927ffbdc"
+  integrity sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==
   dependencies:
-    "@lezer/common" "^0.15.0"
+    "@lezer/common" "^0.16.0"
+
+"@lezer/lr@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-0.16.0.tgz#6b93014421033e7eada163adb8ff1e73440f7995"
+  integrity sha512-LIybGnsodKxscxiBcx24fX9mazEjJG5I295mdOUb5BGNGk4B9xyMYBUgB6uErIUttHQmfgAzPzfdZVRrcCgaHQ==
+  dependencies:
+    "@lezer/common" "^0.16.0"
 
 "@manypkg/cli@^0.17.0":
   version "0.17.0"
@@ -12537,15 +12504,15 @@ grapheme-splitter@^1.0.4:
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
 "graphiql@file:packages/graphiql":
-  version "1.8.5"
+  version "1.8.7"
   dependencies:
     "@graphiql/toolkit" "^0.4.3"
     codemirror "^5.58.2"
-    codemirror-graphql "^1.2.16"
+    codemirror-graphql "^1.2.17"
     copy-to-clipboard "^3.2.0"
     entities "^2.0.0"
     escape-html "^1.0.3"
-    graphql-language-service "^5.0.2"
+    graphql-language-service "^5.0.3"
     markdown-it "^12.2.0"
     set-value "^4.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5977,7 +5977,7 @@
   dependencies:
     "@types/tern" "*"
 
-"@types/codemirror@^5.58.2":
+"@types/codemirror@^5.60.5":
   version "5.60.5"
   resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.5.tgz#5b989a3b4bbe657458cf372c92b6bfda6061a2b7"
   integrity sha512-TiECZmm8St5YxjFUp64LK0c8WU5bxMDt9YaAek1UqUb9swrSCoJhh92fWu1p3mTEqlHjhB5sY7OFBhWroJXZVg==
@@ -8986,10 +8986,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@^5.58.2:
-  version "5.58.2"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.58.2.tgz#ed54a1796de1498688bea1cdd4e9eeb187565d1b"
-  integrity sha512-K/hOh24cCwRutd1Mk3uLtjWzNISOkm4fvXiMO7LucCrqbh6aJDdtqUziim3MZUI6wOY0rvY1SlL1Ork01uMy6w==
+codemirror@^5.65.3:
+  version "5.65.3"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.65.3.tgz#2d029930d5a293bc5fb96ceea64654803c0d4ac7"
+  integrity sha512-kCC0iwGZOVZXHEKW3NDTObvM7pTIyowjty4BUqeREROc/3I6bWbgZDA3fGDwlA+rbgRjvnRnfqs9SfXynel1AQ==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -12507,7 +12507,7 @@ grapheme-splitter@^1.0.4:
   version "1.8.7"
   dependencies:
     "@graphiql/toolkit" "^0.4.3"
-    codemirror "^5.58.2"
+    codemirror "^5.65.3"
     codemirror-graphql "^1.2.17"
     copy-to-clipboard "^3.2.0"
     entities "^2.0.0"


### PR DESCRIPTION
It looks like when [CodeMirror 6 support](https://github.com/graphql/graphiql/issues/2022) was [first added](https://github.com/graphql/graphiql/pull/2035) to the `codemirror-graphql` package, `@codemirror/stream-parser` was mistakenly added as a regular dependency rather than a peer dependency (unlike the CM5 `codemirror` package).

This may lead to conflicts when upgrading upstream CM6 packages in a project that depends on this package (especially when upgrading major/minor versions) since you end up with multiple versions of core packages like `@codemirror/view` which leads to bugs. This is especially relevant as there is now a new release for each of the core CodeMirror packages ([`0.20.0`](https://discuss.codemirror.net/t/release-0-20-0/4302)).

This PR moves `@codemirror/` packages to `peerDependencies` and upgrades the CM6 packages to the latest version in the new release. Note that I remove `@codemirror/stream-parser` in favor of `@codemirror/language` as per the release notes linked above.