### PR TITLE
add more tests for findGraphQLTags, fix cache/schema tests

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -9,7 +9,9 @@
 
 jest.mock('cross-undici-fetch', () => ({
   fetch: require('fetch-mock').fetchHandler,
+  AbortController: global.AbortController,
 }));
+
 import { GraphQLSchema } from 'graphql/type';
 import { parse } from 'graphql/language';
 import { loadConfig, GraphQLExtensionDeclaration } from 'graphql-config';
@@ -72,8 +74,7 @@ describe('GraphQLCache', () => {
     });
   });
 
-  // TODO: figure out mocking undici
-  describe.skip('getSchema', () => {
+  describe('getSchema', () => {
     it('generates the schema correctly for the test app config', async () => {
       const schema = await cache.getSchema('testWithSchema');
       expect(schema instanceof GraphQLSchema).toEqual(true);


### PR DESCRIPTION
another boring incremental improvement PR 😆 

- re-enable some tests for GraphQLCache that were disabled after an update to `graphql-config` after I found a proper mocking workaround
- add more tests for cases in `findGraphQLTags.ts` as a follow up to #2509