### PR TITLE
reduce CO2 usage by running less unneccesary GH actions workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'examples'
+      - '!examples/monaco-graphql-webpack'
 
 jobs:
   publish-canary:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,15 +18,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - name: Checkout Main
-        uses: actions/checkout@v2
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          fetch-depth: 0
-      - name: Use Node
-        uses: actions/setup-node@v2
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+          node-version: 'current'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Setup NPM credentials
         run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -12,11 +12,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Use Node
-        uses: actions/setup-node@v2
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'current'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: License Check
         run: yarn license-check

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,10 +1,8 @@
 name: License Check
-on: 
-  push:
+on:
+  pull_request:
     paths:
       - 'yarn.lock'
-  pull_request:
-    types: [opened, synchronize]
       
 jobs:
   check:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,13 @@ name: Lint & Build PR
 on: 
   pull_request:
     types: [opened, synchronize]
+    # TODO: ignore this after setting up a separate task to link markdown
+    # and to ignore eslint/prettier issues in examples
+    # paths-ignore:
+    #   - '**.md'
+    #   - 'examples'
+    #   - '!examples/monaco-graphql-webpack'
+
       
 jobs:
   lint:
@@ -9,12 +16,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Use Node
-        uses: actions/setup-node@v2
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'current'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Eslint
         run: yarn lint
@@ -27,11 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-      - name: Use Node
-        uses: actions/setup-node@v2
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'current'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Tyescript Build
         run: yarn build

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -2,6 +2,10 @@ name: Build & Test PR w/ GraphQL Regressions
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '**.md'
+      - 'examples'
+      - '!examples/monaco-graphql-webpack'
 
 # TODO: test matrix?
 

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -18,16 +18,17 @@ jobs:
         release: ['15.5.3', '^15.8.0', '16.1.0', '16.2.0', '16.3.0']
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Use Node
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'current'
+          cache: 'yarn'
 
-      - name: Force GraphQL 15 resolution
+      - name: Force GraphQL ${{ matrix.release }} solution
         run: yarn repo:resolve graphql@${{ matrix.release }}
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1  
+    
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Typescript Build
         run: yarn build

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -1,7 +1,12 @@
 name: Build & Test PR w/ GraphQL Regressions
 on:
-  pull_request:
-    types: [opened, synchronize]
+  push:
+    # only on merge to main.
+    # it's rare that this workflow would
+    # show us an error, but when it does it's important!
+    branches:
+      - main
+    # don't run this regression suite if we don't need to
     paths-ignore:
       - '**.md'
       - 'examples'
@@ -22,7 +27,6 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
           cache: 'yarn'
 
       - name: Force GraphQL ${{ matrix.release }} solution

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,27 +10,20 @@ jobs:
   unit:
     name: Unit Tests
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        node: ['14', '16', '17', '18']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 'current'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 
       - name: Build
         run: yarn build
-    # disabled because the graphiql test suites need more work
-    # for this coverage to matter
-    # also PR comment clutter!
-    # left the config file for when we re-enable
-    #
-    # - name: Run Unit Tests
-    #   run: yarn test --coverage
+
+      - name: Run Unit Tests
+        run: yarn test
 
   e2e:
     name: Cypress E2E Suite
@@ -40,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '16.x'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: ['12', '14', '16', '17', '18']
+        node: ['14', '16', '17', '18']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -37,13 +37,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-        
-      - name: Use Node
-        uses: actions/setup-node@v2
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Run E2E suite
         run: yarn e2e

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,13 +15,12 @@ jobs:
         node: ['12', '14', '16', '17', '18']
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: Use Node
-        uses: actions/setup-node@v2
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Build
         run: yarn build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,13 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@master
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@master
-
-      - name: Yarn Install
-        uses: bahmutov/npm-install@v1
+          node-version: 'current'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -34,20 +34,21 @@
     "graphql": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
-    "@babel/types": "^7.17.0",
     "@babel/parser": "^7.17.3",
+    "@babel/types": "^7.17.0",
+    "@graphql-tools/load": "^7.5.3",
     "dotenv": "8.2.0",
+    "fast-glob": "^3.2.7",
+    "glob": "^7.2.0",
     "graphql-config": "4.3.0",
     "graphql-language-service": "^5.0.6",
     "mkdirp": "^1.0.4",
+    "node-abort-controller": "^3.0.1",
     "node-fetch": "^2.6.1",
     "nullthrows": "^1.0.0",
-    "vscode-languageserver": "^8.0.1",
     "vscode-jsonrpc": "^8.0.1",
-    "fast-glob": "^3.2.7",
-    "vscode-uri": "^3.0.2",
-    "glob": "^7.2.0",
-    "@graphql-tools/load": "^7.5.3"
+    "vscode-languageserver": "^8.0.1",
+    "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
     "@types/mkdirp": "^1.0.1",

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLCache-test.ts
@@ -6,10 +6,11 @@
  *  LICENSE file in the root directory of this source tree.
  *
  */
+import { AbortController as MockAbortController } from 'node-abort-controller';
 
 jest.mock('@whatwg-node/fetch', () => ({
   fetch: require('fetch-mock').fetchHandler,
-  AbortController: global.AbortController,
+  AbortController: MockAbortController,
   TextDecoder: global.TextDecoder,
 }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13414,6 +13414,11 @@ node-abi@^3.3.0:
   dependencies:
     semver "^7.3.5"
 
+node-abort-controller@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
 node-addon-api@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"


### PR DESCRIPTION
because it's good for the earth 🌍 and the patience of contributors 😆 

i wish you could use `paths-ignore` further down, to skip individual tasks

note:

i decided to upgrade `actions/setup-node` usage as well for similar reasons, it appears to be faster but brings some bugs, so i will finish this up tonight