### PR TITLE
[redesign] footer

### DIFF
--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -967,7 +967,7 @@ GraphiQLToolbar.displayName = 'GraphiQLToolbar';
 
 // Configure the UI by providing this Component as a child of GraphiQL.
 function GraphiQLFooter<TProps>(props: PropsWithChildren<TProps>) {
-  return <div className="footer">{props.children}</div>;
+  return <div className="graphiql-footer">{props.children}</div>;
 }
 
 GraphiQLFooter.displayName = 'GraphiQLFooter';

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -464,7 +464,9 @@ describe('GraphiQL', () => {
           </GraphiQL>,
         );
 
-        expect(container.querySelectorAll('.footer button')).toHaveLength(1);
+        expect(
+          container.querySelectorAll('.graphiql-footer button'),
+        ).toHaveLength(1);
       });
 
       it('can be overridden using a named component', () => {
@@ -482,7 +484,9 @@ describe('GraphiQL', () => {
         );
 
         expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
-        expect(container.querySelectorAll('.footer button')).toHaveLength(1);
+        expect(
+          container.querySelectorAll('.graphiql-footer button'),
+        ).toHaveLength(1);
       });
     });
   });

--- a/packages/graphiql/src/css/app.css
+++ b/packages/graphiql/src/css/app.css
@@ -127,24 +127,6 @@
   position: relative;
 }
 
-.graphiql-container .footer {
-  background: #f6f7f8;
-  border-left: 1px solid #e0e0e0;
-  border-top: 1px solid #e0e0e0;
-  margin-left: 12px;
-  position: relative;
-}
-
-.graphiql-container .footer:before {
-  background: #eeeeee;
-  bottom: 0;
-  content: ' ';
-  left: -13px;
-  position: absolute;
-  top: -1px;
-  width: 12px;
-}
-
 .graphiql-container .toolbar-button {
   background: #fdfdfd;
   background: linear-gradient(#f9f9f9, #ececec);

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -18,12 +18,6 @@
   flex-direction: column;
 }
 
-/* The response view */
-.graphiql-container .graphiql-response {
-  flex: 1;
-  position: relative;
-}
-
 /* The query editor */
 .graphiql-container .graphiql-query-editor {
   border-bottom: 1px solid var(--color-neutral-15);
@@ -60,6 +54,19 @@
 .graphiql-container .graphiql-editor-tool {
   flex: 1;
   padding: var(--px-16);
+}
+
+/* The response view */
+.graphiql-container .graphiql-response {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  position: relative;
+}
+
+/* The footer below the response view */
+.graphiql-container .graphiql-footer {
+  border-top: 1px solid var(--color-neutral-15);
 }
 
 /* Generic loading spinner */


### PR DESCRIPTION
Quick one: This fixes the layout for the custom footer that is displayed beneath the response editor. As there is none in the preview, here's the visual diff:

| Before | After |
| --- | --- |
| <img width="822" alt="CleanShot 2022-07-04 at 17 55 33@2x" src="https://user-images.githubusercontent.com/22288634/177188700-3cacfaec-b595-4add-84d5-c709d5969d00.png"> | <img width="822" alt="CleanShot 2022-07-04 at 17 55 50@2x" src="https://user-images.githubusercontent.com/22288634/177188706-f6882de4-f7d9-4746-81b5-0e8c84a8558a.png"> |

Note: No changeset here, we already have one for the redesign in #2523 