### PR TITLE
fix(types): components that accept children should declare this

### DIFF
--- a/.changeset/brave-dots-guess.md
+++ b/.changeset/brave-dots-guess.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Add 'children' type definition to various component props

--- a/packages/graphiql-2-rfc-context/src/components/GraphiQL.tsx
+++ b/packages/graphiql-2-rfc-context/src/components/GraphiQL.tsx
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React, { ComponentType, PropsWithChildren } from 'react';
+import React, { ComponentType, PropsWithChildren, ReactNode } from 'react';
 import { GraphQLSchema, OperationDefinitionNode, GraphQLType } from 'graphql';
 
 import type { SchemaConfig } from 'graphql-language-service';
@@ -94,6 +94,7 @@ export type GraphiQLProps = {
   variablesEditorOptions?: monaco.editor.IStandaloneEditorConstructionOptions;
   operationEditorOptions?: monaco.editor.IStandaloneEditorConstructionOptions;
   resultsEditorOptions?: monaco.editor.IStandaloneEditorConstructionOptions;
+  children?: ReactNode;
 } & Partial<Formatters>;
 
 export type GraphiQLState = {

--- a/packages/graphiql/src/components/DocExplorer.tsx
+++ b/packages/graphiql/src/components/DocExplorer.tsx
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { GraphQLSchema, isType, GraphQLNamedType, GraphQLError } from 'graphql';
 import { FieldType } from './DocExplorer/types';
 
@@ -30,6 +30,7 @@ const initialNav: NavStackItem = {
 type DocExplorerProps = {
   schema?: GraphQLSchema | null;
   schemaErrors?: readonly GraphQLError[];
+  children?: ReactNode;
 };
 
 type DocExplorerState = {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -11,6 +11,7 @@ import React, {
   MouseEventHandler,
   Component,
   FunctionComponent,
+  ReactNode,
 } from 'react';
 import {
   buildClientSchema,
@@ -309,6 +310,8 @@ export type GraphiQLProps = {
          */
         onTabChange?: (tab: TabsState) => void;
       };
+
+  children?: ReactNode;
 };
 
 export type GraphiQLState = {

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { QueryStoreItem } from '../utility/QueryStore';
 import HistoryQuery, {
   HandleEditLabelFn,
@@ -24,6 +24,7 @@ type QueryHistoryProps = {
   onSelectQuery: HandleSelectQueryFn;
   storage: StorageAPI;
   maxHistoryLength: number;
+  children?: ReactNode;
 };
 
 type QueryHistoryState = {

--- a/packages/graphiql/src/components/ToolbarMenu.tsx
+++ b/packages/graphiql/src/components/ToolbarMenu.tsx
@@ -5,11 +5,12 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React, { FC, MouseEventHandler } from 'react';
+import React, { FC, MouseEventHandler, ReactNode } from 'react';
 
 type ToolbarMenuProps = {
   title: string;
   label: string;
+  children?: ReactNode;
 };
 
 type ToolbarMenuState = {

--- a/packages/graphiql/src/components/ToolbarSelect.tsx
+++ b/packages/graphiql/src/components/ToolbarSelect.tsx
@@ -5,12 +5,13 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React, { MouseEventHandler } from 'react';
+import React, { MouseEventHandler, ReactNode } from 'react';
 
 type ToolbarSelectProps = {
   title?: string;
   label?: string;
   onSelect?: (selection: string) => void;
+  children?: ReactNode;
 };
 
 type ToolbarSelectState = {


### PR DESCRIPTION
The React components that accept children should declare as much as a prerequisite for compatibility with React 18, see:

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210