### PR TITLE
always use the latest header values for introspection

### DIFF
--- a/.changeset/friendly-cougars-happen.md
+++ b/.changeset/friendly-cougars-happen.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Always use the current value of the headers for the introspection request

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { useStorageContext } from '../storage';
 import { commonKeys, importCodeMirror } from './common';
 import { useEditorContext } from './context';
 import {
@@ -12,7 +11,6 @@ import {
   useMergeQuery,
   usePrettifyEditors,
   useResizeEditor,
-  useSynchronizeValue,
 } from './hooks';
 
 export type UseHeaderEditorArgs = {
@@ -21,7 +19,6 @@ export type UseHeaderEditorArgs = {
   onRunQuery?: EmptyCallback;
   readOnly?: boolean;
   shouldPersistHeaders?: boolean;
-  value?: string;
 };
 
 export function useHeaderEditor({
@@ -30,17 +27,14 @@ export function useHeaderEditor({
   onRunQuery,
   readOnly = false,
   shouldPersistHeaders = false,
-  value,
 }: UseHeaderEditorArgs = {}) {
-  const { headerEditor, setHeaderEditor } = useEditorContext({
+  const { initialHeaders, headerEditor, setHeaderEditor } = useEditorContext({
     nonNull: true,
     caller: useHeaderEditor,
   });
-  const storage = useStorageContext();
   const merge = useMergeQuery({ caller: useHeaderEditor });
   const prettify = usePrettifyEditors({ caller: useHeaderEditor });
   const ref = useRef<HTMLDivElement>(null);
-  const initialValue = useRef(value ?? storage?.get(STORAGE_KEY) ?? '');
 
   useEffect(() => {
     let isActive = true;
@@ -60,7 +54,7 @@ export function useHeaderEditor({
       }
 
       const newEditor = CodeMirror(container, {
-        value: initialValue.current || '',
+        value: initialHeaders,
         lineNumbers: true,
         tabSize: 2,
         mode: { name: 'javascript', json: true },
@@ -108,9 +102,7 @@ export function useHeaderEditor({
     return () => {
       isActive = false;
     };
-  }, [editorTheme, readOnly, setHeaderEditor]);
-
-  useSynchronizeValue(headerEditor, value);
+  }, [editorTheme, initialHeaders, readOnly, setHeaderEditor]);
 
   useChangeHandler(
     headerEditor,
@@ -129,4 +121,4 @@ export function useHeaderEditor({
   return ref;
 }
 
-const STORAGE_KEY = 'headers';
+export const STORAGE_KEY = 'headers';

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 
-import { useStorageContext } from '../storage';
 import { commonKeys, importCodeMirror } from './common';
 import { useEditorContext } from './context';
 import {
@@ -12,7 +11,6 @@ import {
   useMergeQuery,
   usePrettifyEditors,
   useResizeEditor,
-  useSynchronizeValue,
 } from './hooks';
 import { CodeMirrorType } from './types';
 
@@ -21,7 +19,6 @@ export type UseVariableEditorArgs = {
   onEdit?: EditCallback;
   onRunQuery?: EmptyCallback;
   readOnly?: boolean;
-  value?: string;
 };
 
 export function useVariableEditor({
@@ -29,18 +26,19 @@ export function useVariableEditor({
   onEdit,
   onRunQuery,
   readOnly = false,
-  value,
 }: UseVariableEditorArgs = {}) {
-  const { variableEditor, setVariableEditor } = useEditorContext({
+  const {
+    initialVariables,
+    variableEditor,
+    setVariableEditor,
+  } = useEditorContext({
     nonNull: true,
     caller: useVariableEditor,
   });
-  const storage = useStorageContext();
   const merge = useMergeQuery({ caller: useVariableEditor });
   const prettify = usePrettifyEditors({ caller: useVariableEditor });
   const ref = useRef<HTMLDivElement>(null);
   const codeMirrorRef = useRef<CodeMirrorType>();
-  const initialValue = useRef(value ?? storage?.get(STORAGE_KEY) ?? '');
 
   useEffect(() => {
     let isActive = true;
@@ -63,7 +61,7 @@ export function useVariableEditor({
       }
 
       const newEditor = CodeMirror(container, {
-        value: initialValue.current || '',
+        value: initialVariables,
         lineNumbers: true,
         tabSize: 2,
         mode: 'graphql-variables',
@@ -122,9 +120,7 @@ export function useVariableEditor({
     return () => {
       isActive = false;
     };
-  }, [editorTheme, readOnly, setVariableEditor]);
-
-  useSynchronizeValue(variableEditor, value);
+  }, [editorTheme, initialVariables, readOnly, setVariableEditor]);
 
   useChangeHandler(variableEditor, onEdit, STORAGE_KEY);
 
@@ -139,4 +135,4 @@ export function useVariableEditor({
   return ref;
 }
 
-const STORAGE_KEY = 'variables';
+export const STORAGE_KEY = 'variables';

--- a/packages/graphiql/__mocks__/@graphiql/react.ts
+++ b/packages/graphiql/__mocks__/@graphiql/react.ts
@@ -82,13 +82,27 @@ export type {
   UseVariableEditorArgs,
 };
 
+type Name = 'query' | 'variable' | 'header' | 'response';
+
+const NAME_TO_INITIAL_VALUE: Record<
+  Name,
+  'initialQuery' | 'initialVariables' | 'initialHeaders' | undefined
+> = {
+  query: 'initialQuery',
+  variable: 'initialVariables',
+  header: 'initialHeaders',
+  response: undefined,
+};
+
 function useMockedEditor(
-  name: string,
+  name: Name,
   value?: string,
   onEdit?: (newValue: string) => void,
-  defaultValue?: string,
 ) {
-  const [code, setCode] = useState(value ?? defaultValue);
+  const editorContext = useEditorContext({ nonNull: true });
+  const [code, setCode] = useState(
+    value ?? editorContext[NAME_TO_INITIAL_VALUE[name]],
+  );
   const ref = useRef<HTMLDivElement>(null);
 
   const context = useEditorContext({ nonNull: true });
@@ -175,17 +189,14 @@ function useMockedEditor(
 
 export const useHeaderEditor: typeof _useHeaderEditor = function useHeaderEditor({
   onEdit,
-  value,
 }) {
-  return useMockedEditor('header', value, onEdit);
+  return useMockedEditor('header', undefined, onEdit);
 };
 
 export const useQueryEditor: typeof _useQueryEditor = function useQueryEditor({
-  defaultValue = '# Welcome to GraphiQL',
   onEdit,
-  value,
 }) {
-  return useMockedEditor('query', value, onEdit, defaultValue);
+  return useMockedEditor('query', undefined, onEdit);
 };
 
 export const useResponseEditor: typeof _useResponseEditor = function useResponseEditor({
@@ -196,7 +207,6 @@ export const useResponseEditor: typeof _useResponseEditor = function useResponse
 
 export const useVariableEditor: typeof _useVariableEditor = function useVariableEditor({
   onEdit,
-  value,
 }) {
-  return useMockedEditor('variable', value, onEdit);
+  return useMockedEditor('variable', undefined, onEdit);
 };

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -27,7 +27,6 @@ import {
   ExplorerContextProvider,
   HistoryContextProvider,
   SchemaContextProvider,
-  StorageContext,
   StorageContextProvider,
   useAutoCompleteLeafs,
   useCopyQuery,
@@ -366,34 +365,29 @@ export function GraphiQL({
 }: GraphiQLProps) {
   return (
     <StorageContextProvider storage={storage}>
-      <StorageContext.Consumer>
-        {storageContext => (
-          <SchemaContextProvider
-            dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
-            fetcher={props.fetcher}
-            initialHeaders={
-              props.headers !== undefined
-                ? props.headers
-                : storageContext?.get('headers') ?? undefined
-            }
-            inputValueDeprecation={inputValueDeprecation}
-            introspectionQueryName={introspectionQueryName}
-            schema={schema}
-            schemaDescription={schemaDescription}>
-            <ExplorerContextProvider
-              isVisible={docExplorerOpen}
-              onToggleVisibility={onToggleDocs}>
-              <EditorContextProvider>
-                <HistoryContextProvider
-                  maxHistoryLength={maxHistoryLength}
-                  onToggle={onToggleHistory}>
-                  <GraphiQLConsumeContexts {...props} />
-                </HistoryContextProvider>
-              </EditorContextProvider>
-            </ExplorerContextProvider>
-          </SchemaContextProvider>
-        )}
-      </StorageContext.Consumer>
+      <EditorContextProvider
+        defaultQuery={props.defaultQuery}
+        headers={props.headers}
+        query={props.query}
+        variables={props.variables}>
+        <SchemaContextProvider
+          dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
+          fetcher={props.fetcher}
+          inputValueDeprecation={inputValueDeprecation}
+          introspectionQueryName={introspectionQueryName}
+          schema={schema}
+          schemaDescription={schemaDescription}>
+          <ExplorerContextProvider
+            isVisible={docExplorerOpen}
+            onToggleVisibility={onToggleDocs}>
+            <HistoryContextProvider
+              maxHistoryLength={maxHistoryLength}
+              onToggle={onToggleHistory}>
+              <GraphiQLConsumeContexts {...props} />
+            </HistoryContextProvider>
+          </ExplorerContextProvider>
+        </SchemaContextProvider>
+      </EditorContextProvider>
     </StorageContextProvider>
   );
 }
@@ -865,7 +859,6 @@ class GraphiQLWithContext extends React.Component<
             onMouseDown={this.handleResizeStart}>
             <div className="queryWrap" style={queryWrapStyle}>
               <QueryEditor
-                defaultValue={this.props.defaultQuery}
                 editorTheme={this.props.editorTheme}
                 externalFragments={this.props.externalFragments}
                 onEdit={this.handleEditQuery}
@@ -873,7 +866,6 @@ class GraphiQLWithContext extends React.Component<
                 onRunQuery={this.handleEditorRunQuery}
                 readOnly={this.props.readOnly}
                 validationRules={this.props.validationRules}
-                value={this.props.query}
               />
               <section
                 className="variable-editor secondary-editor"
@@ -913,7 +905,6 @@ class GraphiQLWithContext extends React.Component<
                   )}
                 </div>
                 <VariableEditor
-                  value={this.props.variables}
                   onEdit={this.handleEditVariables}
                   onRunQuery={this.handleEditorRunQuery}
                   editorTheme={this.props.editorTheme}
@@ -928,7 +919,6 @@ class GraphiQLWithContext extends React.Component<
                     onRunQuery={this.handleEditorRunQuery}
                     readOnly={this.props.readOnly}
                     shouldPersistHeaders={this.props.shouldPersistHeaders}
-                    value={this.props.headers}
                   />
                 )}
               </section>


### PR DESCRIPTION
Fixes #2442 

After introducing the schema context, we might dispatch introspection queries after the initial one that don't use the latest header values, but the initial ones. This PR fixes this:
- We derive the initial editor values in the `EditorContextProvider` and also expose them on the context value. The editor hooks don't need to do this logic anymore and can just consume the initial value from the context.
- Also syncing the prop value with the editor state (i.e. the calls to `useSynchronizeValue`) have been moved to the `EditorContextProvider`, that way we only need to pass the `defaultQuery`, `query`, `variables`, and `headers` prop to the context provider and not also the editor hooks.
- We consume the editor context inside the `SchemaContextProvider` to make sure that we use the latest header values when initializing an introspection request.