### PR TITLE
feat: add prettier!

### DIFF
--- a/.changeset/fair-snails-drum.md
+++ b/.changeset/fair-snails-drum.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Introduce prettier formatting support to graphiql

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -37,7 +37,8 @@
     "escape-html": "^1.0.3",
     "graphql-language-service": "^5.0.6",
     "markdown-it": "^12.2.0",
-    "set-value": "^4.1.0"
+    "set-value": "^4.1.0",
+    "prettier": "^2.7.0"
   },
   "devDependencies": {
     "@types/codemirror": "^5.60.5",

--- a/packages/graphiql/cypress/integration/prettify.spec.ts
+++ b/packages/graphiql/cypress/integration/prettify.spec.ts
@@ -10,7 +10,8 @@ const prettifiedQuery = `{
   longDescriptionType {
     id
   }
-}`;
+}
+`;
 
 const prettifiedVariables = `{
   "a": 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -15752,6 +15752,11 @@ prettier@^2.0.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.4.tgz#2d1bae173e355996ee355ec9830a7a1ee05457ef"
   integrity sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==
 
+prettier@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.0.tgz#a4fdae07e5596c51c9857ea676cd41a0163879d6"
+  integrity sha512-nwoX4GMFgxoPC6diHvSwmK/4yU8FFH3V8XWtLQrbj4IBsK2pkYhG4kf/ljF/haaZ/aii+wNJqISrCDPgxGWDVQ==
+
 pretty-bytes@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.5.0.tgz#0cecda50a74a941589498011cf23275aa82b339e"


### PR DESCRIPTION
This introduces prettier formatting by dynamically importing prettier's core library and the graphql plugin.  This is how we've imported prettier in `monaco-graphql`'s webworker compatible language service since 2020!

It's not ideal for UX, because the dependency is fetched only when using `format` for the first time. I would prefer to use pre-fetching, but I'm not sure how to implement `import()` prefetching in a cross-bundler compliant way. We could also manually prefetch on a triggered event, such as blur/focus of the format button.