### PR TITLE
feat: Add support for graphql in python snippets

### DIFF
--- a/packages/vscode-graphql/grammars/graphql.python.json
+++ b/packages/vscode-graphql/grammars/graphql.python.json
@@ -1,0 +1,147 @@
+{
+  "fileTypes": ["python"],
+  "injectionSelector": "L:source.python -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s+(gql)\\s*\\(\\s*(''')",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function"
+        },
+        "2": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "end": "(''')",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s+(gql)\\s*\\(\\s*(\"\"\")",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function"
+        },
+        "2": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "end": "(\"\"\")",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s+(gql)\\s*\\(\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function"
+        }
+      },
+      "end": "\\)|,",
+      "patterns": [
+        {
+          "begin": "^\\s*(''')",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.multi.python"
+            }
+          },
+          "end": "(''')",
+          "endCaptures": {
+            "1": {
+              "name": "string.quoted.multi.python"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        },
+        {
+          "begin": "^\\s*(\"\"\")",
+          "beginCaptures": {
+            "1": {
+              "name": "string.quoted.multi.python"
+            }
+          },
+          "end": "(\"\"\")",
+          "endCaptures": {
+            "1": {
+              "name": "string.quoted.multi.python"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "begin": "(''')(#graphql)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        },
+        "2": {
+          "name": "comment.line.graphql.js"
+        }
+      },
+      "end": "(''')",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "begin": "(\"\"\")(#graphql)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        },
+        "2": {
+          "name": "comment.line.graphql.js"
+        }
+      },
+      "end": "(\"\"\")",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.multi.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql.python"
+}

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -109,6 +109,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "source.python"
+        ],
+        "scopeName": "inline.graphql.python",
+        "path": "./grammars/graphql.python.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ],
     "snippets": [


### PR DESCRIPTION
fixes #2547

![image](https://user-images.githubusercontent.com/19194187/178070290-809eb9d0-406b-4121-9cc0-c3867a6cc82f.png)

- Add support for syntax highlighting in python files
- Supports `#graphql` comment
- Support `gql("""` syntax (including with a line break)

Looking into adding tests, but that could be a separate pr. Thanks for having a look!