### PR TITLE
fix the `onSchemaChange` prop

### DIFF
--- a/.changeset/flat-humans-attend.md
+++ b/.changeset/flat-humans-attend.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix the `onSchemaChange` prop, it is now again called after the schema is fetched (this was broken since v1.9.3)

--- a/.changeset/warm-weeks-allow.md
+++ b/.changeset/warm-weeks-allow.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add `onSchemaChange` callback prop to the `SchemaContextProvider` component

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -437,6 +437,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     inputValueDeprecation,
     introspectionQueryName,
     maxHistoryLength,
+    onSchemaChange,
     onToggleHistory,
     onToggleDocs,
     storage,
@@ -470,6 +471,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             fetcher={fetcher}
             inputValueDeprecation={inputValueDeprecation}
             introspectionQueryName={introspectionQueryName}
+            onSchemaChange={onSchemaChange}
             schema={schema}
             schemaDescription={schemaDescription}>
             <ExecutionContextProvider
@@ -504,6 +506,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'inputValueDeprecation'
   | 'introspectionQueryName'
   | 'maxHistoryLength'
+  | 'onSchemaChange'
   | 'onToggleDocs'
   | 'onToggleHistory'
   | 'query'


### PR DESCRIPTION
Fixes #2503 

This broke when we introduced the `SchemaContextProvider` from `@graphiql/react` in v1.9.3 (see #2420)