### PR TITLE
run release script if specified for non npm releases

### DIFF
--- a/.changeset/violet-peaches-compete.md
+++ b/.changeset/violet-peaches-compete.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+No longer load dotenv in the LSP server

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prepublishOnly": "./scripts/prepublish.sh",
     "pretty": "node scripts/pretty.js",
     "pretty-check": "node scripts/pretty.js --check",
-    "release": "yarn build && yarn build-bundles && yarn changeset publish",
+    "release": "yarn build && yarn build-bundles && (wsrun release --exclude-missing --serial --recursive --changedSince main || true) && yarn changeset publish",
     "release:canary": "(node scripts/canary-release.js && yarn build && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",
     "repo:fix": "manypkg fix",

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -81,9 +81,6 @@ const writeFileAsync = promisify(writeFile);
 const configDocLink =
   'https://www.npmjs.com/package/graphql-language-service-server#user-content-graphql-configuration-file';
 
-// import dotenv config as early as possible for graphql-config cjs pattern
-require('dotenv').config();
-
 type CachedDocumentType = {
   version: number;
   contents: CachedContent[];

--- a/scripts/prepublish.sh
+++ b/scripts/prepublish.sh
@@ -17,7 +17,3 @@ if [ "$CI" != true ]; then
 fi;
 
 yarn lint && yarn build && yarn build-bundles && yarn test && yarn e2e;
-
-# attempt a release against vscode-graphql and any workspace that specifies 'release'
-# if semantic release incremented the version it will publish
-(wsrun -m -s release --changedSince main || true);


### PR DESCRIPTION
I also made a change to the LSP server to make sure we see releases in tandem.

It removes dotenv from the LSP server itself, as the docs now reccomend requiring it in-file