### PR TITLE
[@graphiql/react] deduplicate props

### DIFF
--- a/.changeset/afraid-kiwis-notice.md
+++ b/.changeset/afraid-kiwis-notice.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+BREAKING: The `ExecutionContextProvider` and `QueryEditor` components no longer accept the `externalFragments` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will normalize the prop value and provide a map of type `Map<string, FragmentDefinitionNode>` (using the fragment names as keys) as part of the value of the `EditorContext`.

--- a/.changeset/afraid-kiwis-notice.md
+++ b/.changeset/afraid-kiwis-notice.md
@@ -2,4 +2,6 @@
 '@graphiql/react': minor
 ---
 
-BREAKING: The `ExecutionContextProvider` and `QueryEditor` components no longer accept the `externalFragments` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will normalize the prop value and provide a map of type `Map<string, FragmentDefinitionNode>` (using the fragment names as keys) as part of the value of the `EditorContext`.
+BREAKING:
+- The `ExecutionContextProvider` and `QueryEditor` components no longer accept the `externalFragments` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will normalize the prop value and provide a map of type `Map<string, FragmentDefinitionNode>` (using the fragment names as keys) as part of the value of the `EditorContext`.
+- The `QueryEditor` component no longer accept the `validationRules` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will provide the list of validation rules (empty if there are none) as part of the value of the `EditorContext`.

--- a/.changeset/afraid-kiwis-notice.md
+++ b/.changeset/afraid-kiwis-notice.md
@@ -5,3 +5,4 @@
 BREAKING:
 - The `ExecutionContextProvider` and `QueryEditor` components no longer accept the `externalFragments` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will normalize the prop value and provide a map of type `Map<string, FragmentDefinitionNode>` (using the fragment names as keys) as part of the value of the `EditorContext`.
 - The `QueryEditor` component no longer accept the `validationRules` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will provide the list of validation rules (empty if there are none) as part of the value of the `EditorContext`.
+- The `ExecutionContextProvider` and `HeaderEditor` components no longer accept the `shouldPersistHeaders` prop. Instead the `EditorContextProvider` component now provides the value of its equally named prop as part of the value of the `EditorContext`.

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -59,6 +59,8 @@ export type EditorContextType = {
 
   externalFragments: Map<string, FragmentDefinitionNode>;
   validationRules: ValidationRule[];
+
+  shouldPersistHeaders: boolean;
 };
 
 export const EditorContext = createNullableContext<EditorContextType>(
@@ -241,6 +243,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
       externalFragments,
       validationRules,
+
+      shouldPersistHeaders: props.shouldPersistHeaders || false,
     }),
     [
       tabState,
@@ -256,6 +260,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
       externalFragments,
       validationRules,
+
+      props.shouldPersistHeaders,
     ],
   );
 

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -3,6 +3,7 @@ import {
   FragmentDefinitionNode,
   OperationDefinitionNode,
   parse,
+  ValidationRule,
   visit,
 } from 'graphql';
 import { VariableToType } from 'graphql-language-service';
@@ -57,6 +58,7 @@ export type EditorContextType = {
   initialVariables: string;
 
   externalFragments: Map<string, FragmentDefinitionNode>;
+  validationRules: ValidationRule[];
 };
 
 export const EditorContext = createNullableContext<EditorContextType>(
@@ -71,6 +73,7 @@ type EditorContextProviderProps = {
   onTabChange?(tabs: TabsState): void;
   query?: string;
   shouldPersistHeaders?: boolean;
+  validationRules?: ValidationRule[];
   variables?: string;
 };
 
@@ -213,6 +216,10 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     return map;
   }, [props.externalFragments]);
 
+  const validationRules = useMemo(() => props.validationRules || [], [
+    props.validationRules,
+  ]);
+
   const value = useMemo<EditorContextType>(
     () => ({
       ...tabState,
@@ -233,6 +240,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       ...initialValues.current,
 
       externalFragments,
+      validationRules,
     }),
     [
       tabState,
@@ -247,6 +255,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       variableEditor,
 
       externalFragments,
+      validationRules,
     ],
   );
 

--- a/packages/graphiql-react/src/editor/header-editor.tsx
+++ b/packages/graphiql-react/src/editor/header-editor.tsx
@@ -23,7 +23,6 @@ export type UseHeaderEditorArgs = {
   editorTheme?: string;
   onEdit?: EditCallback;
   readOnly?: boolean;
-  shouldPersistHeaders?: boolean;
   keyMap?: KeyMap;
 };
 
@@ -32,9 +31,13 @@ export function useHeaderEditor({
   keyMap = DEFAULT_KEY_MAP,
   onEdit,
   readOnly = false,
-  shouldPersistHeaders = false,
 }: UseHeaderEditorArgs = {}) {
-  const { initialHeaders, headerEditor, setHeaderEditor } = useEditorContext({
+  const {
+    initialHeaders,
+    headerEditor,
+    setHeaderEditor,
+    shouldPersistHeaders,
+  } = useEditorContext({
     nonNull: true,
     caller: useHeaderEditor,
   });

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -47,7 +47,6 @@ export type UseQueryEditorArgs = {
   onEdit?(value: string, documentAST?: DocumentNode): void;
   onEditOperationName?: EditCallback;
   readOnly?: boolean;
-  validationRules?: ValidationRule[];
   keyMap?: KeyMap;
 };
 
@@ -59,7 +58,6 @@ export function useQueryEditor({
   onEdit,
   onEditOperationName,
   readOnly = false,
-  validationRules,
 }: UseQueryEditorArgs = {}) {
   const { schema } = useSchemaContext({
     nonNull: true,
@@ -70,6 +68,7 @@ export function useQueryEditor({
     initialQuery,
     queryEditor,
     setQueryEditor,
+    validationRules,
     variableEditor,
     updateActiveTabValues,
   } = useEditorContext({

--- a/packages/graphiql-react/src/editor/query-editor.tsx
+++ b/packages/graphiql-react/src/editor/query-editor.tsx
@@ -7,7 +7,7 @@ import type {
   ValidationRule,
 } from 'graphql';
 import { getOperationFacts } from 'graphql-language-service';
-import { MutableRefObject, useEffect, useRef } from 'react';
+import { MutableRefObject, useEffect, useMemo, useRef } from 'react';
 
 import { useExecutionContext } from '../execution';
 import { useExplorerContext } from '../explorer';
@@ -42,7 +42,6 @@ type OnClickReference = (reference: SchemaReference) => void;
 
 export type UseQueryEditorArgs = {
   editorTheme?: string;
-  externalFragments?: string | FragmentDefinitionNode[];
   onClickReference?: OnClickReference;
   onCopyQuery?: CopyQueryCallback;
   onEdit?(value: string, documentAST?: DocumentNode): void;
@@ -55,7 +54,6 @@ export type UseQueryEditorArgs = {
 export function useQueryEditor({
   editorTheme = DEFAULT_EDITOR_THEME,
   keyMap = DEFAULT_KEY_MAP,
-  externalFragments,
   onClickReference,
   onCopyQuery,
   onEdit,
@@ -68,6 +66,7 @@ export function useQueryEditor({
     caller: useQueryEditor,
   });
   const {
+    externalFragments,
     initialQuery,
     queryEditor,
     setQueryEditor,
@@ -396,25 +395,29 @@ function useSynchronizeValidationRules(
 
 function useSynchronizeExternalFragments(
   editor: CodeMirrorEditor | null,
-  externalFragments: string | FragmentDefinitionNode[] | undefined,
+  externalFragments: Map<string, FragmentDefinitionNode>,
   codeMirrorRef: MutableRefObject<CodeMirrorType | undefined>,
 ) {
+  const externalFragmentList = useMemo(() => [...externalFragments.values()], [
+    externalFragments,
+  ]);
+
   useEffect(() => {
     if (!editor) {
       return;
     }
 
     const didChange =
-      editor.options.lint.externalFragments !== externalFragments;
+      editor.options.lint.externalFragments !== externalFragmentList;
 
-    editor.state.lint.linterOptions.externalFragments = externalFragments;
-    editor.options.lint.externalFragments = externalFragments;
-    editor.options.hintOptions.externalFragments = externalFragments;
+    editor.state.lint.linterOptions.externalFragments = externalFragmentList;
+    editor.options.lint.externalFragments = externalFragmentList;
+    editor.options.hintOptions.externalFragments = externalFragmentList;
 
     if (didChange && codeMirrorRef.current) {
       codeMirrorRef.current.signal(editor, 'change', editor);
     }
-  }, [editor, externalFragments, codeMirrorRef]);
+  }, [editor, externalFragmentList, codeMirrorRef]);
 }
 
 const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -1,5 +1,5 @@
 import { StorageAPI } from '@graphiql/toolkit';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import debounce from '../utility/debounce';
 import { CodeMirrorEditorWithOperationFacts } from './context';
@@ -157,10 +157,11 @@ export function useStoreTabs({
   storage: StorageAPI | null;
   shouldPersistHeaders?: boolean;
 }) {
-  const store = useCallback(
-    debounce(500, (value: string) => {
-      storage?.set(STORAGE_KEY, value);
-    }),
+  const store = useMemo(
+    () =>
+      debounce(500, (value: string) => {
+        storage?.set(STORAGE_KEY, value);
+      }),
     [storage],
   );
   return useCallback(

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -7,13 +7,7 @@ import {
   isObservable,
   Unsubscribable,
 } from '@graphiql/toolkit';
-import {
-  ExecutionResult,
-  FragmentDefinitionNode,
-  parse,
-  print,
-  visit,
-} from 'graphql';
+import { ExecutionResult, FragmentDefinitionNode, print } from 'graphql';
 import { getFragmentDependenciesForAST } from 'graphql-language-service';
 import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import setValue from 'set-value';
@@ -36,7 +30,6 @@ export const ExecutionContext = createNullableContext<ExecutionContextType>(
 
 type ExecutionContextProviderProps = {
   children: ReactNode;
-  externalFragments?: FragmentDefinitionNode[] | string;
   fetcher: Fetcher;
   onEditOperationName?: EditCallback;
   shouldPersistHeaders?: boolean;
@@ -44,6 +37,7 @@ type ExecutionContextProviderProps = {
 
 export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
   const {
+    externalFragments,
     headerEditor,
     queryEditor,
     responseEditor,
@@ -64,12 +58,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     setSubscription(null);
   }, [subscription]);
 
-  const {
-    externalFragments,
-    fetcher,
-    onEditOperationName,
-    shouldPersistHeaders,
-  } = props;
+  const { fetcher, onEditOperationName, shouldPersistHeaders } = props;
   const run = useCallback<ExecutionContextType['run']>(
     async _selectedOperationName => {
       if (!queryEditor || !responseEditor) {
@@ -158,24 +147,10 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
       }
 
       if (externalFragments) {
-        const externalFragmentsMap = new Map<string, FragmentDefinitionNode>();
-
-        if (Array.isArray(externalFragments)) {
-          externalFragments.forEach(def => {
-            externalFragmentsMap.set(def.name.value, def);
-          });
-        } else {
-          visit(parse(externalFragments, {}), {
-            FragmentDefinition(def) {
-              externalFragmentsMap.set(def.name.value, def);
-            },
-          });
-        }
-
         const fragmentDependencies = queryEditor.documentAST
           ? getFragmentDependenciesForAST(
               queryEditor.documentAST,
-              externalFragmentsMap,
+              externalFragments,
             )
           : [];
         if (fragmentDependencies.length > 0) {

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -32,7 +32,6 @@ type ExecutionContextProviderProps = {
   children: ReactNode;
   fetcher: Fetcher;
   onEditOperationName?: EditCallback;
-  shouldPersistHeaders?: boolean;
 };
 
 export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
@@ -41,6 +40,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     headerEditor,
     queryEditor,
     responseEditor,
+    shouldPersistHeaders,
     variableEditor,
     updateActiveTabValues,
   } = useEditorContext({ nonNull: true, caller: ExecutionContextProvider });
@@ -58,7 +58,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     setSubscription(null);
   }, [subscription]);
 
-  const { fetcher, onEditOperationName, shouldPersistHeaders } = props;
+  const { fetcher, onEditOperationName } = props;
   const run = useCallback<ExecutionContextType['run']>(
     async _selectedOperationName => {
       if (!queryEditor || !responseEditor) {

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -210,7 +210,6 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
 
     fetchIntrospectionData()
       .then(introspectionData => {
-        console.log(counter, counterRef.current);
         /**
          * Don't continue if another introspection request has been started in
          * the meantime or if there is no introspection data.

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -436,6 +436,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
   {
     dangerouslyAssumeSchemaIsValid,
     docExplorerOpen,
+    externalFragments,
     fetcher,
     inputValueDeprecation,
     introspectionQueryName,
@@ -462,6 +463,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
         onToggle={onToggleHistory}>
         <EditorContextProvider
           defaultQuery={props.defaultQuery}
+          externalFragments={externalFragments}
           headers={props.headers}
           onTabChange={
             typeof props.tabs === 'object' ? props.tabs.onTabChange : undefined
@@ -478,7 +480,6 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             schema={schema}
             schemaDescription={schemaDescription}>
             <ExecutionContextProvider
-              externalFragments={props.externalFragments}
               fetcher={fetcher}
               onEditOperationName={props.onEditOperationName}
               shouldPersistHeaders={props.shouldPersistHeaders}>
@@ -504,6 +505,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'dangerouslyAssumeSchemaIsValid'
   | 'defaultQuery'
   | 'docExplorerOpen'
+  | 'externalFragments'
   | 'fetcher'
   | 'headers'
   | 'inputValueDeprecation'
@@ -764,7 +766,6 @@ class GraphiQLWithContext extends React.Component<
                   <div ref={this.props.secondaryEditorResize.firstRef}>
                     <QueryEditor
                       editorTheme={this.props.editorTheme}
-                      externalFragments={this.props.externalFragments}
                       onClickReference={() => {
                         if (this.props.docResize.hiddenElement === 'second') {
                           this.props.docResize.setHiddenElement(null);

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -447,6 +447,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     storage,
     schema,
     schemaDescription,
+    shouldPersistHeaders,
     validationRules,
     ...props
   },
@@ -470,7 +471,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             typeof props.tabs === 'object' ? props.tabs.onTabChange : undefined
           }
           query={props.query}
-          shouldPersistHeaders={props.shouldPersistHeaders}
+          shouldPersistHeaders={shouldPersistHeaders}
           validationRules={validationRules}
           variables={props.variables}>
           <SchemaContextProvider
@@ -483,8 +484,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             schemaDescription={schemaDescription}>
             <ExecutionContextProvider
               fetcher={fetcher}
-              onEditOperationName={props.onEditOperationName}
-              shouldPersistHeaders={props.shouldPersistHeaders}>
+              onEditOperationName={props.onEditOperationName}>
               <ExplorerContextProvider
                 isVisible={docExplorerOpen}
                 onToggleVisibility={onToggleDocs}>
@@ -519,6 +519,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'query'
   | 'schema'
   | 'schemaDescription'
+  | 'shouldPersistHeaders'
   | 'storage'
   | 'validationRules'
   | 'variables'
@@ -865,7 +866,6 @@ class GraphiQLWithContext extends React.Component<
                           editorTheme={this.props.editorTheme}
                           onEdit={this.props.onEditHeaders}
                           readOnly={this.props.readOnly}
-                          shouldPersistHeaders={this.props.shouldPersistHeaders}
                           keyMap={this.props.keyMap}
                         />
                       )}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -447,6 +447,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     storage,
     schema,
     schemaDescription,
+    validationRules,
     ...props
   },
   ref,
@@ -470,6 +471,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
           }
           query={props.query}
           shouldPersistHeaders={props.shouldPersistHeaders}
+          validationRules={validationRules}
           variables={props.variables}>
           <SchemaContextProvider
             dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
@@ -518,6 +520,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'schema'
   | 'schemaDescription'
   | 'storage'
+  | 'validationRules'
   | 'variables'
 >;
 
@@ -776,7 +779,6 @@ class GraphiQLWithContext extends React.Component<
                       onEdit={this.props.onEditQuery}
                       onEditOperationName={this.props.onEditOperationName}
                       readOnly={this.props.readOnly}
-                      validationRules={this.props.validationRules}
                     />
                   </div>
                   <div ref={this.props.secondaryEditorResize.dragBarRef}>


### PR DESCRIPTION
In the midst of some final cleanup for v2 I noticed that after the initial refactoring there are some props which are now "duplicated" in some places. In particular:
- `externalFragments` was passed separately to `ExecutionContextProvider` and `QueryEditor`
- `shouldPersistHeaders` was passed separately to `EditorContextProvider`, `ExecutionContextProvider` and `HeaderEditor`

This makes it possible to have somewhat inconsistent state. This PR attempts to clean this up by only passing these two props to `EditorContextProvider` (semantically it makes the most sense to have it there). The provider component includes the props in the context value, so they can be consumed by other parts of the UI.

I also did the same for `validationRules` even though it was only passed to one component (`QueryEditor`). It felt inconsistent for me to have `externalFragment` on the editor context value and `validationRules` not. (Both are used for the same purpose, i.e. to customize how operations are validated.)

Sidenote: Technically this is a breaking change for `@graphiql/react`, but we only do a minor version bump as we're still in the `0.x` range and the package is not stable yet.