### PR TITLE
feat(graphiql): pass introspection data to `schema` prop

### DIFF
--- a/.changeset/nine-elephants-retire.md
+++ b/.changeset/nine-elephants-retire.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Allow passing introspection data to the `schema` prop of the `SchemaContextProvider` component

--- a/.changeset/nine-eyes-relax.md
+++ b/.changeset/nine-eyes-relax.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+Allow passing introspection data to the `schema` prop of the `GraphiQL` component

--- a/.changeset/serious-ties-compete.md
+++ b/.changeset/serious-ties-compete.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Set the schema correctly after refetching introspection (e.g. when the `fetcher` prop changes)

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -119,6 +119,7 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
     }
 
     let isActive = true;
+    setSchema(undefined);
 
     const maybeIntrospectionData = props.schema;
     async function introspect() {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -18,6 +18,7 @@ import {
   ValidationRule,
   FragmentDefinitionNode,
   DocumentNode,
+  IntrospectionQuery,
 } from 'graphql';
 
 import {
@@ -106,9 +107,11 @@ export type GraphiQLProps = {
    */
   fetcher: Fetcher;
   /**
-   * Optionally provide the `GraphQLSchema`. If present, GraphiQL skips schema introspection.
+   * Optionally provide the `GraphQLSchema`. If present, GraphiQL skips schema
+   * introspection. This prop also accepts the result of an introspection query
+   * which will be used to create a `GraphQLSchema`
    */
-  schema?: GraphQLSchema | null;
+  schema?: GraphQLSchema | IntrospectionQuery | null;
   /**
    * An array of graphql ValidationRules
    */


### PR DESCRIPTION
This is a small QoL improvement: The `schema` prop now also accepts introspection data as an alternative to a `GraphQLSchema` instance. Also, this fixes a bug where the schema was not updated after rerunning introspection.

We had a use-case for this feature at Stellate: We store introspection data for different endpoints, and we want to use this to render GraphiQL on the client without running introspection (because this is likely to be disabled for lots of production APIs). We'd now have to add `graphql` as first-class dependency just to call `buildClientSchema` once. With this tiny change the `SchemaContextProvider` does that for us, which is a lot nicer DX.

💡 Reviewing with whitespace turned off halves the LOCs!