### PR TITLE
add `useSynchronizeOption` hook and avoid recreating editor instances

### DIFF
--- a/packages/graphiql-react/src/editor/common.ts
+++ b/packages/graphiql-react/src/editor/common.ts
@@ -1,3 +1,8 @@
+import { KeyMap } from './types';
+
+export const DEFAULT_EDITOR_THEME = 'graphiql';
+export const DEFAULT_KEY_MAP: KeyMap = 'sublime';
+
 let isMacOs = false;
 
 if (typeof window === 'object') {

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef } from 'react';
 
 import { useExecutionContext } from '../execution';
-import { commonKeys, importCodeMirror } from './common';
+import {
+  commonKeys,
+  DEFAULT_EDITOR_THEME,
+  DEFAULT_KEY_MAP,
+  importCodeMirror,
+} from './common';
 import { useEditorContext } from './context';
 import {
   EditCallback,
@@ -10,6 +15,7 @@ import {
   useKeyMap,
   useMergeQuery,
   usePrettifyEditors,
+  useSynchronizeOption,
 } from './hooks';
 import { KeyMap } from './types';
 
@@ -22,8 +28,8 @@ export type UseHeaderEditorArgs = {
 };
 
 export function useHeaderEditor({
-  editorTheme = 'graphiql',
-  keyMap,
+  editorTheme = DEFAULT_EDITOR_THEME,
+  keyMap = DEFAULT_KEY_MAP,
   onEdit,
   readOnly = false,
   shouldPersistHeaders = false,
@@ -60,7 +66,6 @@ export function useHeaderEditor({
         tabSize: 2,
         mode: { name: 'javascript', json: true },
         theme: editorTheme,
-        keyMap: keyMap ?? 'sublime',
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -103,7 +108,9 @@ export function useHeaderEditor({
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialHeaders, keyMap, readOnly, setHeaderEditor]);
+  }, [editorTheme, initialHeaders, readOnly, setHeaderEditor]);
+
+  useSynchronizeOption(headerEditor, 'keyMap', keyMap);
 
   useChangeHandler(
     headerEditor,

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -1,5 +1,5 @@
 import { fillLeafs, GetDefaultFieldNamesFn, mergeAst } from '@graphiql/toolkit';
-import { EditorChange } from 'codemirror';
+import type { EditorChange, EditorConfiguration } from 'codemirror';
 import copyToClipboard from 'copy-to-clipboard';
 import { parse, print } from 'graphql';
 import { useCallback, useEffect } from 'react';
@@ -21,6 +21,18 @@ export function useSynchronizeValue(
       editor.setValue(value);
     }
   }, [editor, value]);
+}
+
+export function useSynchronizeOption<K extends keyof EditorConfiguration>(
+  editor: CodeMirrorEditor | null,
+  option: K,
+  value: EditorConfiguration[K],
+) {
+  useEffect(() => {
+    if (editor) {
+      editor.setOption(option, value);
+    }
+  }, [editor, option, value]);
 }
 
 export type EditCallback = (value: string) => void;

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -15,7 +15,12 @@ import { markdown } from '../markdown';
 import { useSchemaContext } from '../schema';
 import { useStorageContext } from '../storage';
 import debounce from '../utility/debounce';
-import { commonKeys, importCodeMirror } from './common';
+import {
+  commonKeys,
+  DEFAULT_EDITOR_THEME,
+  DEFAULT_KEY_MAP,
+  importCodeMirror,
+} from './common';
 import {
   CodeMirrorEditorWithOperationFacts,
   useEditorContext,
@@ -28,6 +33,7 @@ import {
   useKeyMap,
   useMergeQuery,
   usePrettifyEditors,
+  useSynchronizeOption,
 } from './hooks';
 import { CodeMirrorEditor, CodeMirrorType, KeyMap } from './types';
 import { normalizeWhitespace } from './whitespace';
@@ -47,8 +53,8 @@ export type UseQueryEditorArgs = {
 };
 
 export function useQueryEditor({
-  editorTheme = 'graphiql',
-  keyMap,
+  editorTheme = DEFAULT_EDITOR_THEME,
+  keyMap = DEFAULT_KEY_MAP,
   externalFragments,
   onClickReference,
   onCopyQuery,
@@ -131,7 +137,6 @@ export function useQueryEditor({
         foldGutter: true,
         mode: 'graphql',
         theme: editorTheme,
-        keyMap: keyMap ?? 'sublime',
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -219,7 +224,9 @@ export function useQueryEditor({
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialQuery, keyMap, readOnly, setQueryEditor]);
+  }, [editorTheme, initialQuery, readOnly, setQueryEditor]);
+
+  useSynchronizeOption(queryEditor, 'keyMap', keyMap);
 
   /**
    * We don't use the generic `useChangeHandler` hook here because we want to

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -4,10 +4,15 @@ import { ComponentType, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { useSchemaContext } from '../schema';
 
-import { commonKeys, importCodeMirror } from './common';
+import {
+  commonKeys,
+  DEFAULT_EDITOR_THEME,
+  DEFAULT_KEY_MAP,
+  importCodeMirror,
+} from './common';
 import { ImagePreview } from './components';
 import { useEditorContext } from './context';
-import { useSynchronizeValue } from './hooks';
+import { useSynchronizeOption, useSynchronizeValue } from './hooks';
 import { CodeMirrorEditor, KeyMap } from './types';
 
 export type ResponseTooltipType = ComponentType<{ pos: Position }>;
@@ -21,8 +26,8 @@ export type UseResponseEditorArgs = {
 
 export function useResponseEditor({
   ResponseTooltip,
-  editorTheme = 'graphiql',
-  keyMap,
+  editorTheme = DEFAULT_EDITOR_THEME,
+  keyMap = DEFAULT_KEY_MAP,
   value,
 }: UseResponseEditorArgs = {}) {
   const { fetchError, validationErrors } = useSchemaContext({
@@ -105,7 +110,6 @@ export function useResponseEditor({
         readOnly: true,
         theme: editorTheme,
         mode: 'graphql-results',
-        keyMap: keyMap ?? 'sublime',
         foldGutter: true,
         gutters: ['CodeMirror-foldgutter'],
         // @ts-expect-error
@@ -120,6 +124,8 @@ export function useResponseEditor({
       isActive = false;
     };
   }, [editorTheme, setResponseEditor]);
+
+  useSynchronizeOption(responseEditor, 'keyMap', keyMap);
 
   useSynchronizeValue(responseEditor, value);
 

--- a/packages/graphiql-react/src/editor/variable-editor.tsx
+++ b/packages/graphiql-react/src/editor/variable-editor.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef } from 'react';
 
 import { useExecutionContext } from '../execution';
-import { commonKeys, importCodeMirror } from './common';
+import {
+  commonKeys,
+  DEFAULT_EDITOR_THEME,
+  DEFAULT_KEY_MAP,
+  importCodeMirror,
+} from './common';
 import { useEditorContext } from './context';
 import {
   EditCallback,
@@ -10,6 +15,7 @@ import {
   useKeyMap,
   useMergeQuery,
   usePrettifyEditors,
+  useSynchronizeOption,
 } from './hooks';
 import { CodeMirrorType, KeyMap } from './types';
 
@@ -21,8 +27,8 @@ export type UseVariableEditorArgs = {
 };
 
 export function useVariableEditor({
-  editorTheme = 'graphiql',
-  keyMap,
+  editorTheme = DEFAULT_EDITOR_THEME,
+  keyMap = DEFAULT_KEY_MAP,
   onEdit,
   readOnly = false,
 }: UseVariableEditorArgs = {}) {
@@ -66,7 +72,6 @@ export function useVariableEditor({
         tabSize: 2,
         mode: 'graphql-variables',
         theme: editorTheme,
-        keyMap: keyMap ?? 'sublime',
         autoCloseBrackets: true,
         matchBrackets: true,
         showCursorWhenSelecting: true,
@@ -120,7 +125,9 @@ export function useVariableEditor({
     return () => {
       isActive = false;
     };
-  }, [editorTheme, initialVariables, keyMap, readOnly, setVariableEditor]);
+  }, [editorTheme, initialVariables, readOnly, setVariableEditor]);
+
+  useSynchronizeOption(variableEditor, 'keyMap', keyMap);
 
   useChangeHandler(
     variableEditor,


### PR DESCRIPTION
Following up on https://github.com/graphql/graphiql/pull/2561#issuecomment-1180138566, this adds a new hook that allows us to sync an editor option without needing to recreate the instance.