### PR TITLE
fix persisting headers in tab state

### DIFF
--- a/.changeset/witty-papayas-remain.md
+++ b/.changeset/witty-papayas-remain.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix persisting headers in tab state and avoid opening duplicate tabs when reloading

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -762,7 +762,7 @@ class GraphiQLWithContext extends React.Component<
         'tabState',
         JSON.stringify(this.state.tabs, (key, value) =>
           key === 'response' ||
-          (this.state.shouldPersistHeaders && key === 'headers')
+          (!this.state.shouldPersistHeaders && key === 'headers')
             ? undefined
             : value,
         ),


### PR DESCRIPTION
The logic for persisting headers in tabs was exactly switched, i.e. we stripped headers when `shouldPersistHeaders` was `true`. This also caused GraphiQL to open duplicate tabs when the `headers` prop was used: #2380