### PR TITLE
fix error display for websocket fetchers

### DIFF
--- a/.changeset/thirty-grapes-pay.md
+++ b/.changeset/thirty-grapes-pay.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+Fix error formatting for websocket requests and make error formatting more generic in general

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -302,23 +302,17 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
             }),
           );
         } else if (isAsyncIterable(value)) {
-          (async () => {
-            try {
-              for await (const result of value) {
-                handleResponse(result);
-              }
-              setIsFetching(false);
-              setSubscription(null);
-            } catch (error) {
-              setIsFetching(false);
-              setResponse(
-                formatError(
-                  error instanceof Error ? error : new Error(`${error}`),
-                ),
-              );
-              setSubscription(null);
+          try {
+            for await (const result of value) {
+              handleResponse(result);
             }
-          })();
+            setIsFetching(false);
+            setSubscription(null);
+          } catch (error) {
+            setIsFetching(false);
+            setResponse(formatError(error));
+            setSubscription(null);
+          }
 
           setSubscription({
             unsubscribe: () => value[Symbol.asyncIterator]().return?.(),
@@ -328,9 +322,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
         }
       } catch (error) {
         setIsFetching(false);
-        setResponse(
-          formatError(error instanceof Error ? error : new Error(`${error}`)),
-        );
+        setResponse(formatError(error));
         setSubscription(null);
       }
     },

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -302,6 +302,10 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
             }),
           );
         } else if (isAsyncIterable(value)) {
+          setSubscription({
+            unsubscribe: () => value[Symbol.asyncIterator]().return?.(),
+          });
+
           try {
             for await (const result of value) {
               handleResponse(result);
@@ -313,10 +317,6 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
             setResponse(formatError(error));
             setSubscription(null);
           }
-
-          setSubscription({
-            unsubscribe: () => value[Symbol.asyncIterator]().return?.(),
-          });
         } else {
           handleResponse(value);
         }

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -224,7 +224,7 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
           setSchema(newSchema);
           onSchemaChange?.(newSchema);
         } catch (error) {
-          setFetchError(formatError(error as Error));
+          setFetchError(formatError(error));
         }
       })
       .catch(error => {

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -1,4 +1,4 @@
-import { DocumentNode, visit, GraphQLError } from 'graphql';
+import { DocumentNode, visit } from 'graphql';
 import { meros } from 'meros';
 import {
   Client,
@@ -115,20 +115,14 @@ export const createWebsocketsFetcherFromClient = (wsClient: Client) => (
     wsClient!.subscribe(graphQLParams, {
       ...sink,
       error: err => {
-        if (err instanceof Error) {
-          sink.error(err);
-        } else if (err instanceof CloseEvent) {
+        if (err instanceof CloseEvent) {
           sink.error(
             new Error(
               `Socket closed with event ${err.code} ${err.reason || ''}`.trim(),
             ),
           );
         } else {
-          sink.error(
-            new Error(
-              (err as GraphQLError[]).map(({ message }) => message).join(', '),
-            ),
-          );
+          sink.error(err);
         }
       },
     }),

--- a/packages/graphiql-toolkit/src/format/index.ts
+++ b/packages/graphiql-toolkit/src/format/index.ts
@@ -1,46 +1,30 @@
-import { GraphQLError, GraphQLFormattedError } from 'graphql';
-
 function stringify(obj: unknown): string {
   return JSON.stringify(obj, null, 2);
 }
 
-const formatSingleError = (error: Error): Error => ({
-  ...error,
-  // Raise these details even if they're non-enumerable
-  message: error.message,
-  stack: error.stack,
-});
+function formatSingleError(error: Error): Error {
+  return {
+    ...error,
+    // Raise these details even if they're non-enumerable
+    message: error.message,
+    stack: error.stack,
+  };
+}
 
-type InputError = Error | GraphQLError | string;
-
-function handleSingleError(
-  error: InputError,
-): GraphQLFormattedError | Error | string {
-  if (error instanceof GraphQLError) {
-    return error.toString();
-  }
+function handleSingleError(error: unknown) {
   if (error instanceof Error) {
     return formatSingleError(error);
   }
   return error;
 }
 
-type GenericError =
-  | Error
-  | readonly Error[]
-  | string
-  | readonly string[]
-  | GraphQLError
-  | readonly GraphQLError[];
-
-export function formatError(error: GenericError): string {
+export function formatError(error: unknown): string {
   if (Array.isArray(error)) {
     return stringify({
-      errors: error.map((e: InputError) => handleSingleError(e)),
+      errors: error.map(e => handleSingleError(e)),
     });
   }
-  // @ts-ignore
-  return stringify({ errors: handleSingleError(error) });
+  return stringify({ errors: [handleSingleError(error)] });
 }
 
 export function formatResult(result: any): string {

--- a/packages/graphiql/cypress/integration/errors.spec.ts
+++ b/packages/graphiql/cypress/integration/errors.spec.ts
@@ -1,3 +1,5 @@
+import { version } from 'graphql';
+
 describe('Errors', () => {
   it('Should show an error when the HTTP request fails', () => {
     cy.visit('/?http-error=true');
@@ -30,7 +32,9 @@ describe('Errors', () => {
      */
     cy.get('section.result-window').should(element => {
       expect(element.get(0).innerText).to.contain(
-        'Names must only contain [_a-zA-Z0-9] but \\"<img src=x onerror=alert(document.domain)>\\" does not.',
+        version.startsWith('16.')
+          ? 'Names must only contain [_a-zA-Z0-9] but \\"<img src=x onerror=alert(document.domain)>\\" does not.'
+          : 'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \\"<img src=x onerror=alert(document.domain)>\\" does not.',
       );
     });
   });

--- a/packages/graphiql/cypress/integration/errors.spec.ts
+++ b/packages/graphiql/cypress/integration/errors.spec.ts
@@ -1,0 +1,62 @@
+describe('Errors', () => {
+  it('Should show an error when the HTTP request fails', () => {
+    cy.visit('/?http-error=true');
+    cy.assertQueryResult({
+      errors: [
+        {
+          /**
+           * The exact error message can differ depending on the browser and
+           * its JSON parser. This is the error you get in Electron (which
+           * we use to run the tests headless), the error in the latest Chrome
+           * version is different!
+           */
+          message: 'Unexpected token B in JSON at position 0',
+          stack: 'SyntaxError: Unexpected token B in JSON at position 0',
+        },
+      ],
+    });
+  });
+  it('Should show an error when introspection fails', () => {
+    cy.visit('/?graphql-error=true');
+    cy.assertQueryResult({
+      errors: [{ message: 'Something unexpected happened...' }],
+    });
+  });
+  it('Should show an error when the schema is invalid', () => {
+    cy.visit('/?bad=true');
+    /**
+     * We can't use `cy.assertQueryResult` here because the stack contains line
+     * and column numbers of the `graphiql.min.js` bundle which are not stable.
+     */
+    cy.get('section.result-window').should(element => {
+      expect(element.get(0).innerText).to.contain(
+        'Names must only contain [_a-zA-Z0-9] but \\"<img src=x onerror=alert(document.domain)>\\" does not.',
+      );
+    });
+  });
+  it('Should show an error when sending an invalid query', () => {
+    cy.visitWithOp({ query: '{thisDoesNotExist}' });
+    cy.clickExecuteQuery();
+    cy.assertQueryResult({
+      errors: [
+        {
+          message: 'Cannot query field "thisDoesNotExist" on type "Test".',
+          locations: [{ line: 1, column: 2 }],
+        },
+      ],
+    });
+  });
+  it('Should show an error when sending an invalid subscription', () => {
+    cy.visitWithOp({ query: 'subscription {thisDoesNotExist}' });
+    cy.clickExecuteQuery();
+    cy.assertQueryResult({
+      errors: [
+        {
+          message:
+            'Cannot query field "thisDoesNotExist" on type "SubscriptionType".',
+          locations: [{ line: 1, column: 15 }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/graphiql/cypress/integration/graphqlWs.spec.ts
+++ b/packages/graphiql/cypress/integration/graphqlWs.spec.ts
@@ -12,11 +12,10 @@ describe('IncrementalDelivery support via fetcher', () => {
     };
 
     it('Expects a subscription to resolve', () => {
-      cy.assertQueryResult(
-        { query: testSubscription, variables: { delay: 0 } },
-        mockSubscriptionSuccess,
-        1200,
-      );
+      cy.visitWithOp({ query: testSubscription, variables: { delay: 0 } });
+      cy.clickExecuteQuery();
+      cy.wait(1200);
+      cy.assertQueryResult(mockSubscriptionSuccess);
     });
   });
 });

--- a/packages/graphiql/cypress/integration/incrementalDelivery.spec.ts
+++ b/packages/graphiql/cypress/integration/incrementalDelivery.spec.ts
@@ -59,20 +59,16 @@ describeOrSkip('IncrementalDelivery support via fetcher', () => {
       const delay = 100;
       const timeout = mockStreamSuccess.data.streamable.length * (delay * 1.5);
 
-      cy.visit(`/?query=${testStreamQuery}`);
-      cy.assertQueryResult(
-        { query: testStreamQuery, variables: { delay } },
-        mockStreamSuccess,
-        timeout,
-      );
+      cy.visitWithOp({ query: testStreamQuery, variables: { delay } });
+      cy.clickExecuteQuery();
+      cy.wait(timeout);
+      cy.assertQueryResult(mockStreamSuccess);
     });
 
     it('Expects a quick stream to resolve in a single increment', () => {
-      cy.visit(`/?query=${testStreamQuery}`);
-      cy.assertQueryResult(
-        { query: testStreamQuery, variables: { delay: 0 } },
-        mockStreamSuccess,
-      );
+      cy.visitWithOp({ query: testStreamQuery, variables: { delay: 0 } });
+      cy.clickExecuteQuery();
+      cy.assertQueryResult(mockStreamSuccess);
     });
   });
 
@@ -92,21 +88,19 @@ describeOrSkip('IncrementalDelivery support via fetcher', () => {
         }
       `;
 
-      cy.visit(`/?query=${testQuery}`);
-      cy.assertQueryResult(
-        { query: testQuery, variables: { delay } },
-        {
-          data: {
-            deferrable: {
-              normalString: 'Nice',
-              deferredString:
-                'Oops, this took 1 seconds longer than I thought it would!',
-            },
+      cy.visitWithOp({ query: testQuery, variables: { delay } });
+      cy.clickExecuteQuery();
+      cy.wait(timeout);
+      cy.assertQueryResult({
+        data: {
+          deferrable: {
+            normalString: 'Nice',
+            deferredString:
+              'Oops, this took 1 seconds longer than I thought it would!',
           },
-          hasNext: false,
         },
-        timeout,
-      );
+        hasNext: false,
+      });
     });
 
     it('Expects to merge types when members arrive at different times', () => {
@@ -142,38 +136,36 @@ describeOrSkip('IncrementalDelivery support via fetcher', () => {
         }
       `;
 
-      cy.visit(`/?query=${testQuery}`);
-      cy.assertQueryResult(
-        { query: testQuery, variables: { delay } },
-        {
-          data: {
-            person: {
-              name: 'Mark',
-              friends: [
-                {
-                  name: 'James',
-                  age: 1000,
-                },
-                {
-                  name: 'Mary',
-                  age: 1000,
-                },
-                {
-                  name: 'John',
-                  age: 1000,
-                },
-                {
-                  name: 'Patrica',
-                  age: 1000,
-                },
-              ],
-              age: 1000,
-            },
+      cy.visitWithOp({ query: testQuery, variables: { delay } });
+      cy.clickExecuteQuery();
+      cy.wait(timeout);
+      cy.assertQueryResult({
+        data: {
+          person: {
+            name: 'Mark',
+            friends: [
+              {
+                name: 'James',
+                age: 1000,
+              },
+              {
+                name: 'Mary',
+                age: 1000,
+              },
+              {
+                name: 'John',
+                age: 1000,
+              },
+              {
+                name: 'Patrica',
+                age: 1000,
+              },
+            ],
+            age: 1000,
           },
-          hasNext: false,
         },
-        timeout,
-      );
+        hasNext: false,
+      });
     });
   });
 });

--- a/packages/graphiql/cypress/integration/init.spec.ts
+++ b/packages/graphiql/cypress/integration/init.spec.ts
@@ -43,7 +43,9 @@ describe('GraphiQL On Initialization', () => {
   });
 
   it('Executes a GraphQL query over HTTP that has the expected result', () => {
-    cy.assertQueryResult({ query: testQuery }, mockSuccess);
+    cy.visitWithOp({ query: testQuery });
+    cy.clickExecuteQuery();
+    cy.assertQueryResult(mockSuccess);
   });
   it('Shows the expected error when the schema is invalid', () => {
     cy.visit(`/?bad=true`);

--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -34,11 +34,7 @@ declare namespace Cypress {
     visitWithOp(op: Op): Chainable<Element>;
     clickPrettify(): Chainable<Element>;
     assertHasValues(op: Op): Chainable<Element>;
-    assertQueryResult(
-      op: Op,
-      expectedResult: MockResult,
-      timeout?: number,
-    ): Chainable<Element>;
+    assertQueryResult(expectedResult: MockResult): Chainable<Element>;
     assertLinterMarkWithMessage(
       text: string,
       severity: 'error' | 'warning',
@@ -117,13 +113,10 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add('assertQueryResult', (op, mockSuccess, timeout = 200) => {
-  cy.visitWithOp(op);
-  cy.clickExecuteQuery();
-  cy.wait(timeout);
+Cypress.Commands.add('assertQueryResult', expectedResult => {
   cy.get('section.result-window').should(element => {
     expect(normalizeWhitespace(element.get(0).innerText)).to.equal(
-      JSON.stringify(mockSuccess, null, 2),
+      JSON.stringify(expectedResult, null, 2),
     );
   });
 });

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -77,8 +77,12 @@ function getSchemaUrl() {
 
   if (isDev) {
     // This supports an e2e test which ensures that invalid schemas do not load.
-    if (parameters.bad && parameters.bad === 'true') {
+    if (parameters.bad === 'true') {
       return '/bad/graphql';
+    } else if (parameters['http-error'] === 'true') {
+      return '/http-error/graphql';
+    } else if (parameters['graphql-error'] === 'true') {
+      return '/graphql-error/graphql';
     } else {
       return '/graphql';
     }

--- a/packages/graphiql/test/e2e-server.js
+++ b/packages/graphiql/test/e2e-server.js
@@ -9,6 +9,7 @@
 const express = require('express');
 const path = require('path');
 const { graphqlHTTP } = require('express-graphql');
+const { GraphQLError } = require('graphql');
 const schema = require('./schema');
 const app = express();
 const { schema: badSchema } = require('./bad-schema');
@@ -26,6 +27,16 @@ app.get(
 
 app.post('/bad/graphql', (_req, res, next) => {
   res.json({ data: badSchema });
+  next();
+});
+
+app.post('/http-error/graphql', (_req, res, next) => {
+  res.status(502).send('Bad Gateway');
+  next();
+});
+
+app.post('/graphql-error/graphql', (_req, res, next) => {
+  res.json({ errors: [new GraphQLError('Something unexpected happened...')] });
   next();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7432,18 +7432,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cross-undici-fetch@0.1.20:
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/cross-undici-fetch/-/cross-undici-fetch-0.1.20.tgz#935c252d3224a31c96d2107d1a379733732e9333"
-  integrity sha512-czQhJIgyRnyZ6WqbZ3H1FDXwqOnIWFOWB9JOCKSSdlV1W6huHfzDRFiLePljXMxvwLBiQ7Ag7gGuCFtTw+1zHg==
-  dependencies:
-    abort-controller "^3.0.0"
-    form-data-encoder "^1.7.1"
-    formdata-node "^4.3.1"
-    node-fetch "^2.6.7"
-    undici "^4.9.3"
-    web-streams-polyfill "^3.2.0"
-
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -17656,11 +17644,6 @@ underscore@^1.12.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
-
-undici@^4.9.3:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-4.16.0.tgz#469bb87b3b918818d3d7843d91a1d08da357d5ff"
-  integrity sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==
 
 undici@^5.8.0:
   version "5.8.0"


### PR DESCRIPTION
Fixes #2534

The issue is caused by the default ws-fetcher which wraps joins multiple error messages and wraps them in a new error.

Open TODOs:
- [x] add changeset
- [x] write some tests for displaying correctly formatted errors in general