### PR TITLE
fix(css): use pointer-events:none on Menu dropdown SVG

### DIFF
--- a/.changeset/sweet-ants-knock.md
+++ b/.changeset/sweet-ants-knock.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Add 'pointer-events: none' to SVG style for dropdown arrow in GraphiQL.Menu component

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -289,6 +289,7 @@
   width: 34px;
 }
 
+.graphiql-container .toolbar-button > svg,
 .graphiql-container .execute-button svg {
   pointer-events: none;
 }


### PR DESCRIPTION
In React 18 the event handling has changed, I believe this is why in React 18 clicking on the specific arrow on the Menu results in no action (whereas clicking the rest of the button works fine). This is easily solved with the `pointer-events: none` CSS trick for the SVG as used elsewhere.