### PR TITLE
[redesign] add dark mode

### DIFF
--- a/.changeset/five-pillows-fail.md
+++ b/.changeset/five-pillows-fail.md
@@ -3,7 +3,7 @@
 ---
 
 Add new components:
-- UI components (`Button`, `Dialog`, `Dropdown`, `Spinner`, `Tab`, `Tabs`, `UnStyledButton` and lots of icon components)
+- UI components (`Button`, `ButtonGroup`, `Dialog`, `Dropdown`, `Spinner`, `Tab`, `Tabs`, `UnStyledButton` and lots of icon components)
 - Editor components (`QueryEditor`, `VariableEditor`, `HeaderEditor` and `ResponseEditor`)
 - Toolbar components (`ExecuteButton` and `ToolbarButton`)
 - Docs components (`Argument`, `DefaultValue`, `DeprecationReason`, `Directive`, `DocExplorer`, `ExplorerSection`, `FieldDocumentation`, `FieldLink`, `SchemaDocumentation`, `Search`, `TypeDocumentation` and `TypeLink`)

--- a/.changeset/ninety-pumpkins-reflect.md
+++ b/.changeset/ninety-pumpkins-reflect.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+GraphiQL now ships with a dark theme. By default the interface respects the system settings, the theme can also be explicitly chosen via the new settings dialog.

--- a/packages/graphiql-react/src/explorer/components/search.css
+++ b/packages/graphiql-react/src/explorer/components/search.css
@@ -36,6 +36,7 @@
 }
 
 [data-reach-combobox-popover] {
+  background-color: var(--color-neutral-0);
   border: none;
   border-bottom-left-radius: var(--border-radius-4);
   border-bottom-right-radius: var(--border-radius-4);
@@ -69,6 +70,10 @@
 
   &:hover {
     background-color: var(--color-neutral-10);
+  }
+
+  &[data-highlighted]:hover {
+    background-color: var(--color-neutral-15);
   }
 
   & + & {

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -56,6 +56,7 @@ export {
   StorageContextProvider,
   useStorageContext,
 } from './storage';
+export { useTheme } from './theme';
 export * from './toolbar';
 export * from './ui';
 export { useDragResize } from './utility/resize';
@@ -80,5 +81,6 @@ export type {
 export type { HistoryContextType } from './history';
 export type { SchemaContextType } from './schema';
 export type { StorageContextType } from './storage';
+export type { Theme } from './theme';
 
 import './style/root.css';

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -68,6 +68,46 @@ reach-portal {
   --session-header-height: 51px;
 }
 
+@media (prefers-color-scheme: dark) {
+  body:not(.graphiql-light) .graphiql-container,
+  body:not(.graphiql-light) .CodeMirror-info,
+  body:not(.graphiql-light) .CodeMirror-lint-tooltip,
+  body:not(.graphiql-light) reach-portal {
+    --color-pink: #ff5895;
+    --color-purple: #918cff;
+    --color-blue: #6fbcff;
+    --color-orche: #ffcc99;
+    --color-neutral-100: #b7c2d7;
+    --color-neutral-60: #5a687f;
+    --color-neutral-40: #465877;
+    --color-neutral-15: #2d384c;
+    --color-neutral-10: #26303f;
+    --color-neutral-7: #293242;
+    --color-neutral-0: #222b39;
+
+    --color-pink-dark: #ff357f;
+  }
+}
+
+body.graphiql-dark .graphiql-container,
+body.graphiql-dark .CodeMirror-info,
+body.graphiql-dark .CodeMirror-lint-tooltip,
+body.graphiql-dark reach-portal {
+  --color-pink: #ff5895;
+  --color-purple: #918cff;
+  --color-blue: #6fbcff;
+  --color-orche: #ffcc99;
+  --color-neutral-100: #b7c2d7;
+  --color-neutral-60: #5a687f;
+  --color-neutral-40: #465877;
+  --color-neutral-15: #2d384c;
+  --color-neutral-10: #26303f;
+  --color-neutral-7: #293242;
+  --color-neutral-0: #222b39;
+
+  --color-pink-dark: #ff357f;
+}
+
 .graphiql-container,
 .CodeMirror-info,
 .CodeMirror-lint-tooltip,

--- a/packages/graphiql-react/src/theme.ts
+++ b/packages/graphiql-react/src/theme.ts
@@ -1,0 +1,56 @@
+import { useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import { useStorageContext } from './storage';
+
+/**
+ * The value `null` semantically means that the user does not explicity choose
+ * any theme, so we use the system default.
+ */
+export type Theme = 'light' | 'dark' | null;
+
+export function useTheme() {
+  const storageContext = useStorageContext();
+
+  const [theme, setThemeInternal] = useState<Theme>(() => {
+    if (!storageContext) {
+      return null;
+    }
+
+    const stored = storageContext.get(STORAGE_KEY);
+    switch (stored) {
+      case 'light':
+        return 'light';
+      case 'dark':
+        return 'dark';
+      default:
+        if (typeof stored === 'string') {
+          // Remove the invalid stored value
+          storageContext.set(STORAGE_KEY, '');
+        }
+        return null;
+    }
+  });
+
+  useLayoutEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    document.body.classList.remove(`graphiql-light`);
+    document.body.classList.remove(`graphiql-dark`);
+    if (theme) {
+      document.body.classList.add(`graphiql-${theme}`);
+    }
+  }, [theme]);
+
+  const setTheme = useCallback(
+    (newTheme: Theme) => {
+      storageContext?.set(STORAGE_KEY, newTheme || '');
+      setThemeInternal(newTheme);
+    },
+    [storageContext],
+  );
+
+  return useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+}
+
+const STORAGE_KEY = 'theme';

--- a/packages/graphiql-react/src/toolbar/execute.css
+++ b/packages/graphiql-react/src/toolbar/execute.css
@@ -20,7 +20,7 @@
   }
 
   & > svg {
-    color: var(--color-neutral-0);
+    color: white;
     display: block;
     height: var(--px-16);
     margin: auto;

--- a/packages/graphiql-react/src/ui/button-group.css
+++ b/packages/graphiql-react/src/ui/button-group.css
@@ -1,0 +1,15 @@
+.graphiql-button-group {
+  background-color: var(--color-neutral-7);
+  /* Border radius of button plus padding */
+  border-radius: calc(var(--border-radius-4) + var(--px-4));
+  display: flex;
+  padding: var(--px-4);
+
+  & > button.graphiql-button.active {
+    background-color: var(--color-neutral-0);
+  }
+
+  & > * + * {
+    margin-left: var(--px-8);
+  }
+}

--- a/packages/graphiql-react/src/ui/button-group.tsx
+++ b/packages/graphiql-react/src/ui/button-group.tsx
@@ -1,0 +1,10 @@
+import './button-group.css';
+
+export function ButtonGroup(props: JSX.IntrinsicElements['div']) {
+  return (
+    <div
+      {...props}
+      className={`graphiql-button-group ${props.className || ''}`.trim()}
+    />
+  );
+}

--- a/packages/graphiql-react/src/ui/index.ts
+++ b/packages/graphiql-react/src/ui/index.ts
@@ -1,4 +1,5 @@
 export * from './button';
+export * from './button-group';
 export * from './dialog';
 export * from './dropdown';
 export * from './markdown';

--- a/packages/graphiql/__mocks__/@graphiql/react.tsx
+++ b/packages/graphiql/__mocks__/@graphiql/react.tsx
@@ -15,6 +15,7 @@ export {
   Argument,
   ArgumentIcon,
   Button,
+  ButtonGroup,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronUpIcon,

--- a/packages/graphiql/__mocks__/@graphiql/react.tsx
+++ b/packages/graphiql/__mocks__/@graphiql/react.tsx
@@ -89,6 +89,7 @@ export {
   usePrettifyEditors,
   useSchemaContext,
   useStorageContext,
+  useTheme,
 } from '@graphiql/react';
 
 export type {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -23,6 +23,7 @@ import {
 
 import {
   Button,
+  ButtonGroup,
   ChevronDownIcon,
   ChevronUpIcon,
   CopyIcon,
@@ -58,6 +59,7 @@ import {
   Tab,
   Tabs,
   TabsState,
+  Theme,
   ToolbarButton,
   UnStyledButton,
   useAutoCompleteLeafs,
@@ -71,6 +73,7 @@ import {
   usePrettifyEditors,
   useSchemaContext,
   useStorageContext,
+  useTheme,
   VariableEditor,
 } from '@graphiql/react';
 
@@ -527,6 +530,8 @@ const GraphiQLConsumeContexts = forwardRef<
   const merge = useMergeQuery();
   const prettify = usePrettifyEditors();
 
+  const { theme, setTheme } = useTheme();
+
   const pluginResize = useDragResize({
     defaultSizeRelation: 1 / 3,
     direction: 'horizontal',
@@ -584,6 +589,8 @@ const GraphiQLConsumeContexts = forwardRef<
       pluginResize={pluginResize}
       editorResize={editorResize}
       editorToolsResize={editorToolsResize}
+      theme={theme}
+      setTheme={setTheme}
       ref={ref}
     />
   );
@@ -608,6 +615,9 @@ type GraphiQLWithContextConsumerProps = Omit<
   pluginResize: ReturnType<typeof useDragResize>;
   editorResize: ReturnType<typeof useDragResize>;
   editorToolsResize: ReturnType<typeof useDragResize>;
+
+  theme: Theme;
+  setTheme(theme: Theme): void;
 };
 
 export type GraphiQLState = {
@@ -1005,6 +1015,39 @@ class GraphiQLWithContext extends React.Component<
                 });
               }}
             />
+          </div>
+          <div className="graphiql-dialog-section">
+            <div>
+              <div className="graphiql-dialog-section-title">Theme</div>
+              <div className="graphiql-dialog-section-caption">
+                Adjust how the interface looks like.
+              </div>
+            </div>
+            <div>
+              <ButtonGroup>
+                <Button
+                  className={this.props.theme === null ? 'active' : ''}
+                  onClick={() => {
+                    this.props.setTheme(null);
+                  }}>
+                  System
+                </Button>
+                <Button
+                  className={this.props.theme === 'light' ? 'active' : ''}
+                  onClick={() => {
+                    this.props.setTheme('light');
+                  }}>
+                  Light
+                </Button>
+                <Button
+                  className={this.props.theme === 'dark' ? 'active' : ''}
+                  onClick={() => {
+                    this.props.setTheme('dark');
+                  }}>
+                  Dark
+                </Button>
+              </ButtonGroup>
+            </div>
           </div>
           {this.props.storageContext ? (
             <div className="graphiql-dialog-section">

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -1,5 +1,6 @@
 /* Everything */
 .graphiql-container {
+  background-color: var(--color-neutral-0);
   display: flex;
   height: 100%;
   margin: 0;


### PR DESCRIPTION
FINALLY 🌚 🌚 🌚 

This PR adds a dark theme. By default GraphiQL chooses the preferred system color scheme. In any case the theme can explicitly be chosen in the settings dialog.