### PR TITLE
don't invoke callback on empty changes

### DIFF
--- a/.changeset/real-avocados-brush.md
+++ b/.changeset/real-avocados-brush.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Don't invoke editor change callbacks when manually signaling "empty" changes.

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -63,7 +63,16 @@ export function useChangeHandler(
       updateActiveTabValues({ [tabProperty]: value });
     });
 
-    const handleChange = (editorInstance: CodeMirrorEditor) => {
+    const handleChange = (
+      editorInstance: CodeMirrorEditor,
+      changeObj: EditorChange | undefined,
+    ) => {
+      // When we signal a change manually without actually changing anything
+      // we don't want to invoke the callback.
+      if (!changeObj) {
+        return;
+      }
+
       const newValue = editorInstance.getValue();
       store(newValue);
       updateTab(newValue);


### PR DESCRIPTION
Fixes #2548 

This prevents us from firing change handlers on "empty" changes, in particular when calling `codeMirror.signal(editorInstance, "change", editorInstance)` (we do this when updating metadata stored on the editor objects like variable types, document AST, etc)