### PR TITLE
fix bad changeset and avoid warnings

### DIFF
--- a/.changeset/hungry-colts-raise.md
+++ b/.changeset/hungry-colts-raise.md
@@ -1,8 +1,5 @@
 ---
-'example-graphiql-webpack': patch
-'example-monaco-graphql-webpack': patch
 'graphiql': patch
-'graphiql-2-rfc-context': patch
 ---
 
 upgrade to React v17

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -9,11 +9,11 @@
     "start": "cross-env NODE_ENV=development webpack-dev-server"
   },
   "dependencies": {
-    "graphiql": "file:../../packages/graphiql",
-    "@graphiql/toolkit": "file:../../packages/graphiql-toolkit",
+    "@graphiql/toolkit": "^0.4.4",
+    "graphiql": "^1.8.9",
     "graphql": "^16.4.0",
-    "react": "17.0.2",
-    "graphql-ws": "^5.5.5"
+    "graphql-ws": "^5.5.5",
+    "react": "^17.0.2"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3573,12 +3573,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@graphiql/toolkit@file:packages/graphiql-toolkit":
-  version "0.4.4"
-  dependencies:
-    "@n1ru4l/push-pull-async-iterable-iterator" "^3.1.0"
-    meros "^1.1.4"
-
 "@graphql-tools/batch-execute@8.4.2":
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.4.2.tgz#9cd05c9bcb0eb29435547ea5fae202d4c6f2ecb7"
@@ -12160,19 +12154,6 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
 
-"graphiql@file:packages/graphiql":
-  version "1.8.9"
-  dependencies:
-    "@graphiql/toolkit" "^0.4.4"
-    codemirror "^5.65.3"
-    codemirror-graphql "^1.3.0"
-    copy-to-clipboard "^3.2.0"
-    entities "^2.0.0"
-    escape-html "^1.0.3"
-    graphql-language-service "^5.0.4"
-    markdown-it "^12.2.0"
-    set-value "^4.1.0"
-
 graphql-config@^4.1.0, graphql-config@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-4.3.0.tgz#b9bb7bf9c892a90e66ea937e8d7ed170eb1fd5e2"
@@ -18625,7 +18606,7 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.2, react@^17.0.2:
+react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
I added a bad changeset in #2397 that contained ignored packages. This currently breaks the `release` workflow: https://github.com/graphql/graphiql/runs/6395880044?check_suite_focus=true

I also changed the dependencies in the webpack example to avoid the warnings printed above the error.