### PR TITLE
fix linting in query and variable editor

### DIFF
--- a/.changeset/olive-cooks-juggle.md
+++ b/.changeset/olive-cooks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Mark `graphql` as external dependency to avoid importing multiple instances

--- a/.changeset/orange-clocks-march.md
+++ b/.changeset/orange-clocks-march.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix linting by also updating the options object in the internal codemirror state

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -235,6 +235,7 @@ function useSynchronizeSchema(
 
     const didChange = editor.options.lint.schema !== schema;
 
+    editor.state.lint.linterOptions.schema = schema;
     editor.options.lint.schema = schema;
     editor.options.hintOptions.schema = schema;
     editor.options.info.schema = schema;
@@ -258,6 +259,7 @@ function useSynchronizeValidationRules(
 
     const didChange = editor.options.lint.validationRules !== validationRules;
 
+    editor.state.lint.linterOptions.validationRules = validationRules;
     editor.options.lint.validationRules = validationRules;
 
     if (didChange && codeMirrorRef.current) {
@@ -279,6 +281,7 @@ function useSynchronizeExternalFragments(
     const didChange =
       editor.options.lint.externalFragments !== externalFragments;
 
+    editor.state.lint.linterOptions.externalFragments = externalFragments;
     editor.options.lint.externalFragments = externalFragments;
     editor.options.hintOptions.externalFragments = externalFragments;
 

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -161,6 +161,7 @@ function useSynchronizeVariableTypes(
 
     const didChange = editor.options.lint.variableToType !== variableToType;
 
+    editor.state.lint.linterOptions.variableToType = variableToType;
     editor.options.lint.variableToType = variableToType;
     editor.options.hintOptions.variableToType = variableToType;
 

--- a/packages/graphiql-react/vite.config.ts
+++ b/packages/graphiql-react/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       formats: ['cjs', 'es'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['graphql', 'react', 'react-dom'],
       output: {
         chunkFileNames: '[name].[format].js',
       },


### PR DESCRIPTION
Linting in the query and variable editor broke with the latest upgrade of the codemirror version: https://github.com/graphql/graphiql/commit/eab257ba3e65e47625216fc3545b56426e0c4e61

The reason are internal changes to the lint addon implementation, in particular the options object is not split up between `options` and `linterOptions` where our custom properties (e.g. `schema`) are added to the latter: https://github.com/codemirror/CodeMirror/commit/70c615c5ff7d25e91dd50190945ef295b9ce7f09

To fix this we also modify the `linterOptions` object in the editor state when we want to update one of our custom options.

Props @benjie who noticed the broken linting 👏 