### PR TITLE
changeset & publishing fix for LSP bugfix

### DIFF
--- a/.changeset/curly-poets-pump.md
+++ b/.changeset/curly-poets-pump.md
@@ -3,4 +3,4 @@
 'vscode-graphql': patch
 ---
 
-Fix bugs for introspection schema fetching from the LSP, and users loading .gql/.graphql files
+In #2624, fix introspection schema fetching regression in lsp server, and fix for users writing new .gql/.graphql files

--- a/.changeset/curly-poets-pump.md
+++ b/.changeset/curly-poets-pump.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+Fix bugs for introspection schema fetching from the LSP, and users loading .gql/.graphql files

--- a/packages/vscode-graphql-syntax/package.json
+++ b/packages/vscode-graphql-syntax/package.json
@@ -5,6 +5,7 @@
   "description": "Adds syntax highlighting support for .graphql & embedded support for javascript, typescript, vue, markdown, python, php, reason, ocaml and rescript",
   "publisher": "GraphQL",
   "license": "MIT",
+  "private": true,
   "engines": {
     "vscode": "^1.63.0"
   },


### PR DESCRIPTION
If a `.graphql` or `.gql` file is not found in `includes` or `documents` it seems to cause a warning sometimes when handled by the message processor, but in the language service, a missing project for a graphql file seems to actually crash the server.  This appeared to fix the issue in the case where I could reproduce it.

This error is completely unnecessary! I don't know why we ever showed it. It seems I added it by accident during the typescript migration.

for now, when schema information isn't present we just no-op. eventually I would like to offer a lot more schemaless features, in new major versions of the language services where we refactor the interfaces