### PR TITLE
fix link typo in `vscode-graphql` readme

### DIFF
--- a/packages/vscode-graphql/README.md
+++ b/packages/vscode-graphql/README.md
@@ -1,4 +1,4 @@
-[Changelog](https://github.com/graphql/graphiql/blob/main/packages/vscode-graphql/CHANGELOG.md) | [Discord Channel](https://discord.gg/r4BxrAG6fN) | [LSP Server Docs](<[https://g](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-server/README.md)>)
+[Changelog](https://github.com/graphql/graphiql/blob/main/packages/vscode-graphql/CHANGELOG.md) | [Discord Channel](https://discord.gg/r4BxrAG6fN) | [LSP Server Docs](https://github.com/graphql/graphiql/blob/main/packages/graphql-language-service-server/README.md)
 
 GraphQL extension VSCode built with the aim to tightly integrate the GraphQL Ecosystem with VSCode for an awesome developer experience.
 


### PR DESCRIPTION
fix vscode readme md link to the LSP Server configuration docs