### PR TITLE
pre release for lsp

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "graphql-language-service-cli": "3.3.0",
+    "graphql-language-service-server": "2.8.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
put `graphql-language-service-server` into `@next` tag pre-release mode, but leave `vscode-graphql` stable and also depending on stable `graphql-language-service-server`.

workspaces support will come with some optimizations and some rewrites that we want to fine tune and test first