### PR TITLE
fix vscode publishing with changesets

### DIFF
--- a/.changeset/happy-kangaroos-taste.md
+++ b/.changeset/happy-kangaroos-taste.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql': patch
+---
+
+Release `vscode-graphql` changes since publishing was broken

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -220,7 +220,7 @@
     "env:source": "export $(cat .envrc | xargs)",
     "vsce:publish": "vsce publish --yarn --pat \"$PAT_TOKEN\"",
     "open-vsx:publish": "ovsx publish --pat \"$OPEN_VSX_ACCESS_TOKEN\"",
-    "postpublish": "npm run vsce:publish && npm run open-vsx:publish"
+    "postversion": "npm run vsce:publish && npm run open-vsx:publish"
   },
   "devDependencies": {
     "@types/capitalize": "2.0.0",


### PR DESCRIPTION
This gets `vscode-graphql` publishing properly in concert with `changesets`.

When the workspace is marked `private: true`, we can't expect `postpublish` to fire, but `postversion` should!