### PR TITLE
fix doc explorer style regressions

### DIFF
--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -3,17 +3,18 @@
   display: flex;
   justify-content: space-between;
   position: relative;
+
+  &:focus-within
+    > .graphiql-doc-explorer-header-content
+    > *:not(a.graphiql-doc-explorer-back) {
+    /* Hide the header when focussing the search input */
+    visibility: hidden;
+  }
 }
 .graphiql-doc-explorer-header-content {
   display: flex;
   flex-direction: column;
   min-width: 0;
-}
-.graphiql-doc-explorer-header:focus-within
-  > .graphiql-doc-explorer-header-content
-  > *:not(a.graphiql-doc-explorer-back) {
-  /* Hide the header when focussing the search input */
-  visibility: hidden;
 }
 
 /* The search input in the header of the doc explorer */
@@ -22,16 +23,19 @@
   position: absolute;
   right: 0;
   top: 0;
-}
-.graphiql-doc-explorer-search:focus-within {
-  left: 0;
-}
-.graphiql-doc-explorer-search [data-reach-combobox-input] {
-  height: 24px;
-  width: 4ch;
-}
-.graphiql-doc-explorer-search [data-reach-combobox-input]:focus {
-  width: 100%;
+
+  &:focus-within {
+    left: 0;
+  }
+
+  & [data-reach-combobox-input] {
+    height: 24px;
+    width: 4ch;
+  }
+
+  & [data-reach-combobox-input]:focus {
+    width: 100%;
+  }
 }
 
 /* The back-button in the doc explorer */
@@ -63,10 +67,10 @@ a.graphiql-doc-explorer-back {
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.graphiql-doc-explorer-title:not(:first-child) {
-  font-size: var(--font-size-h3);
-  margin-top: var(--px-8);
+  &:not(:first-child) {
+    font-size: var(--font-size-h3);
+    margin-top: var(--px-8);
+  }
 }
 
 /* The contents of the currently active page in the doc explorer */

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -4,9 +4,7 @@
   justify-content: space-between;
   position: relative;
 
-  &:focus-within
-    > .graphiql-doc-explorer-header-content
-    > *:not(a.graphiql-doc-explorer-back) {
+  &:focus-within .graphiql-doc-explorer-title {
     /* Hide the header when focussing the search input */
     visibility: hidden;
   }
@@ -51,6 +49,11 @@ a.graphiql-doc-explorer-back {
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:focus + .graphiql-doc-explorer-title {
+    /* Don't hide the header when focussing the back link */
+    visibility: unset;
   }
 
   & > svg {

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -43,17 +43,17 @@ a.graphiql-doc-explorer-back {
   display: flex;
   text-decoration: none;
 
-  &:visited {
-    color: var(--color-neutral-60);
-  }
-
   &:hover {
     text-decoration: underline;
   }
 
-  &:focus + .graphiql-doc-explorer-title {
-    /* Don't hide the header when focussing the back link */
-    visibility: unset;
+  &:focus {
+    outline: var(--color-neutral-60) auto 1px;
+
+    & + .graphiql-doc-explorer-title {
+      /* Don't hide the header when focussing the back link */
+      visibility: unset;
+    }
   }
 
   & > svg {

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -11,7 +11,7 @@
 }
 .graphiql-doc-explorer-header:focus-within
   > .graphiql-doc-explorer-header-content
-  > *:not(.graphiql-doc-explorer-back) {
+  > *:not(a.graphiql-doc-explorer-back) {
   /* Hide the header when focussing the search input */
   visibility: hidden;
 }
@@ -35,19 +35,25 @@
 }
 
 /* The back-button in the doc explorer */
-.graphiql-doc-explorer-back {
+a.graphiql-doc-explorer-back {
   align-items: center;
   color: var(--color-neutral-60);
   display: flex;
   text-decoration: none;
-}
-.graphiql-doc-explorer-back:hover {
-  text-decoration: underline;
-}
-.graphiql-doc-explorer-back > svg {
-  height: var(--px-8);
-  margin-right: var(--px-8);
-  width: var(--px-8);
+
+  &:visited {
+    color: var(--color-neutral-60);
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  & > svg {
+    height: var(--px-8);
+    margin-right: var(--px-8);
+    width: var(--px-8);
+  }
 }
 
 /* The title of the currently active page in the doc explorer */

--- a/packages/graphiql-react/src/explorer/components/field-link.css
+++ b/packages/graphiql-react/src/explorer/components/field-link.css
@@ -1,6 +1,10 @@
-.graphiql-doc-explorer-field-name {
+a.graphiql-doc-explorer-field-name {
   color: var(--color-blue);
   text-decoration: none;
+
+  &:visited {
+    color: var(--color-blue);
+  }
 
   &:hover {
     text-decoration: underline;

--- a/packages/graphiql-react/src/explorer/components/field-link.css
+++ b/packages/graphiql-react/src/explorer/components/field-link.css
@@ -2,10 +2,6 @@ a.graphiql-doc-explorer-field-name {
   color: var(--color-blue);
   text-decoration: none;
 
-  &:visited {
-    color: var(--color-blue);
-  }
-
   &:hover {
     text-decoration: underline;
   }

--- a/packages/graphiql-react/src/explorer/components/type-link.css
+++ b/packages/graphiql-react/src/explorer/components/type-link.css
@@ -1,6 +1,10 @@
-.graphiql-doc-explorer-type-name {
+a.graphiql-doc-explorer-type-name {
   color: var(--color-orche);
   text-decoration: none;
+
+  &:visited {
+    color: var(--color-orche);
+  }
 
   &:hover {
     text-decoration: underline;

--- a/packages/graphiql-react/src/explorer/components/type-link.css
+++ b/packages/graphiql-react/src/explorer/components/type-link.css
@@ -2,10 +2,6 @@ a.graphiql-doc-explorer-type-name {
   color: var(--color-orche);
   text-decoration: none;
 
-  &:visited {
-    color: var(--color-orche);
-  }
-
   &:hover {
     text-decoration: underline;
   }

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -1,3 +1,5 @@
+import './style/root.css';
+
 export {
   EditorContext,
   EditorContextProvider,
@@ -82,5 +84,3 @@ export type { HistoryContextType } from './history';
 export type { SchemaContextType } from './schema';
 export type { StorageContextType } from './storage';
 export type { Theme } from './theme';
-
-import './style/root.css';

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -134,8 +134,8 @@ reach-portal {
   & a {
     color: var(--color-pink);
 
-    &:visited {
-      color: var(--color-pink-dark);
+    &:focus {
+      outline: var(--color-pink) auto 1px;
     }
   }
 }


### PR DESCRIPTION
Fixes #2629

In fact, this is set of fixes for the doc explorer:
- The issue obviously, i.e. fixing the selector specificity and making sure to load the `root.css` file first.
- Making sure the headline in the docs is hidden only when the search input is focussed, in particular not hiding it when focussing the back-link
- Making sure the outlines of focussed links match the design colors.