### PR TITLE
upgrade vscode-languageserver

### DIFF
--- a/.changeset/chatty-insects-poke.md
+++ b/.changeset/chatty-insects-poke.md
@@ -1,0 +1,9 @@
+---
+'graphql-language-service-server': minor
+'graphql-language-service-cli': minor
+'vscode-graphql': minor
+---
+
+upgrades the `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the lsp server to the latest. also upgrades `vscode-languageclient` in `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in `vscode-graphql` at least!
+
+hopefully this solves #2230 once and for all!

--- a/packages/graphql-language-service-cli/src/cli.ts
+++ b/packages/graphql-language-service-cli/src/cli.ts
@@ -110,10 +110,11 @@ if (!command) {
 switch (command) {
   case 'server':
     process.on('uncaughtException', error => {
-      process.stdout.write(
+      process.stderr.write(
         'An error was thrown from GraphQL language service: ' + String(error),
       );
-      process.exit(0);
+      // don't exit at all if there is an uncaughtException
+      // process.exit(0);
     });
 
     const options: { [key: string]: any } = {};

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -42,10 +42,8 @@
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.1",
     "nullthrows": "^1.0.0",
-    "vscode-jsonrpc": "^5.0.1",
-    "vscode-languageserver": "^6.1.1",
-    "vscode-languageserver-protocol": "~3.15.3",
-    "vscode-languageserver-types": "~3.15.1",
+    "vscode-languageserver": "^8.0.1",
+    "vscode-jsonrpc": "^8.0.1",
     "fast-glob": "^3.2.7",
     "vscode-uri": "^3.0.2",
     "glob": "^7.2.0",
@@ -54,7 +52,6 @@
   "devDependencies": {
     "@types/mkdirp": "^1.0.1",
     "cross-env": "^7.0.2",
-    "graphql": "^16.4.0",
-    "vscode-languageserver-types": "^3.15.1"
+    "graphql": "^16.4.0"
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -32,7 +32,7 @@ import type {
   DidSaveTextDocumentParams,
   DidOpenTextDocumentParams,
   DidChangeConfigurationParams,
-} from 'vscode-languageserver-protocol';
+} from 'vscode-languageserver/node';
 
 import type {
   Diagnostic,
@@ -53,9 +53,9 @@ import type {
   DocumentSymbolParams,
   SymbolInformation,
   WorkspaceSymbolParams,
-  IConnection,
+  Connection,
   DidChangeConfigurationRegistrationOptions,
-} from 'vscode-languageserver';
+} from 'vscode-languageserver/node';
 
 import type { UnnormalizedTypeDefPointer } from '@graphql-tools/load';
 
@@ -90,7 +90,7 @@ function toPosition(position: VscodePosition): IPosition {
 }
 
 export class MessageProcessor {
-  _connection: IConnection;
+  _connection: Connection;
   _graphQLCache!: GraphQLCache;
   _graphQLConfig: GraphQLConfig | undefined;
   _languageService!: GraphQLLanguageService;
@@ -126,7 +126,7 @@ export class MessageProcessor {
     config?: GraphQLConfig;
     parser?: typeof parseDocument;
     tmpDir?: string;
-    connection: IConnection;
+    connection: Connection;
   }) {
     this._connection = connection;
     this._textDocumentCache = new Map();
@@ -154,10 +154,10 @@ export class MessageProcessor {
       mkdirp(this._tmpDirBase);
     }
   }
-  get connection(): IConnection {
+  get connection(): Connection {
     return this._connection;
   }
-  set connection(connection: IConnection) {
+  set connection(connection: Connection) {
     this._connection = connection;
   }
 

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -16,7 +16,7 @@ import {
   SocketMessageWriter,
   StreamMessageReader,
   StreamMessageWriter,
-} from 'vscode-jsonrpc';
+} from 'vscode-jsonrpc/node';
 
 import {
   CompletionRequest,
@@ -37,8 +37,9 @@ import {
   PublishDiagnosticsParams,
   WorkspaceSymbolRequest,
   createConnection,
-  IConnection,
-} from 'vscode-languageserver';
+  Connection,
+  DidSaveTextDocumentParams,
+} from 'vscode-languageserver/node';
 
 import { Logger } from './Logger';
 import {
@@ -228,7 +229,7 @@ async function initializeHandlers({
   writer,
   logger,
   options,
-}: InitializerParams): Promise<IConnection> {
+}: InitializerParams): Promise<Connection> {
   try {
     const connection = createConnection(reader, writer);
 
@@ -243,7 +244,7 @@ async function initializeHandlers({
 
 function reportDiagnostics(
   diagnostics: PublishDiagnosticsParams | null,
-  connection: IConnection,
+  connection: Connection,
 ) {
   if (diagnostics) {
     connection.sendNotification(
@@ -254,7 +255,7 @@ function reportDiagnostics(
 }
 
 type HandlerOptions = {
-  connection: IConnection;
+  connection: Connection;
   logger: Logger;
   config?: GraphQLConfig;
   parser?: typeof parseDocument;
@@ -303,7 +304,7 @@ async function addHandlers({
   );
   connection.onNotification(
     DidSaveTextDocumentNotification.type,
-    async params => {
+    async (params: DidSaveTextDocumentParams) => {
       const diagnostics = await messageProcessor.handleDidOpenOrSaveNotification(
         params,
       );

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -38,7 +38,6 @@ import {
   WorkspaceSymbolRequest,
   createConnection,
   Connection,
-  DidSaveTextDocumentParams,
 } from 'vscode-languageserver/node';
 
 import { Logger } from './Logger';
@@ -304,7 +303,7 @@ async function addHandlers({
   );
   connection.onNotification(
     DidSaveTextDocumentNotification.type,
-    async (params: DidSaveTextDocumentParams) => {
+    async params => {
       const diagnostics = await messageProcessor.handleDidOpenOrSaveNotification(
         params,
       );

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -35,7 +35,7 @@
     "graphql": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
-    "vscode-languageserver-types": "^3.15.1",
+    "vscode-languageserver-types": "^3.17.1",
     "nullthrows": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
@@ -126,11 +126,8 @@ describe('getAutocompleteSuggestions', () => {
       { label: 'skip' },
     ];
 
-    console.log({ graphQLVersion });
-
     // TODO: remove this once defer and stream are merged to `graphql`
     if (graphQLVersion.startsWith('16.0.0-experimental-stream-defer')) {
-      console.log('expect stream');
       expectedDirectiveSuggestions.push({ label: 'stream' }, { label: 'test' });
     } else {
       expectedDirectiveSuggestions.push({ label: 'test' });

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -6,10 +6,6 @@
  *  LICENSE file in the root directory of this source tree.
  *
  */
-import {
-  CompletionItemKind,
-  InsertTextFormat,
-} from 'vscode-languageserver-types';
 
 import {
   FragmentDefinitionNode,
@@ -31,7 +27,13 @@ import {
   isNonNullType,
 } from 'graphql';
 
-import { CompletionItem, AllTypeInfo, IPosition } from '../types';
+import {
+  CompletionItem,
+  AllTypeInfo,
+  IPosition,
+  CompletionItemKind,
+  InsertTextFormat,
+} from '../types';
 
 import {
   GraphQLBoolean,

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -11,6 +11,8 @@ import type {
   CompletionItem as CompletionItemType,
 } from 'vscode-languageserver-types';
 
+export { InsertTextFormat } from 'vscode-languageserver-types';
+
 import type { ASTNode, GraphQLSchema } from 'graphql';
 
 import type {

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "graphql": "^16.4.0",
     "monaco-editor": "^0.31.0",
-    "vscode-languageserver-types": "^3.15.1"
+    "vscode-languageserver-types": "^3.17.1"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -229,8 +229,8 @@
     "vsce": "^2.7.0"
   },
   "dependencies": {
-    "graphql": "16.0.0-experimental-stream-defer.5",
+    "graphql": "^16.4.0",
     "graphql-language-service-server": "^2.7.29",
-    "vscode-languageclient": "5.2.1"
+    "vscode-languageclient": "^8.0.1"
   }
 }

--- a/packages/vscode-graphql/src/apis/statusBar.ts
+++ b/packages/vscode-graphql/src/apis/statusBar.ts
@@ -6,7 +6,7 @@ import {
   ThemeColor,
   version,
 } from 'vscode';
-import { LanguageClient, State } from 'vscode-languageclient';
+import { LanguageClient, State } from 'vscode-languageclient/node';
 
 enum Status {
   INIT = 1,

--- a/packages/vscode-graphql/src/apis/statusBar.ts
+++ b/packages/vscode-graphql/src/apis/statusBar.ts
@@ -6,6 +6,7 @@ import {
   ThemeColor,
   version,
 } from 'vscode';
+
 import { LanguageClient, State } from 'vscode-languageclient/node';
 
 enum Status {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10976,11 +10976,6 @@ graphql-ws@^5.4.1, graphql-ws@^5.5.5:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.5.tgz#f375486d3f196e2a2527b503644693ae3a8670a9"
   integrity sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==
 
-graphql@16.0.0-experimental-stream-defer.5:
-  version "16.0.0-experimental-stream-defer.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.0.0-experimental-stream-defer.5.tgz#d668566fd33053a054dc5367c38c20a4ac4e4224"
-  integrity sha512-bluMjYpxh3a1lwZuNP+FAaEDMWzccVhkv+STcw0ckB2EPtLRTYUdXQhF9YBbUHd3tZSAR7LXzsxIw2GZXhg5rw==
-
 graphql@^16.1.0, graphql@^16.4.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
@@ -19307,26 +19302,14 @@ vscode-jsonrpc@8.0.1, vscode-jsonrpc@^8.0.1:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
   integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
 
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
-vscode-languageclient@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-5.2.1.tgz#7cfc83a294c409f58cfa2b910a8cfeaad0397193"
-  integrity sha512-7jrS/9WnV0ruqPamN1nE7qCxn0phkH5LjSgSp9h6qoJGoeAKzwKz/PF6M+iGA/aklx4GLZg1prddhEPQtuXI1Q==
+vscode-languageclient@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz#bf5535c4463a78daeaca0bcb4f5868aec86bb301"
+  integrity sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==
   dependencies:
-    semver "^5.5.0"
-    vscode-languageserver-protocol "3.14.1"
-
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
+    minimatch "^3.0.4"
+    semver "^7.3.5"
+    vscode-languageserver-protocol "3.17.1"
 
 vscode-languageserver-protocol@3.17.1:
   version "3.17.1"
@@ -19335,11 +19318,6 @@ vscode-languageserver-protocol@3.17.1:
   dependencies:
     vscode-jsonrpc "8.0.1"
     vscode-languageserver-types "3.17.1"
-
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
 vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.17.1:
   version "3.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19302,15 +19302,15 @@ vsce@^2.6.3, vsce@^2.7.0:
     yauzl "^2.3.1"
     yazl "^2.2.2"
 
+vscode-jsonrpc@8.0.1, vscode-jsonrpc@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz#f30b0625ebafa0fb3bc53e934ca47b706445e57e"
+  integrity sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==
+
 vscode-jsonrpc@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
   integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
 vscode-languageclient@5.2.1:
   version "5.2.1"
@@ -19328,30 +19328,30 @@ vscode-languageserver-protocol@3.14.1:
     vscode-jsonrpc "^4.0.0"
     vscode-languageserver-types "3.14.0"
 
-vscode-languageserver-protocol@^3.15.3, vscode-languageserver-protocol@~3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+vscode-languageserver-protocol@3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz#e801762c304f740208b6c804a0cf21f2c87509ed"
+  integrity sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==
   dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
+    vscode-jsonrpc "8.0.1"
+    vscode-languageserver-types "3.17.1"
 
 vscode-languageserver-types@3.14.0:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
 
-vscode-languageserver-types@3.15.1, vscode-languageserver-types@^3.15.1, vscode-languageserver-types@~3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+vscode-languageserver-types@3.17.1, vscode-languageserver-types@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz#c2d87fa7784f8cac389deb3ff1e2d9a7bef07e16"
+  integrity sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ==
 
-vscode-languageserver@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
-  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
+vscode-languageserver@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.1.tgz#56bd7a01f5c88af075a77f1d220edcb30fc4bdc7"
+  integrity sha512-sn7SjBwWm3OlmLtgg7jbM0wBULppyL60rj8K5HF0ny/MzN+GzPBX1kCvYdybhl7UW63V5V5tRVnyB8iwC73lSQ==
   dependencies:
-    vscode-languageserver-protocol "^3.15.3"
+    vscode-languageserver-protocol "3.17.1"
 
 vscode-uri@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
upgrades the `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the lsp server. also upgrades `vscode-languageclient` in `vscode-graphql` to 8. seems to work fine for IPC in `vscode-graphql` at least!

hopefully this solves #2230 once and for all!