### PR TITLE
move more reusable logic into toolkit package

### DIFF
--- a/.changeset/rude-singers-tap.md
+++ b/.changeset/rude-singers-tap.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/toolkit': patch
+---
+
+move async helper functions and formatting functions over into the @graphiql/toolkit package

--- a/.changeset/wise-maps-divide.md
+++ b/.changeset/wise-maps-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+deprecate the unused `shouldPersistHeaders` property from fetcher options to be removed in the next major version

--- a/packages/graphiql-toolkit/src/async-helpers/index.ts
+++ b/packages/graphiql-toolkit/src/async-helpers/index.ts
@@ -1,0 +1,89 @@
+import {
+  FetcherResult,
+  FetcherReturnType,
+  Observable,
+} from '../create-fetcher';
+
+// Duck-type promise detection.
+export function isPromise<T>(value: Promise<T> | any): value is Promise<T> {
+  return typeof value === 'object' && typeof value.then === 'function';
+}
+
+// Duck-type Observable.take(1).toPromise()
+function observableToPromise<T>(observable: Observable<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const subscription = observable.subscribe({
+      next: v => {
+        resolve(v);
+        subscription.unsubscribe();
+      },
+      error: reject,
+      complete: () => {
+        reject(new Error('no value resolved'));
+      },
+    });
+  });
+}
+
+// Duck-type observable detection.
+export function isObservable<T>(value: any): value is Observable<T> {
+  return (
+    typeof value === 'object' &&
+    'subscribe' in value &&
+    typeof value.subscribe === 'function'
+  );
+}
+
+export function isAsyncIterable(
+  input: unknown,
+): input is AsyncIterable<unknown> {
+  return (
+    typeof input === 'object' &&
+    input !== null &&
+    // Some browsers still don't have Symbol.asyncIterator implemented (iOS Safari)
+    // That means every custom AsyncIterable must be built using a AsyncGeneratorFunction (async function * () {})
+    ((input as any)[Symbol.toStringTag] === 'AsyncGenerator' ||
+      Symbol.asyncIterator in input)
+  );
+}
+
+function asyncIterableToPromise<T>(
+  input: AsyncIterable<T> | AsyncIterableIterator<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    // Also support AsyncGenerator on Safari iOS.
+    // As mentioned in the isAsyncIterable function there is no Symbol.asyncIterator available
+    // so every AsyncIterable must be implemented using AsyncGenerator.
+    const iteratorReturn = ('return' in input
+      ? input
+      : input[Symbol.asyncIterator]()
+    ).return?.bind(input);
+    const iteratorNext = ('next' in input
+      ? input
+      : input[Symbol.asyncIterator]()
+    ).next.bind(input);
+
+    iteratorNext()
+      .then(result => {
+        resolve(result.value);
+        // ensure cleanup
+        iteratorReturn?.();
+      })
+      .catch(err => {
+        reject(err);
+      });
+  });
+}
+
+export function fetcherReturnToPromise(
+  fetcherResult: FetcherReturnType,
+): Promise<FetcherResult> {
+  return Promise.resolve(fetcherResult).then(result => {
+    if (isAsyncIterable(result)) {
+      return asyncIterableToPromise(result);
+    } else if (isObservable(result)) {
+      return observableToPromise(result);
+    }
+    return result;
+  });
+}

--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -33,7 +33,9 @@ export type FetcherParams = {
 export type FetcherOpts = {
   headers?: { [key: string]: any };
   /**
-   * @deprecated This property will be removed in the next major version of `graphiql`
+   * @deprecated This property will be removed in the next major version of
+   * `graphiql`, it just echoes back the value passed as prop to the `GraphiQL`
+   * component with a default value of `false`
    */
   shouldPersistHeaders?: boolean;
   documentAST?: DocumentNode;

--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -32,6 +32,9 @@ export type FetcherParams = {
 
 export type FetcherOpts = {
   headers?: { [key: string]: any };
+  /**
+   * @deprecated This property will be removed in the next major version of `graphiql`
+   */
   shouldPersistHeaders?: boolean;
   documentAST?: DocumentNode;
 };

--- a/packages/graphiql-toolkit/src/format/index.ts
+++ b/packages/graphiql-toolkit/src/format/index.ts
@@ -1,0 +1,48 @@
+import { GraphQLError, GraphQLFormattedError } from 'graphql';
+
+function stringify(obj: unknown): string {
+  return JSON.stringify(obj, null, 2);
+}
+
+const formatSingleError = (error: Error): Error => ({
+  ...error,
+  // Raise these details even if they're non-enumerable
+  message: error.message,
+  stack: error.stack,
+});
+
+type InputError = Error | GraphQLError | string;
+
+function handleSingleError(
+  error: InputError,
+): GraphQLFormattedError | Error | string {
+  if (error instanceof GraphQLError) {
+    return error.toString();
+  }
+  if (error instanceof Error) {
+    return formatSingleError(error);
+  }
+  return error;
+}
+
+type GenericError =
+  | Error
+  | readonly Error[]
+  | string
+  | readonly string[]
+  | GraphQLError
+  | readonly GraphQLError[];
+
+export function formatError(error: GenericError): string {
+  if (Array.isArray(error)) {
+    return stringify({
+      errors: error.map((e: InputError) => handleSingleError(e)),
+    });
+  }
+  // @ts-ignore
+  return stringify({ errors: handleSingleError(error) });
+}
+
+export function formatResult(result: any): string {
+  return stringify(result);
+}

--- a/packages/graphiql-toolkit/src/index.ts
+++ b/packages/graphiql-toolkit/src/index.ts
@@ -1,3 +1,4 @@
 export * from './async-helpers';
 export * from './create-fetcher';
+export * from './format';
 // TODO: move the most useful utilities from graphiql to here

--- a/packages/graphiql-toolkit/src/index.ts
+++ b/packages/graphiql-toolkit/src/index.ts
@@ -1,2 +1,3 @@
+export * from './async-helpers';
 export * from './create-fetcher';
 // TODO: move the most useful utilities from graphiql to here

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -61,12 +61,16 @@ import setValue from 'set-value';
 import type {
   Fetcher,
   FetcherResult,
-  FetcherReturnType,
   FetcherOpts,
   SyncFetcherResult,
-  Observable,
   Unsubscribable,
   FetcherResultPayload,
+} from '@graphiql/toolkit';
+import {
+  fetcherReturnToPromise,
+  isPromise,
+  isObservable,
+  isAsyncIterable,
 } from '@graphiql/toolkit';
 import HistoryStore from '../utility/HistoryStore';
 
@@ -2218,88 +2222,6 @@ const defaultQuery = `# Welcome to GraphiQL
 #
 
 `;
-
-// Duck-type promise detection.
-function isPromise<T>(value: Promise<T> | any): value is Promise<T> {
-  return typeof value === 'object' && typeof value.then === 'function';
-}
-
-// Duck-type Observable.take(1).toPromise()
-function observableToPromise<T>(observable: Observable<T>): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const subscription = observable.subscribe({
-      next: v => {
-        resolve(v);
-        subscription.unsubscribe();
-      },
-      error: reject,
-      complete: () => {
-        reject(new Error('no value resolved'));
-      },
-    });
-  });
-}
-
-// Duck-type observable detection.
-function isObservable<T>(value: any): value is Observable<T> {
-  return (
-    typeof value === 'object' &&
-    'subscribe' in value &&
-    typeof value.subscribe === 'function'
-  );
-}
-
-function isAsyncIterable(input: unknown): input is AsyncIterable<unknown> {
-  return (
-    typeof input === 'object' &&
-    input !== null &&
-    // Some browsers still don't have Symbol.asyncIterator implemented (iOS Safari)
-    // That means every custom AsyncIterable must be built using a AsyncGeneratorFunction (async function * () {})
-    ((input as any)[Symbol.toStringTag] === 'AsyncGenerator' ||
-      Symbol.asyncIterator in input)
-  );
-}
-
-function asyncIterableToPromise<T>(
-  input: AsyncIterable<T> | AsyncIterableIterator<T>,
-): Promise<T> {
-  return new Promise((resolve, reject) => {
-    // Also support AsyncGenerator on Safari iOS.
-    // As mentioned in the isAsyncIterable function there is no Symbol.asyncIterator available
-    // so every AsyncIterable must be implemented using AsyncGenerator.
-    const iteratorReturn = ('return' in input
-      ? input
-      : input[Symbol.asyncIterator]()
-    ).return?.bind(input);
-    const iteratorNext = ('next' in input
-      ? input
-      : input[Symbol.asyncIterator]()
-    ).next.bind(input);
-
-    iteratorNext()
-      .then(result => {
-        resolve(result.value);
-        // ensure cleanup
-        iteratorReturn?.();
-      })
-      .catch(err => {
-        reject(err);
-      });
-  });
-}
-
-function fetcherReturnToPromise(
-  fetcherResult: FetcherReturnType,
-): Promise<FetcherResult> {
-  return Promise.resolve(fetcherResult).then(fetcherResult => {
-    if (isAsyncIterable(fetcherResult)) {
-      return asyncIterableToPromise(fetcherResult);
-    } else if (isObservable(fetcherResult)) {
-      return observableToPromise(fetcherResult);
-    }
-    return fetcherResult;
-  });
-}
 
 // Determines if the React child is of the same type of the provided React component
 function isChildComponentType<T extends ComponentType>(


### PR DESCRIPTION
In particular we move over:
- Async helper functions (promises, observables and async-iterables)
- Formatting functions for result JSON and errors

I also noticed that the `shouldPersistHeaders` property that is part of the fetcher options is never used for anything, and after searching through issues and commit history I found no good reason why they should be in there. (@acao maybe I'm lacking context here?) This PR deprecates it and intends to remove it in the next major version of `graphiql`.