### PR TITLE
Permanently fix cspell + changeset bug

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
   ],
   "ignorePaths": [
     "examples/graphiql-2-rfc-context",
-    "packages/graphiql/src/css"
+    "packages/graphiql/src/css",
+    "**/CHANGELOG.md"
   ]
 }


### PR DESCRIPTION
Fixes #2551. I think?

These don't need to be spellchecked because they are generated files. The source markdown files already are covered by cspell when added to .changeset