### PR TITLE
clean up repository references, more readmes and links

### DIFF
--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -8,7 +8,11 @@
     "Angel Gomez Salazar <agomezs@fb.com>"
   ],
   "homepage": "https://github.com/graphql/graphiql/tree/main/packages/codemirror-graphql#readme",
-  "repository": "https://github.com/graphql/graphiql",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/graphql/graphiql",
+    "directory": "packages/codemirror-graphql"
+  },
   "bugs": {
     "url": "https://github.com/graphql/graphiql/issues?q=issue+label:codemirror-graphql"
   },

--- a/packages/graphiql-react/README.md
+++ b/packages/graphiql-react/README.md
@@ -1,0 +1,7 @@
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/graphiql-react/CHANGELOG.md) | [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphiql_react.html) | [NPM](https://www.npmjs.com/package/@graphiql/react)
+
+A react SDK for building graphql developer experiences for the web
+
+Used by `graphiql@2` and beyond!
+
+(docs coming soon!)

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -14,6 +14,12 @@
   "main": "dist/graphiql-react.cjs.js",
   "module": "dist/graphiql-react.es.js",
   "types": "types/index.d.ts",
+  "keywords": [
+    "react",
+    "graphql",
+    "sdk",
+    "codemirror"
+  ],
   "files": [
     "dist",
     "src",

--- a/packages/graphiql-toolkit/README.md
+++ b/packages/graphiql-toolkit/README.md
@@ -1,4 +1,4 @@
-[Discord Channel](https://discord.gg/NP5vbPeUFp)
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/graphql-toolkit/CHANGELOG.md) | [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphiql_toolkit.html) | [NPM](https://www.npmjs.com/package/@graphiql/toolkit) | [Discord](https://discord.gg/NP5vbPeUFp)
 
 # `@graphiql/toolkit`
 

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -6,7 +6,11 @@
     "Hyohyeon Jeong <asiandrummer@fb.com>",
     "Lee Byron <lee@leebyron.com> (http://leebyron.com/)"
   ],
-  "repository": "http://github.com/graphql/graphiql",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/graphql/graphiql",
+    "directory": "packages/graphiql"
+  },
   "homepage": "http://github.com/graphql/graphiql/tree/master/packages/graphiql#readme",
   "bugs": {
     "url": "https://github.com/graphql/graphiql/issues?q=issue+label:graphiql"

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -6,7 +6,11 @@
     "Hyohyeon Jeong <asiandrummer@fb.com>",
     "Lee Byron <lee@leebyron.com> (http://leebyron.com/)"
   ],
-  "repository": "http://github.com/graphql/graphiql",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/graphql/graphiql",
+    "directory": "packages/graphql-language-service-cli"
+  },
   "homepage": "https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-cli#readme",
   "bugs": {
     "url": "https://github.com/graphql/graphiql/issues?q=issue+label:language-service-cli"

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -4,7 +4,8 @@
 ![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-server?label=npm%20downloads)
 [![License](https://img.shields.io/npm/l/graphql-language-service-server.svg?style=flat-square)](LICENSE)
 
-[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_server.html)
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-server/CHANGELOG.md) |
+[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_server.html) |
 [Discord Channel](https://discord.gg/PXaRYrpgK4)
 
 Server process backing the [GraphQL Language Service](https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service).

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -7,7 +7,11 @@
     "Hyohyeon Jeong <asiandrummer@fb.com>",
     "Lee Byron <lee@leebyron.com> (http://leebyron.com/)"
   ],
-  "repository": "http://github.com/graphql/graphiql",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/graphql/graphiql",
+    "directory": "packages/graphql-language-service-server"
+  },
   "homepage": "https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service-server#readme",
   "bugs": {
     "url": "https://github.com/graphql/graphiql/issues?q=issue+label:language-server"

--- a/packages/graphql-language-service/README.md
+++ b/packages/graphql-language-service/README.md
@@ -1,7 +1,7 @@
 # `graphql-language-service`
 
-[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service.html)
-[Discord Channel](https://discord.gg/wkQCKwazxj)
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service/CHANGELOG.md) | [API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service.html) |
+[Discord](https://discord.gg/wkQCKwazxj)
 
 > **Note**: Still mostly experimental, however it depends mostly on stable libraries.
 > **Migration Note**: As of 3.0.0, the LSP Server command line interface has been moved to [`graphql-language-service-cli`](../graphql-language-service-cli)

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -5,7 +5,11 @@
   "contributors": [
     "GraphQL Contributors"
   ],
-  "repository": "http://github.com/graphql/graphiql",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/graphql/graphiql",
+    "directory": "packages/graphql-language-service"
+  },
   "homepage": "https://github.com/graphql/graphiql/tree/main/packages/graphql-language-service#readme",
   "bugs": {
     "url": "https://github.com/graphql/graphiql/issues?q=issue+label:languageservice"

--- a/packages/monaco-graphql/README.md
+++ b/packages/monaco-graphql/README.md
@@ -1,6 +1,6 @@
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/monaco-graphql/CHANGELOG.md) |
+[API Docs](https://graphiql-test.netlify.app/typedoc/modules/graphql_language_service_server.html) |
 [Discord Channel](https://discord.gg/r4BxrAG6fN)
-
-# Monaco GraphQL
 
 GraphQL language plugin for the Monaco Editor. You can use it to build vscode/codespaces-like web or desktop IDEs using whatever frontend javascript libraries or frameworks you want, or none!
 

--- a/packages/vscode-graphql/README.md
+++ b/packages/vscode-graphql/README.md
@@ -1,16 +1,12 @@
-# VSCode GraphQL
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/vscode-graphql/CHANGELOG.md) | [Discord Channel](https://discord.gg/r4BxrAG6fN) | [LSP Server Docs](<[https://g](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-server/README.md)>)
 
 GraphQL extension VSCode built with the aim to tightly integrate the GraphQL Ecosystem with VSCode for an awesome developer experience.
 
 ![](https://camo.githubusercontent.com/97dc1080d5e6883c4eec3eaa6b7d0f29802e6b4b/687474703a2f2f672e7265636f726469742e636f2f497379504655484e5a342e676966)
 
-> _Operation Execution will be available in a new extension_
-
-## Features
-
-Lots of new improvements happening! We now have a [`CHANGELOG.md`](https://github.com/graphql/graphiql/blob/main/packages/vscode-graphql/CHANGELOG.md#change-log)
-
 ### General features
+
+> _Operation Execution will be re-introduced in a new extension_
 
 - Load the extension on detecting `graphql-config file` at root level or in a parent level directory
 - Load the extension in `.graphql`, `.gql files`
@@ -120,6 +116,8 @@ Notice that `documents` key supports glob pattern and hence `["**/*.graphql"]` i
 <span id="legacy" />
 
 ### I can't load `.graphqlconfig` files anymore
+
+> Note: this option has been set to be enabled by default, however `graphql-config` maintainers do not want to continue to support the legacy format (mostly kept for companies where intellij users are stuck on the old config format), so please migrate to the new `graphql-config` format as soon as possible!
 
 If you need to use a legacy config file, then you just need to enable legacy mode for `graphql-config`:
 
@@ -255,14 +253,12 @@ Thanks to apollo for their [graphql-vscode grammars](https://github.com/apollogr
 
 This plugin uses the [GraphQL language server](https://github.com/graphql/graphql-language-service-server)
 
-1.  Clone the repository - https://github.com/graphql/vscode-graphql
-1.  `npm install`
-1.  Open it in VSCode
-1.  Go to the debugging section and run the launch program "Extension"
+1.  Clone the repository - https://github.com/graphql/graphiql
+1.  `yarn`
+1.  Run "VScode Extension" launcher in vscode
 1.  This will open another VSCode instance with extension enabled
 1.  Open a project with a graphql config file - ":electric_plug: graphql" in VSCode status bar indicates that the extension is in use
 1.  Logs for GraphQL language service will appear in output section under GraphQL Language Service
-    ![GraphQL Language Service Logging](https://s3-ap-southeast-1.amazonaws.com/divyendusingh/vscode-graphql/Screen+Shot+2018-06-25+at+12.31.57+PM.png)
 
 ### Contributing back to this project
 


### PR DESCRIPTION
the absolute links are for npm and other repo mirrors of course
can't wait to improve our typedoc output and use it in a proper docs website soon!

the gatsby docs site experiment I did about 2 years ago is a good starting point, the branch is somewhere, but there are many approaches we can look at. graphql dot org was being rebuilt with gatsby at the time so I figured so should we. whatever folks are comfortable using is fine