### PR TITLE
move state for doc explorer visibility to explorer context in `@graphiql/react`

### DIFF
--- a/.changeset/tough-jobs-shave.md
+++ b/.changeset/tough-jobs-shave.md
@@ -3,4 +3,4 @@
 '@graphiql/react': patch
 ---
 
-Inline logic for clicking a reference to open the docs and remove the `onClickReference` prop of the `QueryEditor` component and the `useQueryEditor` hook
+Inline logic for clicking a reference to open the docs and remove the `onClickReference` and `onHintInformationRender` props of the editor components and hooks

--- a/.changeset/tough-jobs-shave.md
+++ b/.changeset/tough-jobs-shave.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Inline logic for clicking a reference to open the docs and remove the `onClickReference` prop of the `QueryEditor` component and the `useQueryEditor` hook

--- a/.changeset/warm-kings-rhyme.md
+++ b/.changeset/warm-kings-rhyme.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Move visibility state for doc explorer from `graphiql` to the explorer context in `@graphiql/react`

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -4,7 +4,6 @@ import { StorageContext } from '../storage';
 import { commonKeys, importCodeMirror } from './common';
 import { EditorContext } from './context';
 import {
-  CompletionCallback,
   EditCallback,
   EmptyCallback,
   useChangeHandler,
@@ -17,7 +16,6 @@ import {
 export type UseHeaderEditorArgs = {
   editorTheme?: string;
   onEdit?: EditCallback;
-  onHintInformationRender?: CompletionCallback;
   onPrettifyQuery?: EmptyCallback;
   onMergeQuery?: EmptyCallback;
   onRunQuery?: EmptyCallback;
@@ -29,7 +27,6 @@ export type UseHeaderEditorArgs = {
 export function useHeaderEditor({
   editorTheme = 'graphiql',
   onEdit,
-  onHintInformationRender,
   onMergeQuery,
   onPrettifyQuery,
   onRunQuery,
@@ -127,7 +124,7 @@ export function useHeaderEditor({
     shouldPersistHeaders ? STORAGE_KEY : null,
   );
 
-  useCompletion(headerEditor, onHintInformationRender);
+  useCompletion(headerEditor);
 
   useKeyMap(headerEditor, ['Cmd-Enter', 'Ctrl-Enter'], onRunQuery);
   useKeyMap(headerEditor, ['Shift-Ctrl-P'], onPrettifyQuery);

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -16,7 +16,6 @@ import debounce from '../utility/debounce';
 import { commonKeys, importCodeMirror } from './common';
 import { CodeMirrorEditorWithOperationFacts, EditorContext } from './context';
 import {
-  CompletionCallback,
   EditCallback,
   EmptyCallback,
   useCompletion,
@@ -36,7 +35,6 @@ export type UseQueryEditorArgs = {
   onCopyQuery?: EmptyCallback;
   onEdit?: EditCallback;
   onEditOperationName?: EditCallback;
-  onHintInformationRender?: CompletionCallback;
   onPrettifyQuery?: EmptyCallback;
   onMergeQuery?: EmptyCallback;
   onRunQuery?: EmptyCallback;
@@ -52,7 +50,6 @@ export function useQueryEditor({
   onCopyQuery,
   onEdit,
   onEditOperationName,
-  onHintInformationRender,
   onMergeQuery,
   onPrettifyQuery,
   onRunQuery,
@@ -321,7 +318,7 @@ export function useQueryEditor({
 
   useSynchronizeValue(queryEditor, value);
 
-  useCompletion(queryEditor, onHintInformationRender);
+  useCompletion(queryEditor);
 
   useKeyMap(queryEditor, ['Cmd-Enter', 'Ctrl-Enter'], onRunQuery);
   useKeyMap(queryEditor, ['Shift-Ctrl-C'], onCopyQuery);

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -4,7 +4,6 @@ import { StorageContext } from '../storage';
 import { commonKeys, importCodeMirror } from './common';
 import { EditorContext } from './context';
 import {
-  CompletionCallback,
   EditCallback,
   EmptyCallback,
   useChangeHandler,
@@ -18,7 +17,6 @@ import { CodeMirrorType } from './types';
 export type UseVariableEditorArgs = {
   editorTheme?: string;
   onEdit?: EditCallback;
-  onHintInformationRender?: CompletionCallback;
   onPrettifyQuery?: EmptyCallback;
   onMergeQuery?: EmptyCallback;
   onRunQuery?: EmptyCallback;
@@ -29,7 +27,6 @@ export type UseVariableEditorArgs = {
 export function useVariableEditor({
   editorTheme = 'graphiql',
   onEdit,
-  onHintInformationRender,
   onMergeQuery,
   onPrettifyQuery,
   onRunQuery,
@@ -137,7 +134,7 @@ export function useVariableEditor({
 
   useChangeHandler(variableEditor, onEdit, STORAGE_KEY);
 
-  useCompletion(variableEditor, onHintInformationRender);
+  useCompletion(variableEditor);
 
   useKeyMap(variableEditor, ['Cmd-Enter', 'Ctrl-Enter'], onRunQuery);
   useKeyMap(variableEditor, ['Shift-Ctrl-P'], onPrettifyQuery);

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "@graphiql/react": "^0.2.0",
     "@graphiql/toolkit": "^0.6.0",
-    "codemirror-graphql": "^1.3.0",
     "copy-to-clipboard": "^3.2.0",
     "set-value": "^4.1.0",
     "entities": "^2.0.0",

--- a/packages/graphiql/src/components/DocExplorer.tsx
+++ b/packages/graphiql/src/components/DocExplorer.tsx
@@ -24,13 +24,8 @@ import TypeDoc from './DocExplorer/TypeDoc';
  *
  * Shows documentations for GraphQL definitions from the schema.
  *
- * Children:
- *
- *   - Any provided children will be positioned in the right-hand-side of the
- *     top bar. Typically this will be a "close" button for temporary explorer.
- *
  */
-export function DocExplorer(props: { children?: ReactNode }) {
+export function DocExplorer() {
   const { fetchError, isFetching, schema, validationErrors } = useSchema();
   const explorerContext = useExplorerNavStack();
   if (!explorerContext) {
@@ -39,7 +34,7 @@ export function DocExplorer(props: { children?: ReactNode }) {
     );
   }
 
-  const { explorerNavStack, pop, push, showSearch } = explorerContext;
+  const { explorerNavStack, hide, pop, push, showSearch } = explorerContext;
   const navItem = explorerNavStack[explorerNavStack.length - 1];
 
   function handleClickType(type: GraphQLNamedType) {
@@ -121,7 +116,16 @@ export function DocExplorer(props: { children?: ReactNode }) {
         <div className="doc-explorer-title">
           {navItem.title || navItem.name}
         </div>
-        <div className="doc-explorer-rhs">{props.children}</div>
+        <div className="doc-explorer-rhs">
+          <button
+            className="docExplorerHide"
+            onClick={() => {
+              hide();
+            }}
+            aria-label="Close Documentation Explorer">
+            {'\u2715'}
+          </button>
+        </div>
       </div>
       <div className="doc-explorer-contents">
         {shouldSearchBoxAppear && (

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -841,7 +841,6 @@ class GraphiQLWithContext extends React.Component<
                 onCopyQuery={this.handleCopyQuery}
                 onEdit={this.handleEditQuery}
                 onEditOperationName={this.props.onEditOperationName}
-                onHintInformationRender={this.handleHintInformationRender}
                 onMergeQuery={this.handleMergeQuery}
                 onPrettifyQuery={this.handlePrettifyQuery}
                 onRunQuery={this.handleEditorRunQuery}
@@ -889,7 +888,6 @@ class GraphiQLWithContext extends React.Component<
                 <VariableEditor
                   value={this.props.variables}
                   onEdit={this.handleEditVariables}
-                  onHintInformationRender={this.handleHintInformationRender}
                   onPrettifyQuery={this.handlePrettifyQuery}
                   onMergeQuery={this.handleMergeQuery}
                   onRunQuery={this.handleEditorRunQuery}
@@ -902,7 +900,6 @@ class GraphiQLWithContext extends React.Component<
                     active={this.state.headerEditorActive}
                     editorTheme={this.props.editorTheme}
                     onEdit={this.handleEditHeaders}
-                    onHintInformationRender={this.handleHintInformationRender}
                     onMergeQuery={this.handleMergeQuery}
                     onPrettifyQuery={this.handlePrettifyQuery}
                     onRunQuery={this.handleEditorRunQuery}
@@ -1429,41 +1426,8 @@ class GraphiQLWithContext extends React.Component<
     }
   };
 
-  handleHintInformationRender = (elem: HTMLDivElement) => {
-    elem.addEventListener('click', this._onClickHintInformation);
-
-    let onRemoveFn: EventListener;
-    elem.addEventListener(
-      'DOMNodeRemoved',
-      (onRemoveFn = () => {
-        elem.removeEventListener('DOMNodeRemoved', onRemoveFn);
-        elem.removeEventListener('click', this._onClickHintInformation);
-      }),
-    );
-  };
-
   handleEditorRunQuery = () => {
     this._runQueryAtCursor();
-  };
-
-  private _onClickHintInformation = (
-    event: MouseEvent | React.MouseEvent<HTMLDivElement>,
-  ) => {
-    if (
-      event?.currentTarget &&
-      'className' in event.currentTarget &&
-      event.currentTarget.className === 'typeName'
-    ) {
-      const typeName = event.currentTarget.innerHTML;
-      const schema = this.props.schemaContext.schema;
-      if (schema) {
-        const type = schema.getType(typeName);
-        if (type && this.props.explorerContext) {
-          this.props.explorerContext.show();
-          this.props.explorerContext.push({ name: type.name, def: type });
-        }
-      }
-    }
   };
 
   handleSelectHistoryQuery = ({


### PR DESCRIPTION
In addition we can now also move the logic for clicking references to get to the docs into `@graphiql/react`, that way we don't need to pass the `onClickReference` and `onHintInformationRender` props to the editors anymore.