### PR TITLE
move response editor value prop to context provider

### DIFF
--- a/.changeset/silly-squids-cheat.md
+++ b/.changeset/silly-squids-cheat.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+BREAKING: The `ResponseEditor` component no longer accepts the prop `value`. Instead you can now pass the prop `response` to the `EditorContextProvider`. This aligns it with the API design of the other editor components.

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -57,6 +57,7 @@ export type EditorContextType = {
 
   initialHeaders: string;
   initialQuery: string;
+  initialResponse: string;
   initialVariables: string;
 
   externalFragments: Map<string, FragmentDefinitionNode>;
@@ -77,6 +78,7 @@ type EditorContextProviderProps = {
   onEditOperationName?(operationName: string): void;
   onTabChange?(tabs: TabsState): void;
   query?: string;
+  response?: string;
   shouldPersistHeaders?: boolean;
   validationRules?: ValidationRule[];
   variables?: string;
@@ -100,6 +102,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
   useSynchronizeValue(headerEditor, props.headers);
   useSynchronizeValue(queryEditor, props.query);
+  useSynchronizeValue(responseEditor, props.response);
   useSynchronizeValue(variableEditor, props.variables);
 
   // We store this in state but never update it. By passing a function we only
@@ -212,6 +215,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
   const initialValues = useRef({
     initialHeaders: storedEditorValues.headers ?? '',
     initialQuery: storedEditorValues.query ?? defaultQuery,
+    initialResponse: props.response ?? '',
     initialVariables: storedEditorValues.variables ?? '',
   });
 

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -17,7 +17,7 @@ export function useSynchronizeValue(
   value: string | undefined,
 ) {
   useEffect(() => {
-    if (editor && typeof value !== 'undefined' && value !== editor.getValue()) {
+    if (editor && typeof value === 'string' && value !== editor.getValue()) {
       editor.setValue(value);
     }
   }, [editor, value]);

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -12,7 +12,7 @@ import {
 } from './common';
 import { ImagePreview } from './components';
 import { useEditorContext } from './context';
-import { useSynchronizeOption, useSynchronizeValue } from './hooks';
+import { useSynchronizeOption } from './hooks';
 import { CodeMirrorEditor, KeyMap } from './types';
 
 export type ResponseTooltipType = ComponentType<{ pos: Position }>;
@@ -20,7 +20,6 @@ export type ResponseTooltipType = ComponentType<{ pos: Position }>;
 export type UseResponseEditorArgs = {
   ResponseTooltip?: ResponseTooltipType;
   editorTheme?: string;
-  value?: string;
   keyMap?: KeyMap;
 };
 
@@ -28,13 +27,16 @@ export function useResponseEditor({
   ResponseTooltip,
   editorTheme = DEFAULT_EDITOR_THEME,
   keyMap = DEFAULT_KEY_MAP,
-  value,
 }: UseResponseEditorArgs = {}) {
   const { fetchError, validationErrors } = useSchemaContext({
     nonNull: true,
     caller: useResponseEditor,
   });
-  const { responseEditor, setResponseEditor } = useEditorContext({
+  const {
+    initialResponse,
+    responseEditor,
+    setResponseEditor,
+  } = useEditorContext({
     nonNull: true,
     caller: useResponseEditor,
   });
@@ -46,8 +48,6 @@ export function useResponseEditor({
   useEffect(() => {
     responseTooltipRef.current = ResponseTooltip;
   }, [ResponseTooltip]);
-
-  const initialValue = useRef(value);
 
   useEffect(() => {
     let isActive = true;
@@ -105,7 +105,7 @@ export function useResponseEditor({
       }
 
       const newEditor = CodeMirror(container, {
-        value: initialValue.current || '',
+        value: initialResponse,
         lineWrapping: true,
         readOnly: true,
         theme: editorTheme,
@@ -126,8 +126,6 @@ export function useResponseEditor({
   }, [editorTheme, setResponseEditor]);
 
   useSynchronizeOption(responseEditor, 'keyMap', keyMap);
-
-  useSynchronizeValue(responseEditor, value);
 
   useEffect(() => {
     if (fetchError) {

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -438,6 +438,7 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     docExplorerOpen,
     externalFragments,
     fetcher,
+    headers,
     inputValueDeprecation,
     introspectionQueryName,
     maxHistoryLength,
@@ -446,11 +447,14 @@ const GraphiQLProviders: ForwardRefExoticComponent<
     onToggleHistory,
     onToggleDocs,
     operationName,
+    query,
+    response,
     storage,
     schema,
     schemaDescription,
     shouldPersistHeaders,
     validationRules,
+    variables,
     ...props
   },
   ref,
@@ -468,15 +472,16 @@ const GraphiQLProviders: ForwardRefExoticComponent<
         <EditorContextProvider
           defaultQuery={props.defaultQuery}
           externalFragments={externalFragments}
-          headers={props.headers}
+          headers={headers}
           onEditOperationName={onEditOperationName}
           onTabChange={
             typeof props.tabs === 'object' ? props.tabs.onTabChange : undefined
           }
-          query={props.query}
+          query={query}
+          response={response}
           shouldPersistHeaders={shouldPersistHeaders}
           validationRules={validationRules}
-          variables={props.variables}>
+          variables={variables}>
           <SchemaContextProvider
             dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
             fetcher={fetcher}
@@ -522,6 +527,7 @@ type GraphiQLWithContextProviderProps = Omit<
   | 'onToggleHistory'
   | 'operationName'
   | 'query'
+  | 'response'
   | 'schema'
   | 'schemaDescription'
   | 'shouldPersistHeaders'
@@ -888,7 +894,6 @@ class GraphiQLWithContext extends React.Component<
                     </div>
                   )}
                   <ResultViewer
-                    value={this.props.response}
                     editorTheme={this.props.editorTheme}
                     ResponseTooltip={this.props.ResultsTooltip}
                     keyMap={this.props.keyMap}


### PR DESCRIPTION
Noticed this little inconsistency where we passed the value props for all editors *except* the response editor to the context provider. This PR cleans that up, now all editor value props are passed to the `EditorContextProvider`.