### PR TITLE
remove private methods, deprecate public methods, and fix ref forwarding

### DIFF
--- a/.changeset/clean-jokes-build.md
+++ b/.changeset/clean-jokes-build.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Deprecate the public methods `getQueryEditor`, `getVariableEditor`, `getHeaderEditor`, and `refresh` on the `GraphiQL` class.

--- a/.changeset/kind-carrots-lick.md
+++ b/.changeset/kind-carrots-lick.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Continue forwarding the ref to the class component to not break public methods

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -1,6 +1,7 @@
-import { getSelectedOperationName, StorageAPI } from '@graphiql/toolkit';
+import { getSelectedOperationName } from '@graphiql/toolkit';
 import type { SchemaReference } from 'codemirror-graphql/utils/SchemaReference';
 import type {
+  DocumentNode,
   FragmentDefinitionNode,
   GraphQLSchema,
   ValidationRule,
@@ -37,7 +38,7 @@ type OnClickReference = (reference: SchemaReference) => void;
 export type UseQueryEditorArgs = {
   editorTheme?: string;
   externalFragments?: string | FragmentDefinitionNode[];
-  onEdit?: EditCallback;
+  onEdit?(value: string, documentAST?: DocumentNode): void;
   onEditOperationName?: EditCallback;
   onCopyQuery?: CopyQueryCallback;
   readOnly?: boolean;
@@ -276,7 +277,7 @@ export function useQueryEditor({
         }
 
         // Invoke callback props only after the operation facts have been updated
-        onEdit?.(query);
+        onEdit?.(query, operationFacts?.documentAST);
         if (
           onEditOperationName &&
           operationFacts?.operationName !== undefined &&

--- a/packages/graphiql-react/src/history/context.tsx
+++ b/packages/graphiql-react/src/history/context.tsx
@@ -1,8 +1,8 @@
 import { HistoryStore, QueryStoreItem, StorageAPI } from '@graphiql/toolkit';
 import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 
-import { useStorageContext } from './storage';
-import { createContextHook, createNullableContext } from './utility/context';
+import { useStorageContext } from '../storage';
+import { createContextHook, createNullableContext } from '../utility/context';
 
 export type HistoryContextType = {
   addToHistory(operation: {

--- a/packages/graphiql-react/src/history/hooks.ts
+++ b/packages/graphiql-react/src/history/hooks.ts
@@ -1,0 +1,14 @@
+import { QueryStoreItem } from '@graphiql/toolkit';
+import { useEditorContext } from '../editor';
+
+export function useSelectHistoryItem() {
+  const { headerEditor, queryEditor, variableEditor } = useEditorContext({
+    nonNull: true,
+    caller: useSelectHistoryItem,
+  });
+  return (item: QueryStoreItem) => {
+    queryEditor?.setValue(item.query ?? '');
+    variableEditor?.setValue(item.variables ?? '');
+    headerEditor?.setValue(item.headers ?? '');
+  };
+}

--- a/packages/graphiql-react/src/history/index.ts
+++ b/packages/graphiql-react/src/history/index.ts
@@ -1,0 +1,17 @@
+import {
+  HistoryContext,
+  HistoryContextProvider,
+  useHistoryContext,
+} from './context';
+import { useSelectHistoryItem } from './hooks';
+
+import type { HistoryContextType } from './context';
+
+export {
+  HistoryContext,
+  HistoryContextProvider,
+  useHistoryContext,
+  useSelectHistoryItem,
+};
+
+export type { HistoryContextType };

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -27,6 +27,7 @@ import {
   HistoryContext,
   HistoryContextProvider,
   useHistoryContext,
+  useSelectHistoryItem,
 } from './history';
 import {
   SchemaContext,
@@ -86,6 +87,7 @@ export {
   HistoryContext,
   HistoryContextProvider,
   useHistoryContext,
+  useSelectHistoryItem,
   // schema
   SchemaContext,
   SchemaContextProvider,

--- a/packages/graphiql/src/cdn.ts
+++ b/packages/graphiql/src/cdn.ts
@@ -23,7 +23,7 @@ import './css/history.css';
 import { GraphiQL } from './components/GraphiQL';
 // add the static function here for CDN only. otherwise, doing this in the component could
 // add unwanted dependencies to the bundle.
-// @ts-ignore
+// @ts-expect-error
 GraphiQL.createFetcher = createGraphiQLFetcher;
 
 export default GraphiQL;

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -727,7 +727,7 @@ class GraphiQLWithContext extends React.Component<
                   )}
                 </div>
                 <VariableEditor
-                  onEdit={this.handleEditVariables}
+                  onEdit={this.props.onEditVariables}
                   editorTheme={this.props.editorTheme}
                   readOnly={this.props.readOnly}
                   active={this.state.variableEditorActive}
@@ -825,12 +825,6 @@ class GraphiQLWithContext extends React.Component<
   }
 
   // Private methods
-
-  handleEditVariables = (value: string) => {
-    if (this.props.onEditVariables) {
-      this.props.onEditVariables(value);
-    }
-  };
 
   handleEditHeaders = (value: string) => {
     if (this.props.onEditHeaders) {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -10,6 +10,9 @@ import React, {
   PropsWithChildren,
   MouseEventHandler,
   ReactNode,
+  forwardRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
 } from 'react';
 import {
   GraphQLSchema,
@@ -312,20 +315,41 @@ export type GraphiQLState = {
  *
  * @see https://github.com/graphql/graphiql#usage
  */
-export function GraphiQL({
-  dangerouslyAssumeSchemaIsValid,
-  docExplorerOpen,
-  fetcher,
-  inputValueDeprecation,
-  introspectionQueryName,
-  maxHistoryLength,
-  onToggleHistory,
-  onToggleDocs,
-  storage,
-  schema,
-  schemaDescription,
-  ...props
-}: GraphiQLProps) {
+
+export const GraphiQL: ForwardRefExoticComponent<
+  GraphiQLProps & RefAttributes<GraphiQLWithContext>
+> & {
+  formatResult(result: any): string;
+  formatError(error: any): string;
+  Logo: typeof GraphiQLLogo;
+  Toolbar: typeof GraphiQLToolbar;
+  Footer: typeof GraphiQLFooter;
+  QueryEditor: typeof QueryEditor;
+  VariableEditor: typeof VariableEditor;
+  HeaderEditor: typeof HeaderEditor;
+  ResultViewer: typeof ResultViewer;
+  Button: typeof ToolbarButton;
+  ToolbarButton: typeof ToolbarButton;
+  Group: typeof ToolbarGroup;
+  Menu: typeof ToolbarMenu;
+  MenuItem: typeof ToolbarMenuItem;
+} = forwardRef<GraphiQLWithContext, GraphiQLProps>(function GraphiQL(
+  {
+    dangerouslyAssumeSchemaIsValid,
+    docExplorerOpen,
+    fetcher,
+    inputValueDeprecation,
+    introspectionQueryName,
+    maxHistoryLength,
+    onToggleHistory,
+    onToggleDocs,
+    storage,
+    schema,
+    schemaDescription,
+    ...props
+  },
+  ref,
+) {
   // Ensure props are correct
   if (typeof fetcher !== 'function') {
     throw new TypeError('GraphiQL requires a fetcher function.');
@@ -356,7 +380,7 @@ export function GraphiQL({
               <ExplorerContextProvider
                 isVisible={docExplorerOpen}
                 onToggleVisibility={onToggleDocs}>
-                <GraphiQLConsumeContexts {...props} />
+                <GraphiQLConsumeContexts {...props} ref={ref} />
               </ExplorerContextProvider>
             </ExecutionContextProvider>
           </SchemaContextProvider>
@@ -364,7 +388,7 @@ export function GraphiQL({
       </HistoryContextProvider>
     </StorageContextProvider>
   );
-}
+}) as any;
 
 GraphiQL.formatResult = (result: any): string => {
   console.warn(
@@ -421,11 +445,13 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'storage'
 >;
 
-function GraphiQLConsumeContexts({
-  getDefaultFieldNames,
-  onCopyQuery,
-  ...props
-}: GraphiQLWithContextProviderProps) {
+const GraphiQLConsumeContexts = forwardRef<
+  GraphiQLWithContext,
+  GraphiQLWithContextProviderProps
+>(function GraphiQLConsumeContexts(
+  { getDefaultFieldNames, onCopyQuery, ...props },
+  ref,
+) {
   const editorContext = useEditorContext({ nonNull: true });
   const executionContext = useExecutionContext({ nonNull: true });
   const explorerContext = useExplorerContext();
@@ -451,9 +477,10 @@ function GraphiQLConsumeContexts({
       copy={copy}
       merge={merge}
       prettify={prettify}
+      ref={ref}
     />
   );
-}
+});
 
 type GraphiQLWithContextConsumerProps = Omit<
   GraphiQLWithContextProviderProps,

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -736,7 +736,7 @@ class GraphiQLWithContext extends React.Component<
                   <HeaderEditor
                     active={this.state.headerEditorActive}
                     editorTheme={this.props.editorTheme}
-                    onEdit={this.handleEditHeaders}
+                    onEdit={this.props.onEditHeaders}
                     readOnly={this.props.readOnly}
                     shouldPersistHeaders={this.props.shouldPersistHeaders}
                   />
@@ -825,12 +825,6 @@ class GraphiQLWithContext extends React.Component<
   }
 
   // Private methods
-
-  handleEditHeaders = (value: string) => {
-    if (this.props.onEditHeaders) {
-      this.props.onEditHeaders(value);
-    }
-  };
 
   handleSelectHistoryQuery = ({
     query,

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -62,11 +62,7 @@ import find from '../utility/find';
 import { getLeft, getTop } from '../utility/elementPosition';
 
 import { formatError, formatResult } from '@graphiql/toolkit';
-import type {
-  Fetcher,
-  GetDefaultFieldNamesFn,
-  QueryStoreItem,
-} from '@graphiql/toolkit';
+import type { Fetcher, GetDefaultFieldNamesFn } from '@graphiql/toolkit';
 
 import { Tab, TabAddButton, Tabs } from './Tabs';
 
@@ -613,7 +609,7 @@ class GraphiQLWithContext extends React.Component<
           <div
             className="historyPaneWrap"
             style={{ width: '230px', zIndex: 7 }}>
-            <QueryHistory onSelect={this.handleSelectHistoryQuery} />
+            <QueryHistory />
           </div>
         )}
         <div className="editorWrap">
@@ -825,26 +821,6 @@ class GraphiQLWithContext extends React.Component<
   }
 
   // Private methods
-
-  handleSelectHistoryQuery = ({
-    query,
-    variables,
-    headers,
-    operationName,
-  }: QueryStoreItem) => {
-    if (query) {
-      setQuery(this.props, query);
-    }
-    if (variables) {
-      setVariables(this.props, variables);
-    }
-    if (headers) {
-      setHeaders(this.props, headers);
-    }
-    if (operationName) {
-      this.props.onEditOperationName?.(operationName);
-    }
-  };
 
   private handleResizeStart = (downEvent: React.MouseEvent) => {
     if (!this._didClickDragBar(downEvent)) {
@@ -1104,16 +1080,4 @@ function isChildComponentType<T extends ComponentType>(
   }
 
   return child.type === component;
-}
-
-function setQuery(props: GraphiQLWithContextConsumerProps, value: string) {
-  props.editorContext.queryEditor?.setValue(value);
-}
-
-function setVariables(props: GraphiQLWithContextConsumerProps, value: string) {
-  props.editorContext.variableEditor?.setValue(value);
-}
-
-function setHeaders(props: GraphiQLWithContextConsumerProps, value: string) {
-  props.editorContext.headerEditor?.setValue(value);
 }

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -801,6 +801,9 @@ class GraphiQLWithContext extends React.Component<
    * @public
    */
   getQueryEditor() {
+    console.warn(
+      'The method `GraphiQL.getQueryEditor` is deprecated and will be removed in the next major version. To set the value of the editor you can use the `query` prop. To react on changes of the editor value you can pass a callback to the `onEditQuery` prop.',
+    );
     return this.props.editorContext.queryEditor || null;
   }
 
@@ -810,6 +813,9 @@ class GraphiQLWithContext extends React.Component<
    * @public
    */
   public getVariableEditor() {
+    console.warn(
+      'The method `GraphiQL.getVariableEditor` is deprecated and will be removed in the next major version. To set the value of the editor you can use the `variables` prop. To react on changes of the editor value you can pass a callback to the `onEditVariables` prop.',
+    );
     return this.props.editorContext.variableEditor || null;
   }
 
@@ -819,6 +825,9 @@ class GraphiQLWithContext extends React.Component<
    * @public
    */
   public getHeaderEditor() {
+    console.warn(
+      'The method `GraphiQL.getHeaderEditor` is deprecated and will be removed in the next major version. To set the value of the editor you can use the `headers` prop. To react on changes of the editor value you can pass a callback to the `onEditHeaders` prop.',
+    );
     return this.props.editorContext.headerEditor || null;
   }
 
@@ -828,6 +837,9 @@ class GraphiQLWithContext extends React.Component<
    * @public
    */
   public refresh() {
+    console.warn(
+      'The method `GraphiQL.refresh` is deprecated and will be removed in the next major version. Already now, all editors should automatically refresh when their size changes.',
+    );
     this.props.editorContext.queryEditor?.refresh();
     this.props.editorContext.variableEditor?.refresh();
     this.props.editorContext.headerEditor?.refresh();

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -684,7 +684,7 @@ class GraphiQLWithContext extends React.Component<
               <QueryEditor
                 editorTheme={this.props.editorTheme}
                 externalFragments={this.props.externalFragments}
-                onEdit={this.handleEditQuery}
+                onEdit={this.props.onEditQuery}
                 onEditOperationName={this.props.onEditOperationName}
                 readOnly={this.props.readOnly}
                 validationRules={this.props.validationRules}
@@ -825,13 +825,6 @@ class GraphiQLWithContext extends React.Component<
   }
 
   // Private methods
-
-  handleEditQuery = (value: string) => {
-    this.props.onEditQuery?.(
-      value,
-      this.props.editorContext.queryEditor?.documentAST ?? undefined,
-    );
-  };
 
   handleEditVariables = (value: string) => {
     if (this.props.onEditVariables) {


### PR DESCRIPTION
- We remove and replace some private methods:
  - All `handleEditX` were just wrapping the callback props
  - We replace the `handleSelectHistoryQuery` method with a custom hook
- All remaining public methods are now marked as deprecated
- I noticed that we broke these methods with `1.9.0` anyways because we forgot to forward the ref to the class component. Nobody complained, still I'd propose to avoid breaking changes until we release a new major version, so I added ref forwarding.