### PR TITLE
Ensure highlighting works with typescript type parameters

### DIFF
--- a/.changeset/sharp-bags-appear.md
+++ b/.changeset/sharp-bags-appear.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql': patch
+---
+
+Fix bug with typed parameters on the gql/graphql/etc tagged templates!

--- a/packages/vscode-graphql/README.md
+++ b/packages/vscode-graphql/README.md
@@ -247,6 +247,10 @@ const myQuery =
 
 - the output channel occasionally shows "definition not found" when you first start the language service, but once the definition cache is built for each project, definition lookup will work. so if a "peek definition" fails when you first start the editor or when you first install the extension, just try the definition lookup again.
 
+## Attribution
+
+Thanks to apollo for their [graphql-vscode grammars](https://github.com/apollographql/vscode-graphql/blob/main/syntaxes/graphql.js.json)! We have borrowed from these on several occasions. If you are looking for the most replete set of vscode grammars for writing your own extension, look no further!
+
 ## Development
 
 This plugin uses the [GraphQL language server](https://github.com/graphql/graphql-language-service-server)

--- a/packages/vscode-graphql/grammars/graphql.js.json
+++ b/packages/vscode-graphql/grammars/graphql.js.json
@@ -43,6 +43,31 @@
       "patterns": [{ "include": "source.graphql" }]
     },
     {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*(?:<.*>)(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.class.js"
+        },
+        "2": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "3": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "4": {
+          "name": "punctuation.definition.string.template.begin.js"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [{ "include": "source.graphql" }]
+    },
+    {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.graphql",
       "begin": "(`)(#graphql)",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -1,12 +1,11 @@
 {
   "name": "vscode-graphql",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "preview": true,
   "private": true,
   "license": "MIT",
   "displayName": "GraphQL",
   "keywords": [
-    "multi-root ready",
     "graphql",
     "lsp",
     "graph"


### PR DESCRIPTION
At least a partial fix for #2356, enables highlighting for template strings with typescript type parameters

Borrowed from https://github.com/apollographql/vscode-graphql/blob/main/syntaxes/graphql.js.json

Also casually bump the version for vscode-graphql once since 0.4.9 is released already from my local, so 0.4.10 becomes the next resolution we want.

This is not the most ideal way of accomplishing this, but I couldn't get it working with a single pattern

![type param example](https://user-images.githubusercontent.com/1368727/172007945-9e1dd9cf-8acb-475d-810a-4350f7657e27.gif)
