### PR TITLE
manually re-trigger introspection

### DIFF
--- a/.changeset/shy-parents-bow.md
+++ b/.changeset/shy-parents-bow.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+Add a toolbar button for manually triggering introspection

--- a/.changeset/wild-rings-leave.md
+++ b/.changeset/wild-rings-leave.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a method `introspect` to the schema context and provide a short key (`Shift-Ctrl-R`) for triggering introspection

--- a/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
@@ -28,6 +28,7 @@ function TypeDocWithContext(props: { type: GraphQLNamedType }) {
     <SchemaContext.Provider
       value={{
         fetchError: null,
+        introspect() {},
         isFetching: false,
         schema: ExampleSchema,
         setFetchError() {},

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -672,6 +672,11 @@ class GraphiQLWithContext extends React.Component<
           }
           label="History"
         />
+        <ToolbarButton
+          onClick={() => this.props.schemaContext.introspect()}
+          title="Fetch GraphQL schema using introspection (Shift-Ctrl-R)"
+          label="Introspect"
+        />
         {this.props.toolbar?.additionalContent
           ? this.props.toolbar.additionalContent
           : null}

--- a/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
@@ -17,6 +17,7 @@ import { ExampleSchema } from './ExampleSchema';
 
 const defaultSchemaContext: SchemaContextType = {
   fetchError: null,
+  introspect() {},
   isFetching: false,
   schema: ExampleSchema,
   setFetchError() {},

--- a/packages/vscode-graphql-syntax/CHANGELOG.md
+++ b/packages/vscode-graphql-syntax/CHANGELOG.md
@@ -1,20 +1,19 @@
 # vscode-graphql-syntax
 
 ## 1.0.4
+
 ### Patch Changes
 
-
-
 - [#2573](https://github.com/graphql/graphiql/pull/2573) [`a358ac1d`](https://github.com/graphql/graphiql/commit/a358ac1d00082643e124085bca09992adeef212a) Thanks [@acao](https://github.com/acao)! - ## Enhancement
-  
+
   Here we move vscode grammars and basic language support to a new [`GraphQL.vscode-graphql-syntax`](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax) extension. `GraphQL.vscode-graphql` now depends on this new syntax extension. This constitutes no breaking change for `vscode-graphql` users, as this extension will be installed automatically as an `extensionDependency` for `vscode-graphql`. Both extensions will now have independent release lifecycles, but vscode will keep them both up to date for you :)
-  
+
   Firstly, this allows users to only install the syntax highlighting extension if they don't need LSP server features.
-  
+
   Secondly, this subtle but important change allows alternative LSP servers and non-LSP graphql extensions to use (and contribute!) to our shared, graphql community syntax highlighting. In some ways, it acts as a shared tooling & annotation spec, though it is intended just for vscode, it perhaps can be used as a point of reference for others implementing (embedded) graphql syntax highlighting elsewhere!
-  
+
   If your language and/or library and/or framework would like vscode highlighting, come [join the party](https://github.com/graphql/graphiql/tree/main/packages/vscode-graphql-syntax#contributing)!
-  
+
   If you use relay, we would highly reccomend using the `relay-compiler lsp` extension for vscode [Relay Graphql](https://marketplace.visualstudio.com/items?itemName=meta.relay) (`meta.relay`). They will be [using the new standalone syntax extension](https://github.com/facebook/relay/pull/4032) very soon!
-  
+
   Even non-relay users may want to try this extension as an alternative to our reference implementation, as relay's configuration has relative similarity with `graphql-config`'s format, and doesn't necessitate the use of relay client afaik. We are working hard to optimize and improve `graphql-language-service-server` as a typescript reference implementation, and have some exciting features coming soon, however it's hard to offer more than a brand new & highly performant graphql LSP server written in Rust based on the latest graphql spec with a (mostly) paid team and dedicated open source ecosystem community of co-maintainers! And their implementation appears to allow you to opt out of any relay-specific conventions if you need more flexibility.


### PR DESCRIPTION
This PR add a function that contains the logic for running introspection to the schema context from `@graphiql/react`. It also adds a toolbar button and a short key that can be used to trigger this.

(After the refactoring that we did this turned out to be super simple, so I figured we can as well to another minor to push this out in 1.x.)

https://user-images.githubusercontent.com/22288634/182157907-8884b42a-fabd-4508-a306-a31c565e2ad1.mp4
