### PR TITLE
set default background colors via css variables

### DIFF
--- a/packages/graphiql-react/src/editor/style/codemirror.css
+++ b/packages/graphiql-react/src/editor/style/codemirror.css
@@ -16,7 +16,7 @@
 .CodeMirror,
 .CodeMirror-gutters {
   background: none;
-  background-color: var(--color-neutral-0);
+  background-color: var(--editor-background, var(--color-neutral-0));
 }
 
 /* No padding around line number */

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -121,6 +121,7 @@
 }
 
 .graphiql-container .result-window {
+  --editor-background: var(--color-neutral-7);
   flex: 1;
   height: 100%;
   position: relative;


### PR DESCRIPTION
Following up on #2528, setting the editor background to white by default works for query, variable, and header editors, but it's not the right default for the response editor. This PR addresses that by adding a new CSS variable `--editor-background` that allows to define the background for a specific editor. The default is still white.