### PR TITLE
Revert pre-release state

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,9 +1,0 @@
-{
-  "mode": "pre",
-  "tag": "next",
-  "initialVersions": {
-    "graphql-language-service-cli": "3.3.0",
-    "graphql-language-service-server": "2.8.0"
-  },
-  "changesets": []
-}


### PR DESCRIPTION
Reverting pre-release state for LSP temporarily while we get a vscode-graphql stable release out with the new syntax extension