### PR TITLE
Proposing @jonathanawesome as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Without these amazing past maintainers, where would we be?!
 
 ### Active
 
-Maintainers who are active (to varying degrees):
+Maintainers who are currently active (to varying degrees, please contact us via our discord channels!):
 
 - [@imolorhe](https://github.com/imolorhe)
 - [@yoshiakis](https://github.com/yoshiakis)
@@ -189,8 +189,9 @@ Maintainers who are active (to varying degrees):
 - [@B2o5T](https://github.com/B2o5T)
 - [@dotansimha](https://github.com/dotansimha)
 - [@saihaj](https://github.com/saihaj)
+- [@jonathanawesome](https://github.com/jonathanawesome)
 
-> Thank you graphql community for all the help & support! - @acao
+> Thank you graphql community for all the help & support! I did it all for you, and I couldn't have done it without you ❤️ - @acao
 
 ### Fielding Proposals!
 


### PR DESCRIPTION
Living up to his username, @jonathanawesome has done an awesome job helping @thomasheyenbrock, and I would like him to be able to triage tickets and approve @thomasheyenbrock's PRs for the 2.0 rewrite branch, and if he would like, the ability to approve PRs to `main`.

Passionate about graphiql user experience, he has built fantastic prototypes, and like Thomas and others, has spent countless hours in the issue queues, chat histories and beyond to gain a deeper understanding of what a user-driven roadmap looks like for graphiql.

What's more, @thomasheyenbrock tells me he would be delighted to have him as a co-maintainer.