### PR TITLE
chore: use the same TypeScript version throughout the monorepository

### DIFF
--- a/examples/cm6-graphql-parcel/package.json
+++ b/examples/cm6-graphql-parcel/package.json
@@ -26,7 +26,7 @@
     "@codemirror/language": "^0.20.0",
     "codemirror-graphql": "file:../../packages/codemirror-graphql",
     "graphql": "^16.4.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.6.3"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.4",

--- a/examples/graphiql-2-rfc-context/package.json
+++ b/examples/graphiql-2-rfc-context/package.json
@@ -102,7 +102,7 @@
     "start-server-and-test": "^1.10.11",
     "style-loader": "^1.1.3",
     "ts-loader": "^7.0.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.3",
     "webpack": "4.42.1",
     "webpack-bundle-analyzer": "^3.6.1",
     "webpack-cli": "^3.3.11",

--- a/examples/graphiql-parcel/package.json
+++ b/examples/graphiql-parcel/package.json
@@ -26,7 +26,7 @@
     "graphql": "^16.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "typescript": "^3.4.4"
+    "typescript": "^4.6.3"
   },
   "devDependencies": {
     "parcel": "^2.5.0",

--- a/examples/monaco-graphql-webpack/package.json
+++ b/examples/monaco-graphql-webpack/package.json
@@ -35,7 +35,7 @@
     "monaco-editor-webpack-plugin": "^5.0.0",
     "react-dom": "^17.0.2",
     "style-loader": "^1.1.3",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.3",
     "webpack": "4.42.1",
     "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.10.3",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "serverless-http": "^2.7.0",
     "ts-jest": "^25.3.1",
     "typedoc": "^0.19.2",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.3",
     "whatwg-url": "^8.4.0",
     "wsrun": "^5.2.4"
   }

--- a/packages/codemirror-graphql/src/utils/jsonParse.ts
+++ b/packages/codemirror-graphql/src/utils/jsonParse.ts
@@ -155,8 +155,18 @@ function expect(str: string) {
   throw syntaxError(`Expected ${str} but found ${found}.`);
 }
 
+type SyntaxErrorPosition = { start: number; end: number };
+
+export class JSONSyntaxError extends Error {
+  readonly position: SyntaxErrorPosition;
+  constructor(message: string, position: SyntaxErrorPosition) {
+    super(message);
+    this.position = position;
+  }
+}
+
 function syntaxError(message: string) {
-  return { message, start, end };
+  return new JSONSyntaxError(message, { start, end });
 }
 
 function skip(k: string) {

--- a/packages/codemirror-graphql/src/variables/lint.ts
+++ b/packages/codemirror-graphql/src/variables/lint.ts
@@ -18,6 +18,7 @@ import {
 } from 'graphql';
 
 import jsonParse, {
+  JSONSyntaxError,
   ParseArrayOutput,
   ParseObjectOutput,
   ParseValueOutput,
@@ -57,11 +58,11 @@ CodeMirror.registerHelper(
     let ast;
     try {
       ast = jsonParse(text);
-    } catch (syntaxError) {
-      if (syntaxError.stack) {
-        throw syntaxError;
+    } catch (error) {
+      if (error instanceof JSONSyntaxError) {
+        return [lintError(editor, error.position, error.message)];
       }
-      return [lintError(editor, syntaxError, syntaxError.message)];
+      throw error;
     }
 
     // If there are not yet known variables, do nothing.

--- a/packages/graphiql-react/src/history/context.tsx
+++ b/packages/graphiql-react/src/history/context.tsx
@@ -154,7 +154,9 @@ export function HistoryContextProvider(props: HistoryContextProviderProps) {
   );
 }
 
-export const useHistoryContext = createContextHook(HistoryContext);
+export const useHistoryContext = createContextHook<HistoryContextType>(
+  HistoryContext,
+);
 
 const DEFAULT_HISTORY_LENGTH = 20;
 const STORAGE_KEY = 'historyPaneOpen';

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -94,7 +94,7 @@
     "style-loader": "^1.1.3",
     "subscriptions-transport-ws": "0.11.0",
     "ts-loader": "^7.0.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.6.3",
     "webpack": "^4.42.1",
     "webpack-bundle-analyzer": "^3.6.1",
     "webpack-cli": "^3.3.11",

--- a/packages/graphiql/src/components/QueryHistory.tsx
+++ b/packages/graphiql/src/components/QueryHistory.tsx
@@ -5,12 +5,18 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { useHistoryContext, useSelectHistoryItem } from '@graphiql/react';
+import {
+  HistoryContextType,
+  useHistoryContext,
+  useSelectHistoryItem,
+} from '@graphiql/react';
 import { QueryStoreItem } from '@graphiql/toolkit';
 import React, { useEffect, useRef, useState } from 'react';
 
 export function QueryHistory() {
-  const { hide, items } = useHistoryContext({ nonNull: true });
+  const { hide, items } = useHistoryContext({
+    nonNull: true,
+  }) as HistoryContextType;
 
   return (
     <section aria-label="History">

--- a/packages/graphiql/src/components/ToolbarButton.tsx
+++ b/packages/graphiql/src/components/ToolbarButton.tsx
@@ -49,7 +49,11 @@ export class ToolbarButton extends React.Component<
       this.props.onClick();
       this.setState({ error: null });
     } catch (error) {
-      this.setState({ error });
+      if (error instanceof Error) {
+        this.setState({ error });
+        return;
+      }
+      throw error;
     }
   };
 }

--- a/packages/graphql-language-service-cli/src/cli.ts
+++ b/packages/graphql-language-service-cli/src/cli.ts
@@ -130,7 +130,7 @@ switch (command) {
       startServer(options);
     } catch (error) {
       const logger = new Logger();
-      logger.error(error);
+      logger.error(String(error));
     }
     break;
   default: {

--- a/packages/graphql-language-service-cli/src/client.ts
+++ b/packages/graphql-language-service-cli/src/client.ts
@@ -79,6 +79,14 @@ interface AutocompleteResultsMap {
   [i: number]: CompletionItem;
 }
 
+function formatUnknownError(error: unknown) {
+  let message: string | undefined;
+  if (error instanceof Error) {
+    message = error.stack;
+  }
+  return message ?? String(error);
+}
+
 function _getAutocompleteSuggestions(
   queryText: string,
   point: Position,
@@ -104,7 +112,7 @@ function _getAutocompleteSuggestions(
     process.stdout.write(JSON.stringify(resultObject, null, 2));
     return GRAPHQL_SUCCESS_CODE;
   } catch (error) {
-    process.stderr.write((error?.stack ?? String(error)) + '\n');
+    process.stderr.write(formatUnknownError(error) + '\n');
     return GRAPHQL_FAILURE_CODE;
   }
 }
@@ -133,7 +141,7 @@ function _getDiagnostics(
     process.stdout.write(JSON.stringify(resultObject, null, 2));
     return GRAPHQL_SUCCESS_CODE;
   } catch (error) {
-    process.stderr.write((error?.stack ?? String(error)) + '\n');
+    process.stderr.write(formatUnknownError(error) + '\n');
     return GRAPHQL_FAILURE_CODE;
   }
 }
@@ -147,7 +155,7 @@ function _getOutline(queryText: string): EXIT_CODE {
       throw Error('Error parsing or no outline tree found');
     }
   } catch (error) {
-    process.stderr.write((error?.stack ?? String(error)) + '\n');
+    process.stderr.write(formatUnknownError(error) + '\n');
     return GRAPHQL_FAILURE_CODE;
   }
   return GRAPHQL_SUCCESS_CODE;
@@ -161,7 +169,7 @@ function ensureText(queryText: string, filePath: string): string {
     try {
       text = fs.readFileSync(filePath, 'utf8');
     } catch (error) {
-      throw new Error(error);
+      throw new Error(String(error));
     }
   }
   return text;

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -15,6 +15,7 @@ import {
   NamedTypeNode,
   ValidationRule,
   FieldNode,
+  GraphQLError,
 } from 'graphql';
 
 import {
@@ -161,17 +162,23 @@ export class GraphQLLanguageService {
           return false;
         });
       }
-    } catch (err) {
-      const error = err as any;
-      const range = getRange(error.locations[0], document);
-      return [
-        {
-          severity: DIAGNOSTIC_SEVERITY.Error,
-          message: error.message,
-          source: 'GraphQL: Syntax',
-          range,
-        },
-      ];
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        const range = getRange(
+          error.locations?.[0] ?? { column: 0, line: 0 },
+          document,
+        );
+        return [
+          {
+            severity: DIAGNOSTIC_SEVERITY.Error,
+            message: error.message,
+            source: 'GraphQL: Syntax',
+            range,
+          },
+        ];
+      }
+
+      throw error;
     }
 
     // If there's a matching config, proceed to prepare to run validation

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -321,7 +321,7 @@ export class MessageProcessor {
         }
       }
     } catch (err) {
-      this._logger.error(err);
+      this._logger.error(String(err));
     }
 
     // Here, we set the workspace settings in memory,
@@ -910,7 +910,7 @@ export class MessageProcessor {
         await this._updateObjectTypeDefinition(uri, contents);
       }
     } catch (err) {
-      this._logger.error(err);
+      this._logger.error(String(err));
     }
   }
   async _cacheSchemaFile(
@@ -1078,7 +1078,7 @@ export class MessageProcessor {
         }
       }
     } catch (err) {
-      this._logger.error(err);
+      this._logger.error(String(err));
     }
   }
   /**
@@ -1119,7 +1119,7 @@ export class MessageProcessor {
       this._logger.error(
         `invalid/unknown file in graphql config documents entry:\n '${project.documents}'`,
       );
-      this._logger.error(err);
+      this._logger.error(String(err));
     }
   }
   /**

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -95,7 +95,7 @@ export function findGraphQLTags(
     logger.error(
       `Could not parse the ${type} file at ${uri} to extract the graphql tags:`,
     );
-    logger.error(error);
+    logger.error(String(error));
     return [];
   }
   const ast = parsedAST!;

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -211,7 +211,7 @@ export default async function startServer(
       serverWithHandlers.listen();
     } catch (err) {
       logger.error('There was a Graphql LSP handler exception:');
-      logger.error(err);
+      logger.error(String(err));
     }
   }
 }
@@ -236,7 +236,7 @@ async function initializeHandlers({
     return connection;
   } catch (err) {
     logger.error('There was an error initializing the server connection');
-    logger.error(err);
+    logger.error(String(err));
     process.exit(1);
   }
 }

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.15",
     "platform": "^1.3.5",
     "ts-node": "^8.10.2",
-    "typescript": "^4.1.3"
+    "typescript": "^4.6.3"
   },
   "scripts": {
     "benchmark": "ts-node benchmark/index.ts"

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -81,15 +81,22 @@ export function getDiagnostics(
   try {
     ast = parse(query);
   } catch (error) {
-    const range = getRange(error.locations[0], query);
-    return [
-      {
-        severity: DIAGNOSTIC_SEVERITY.Error as DiagnosticSeverity,
-        message: error.message,
-        source: 'GraphQL: Syntax',
-        range,
-      },
-    ];
+    if (error instanceof GraphQLError) {
+      const range = getRange(
+        error.locations?.[0] ?? { line: 0, column: 0 },
+        query,
+      );
+
+      return [
+        {
+          severity: DIAGNOSTIC_SEVERITY.Error as DiagnosticSeverity,
+          message: error.message,
+          source: 'GraphQL: Syntax',
+          range,
+        },
+      ];
+    }
+    throw error;
   }
 
   return validateQuery(ast, schema, customRules, isRelayCompatMode);

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -196,7 +196,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
   StringValue: [
     {
       style: 'string',
-      match: token => token.kind === 'String',
+      match: (token: Token) => token.kind === 'String',
       update(state: State, token: Token) {
         if (token.value.startsWith('"""')) {
           state.inBlockstring = !token.value.slice(3).endsWith('"""');

--- a/yarn.lock
+++ b/yarn.lock
@@ -18443,11 +18443,6 @@ typedoc@^0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-typescript@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-
 typescript@^4.6.3:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"


### PR DESCRIPTION
GraphQL.js 17 requires TypeScript >= 4.4; This is a base PR for a stacked GraphQL v17 update PR.