### PR TITLE
don't crash lsp server on graphql config errors

### DIFF
--- a/.changeset/tidy-ghosts-happen.md
+++ b/.changeset/tidy-ghosts-happen.md
@@ -1,0 +1,13 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+Aims to resolve #2421
+
+- graphql config errors only log to output channel, no longer crash the LSP
+- more performant LSP request no-ops for failing/missing config
+
+this used to fail silently in the output channel, but vscode introduced a new retry and notification for this
+
+would like to provide more helpful graphql config DX in the future but this should be better for now

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "npm.packageManager": "yarn"
+  "npm.packageManager": "yarn",
+  "cSpell.words": ["graphqlrc"]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "yarn build:clean && yarn build:packages && yarn build:graphiql-react && yarn build:graphiql",
-    "build-bundles": "yarn prebuild-bundles && yarn workspace graphiql run build-bundles",
+    "build-bundles": "yarn prebuild-bundles && wsrun -p -m -s build-bundles",
     "build-bundles-clean": "rimraf '{packages,examples,plugins}/**/{bundle,cdn,webpack}' && yarn workspace graphiql run build-bundles-clean",
     "build-clean": "wsrun -m build-clean ",
     "build-demo": "wsrun -m -s build-demo",
@@ -60,7 +60,7 @@
     "prepublishOnly": "./scripts/prepublish.sh",
     "pretty": "node scripts/pretty.js",
     "pretty-check": "node scripts/pretty.js --check",
-    "release": "yarn build && yarn build-bundles && (wsrun -m -s release --changedSince main || echo Some releases failed) && yarn changeset publish",
+    "release": "yarn build && yarn build-bundles && yarn changeset publish",
     "release:canary": "(node scripts/canary-release.js && yarn build && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",
     "repo:fix": "manypkg fix",

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -35,6 +35,7 @@ import stringToHash from './stringToHash';
 import glob from 'glob';
 import { LoadConfigOptions } from './types';
 import { URI } from 'vscode-uri';
+import { Logger } from './Logger';
 
 // Maximum files to read when processing GraphQL files.
 const MAX_READS = 200;
@@ -59,10 +60,12 @@ const {
 
 export async function getGraphQLCache({
   parser,
+  logger,
   loadConfigOptions,
   config,
 }: {
   parser: typeof parseDocument;
+  logger: Logger;
   loadConfigOptions: LoadConfigOptions;
   config?: GraphQLConfig;
 }): Promise<GraphQLCache> {
@@ -74,6 +77,7 @@ export async function getGraphQLCache({
     configDir: loadConfigOptions.rootDir as string,
     config: graphQLConfig as GraphQLConfig,
     parser,
+    logger,
   });
 }
 
@@ -86,15 +90,18 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _fragmentDefinitionsCache: Map<Uri, Map<string, FragmentInfo>>;
   _typeDefinitionsCache: Map<Uri, Map<string, ObjectTypeInfo>>;
   _parser: typeof parseDocument;
+  _logger: Logger;
 
   constructor({
     configDir,
     config,
     parser,
+    logger,
   }: {
     configDir: Uri;
     config: GraphQLConfig;
     parser: typeof parseDocument;
+    logger: Logger;
   }) {
     this._configDir = configDir;
     this._graphQLConfig = config;
@@ -104,12 +111,21 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._typeDefinitionsCache = new Map();
     this._typeExtensionMap = new Map();
     this._parser = parser;
+    this._logger = logger;
   }
 
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;
 
   getProjectForFile = (uri: string): GraphQLProjectConfig => {
-    return this._graphQLConfig.getProjectForFile(URI.parse(uri).fsPath);
+    try {
+      return this._graphQLConfig.getProjectForFile(URI.parse(uri).fsPath);
+    } catch (err) {
+      this._logger.error(
+        `there was an error loading the project config for this file ${err}`,
+      );
+      // @ts-expect-error
+      return null;
+    }
   };
 
   getFragmentDependencies = async (

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -49,7 +49,7 @@ export type {
 export interface GraphQLCache {
   getGraphQLConfig: () => GraphQLConfig;
 
-  getProjectForFile: (uri: string) => GraphQLProjectConfig;
+  getProjectForFile: (uri: string) => GraphQLProjectConfig | void;
 
   getObjectTypeDependencies: (
     query: string,

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -17,3 +17,7 @@ if [ "$CI" != true ]; then
 fi;
 
 yarn lint && yarn build && yarn build-bundles && yarn test && yarn e2e;
+
+# attempt a release against vscode-graphql and any workspace that specifies 'release'
+# if semantic release incremented the version it will publish
+(wsrun -m -s release --changedSince main || true);


### PR DESCRIPTION
Aims to resolve #2421

- graphql config errors only log to output channel, no longer crash the LSP
- improve readability, add a helpful link for users
- more performant LSP request no-ops for failing/missing config

this used to fail silently in the output channel, but vscode introduced a new retry and notification for this. in previous versions of vscode, the server exited non-0, but this didn't cause notifications for the user. this should introduce bugfixes and improvements for non-vscode users of the LSP server as well.

would like to provide more helpful graphql config DX in the future but this should be better for now.

if your LSP server cli implementation needs a non-zero exit for missing/invalid lsp config, let me know and we can add a feature to enable a non-zero failure on config errors for LSP and/or the CLI service wrapper