### PR TITLE
set default background color for editors

### DIFF
--- a/.changeset/serious-actors-accept.md
+++ b/.changeset/serious-actors-accept.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Set background color for editor to white by default

--- a/packages/graphiql-react/src/editor/style/codemirror.css
+++ b/packages/graphiql-react/src/editor/style/codemirror.css
@@ -12,11 +12,11 @@
   font-family: var(--font-family-mono);
 }
 
-/* Reset any background color */
+/* Set default background color */
 .CodeMirror,
 .CodeMirror-gutters {
   background: none;
-  background-color: transparent;
+  background-color: var(--color-neutral-0);
 }
 
 /* No padding around line number */

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -17,9 +17,6 @@
   flex: 1;
   flex-direction: column;
 }
-.graphiql-container .graphiql-editors .CodeMirror-gutters {
-  background-color: var(--color-neutral-0);
-}
 
 /* The response view */
 .graphiql-container .graphiql-response {


### PR DESCRIPTION
A tiny change for better defaults: Making the gutter background transparent would lead to overlapping code and line numbers for long lines. Setting the background to white (i.e. the css variable representing white) is a better default.

<img width="521" alt="CleanShot 2022-06-30 at 18 27 18@2x" src="https://user-images.githubusercontent.com/22288634/176729545-c81b6995-d007-47f7-b1b4-3a56b8717ffe.png">
