### PR TITLE
don't introspect the schema if it's provided via props

### DIFF
--- a/.changeset/mean-trees-work.md
+++ b/.changeset/mean-trees-work.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+don't introspect the schema if it's provided via props


### PR DESCRIPTION
Fixes #2441 

We only start introspecting when there is no schema provided via props. When `null` is passed we also don't introspect and run GraphiQL without schema. We also make sure to avoid race conditions between prop changes (that also update the state) and the async introspection request, i.e. if the state changed between starting and resolving the introspection request, we don't override the state with the new schema.