### PR TITLE
add caller argument to editor hooks

### DIFF
--- a/packages/graphiql-react/src/editor/components/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/components/header-editor.tsx
@@ -14,7 +14,7 @@ export function HeaderEditor({ isHidden, ...hookArgs }: HeaderEditorProps) {
     nonNull: true,
     caller: HeaderEditor,
   });
-  const ref = useHeaderEditor(hookArgs);
+  const ref = useHeaderEditor(hookArgs, HeaderEditor);
 
   useEffect(() => {
     if (headerEditor && !isHidden) {

--- a/packages/graphiql-react/src/editor/components/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/components/query-editor.tsx
@@ -10,6 +10,6 @@ import '../style/auto-insertion.css';
 import '../style/editor.css';
 
 export function QueryEditor(props: UseQueryEditorArgs) {
-  const ref = useQueryEditor(props);
+  const ref = useQueryEditor(props, QueryEditor);
   return <div className="graphiql-editor" ref={ref} />;
 }

--- a/packages/graphiql-react/src/editor/components/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/components/response-editor.tsx
@@ -6,7 +6,7 @@ import '../style/info.css';
 import '../style/editor.css';
 
 export function ResponseEditor(props: UseResponseEditorArgs) {
-  const ref = useResponseEditor(props);
+  const ref = useResponseEditor(props, ResponseEditor);
   return (
     <section
       className="result-window"

--- a/packages/graphiql-react/src/editor/components/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/components/variable-editor.tsx
@@ -18,7 +18,7 @@ export function VariableEditor({ isHidden, ...hookArgs }: VariableEditorProps) {
     nonNull: true,
     caller: VariableEditor,
   });
-  const ref = useVariableEditor(hookArgs);
+  const ref = useVariableEditor(hookArgs, VariableEditor);
 
   useEffect(() => {
     if (variableEditor && !isHidden) {

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -21,20 +21,23 @@ export type UseHeaderEditorArgs = {
   keyMap?: KeyMap;
 };
 
-export function useHeaderEditor({
-  editorTheme = 'graphiql',
-  keyMap,
-  onEdit,
-  readOnly = false,
-  shouldPersistHeaders = false,
-}: UseHeaderEditorArgs = {}) {
+export function useHeaderEditor(
+  {
+    editorTheme = 'graphiql',
+    keyMap,
+    onEdit,
+    readOnly = false,
+    shouldPersistHeaders = false,
+  }: UseHeaderEditorArgs = {},
+  caller?: Function,
+) {
   const { initialHeaders, headerEditor, setHeaderEditor } = useEditorContext({
     nonNull: true,
-    caller: useHeaderEditor,
+    caller: caller || useHeaderEditor,
   });
   const executionContext = useExecutionContext();
-  const merge = useMergeQuery({ caller: useHeaderEditor });
-  const prettify = usePrettifyEditors({ caller: useHeaderEditor });
+  const merge = useMergeQuery({ caller: caller || useHeaderEditor });
+  const prettify = usePrettifyEditors({ caller: caller || useHeaderEditor });
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -46,20 +46,23 @@ export type UseQueryEditorArgs = {
   keyMap?: KeyMap;
 };
 
-export function useQueryEditor({
-  editorTheme = 'graphiql',
-  keyMap,
-  externalFragments,
-  onClickReference,
-  onCopyQuery,
-  onEdit,
-  onEditOperationName,
-  readOnly = false,
-  validationRules,
-}: UseQueryEditorArgs = {}) {
+export function useQueryEditor(
+  {
+    editorTheme = 'graphiql',
+    keyMap,
+    externalFragments,
+    onClickReference,
+    onCopyQuery,
+    onEdit,
+    onEditOperationName,
+    readOnly = false,
+    validationRules,
+  }: UseQueryEditorArgs = {},
+  caller?: Function,
+) {
   const { schema } = useSchemaContext({
     nonNull: true,
-    caller: useQueryEditor,
+    caller: caller || useQueryEditor,
   });
   const {
     initialQuery,
@@ -69,14 +72,14 @@ export function useQueryEditor({
     updateActiveTabValues,
   } = useEditorContext({
     nonNull: true,
-    caller: useQueryEditor,
+    caller: caller || useQueryEditor,
   });
   const executionContext = useExecutionContext();
   const storage = useStorageContext();
   const explorer = useExplorerContext();
-  const copy = useCopyQuery({ caller: useQueryEditor, onCopyQuery });
-  const merge = useMergeQuery({ caller: useQueryEditor });
-  const prettify = usePrettifyEditors({ caller: useQueryEditor });
+  const copy = useCopyQuery({ caller: caller || useQueryEditor, onCopyQuery });
+  const merge = useMergeQuery({ caller: caller || useQueryEditor });
+  const prettify = usePrettifyEditors({ caller: caller || useQueryEditor });
   const ref = useRef<HTMLDivElement>(null);
   const codeMirrorRef = useRef<CodeMirrorType>();
 

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -19,19 +19,22 @@ export type UseResponseEditorArgs = {
   keyMap?: KeyMap;
 };
 
-export function useResponseEditor({
-  ResponseTooltip,
-  editorTheme = 'graphiql',
-  keyMap,
-  value,
-}: UseResponseEditorArgs = {}) {
+export function useResponseEditor(
+  {
+    ResponseTooltip,
+    editorTheme = 'graphiql',
+    keyMap,
+    value,
+  }: UseResponseEditorArgs = {},
+  caller?: Function,
+) {
   const { fetchError, validationErrors } = useSchemaContext({
     nonNull: true,
-    caller: useResponseEditor,
+    caller: caller || useResponseEditor,
   });
   const { responseEditor, setResponseEditor } = useEditorContext({
     nonNull: true,
-    caller: useResponseEditor,
+    caller: caller || useResponseEditor,
   });
   const ref = useRef<HTMLDivElement>(null);
 

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -20,23 +20,26 @@ export type UseVariableEditorArgs = {
   keyMap?: KeyMap;
 };
 
-export function useVariableEditor({
-  editorTheme = 'graphiql',
-  keyMap,
-  onEdit,
-  readOnly = false,
-}: UseVariableEditorArgs = {}) {
+export function useVariableEditor(
+  {
+    editorTheme = 'graphiql',
+    keyMap,
+    onEdit,
+    readOnly = false,
+  }: UseVariableEditorArgs = {},
+  caller?: Function,
+) {
   const {
     initialVariables,
     variableEditor,
     setVariableEditor,
   } = useEditorContext({
     nonNull: true,
-    caller: useVariableEditor,
+    caller: caller || useVariableEditor,
   });
   const executionContext = useExecutionContext();
-  const merge = useMergeQuery({ caller: useVariableEditor });
-  const prettify = usePrettifyEditors({ caller: useVariableEditor });
+  const merge = useMergeQuery({ caller: caller || useVariableEditor });
+  const prettify = usePrettifyEditors({ caller: caller || useVariableEditor });
   const ref = useRef<HTMLDivElement>(null);
   const codeMirrorRef = useRef<CodeMirrorType>();
 


### PR DESCRIPTION
Small quality-of-life improvement: When rendering an editor component without the necessary context, the error message will now blame the component instead of the hook.