### PR TITLE
remove deprecated and default prettier config options

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,5 @@
 {
-  "jsxBracketSameLine": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "endOfLine": "lf",
-  "arrowParens": "avoid" 
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
Follow up to #2648, this cleans up the config and removes settings that are deprecated of mirror the default value.