### PR TITLE
apply fixes for ESLint `no-useless-catch` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
     'valid-typeof': 'error',
 
     // Best Practices (http://eslint.org/docs/rules/#best-practices)
+    'no-useless-catch': 'error',
     'accessor-pairs': 1,
     'array-callback-return': 0,
     'block-scoped-var': 0,

--- a/examples/graphiql-2-rfc-context/src/workers/graphql.worker.ts
+++ b/examples/graphiql-2-rfc-context/src/workers/graphql.worker.ts
@@ -15,14 +15,9 @@ import type { ICreateData } from 'monaco-graphql/esm/typings';
 import { GraphQLWorker } from 'monaco-graphql/esm/GraphQLWorker';
 
 self.onmessage = () => {
-  try {
-    // ignore the first message
-    worker.initialize(
-      (ctx: WorkerNamespace.IWorkerContext, createData: ICreateData) => {
-        return new GraphQLWorker(ctx, createData);
-      },
-    );
-  } catch (err) {
-    throw err;
-  }
+  // ignore the first message
+  worker.initialize(
+    (ctx: WorkerNamespace.IWorkerContext, createData: ICreateData) =>
+      new GraphQLWorker(ctx, createData),
+  );
 };

--- a/packages/monaco-graphql/src/graphql.worker.ts
+++ b/packages/monaco-graphql/src/graphql.worker.ts
@@ -14,13 +14,8 @@ import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker';
 import { GraphQLWorker } from './GraphQLWorker';
 
 self.onmessage = () => {
-  try {
-    initialize(
-      (ctx: WorkerNamespace.IWorkerContext, createData: ICreateData) => {
-        return new GraphQLWorker(ctx, createData);
-      },
-    );
-  } catch (err) {
-    throw err;
-  }
+  initialize(
+    (ctx: WorkerNamespace.IWorkerContext, createData: ICreateData) =>
+      new GraphQLWorker(ctx, createData),
+  );
 };


### PR DESCRIPTION
Why:
1. this rule is included in the default `eslint:recommended` config
2. just rethrowing an error in the catch block is redundant and confusing