### PR TITLE
avoid top-level dynamic codemirror imports

### DIFF
--- a/.changeset/tame-owls-wink.md
+++ b/.changeset/tame-owls-wink.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Avoid top-level imports from `codemirror` that break importing the package in non-browser environments

--- a/.changeset/tame-owls-wink.md
+++ b/.changeset/tame-owls-wink.md
@@ -2,4 +2,4 @@
 '@graphiql/react': patch
 ---
 
-Avoid top-level imports from `codemirror` that break importing the package in non-browser environments
+Avoid top-level dynamic imports from `codemirror` that break importing the package in non-browser environments

--- a/packages/graphiql-react/src/editor/common.ts
+++ b/packages/graphiql-react/src/editor/common.ts
@@ -17,20 +17,6 @@ export const commonKeys = {
   'Alt-Right': 'goGroupRight',
 };
 
-export const commonCodeMirrorAddons = [
-  import('codemirror/addon/hint/show-hint'),
-  import('codemirror/addon/edit/matchbrackets'),
-  import('codemirror/addon/edit/closebrackets'),
-  import('codemirror/addon/fold/brace-fold'),
-  import('codemirror/addon/fold/foldgutter'),
-  import('codemirror/addon/lint/lint'),
-  import('codemirror/addon/search/searchcursor'),
-  import('codemirror/addon/search/jump-to-line'),
-  import('codemirror/addon/dialog/dialog'),
-  // @ts-expect-error
-  import('codemirror/keymap/sublime'),
-];
-
 /**
  * Dynamically import codemirror and dependencies
  * This works for codemirror 5, not sure if the same imports work for 6
@@ -47,7 +33,20 @@ export async function importCodeMirror(
   const allAddons =
     options?.useCommonAddons === false
       ? addons
-      : commonCodeMirrorAddons.concat(addons);
+      : [
+          import('codemirror/addon/hint/show-hint'),
+          import('codemirror/addon/edit/matchbrackets'),
+          import('codemirror/addon/edit/closebrackets'),
+          import('codemirror/addon/fold/brace-fold'),
+          import('codemirror/addon/fold/foldgutter'),
+          import('codemirror/addon/lint/lint'),
+          import('codemirror/addon/search/searchcursor'),
+          import('codemirror/addon/search/jump-to-line'),
+          import('codemirror/addon/dialog/dialog'),
+          // @ts-expect-error
+          import('codemirror/keymap/sublime'),
+          ...addons,
+        ];
   await Promise.all(allAddons.map(addon => addon));
   return CodeMirror;
 }


### PR DESCRIPTION
Fixes #2368 

This should fix breaking imports of `@graphiql/react` (or its dependent `graphiql`) in non-browser environments like Node.js. Remix for example breaks during SSR because these imports also get loaded and executed. `codemirror` assumes to always run in a browser env though.