### PR TITLE
prevent display of "unexpected EOF" parser errors in diagnostics

### DIFF
--- a/.changeset/moody-oranges-move.md
+++ b/.changeset/moody-oranges-move.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Stop reporting unnecessary EOF errors when authoring new queries

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -123,7 +123,7 @@ export class GraphQLLanguageService {
     let documentHasExtensions = false;
     const projectConfig = this.getConfigForURI(uri);
     // skip validation when there's nothing to validate, prevents noisy unexpected EOF errors
-    if (!projectConfig || !document || document.trim().length < 4) {
+    if (!projectConfig || !document || document.trim().length < 2) {
       return [];
     }
     const { schema: schemaPath, name: projectName, extensions } = projectConfig;

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -114,23 +114,24 @@ export class GraphQLLanguageService {
   }
 
   public async getDiagnostics(
-    query: string,
+    document: string,
     uri: Uri,
     isRelayCompatMode?: boolean,
   ): Promise<Array<Diagnostic>> {
     // Perform syntax diagnostics first, as this doesn't require
     // schema/fragment definitions, even the project configuration.
-    let queryHasExtensions = false;
+    let documentHasExtensions = false;
     const projectConfig = this.getConfigForURI(uri);
-    if (!projectConfig) {
+    // skip validation when there's nothing to validate, prevents noisy unexpected EOF errors
+    if (!projectConfig || !document || document.trim().length < 4) {
       return [];
     }
     const { schema: schemaPath, name: projectName, extensions } = projectConfig;
 
     try {
-      const queryAST = parse(query);
+      const documentAST = parse(document);
       if (!schemaPath || uri !== schemaPath) {
-        queryHasExtensions = queryAST.definitions.some(definition => {
+        documentHasExtensions = documentAST.definitions.some(definition => {
           switch (definition.kind) {
             case OBJECT_TYPE_DEFINITION:
             case INTERFACE_TYPE_DEFINITION:
@@ -152,7 +153,7 @@ export class GraphQLLanguageService {
         });
       }
     } catch (error) {
-      const range = getRange(error.locations[0], query);
+      const range = getRange(error.locations[0], document);
       return [
         {
           severity: DIAGNOSTIC_SEVERITY.Error,
@@ -164,13 +165,13 @@ export class GraphQLLanguageService {
     }
 
     // If there's a matching config, proceed to prepare to run validation
-    let source = query;
+    let source = document;
     const fragmentDefinitions = await this._graphQLCache.getFragmentDefinitions(
       projectConfig,
     );
 
     const fragmentDependencies = await this._graphQLCache.getFragmentDependencies(
-      query,
+      document,
       fragmentDefinitions,
     );
 
@@ -204,7 +205,7 @@ export class GraphQLLanguageService {
     }
     const schema = await this._graphQLCache.getSchema(
       projectName,
-      queryHasExtensions,
+      documentHasExtensions,
     );
 
     if (!schema) {

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
@@ -93,6 +93,25 @@ describe('GraphQLLanguageService', () => {
     );
   });
 
+  it('avoids reporting validation errors when not enough characters are present', async () => {
+    const diagnostics = await languageService.getDiagnostics(
+      ' \n   \n typ\n\n',
+      './queries/testQuery.graphql',
+    );
+    expect(diagnostics.length).toEqual(0);
+  });
+
+  it('still reports errors on empty anonymous op', async () => {
+    const diagnostics = await languageService.getDiagnostics(
+      ' \n   {\n  \n}\n\n',
+      './queries/testQuery.graphql',
+    );
+    expect(diagnostics.length).toEqual(1);
+    expect(diagnostics[0].message).toEqual(
+      'Syntax Error: Expected Name, found "}".',
+    );
+  });
+
   it('runs definition service as expected', async () => {
     const definitionQueryResult = await languageService.getDefinition(
       'type Query { hero(episode: Episode): Character }',

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
@@ -95,7 +95,7 @@ describe('GraphQLLanguageService', () => {
 
   it('avoids reporting validation errors when not enough characters are present', async () => {
     const diagnostics = await languageService.getDiagnostics(
-      ' \n   \n typ\n\n',
+      ' \n   \n  \n\n',
       './queries/testQuery.graphql',
     );
     expect(diagnostics.length).toEqual(0);

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -60,7 +60,7 @@ export class GraphQLWorker {
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
-      if (!document || document.trim().length < 4) {
+      if (!document) {
         return [];
       }
       const graphQLPosition = toGraphQLPosition(position);

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -60,8 +60,7 @@ export class GraphQLWorker {
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
-      if (!document) {
-        console.log('no document');
+      if (!document || document.trim().length < 4) {
         return [];
       }
       const graphQLPosition = toGraphQLPosition(position);

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -229,7 +229,7 @@ export class LanguageService {
     customRules?: ValidationRule[],
   ) => {
     const schema = this.getSchemaForFile(uri);
-    if (!documentText || documentText.length < 1 || !schema?.schema) {
+    if (!documentText || documentText.trim().length < 2 || !schema?.schema) {
       return [];
     }
     return getDiagnostics(


### PR DESCRIPTION
**Current Behavior:**

The lsp server shows useless validation errors for empty graphql strings

**Expected Behavior:**

Ignore newlines and whitespace

**Details:**

the last release eliminated parse errors that would actually crash the server - these were my mistake, oops!

this fixes another annoying, non-useful parse error that is often seen when authoring a new operation

this should work in most cases, except for cases where there are only comments and no actual graphql types, but it's hard to come up with an efficient pass. this takes care of this bug, when authoring graphql and your cursor is here:

```ts
gql`|`
```

or with newlines:
```ts
gql`
|
`
```

or with whitespace & newlines:

```ts
gql`
  |
`
```

or something as short as:

```ts

typ

```

where op validation doesn't need to kick in yet.