### PR TITLE
fix babel config for webpack build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -29,5 +29,9 @@ module.exports = {
       compact: false,
     },
   },
-  plugins: [require.resolve('@babel/plugin-proposal-class-properties')],
+  plugins: [
+    require.resolve('@babel/plugin-proposal-class-properties'),
+    require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+    require.resolve('@babel/plugin-proposal-optional-chaining'),
+  ],
 };


### PR DESCRIPTION
We had [a very strange `babel-loader` failure](https://github.com/graphql/graphiql/runs/6245830017?check_suite_focus=true#step:5:53) in a PR today, which appears to be caused by some kind of regression in an upstream babel dependency. Perhaps should consider pinning dev dependencies. When we move to vite as proposed #2371, we will be removing babel