### PR TITLE
pass missing props to `EditorContextProvider`

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -363,7 +363,11 @@ export const GraphiQL: ForwardRefExoticComponent<
         <EditorContextProvider
           defaultQuery={props.defaultQuery}
           headers={props.headers}
+          onTabChange={
+            typeof props.tabs === 'object' ? props.tabs.onTabChange : undefined
+          }
           query={props.query}
+          shouldPersistHeaders={props.shouldPersistHeaders}
           variables={props.variables}>
           <SchemaContextProvider
             dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}


### PR DESCRIPTION
I somehow messed this up in #2452. This also caused the problem with duplicate tabs on reload to re-appear, lucky we didn't release the changes yet.