### PR TITLE
add missing `caller` arguments

### DIFF
--- a/.changeset/short-gifts-heal.md
+++ b/.changeset/short-gifts-heal.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Add missing `caller` arguments to hook calls so that the error message printed when a context provider is missing is more accurate about the component or hook that caused the error

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -113,7 +113,7 @@ export function useHeaderEditor({
     useHeaderEditor,
   );
 
-  useCompletion(headerEditor);
+  useCompletion(headerEditor, useHeaderEditor);
 
   useKeyMap(headerEditor, ['Cmd-Enter', 'Ctrl-Enter'], executionContext?.run);
   useKeyMap(headerEditor, ['Shift-Ctrl-P'], prettify);

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -69,8 +69,11 @@ export function useChangeHandler(
   ]);
 }
 
-export function useCompletion(editor: CodeMirrorEditor | null) {
-  const { schema } = useSchemaContext({ nonNull: true, caller: useCompletion });
+export function useCompletion(
+  editor: CodeMirrorEditor | null,
+  caller: Function,
+) {
+  const { schema } = useSchemaContext({ nonNull: true, caller });
   const explorer = useExplorerContext();
   useEffect(() => {
     if (!editor) {

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -324,7 +324,7 @@ export function useQueryEditor({
     codeMirrorRef,
   );
 
-  useCompletion(queryEditor);
+  useCompletion(queryEditor, useQueryEditor);
 
   useKeyMap(queryEditor, ['Cmd-Enter', 'Ctrl-Enter'], executionContext?.run);
   useKeyMap(queryEditor, ['Shift-Ctrl-C'], copy);

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -130,7 +130,7 @@ export function useVariableEditor({
     useVariableEditor,
   );
 
-  useCompletion(variableEditor);
+  useCompletion(variableEditor, useVariableEditor);
 
   useKeyMap(variableEditor, ['Cmd-Enter', 'Ctrl-Enter'], executionContext?.run);
   useKeyMap(variableEditor, ['Shift-Ctrl-P'], prettify);

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -51,7 +51,9 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     updateActiveTabValues,
   } = useEditorContext({ nonNull: true, caller: ExecutionContextProvider });
   const history = useHistoryContext();
-  const autoCompleteLeafs = useAutoCompleteLeafs();
+  const autoCompleteLeafs = useAutoCompleteLeafs({
+    caller: ExecutionContextProvider,
+  });
   const [isFetching, setIsFetching] = useState(false);
   const [subscription, setSubscription] = useState<Unsubscribable | null>(null);
   const queryIdRef = useRef(0);


### PR DESCRIPTION
For users of `@graphiql/react` we want to make clear which hook or component is missing which context provider. We achieve this by forwarding the function that was called by the user via `caller` attributes to the editor consumers that require a certain context to be present.

We are already doing this for lots of places, just in some this was missing (which is my oversight 😅 ), so this is just a tiny usability fix.