### PR TITLE
use graphql-config legacy mode by default

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -141,7 +141,8 @@ export class MessageProcessor {
     this._tmpDir = tmpDir || tmpdir();
     this._tmpDirBase = path.join(this._tmpDir, 'graphql-language-service');
     this._tmpUriBase = URI.file(this._tmpDirBase).toString();
-    this._loadConfigOptions = loadConfigOptions;
+    // use legacy mode by default for backwards compatibility
+    this._loadConfigOptions = { legacy: true, ...loadConfigOptions };
     if (
       loadConfigOptions.extensions &&
       loadConfigOptions.extensions?.length > 0


### PR DESCRIPTION
since many of the folks using `.graphqlrc` files still are dealing with abstractions that don't make it easy to provide LSP settings for config request, i think we should just make this the default for now.