### PR TITLE
fix operation name props

### DIFF
--- a/.changeset/eight-poems-call.md
+++ b/.changeset/eight-poems-call.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix controlling the operation name sent with the request using the `operationName` prop

--- a/.changeset/five-carrots-learn.md
+++ b/.changeset/five-carrots-learn.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a new prop `operationName` to the `ExecutionContextProvider` component that controls the operation sent with the request

--- a/.changeset/mean-peas-rush.md
+++ b/.changeset/mean-peas-rush.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+BREAKING: The `ExecutionContextProvider` and `QueryEditor` components no longer accepts the `onEditOperationName` prop. Instead you can now pass this prop to the `EditorContextProvider` component.

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -53,6 +53,8 @@ export type EditorContextType = {
   setResponseEditor(newEditor: CodeMirrorEditor): void;
   setVariableEditor(newEditor: CodeMirrorEditor): void;
 
+  setOperationName(operationName: string): void;
+
   initialHeaders: string;
   initialQuery: string;
   initialVariables: string;
@@ -72,6 +74,7 @@ type EditorContextProviderProps = {
   defaultQuery?: string;
   externalFragments?: string | FragmentDefinitionNode[];
   headers?: string;
+  onEditOperationName?(operationName: string): void;
   onTabChange?(tabs: TabsState): void;
   query?: string;
   shouldPersistHeaders?: boolean;
@@ -190,6 +193,20 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     [onTabChange, storeTabs],
   );
 
+  const { onEditOperationName } = props;
+  const setOperationName = useCallback<EditorContextType['setOperationName']>(
+    operationName => {
+      if (!queryEditor) {
+        return;
+      }
+
+      queryEditor.operationName = operationName;
+      updateActiveTabValues({ operationName });
+      onEditOperationName?.(operationName);
+    },
+    [onEditOperationName, queryEditor, updateActiveTabValues],
+  );
+
   const defaultQuery =
     tabState.activeTabIndex > 0 ? '' : props.defaultQuery ?? DEFAULT_QUERY;
   const initialValues = useRef({
@@ -239,6 +256,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       setResponseEditor,
       setVariableEditor,
 
+      setOperationName,
+
       ...initialValues.current,
 
       externalFragments,
@@ -257,6 +276,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       queryEditor,
       responseEditor,
       variableEditor,
+
+      setOperationName,
 
       externalFragments,
       validationRules,

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -13,13 +13,12 @@ import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import setValue from 'set-value';
 
 import { useAutoCompleteLeafs, useEditorContext } from './editor';
-import { EditCallback } from './editor/hooks';
 import { useHistoryContext } from './history';
 import { createContextHook, createNullableContext } from './utility/context';
 
 export type ExecutionContextType = {
   isFetching: boolean;
-  run(selectedOperationName?: string): void;
+  run(): void;
   stop(): void;
   subscription: Unsubscribable | null;
 };
@@ -31,7 +30,6 @@ export const ExecutionContext = createNullableContext<ExecutionContextType>(
 type ExecutionContextProviderProps = {
   children: ReactNode;
   fetcher: Fetcher;
-  onEditOperationName?: EditCallback;
 };
 
 export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
@@ -58,265 +56,225 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     setSubscription(null);
   }, [subscription]);
 
-  const { fetcher, onEditOperationName } = props;
-  const run = useCallback<ExecutionContextType['run']>(
-    async _selectedOperationName => {
-      if (!queryEditor || !responseEditor) {
-        return;
-      }
+  const { fetcher } = props;
+  const run = useCallback<ExecutionContextType['run']>(async () => {
+    if (!queryEditor || !responseEditor) {
+      return;
+    }
 
-      // If there's an active subscription, unsubscribe it and return
-      if (subscription) {
-        stop();
-        return;
-      }
+    // If there's an active subscription, unsubscribe it and return
+    if (subscription) {
+      stop();
+      return;
+    }
 
-      const setResponse = (value: string) => {
-        responseEditor.setValue(value);
-        updateActiveTabValues({ response: value });
-      };
+    const setResponse = (value: string) => {
+      responseEditor.setValue(value);
+      updateActiveTabValues({ response: value });
+    };
 
-      queryIdRef.current += 1;
-      const queryId = queryIdRef.current;
+    queryIdRef.current += 1;
+    const queryId = queryIdRef.current;
 
-      // Use the edited query after autoCompleteLeafs() runs or,
-      // in case autoCompletion fails (the function returns undefined),
-      // the current query from the editor.
-      let query = autoCompleteLeafs() || queryEditor.getValue();
+    // Use the edited query after autoCompleteLeafs() runs or,
+    // in case autoCompletion fails (the function returns undefined),
+    // the current query from the editor.
+    let query = autoCompleteLeafs() || queryEditor.getValue();
 
-      const variablesString = variableEditor?.getValue();
-      let variables: Record<string, unknown> | undefined;
-      try {
-        variables = tryParseJsonObject({
-          json: variablesString,
-          errorMessageParse: 'Variables are invalid JSON',
-          errorMessageType: 'Variables are not a JSON object.',
-        });
-      } catch (error) {
-        setResponse(error instanceof Error ? error.message : `${error}`);
-        return;
-      }
-
-      const headersString = headerEditor?.getValue();
-      let headers: Record<string, unknown> | undefined;
-      try {
-        headers = tryParseJsonObject({
-          json: headersString,
-          errorMessageParse: 'Headers are invalid JSON',
-          errorMessageType: 'Headers are not a JSON object.',
-        });
-      } catch (error) {
-        setResponse(error instanceof Error ? error.message : `${error}`);
-        return;
-      }
-
-      const selectedOperationName =
-        _selectedOperationName ||
-        // If no operation name is provided explicitly then try to derive it
-        // from the current cursor position
-        (() => {
-          if (!queryEditor.operations || !queryEditor.hasFocus()) {
-            return undefined;
-          }
-
-          const cursorIndex = queryEditor.indexFromPos(queryEditor.getCursor());
-
-          // Loop through all operations to see if one contains the cursor.
-          for (const operation of queryEditor.operations) {
-            if (
-              operation.loc &&
-              operation.loc.start <= cursorIndex &&
-              operation.loc.end >= cursorIndex
-            ) {
-              return operation.name?.value;
-            }
-          }
-
-          return undefined;
-        })();
-
-      let operationName = queryEditor.operationName;
-      if (selectedOperationName && selectedOperationName !== operationName) {
-        // If an operation was explicitly provided, different from the current
-        // operation name, then report that it changed.
-        operationName = selectedOperationName;
-
-        queryEditor.operationName = selectedOperationName;
-        updateActiveTabValues({ operationName: selectedOperationName });
-        onEditOperationName?.(selectedOperationName);
-      }
-
-      if (externalFragments) {
-        const fragmentDependencies = queryEditor.documentAST
-          ? getFragmentDependenciesForAST(
-              queryEditor.documentAST,
-              externalFragments,
-            )
-          : [];
-        if (fragmentDependencies.length > 0) {
-          query +=
-            '\n' +
-            fragmentDependencies
-              .map((node: FragmentDefinitionNode) => print(node))
-              .join('\n');
-        }
-      }
-
-      setResponse('');
-      setIsFetching(true);
-
-      history?.addToHistory({
-        query,
-        variables: variablesString,
-        headers: headersString,
-        operationName: operationName ?? undefined,
+    const variablesString = variableEditor?.getValue();
+    let variables: Record<string, unknown> | undefined;
+    try {
+      variables = tryParseJsonObject({
+        json: variablesString,
+        errorMessageParse: 'Variables are invalid JSON',
+        errorMessageType: 'Variables are not a JSON object.',
       });
+    } catch (error) {
+      setResponse(error instanceof Error ? error.message : `${error}`);
+      return;
+    }
 
-      try {
-        let fullResponse: FetcherResultPayload = { data: {} };
-        const handleResponse = (result: ExecutionResult) => {
-          // A different query was dispatched in the meantime, so don't
-          // show the results of this one.
-          if (queryId !== queryIdRef.current) {
-            return;
+    const headersString = headerEditor?.getValue();
+    let headers: Record<string, unknown> | undefined;
+    try {
+      headers = tryParseJsonObject({
+        json: headersString,
+        errorMessageParse: 'Headers are invalid JSON',
+        errorMessageType: 'Headers are not a JSON object.',
+      });
+    } catch (error) {
+      setResponse(error instanceof Error ? error.message : `${error}`);
+      return;
+    }
+
+    if (externalFragments) {
+      const fragmentDependencies = queryEditor.documentAST
+        ? getFragmentDependenciesForAST(
+            queryEditor.documentAST,
+            externalFragments,
+          )
+        : [];
+      if (fragmentDependencies.length > 0) {
+        query +=
+          '\n' +
+          fragmentDependencies
+            .map((node: FragmentDefinitionNode) => print(node))
+            .join('\n');
+      }
+    }
+
+    setResponse('');
+    setIsFetching(true);
+
+    history?.addToHistory({
+      query,
+      variables: variablesString,
+      headers: headersString,
+      operationName: queryEditor.operationName ?? undefined,
+    });
+
+    try {
+      let fullResponse: FetcherResultPayload = { data: {} };
+      const handleResponse = (result: ExecutionResult) => {
+        // A different query was dispatched in the meantime, so don't
+        // show the results of this one.
+        if (queryId !== queryIdRef.current) {
+          return;
+        }
+
+        let maybeMultipart = Array.isArray(result) ? result : false;
+        if (
+          !maybeMultipart &&
+          typeof result === 'object' &&
+          result !== null &&
+          'hasNext' in result
+        ) {
+          maybeMultipart = [result];
+        }
+
+        if (maybeMultipart) {
+          const payload: FetcherResultPayload = {
+            data: fullResponse.data,
+          };
+          const maybeErrors = [
+            ...(fullResponse?.errors || []),
+            ...maybeMultipart
+              .map(i => i.errors)
+              .flat()
+              .filter(Boolean),
+          ];
+
+          if (maybeErrors.length) {
+            payload.errors = maybeErrors;
           }
 
-          let maybeMultipart = Array.isArray(result) ? result : false;
-          if (
-            !maybeMultipart &&
-            typeof result === 'object' &&
-            result !== null &&
-            'hasNext' in result
-          ) {
-            maybeMultipart = [result];
-          }
-
-          if (maybeMultipart) {
-            const payload: FetcherResultPayload = {
-              data: fullResponse.data,
-            };
-            const maybeErrors = [
-              ...(fullResponse?.errors || []),
-              ...maybeMultipart
-                .map(i => i.errors)
-                .flat()
-                .filter(Boolean),
-            ];
-
-            if (maybeErrors.length) {
-              payload.errors = maybeErrors;
-            }
-
-            for (const part of maybeMultipart) {
-              // We pull out errors here, so we dont include it later
-              const { path, data, errors, ...rest } = part;
-              if (path) {
-                if (!data) {
-                  throw new Error(
-                    `Expected part to contain a data property, but got ${part}`,
-                  );
-                }
-
-                setValue(payload.data, path, data, { merge: true });
-              } else if (data) {
-                // If there is no path, we don't know what to do with the payload,
-                // so we just set it.
-                payload.data = part.data;
+          for (const part of maybeMultipart) {
+            // We pull out errors here, so we dont include it later
+            const { path, data, errors, ...rest } = part;
+            if (path) {
+              if (!data) {
+                throw new Error(
+                  `Expected part to contain a data property, but got ${part}`,
+                );
               }
 
-              // Ensures we also bring extensions and alike along for the ride
-              fullResponse = {
-                ...payload,
-                ...rest,
-              };
+              setValue(payload.data, path, data, { merge: true });
+            } else if (data) {
+              // If there is no path, we don't know what to do with the payload,
+              // so we just set it.
+              payload.data = part.data;
             }
 
-            setIsFetching(false);
-            setResponse(formatResult(fullResponse));
-          } else {
-            const response = formatResult(result);
-            setIsFetching(false);
-            setResponse(response);
+            // Ensures we also bring extensions and alike along for the ride
+            fullResponse = {
+              ...payload,
+              ...rest,
+            };
           }
-        };
 
-        const fetch = fetcher(
-          {
-            query,
-            variables,
-            operationName: queryEditor.operationName,
-          },
-          {
-            headers: headers ?? undefined,
-            shouldPersistHeaders,
-            documentAST: queryEditor.documentAST ?? undefined,
-          },
-        );
-
-        const value = await Promise.resolve(fetch);
-        if (isObservable(value)) {
-          // If the fetcher returned an Observable, then subscribe to it, calling
-          // the callback on each next value, and handling both errors and the
-          // completion of the Observable.
-          setSubscription(
-            value.subscribe({
-              next(result) {
-                handleResponse(result);
-              },
-              error(error: Error) {
-                setIsFetching(false);
-                if (error) {
-                  setResponse(formatError(error));
-                }
-                setSubscription(null);
-              },
-              complete() {
-                setIsFetching(false);
-                setSubscription(null);
-              },
-            }),
-          );
-        } else if (isAsyncIterable(value)) {
-          setSubscription({
-            unsubscribe: () => value[Symbol.asyncIterator]().return?.(),
-          });
-
-          try {
-            for await (const result of value) {
-              handleResponse(result);
-            }
-            setIsFetching(false);
-            setSubscription(null);
-          } catch (error) {
-            setIsFetching(false);
-            setResponse(formatError(error));
-            setSubscription(null);
-          }
+          setIsFetching(false);
+          setResponse(formatResult(fullResponse));
         } else {
-          handleResponse(value);
+          const response = formatResult(result);
+          setIsFetching(false);
+          setResponse(response);
         }
-      } catch (error) {
-        setIsFetching(false);
-        setResponse(formatError(error));
-        setSubscription(null);
+      };
+
+      const fetch = fetcher(
+        {
+          query,
+          variables,
+          operationName: queryEditor.operationName,
+        },
+        {
+          headers: headers ?? undefined,
+          shouldPersistHeaders,
+          documentAST: queryEditor.documentAST ?? undefined,
+        },
+      );
+
+      const value = await Promise.resolve(fetch);
+      if (isObservable(value)) {
+        // If the fetcher returned an Observable, then subscribe to it, calling
+        // the callback on each next value, and handling both errors and the
+        // completion of the Observable.
+        setSubscription(
+          value.subscribe({
+            next(result) {
+              handleResponse(result);
+            },
+            error(error: Error) {
+              setIsFetching(false);
+              if (error) {
+                setResponse(formatError(error));
+              }
+              setSubscription(null);
+            },
+            complete() {
+              setIsFetching(false);
+              setSubscription(null);
+            },
+          }),
+        );
+      } else if (isAsyncIterable(value)) {
+        setSubscription({
+          unsubscribe: () => value[Symbol.asyncIterator]().return?.(),
+        });
+
+        try {
+          for await (const result of value) {
+            handleResponse(result);
+          }
+          setIsFetching(false);
+          setSubscription(null);
+        } catch (error) {
+          setIsFetching(false);
+          setResponse(formatError(error));
+          setSubscription(null);
+        }
+      } else {
+        handleResponse(value);
       }
-    },
-    [
-      autoCompleteLeafs,
-      externalFragments,
-      fetcher,
-      headerEditor,
-      history,
-      onEditOperationName,
-      queryEditor,
-      responseEditor,
-      shouldPersistHeaders,
-      stop,
-      subscription,
-      updateActiveTabValues,
-      variableEditor,
-    ],
-  );
+    } catch (error) {
+      setIsFetching(false);
+      setResponse(formatError(error));
+      setSubscription(null);
+    }
+  }, [
+    autoCompleteLeafs,
+    externalFragments,
+    fetcher,
+    headerEditor,
+    history,
+    queryEditor,
+    responseEditor,
+    shouldPersistHeaders,
+    stop,
+    subscription,
+    updateActiveTabValues,
+    variableEditor,
+  ]);
 
   const value = useMemo<ExecutionContextType>(
     () => ({ isFetching, run, stop, subscription }),

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -18,6 +18,7 @@ import { createContextHook, createNullableContext } from './utility/context';
 
 export type ExecutionContextType = {
   isFetching: boolean;
+  operationName: string | null;
   run(): void;
   stop(): void;
   subscription: Unsubscribable | null;
@@ -30,6 +31,7 @@ export const ExecutionContext = createNullableContext<ExecutionContextType>(
 type ExecutionContextProviderProps = {
   children: ReactNode;
   fetcher: Fetcher;
+  operationName?: string;
 };
 
 export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
@@ -126,11 +128,14 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     setResponse('');
     setIsFetching(true);
 
+    const operationName =
+      props.operationName ?? queryEditor.operationName ?? undefined;
+
     history?.addToHistory({
       query,
       variables: variablesString,
       headers: headersString,
-      operationName: queryEditor.operationName ?? undefined,
+      operationName,
     });
 
     try {
@@ -205,7 +210,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
         {
           query,
           variables,
-          operationName: queryEditor.operationName,
+          operationName,
         },
         {
           headers: headers ?? undefined,
@@ -267,6 +272,7 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     fetcher,
     headerEditor,
     history,
+    props.operationName,
     queryEditor,
     responseEditor,
     shouldPersistHeaders,
@@ -277,8 +283,14 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
   ]);
 
   const value = useMemo<ExecutionContextType>(
-    () => ({ isFetching, run, stop, subscription }),
-    [isFetching, run, stop, subscription],
+    () => ({
+      isFetching,
+      operationName: props.operationName ?? null,
+      run,
+      stop,
+      subscription,
+    }),
+    [isFetching, props.operationName, run, stop, subscription],
   );
 
   return (

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -42,17 +42,11 @@ function onEditHeaders(newHeaders) {
   updateURL();
 }
 
-function onEditOperationName(newOperationName) {
-  parameters.operationName = newOperationName;
-  updateURL();
-}
-
 function onTabChange(tabsState) {
   const activeTab = tabsState.tabs[tabsState.activeTabIndex];
   parameters.query = activeTab.query;
   parameters.variables = activeTab.variables;
   parameters.headers = activeTab.headers;
-  parameters.operationName = activeTab.operationName;
   updateURL();
 }
 
@@ -103,12 +97,10 @@ ReactDOM.render(
     query: parameters.query,
     variables: parameters.variables,
     headers: parameters.headers,
-    operationName: parameters.operationName,
     onEditQuery: onEditQuery,
     onEditVariables: onEditVariables,
     onEditHeaders: onEditHeaders,
     defaultSecondaryEditorOpen: true,
-    onEditOperationName: onEditOperationName,
     headerEditorEnabled: true,
     shouldPersistHeaders: true,
     inputValueDeprecation: GraphQLVersion.includes('15.5') ? undefined : true,

--- a/packages/graphiql/src/components/ExecuteButton.tsx
+++ b/packages/graphiql/src/components/ExecuteButton.tsx
@@ -10,7 +10,13 @@ import React, { useState } from 'react';
 
 export function ExecuteButton() {
   const { queryEditor, setOperationName } = useEditorContext({ nonNull: true });
-  const { isFetching, run, stop, subscription } = useExecutionContext({
+  const {
+    isFetching,
+    operationName,
+    run,
+    stop,
+    subscription,
+  } = useExecutionContext({
     nonNull: true,
   });
   const [optionsOpen, setOptionsOpen] = useState(false);
@@ -20,7 +26,7 @@ export function ExecuteButton() {
 
   const isRunning = isFetching || Boolean(subscription);
   const operations = queryEditor?.operations || [];
-  const hasOptions = operations.length > 1;
+  const hasOptions = operations.length > 1 && typeof operationName !== 'string';
 
   return (
     <div className="execute-button-wrap">

--- a/packages/graphiql/src/components/ExecuteButton.tsx
+++ b/packages/graphiql/src/components/ExecuteButton.tsx
@@ -9,7 +9,7 @@ import { OperationDefinitionNode } from 'graphql';
 import React, { useState } from 'react';
 
 export function ExecuteButton() {
-  const { queryEditor } = useEditorContext({ nonNull: true });
+  const { queryEditor, setOperationName } = useEditorContext({ nonNull: true });
   const { isFetching, run, stop, subscription } = useExecutionContext({
     nonNull: true,
   });
@@ -97,7 +97,15 @@ export function ExecuteButton() {
                 onMouseOut={() => setHighlight(null)}
                 onMouseUp={() => {
                   setOptionsOpen(false);
-                  run(operation.name?.value);
+                  const operationName = operation.name?.value;
+                  if (
+                    queryEditor &&
+                    operationName &&
+                    operationName !== queryEditor.operationName
+                  ) {
+                    setOperationName(operationName);
+                  }
+                  run();
                 }}>
                 {opName}
               </li>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -441,6 +441,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     inputValueDeprecation,
     introspectionQueryName,
     maxHistoryLength,
+    onEditOperationName,
     onSchemaChange,
     onToggleHistory,
     onToggleDocs,
@@ -467,6 +468,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
           defaultQuery={props.defaultQuery}
           externalFragments={externalFragments}
           headers={props.headers}
+          onEditOperationName={onEditOperationName}
           onTabChange={
             typeof props.tabs === 'object' ? props.tabs.onTabChange : undefined
           }
@@ -482,9 +484,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             onSchemaChange={onSchemaChange}
             schema={schema}
             schemaDescription={schemaDescription}>
-            <ExecutionContextProvider
-              fetcher={fetcher}
-              onEditOperationName={props.onEditOperationName}>
+            <ExecutionContextProvider fetcher={fetcher}>
               <ExplorerContextProvider
                 isVisible={docExplorerOpen}
                 onToggleVisibility={onToggleDocs}>
@@ -513,6 +513,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'inputValueDeprecation'
   | 'introspectionQueryName'
   | 'maxHistoryLength'
+  | 'onEditOperationName'
   | 'onSchemaChange'
   | 'onToggleDocs'
   | 'onToggleHistory'
@@ -778,7 +779,6 @@ class GraphiQLWithContext extends React.Component<
                       keyMap={this.props.keyMap}
                       onCopyQuery={this.props.onCopyQuery}
                       onEdit={this.props.onEditQuery}
-                      onEditOperationName={this.props.onEditOperationName}
                       readOnly={this.props.readOnly}
                     />
                   </div>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -445,6 +445,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     onSchemaChange,
     onToggleHistory,
     onToggleDocs,
+    operationName,
     storage,
     schema,
     schemaDescription,
@@ -484,7 +485,9 @@ const GraphiQLProviders: ForwardRefExoticComponent<
             onSchemaChange={onSchemaChange}
             schema={schema}
             schemaDescription={schemaDescription}>
-            <ExecutionContextProvider fetcher={fetcher}>
+            <ExecutionContextProvider
+              fetcher={fetcher}
+              operationName={operationName}>
               <ExplorerContextProvider
                 isVisible={docExplorerOpen}
                 onToggleVisibility={onToggleDocs}>
@@ -517,6 +520,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'onSchemaChange'
   | 'onToggleDocs'
   | 'onToggleHistory'
+  | 'operationName'
   | 'query'
   | 'schema'
   | 'schemaDescription'


### PR DESCRIPTION
Currently the `operationName` and `onEditOperationName` props do not really work. I can't trace back exactly when this was introduced, but it's likely that it's again a bug introduced when we started pulling stuff out into `@graphiql/react`.

Now it should work as expected:
- The `operationName` prop controls the operation name sent with the request when executing. It does not check if there actually exists an operation with this name, this has to be done in userland. When this prop is set, the `ExecutionButton` skips showing the dropdown if there are multiple operations.
- The `onEditOperationName` prop is now triggered whenever the operation name is changed. That includes
  - when changing the operation name in the query editor
  - when executing a different operation from the same document
  - when selecting the operation that should be executed from the dropdown menu triggered by the execution button