### PR TITLE
remove methods from `SchemaContext` meant for internal use

### DIFF
--- a/.changeset/famous-dragons-confess.md
+++ b/.changeset/famous-dragons-confess.md
@@ -2,4 +2,7 @@
 '@graphiql/react': minor
 ---
 
-BREAKING: The `ExecutionContext` no longer contains the `subscription` property as this is only meant for internal use.
+BREAKING: The following context properties have been removed as they are only meant for internal use:
+- The `subscription` property of the `ExecutionContext`
+- The `setSchema` method of the `SchemaContext`
+- The `setFetchError` method of the `SchemaContext`

--- a/.changeset/quick-pumas-fly.md
+++ b/.changeset/quick-pumas-fly.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+BREAKING: The `validationErrors` property of the `SchemaContext` is now always non-null. If the schema is valid then it will contain an empty list.

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -128,7 +128,7 @@ export function useResponseEditor({
     if (fetchError) {
       responseEditor?.setValue(fetchError);
     }
-    if (validationErrors) {
+    if (validationErrors.length > 0) {
       responseEditor?.setValue(formatError(validationErrors));
     }
   }, [responseEditor, fetchError, validationErrors]);

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -42,7 +42,7 @@ export type SchemaContextType = {
   introspect(): void;
   isFetching: boolean;
   schema: MaybeGraphQLSchema;
-  validationErrors: readonly GraphQLError[] | null;
+  validationErrors: readonly GraphQLError[];
 };
 
 export const SchemaContext =
@@ -267,10 +267,9 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
    */
   const validationErrors = useMemo(() => {
     if (!schema || props.dangerouslyAssumeSchemaIsValid) {
-      return null;
+      return [];
     }
-    const errors = validateSchema(schema);
-    return errors.length > 0 ? errors : null;
+    return validateSchema(schema);
   }, [schema, props.dangerouslyAssumeSchemaIsValid]);
 
   /**

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -16,9 +16,7 @@ import {
   validateSchema,
 } from 'graphql';
 import {
-  Dispatch,
   ReactNode,
-  SetStateAction,
   useCallback,
   useEffect,
   useMemo,
@@ -44,8 +42,6 @@ export type SchemaContextType = {
   introspect(): void;
   isFetching: boolean;
   schema: MaybeGraphQLSchema;
-  setFetchError: Dispatch<SetStateAction<string | null>>;
-  setSchema: Dispatch<SetStateAction<MaybeGraphQLSchema>>;
   validationErrors: readonly GraphQLError[] | null;
 };
 
@@ -286,8 +282,6 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
       introspect,
       isFetching,
       schema,
-      setFetchError,
-      setSchema,
       validationErrors,
     }),
     [fetchError, introspect, isFetching, schema, validationErrors],

--- a/packages/graphiql/src/components/DocExplorer.tsx
+++ b/packages/graphiql/src/components/DocExplorer.tsx
@@ -52,7 +52,7 @@ export function DocExplorer(props: DocExplorerProps) {
   let content: ReactNode = null;
   if (fetchError) {
     content = <div className="error-container">Error fetching schema</div>;
-  } else if (validationErrors) {
+  } else if (validationErrors.length > 0) {
     content = (
       <div className="error-container">
         Schema is invalid: {validationErrors[0].message}

--- a/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
@@ -31,8 +31,6 @@ function TypeDocWithContext(props: { type: GraphQLNamedType }) {
         introspect() {},
         isFetching: false,
         schema: ExampleSchema,
-        setFetchError() {},
-        setSchema() {},
         validationErrors: null,
       }}
     >

--- a/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
+++ b/packages/graphiql/src/components/DocExplorer/__tests__/TypeDoc.spec.tsx
@@ -31,7 +31,7 @@ function TypeDocWithContext(props: { type: GraphQLNamedType }) {
         introspect() {},
         isFetching: false,
         schema: ExampleSchema,
-        validationErrors: null,
+        validationErrors: [],
       }}
     >
       <ExplorerContext.Provider

--- a/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
@@ -20,7 +20,7 @@ const defaultSchemaContext: SchemaContextType = {
   introspect() {},
   isFetching: false,
   schema: ExampleSchema,
-  validationErrors: null,
+  validationErrors: [],
 };
 
 function DocExplorerWithContext(

--- a/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/DocExplorer.spec.tsx
@@ -20,8 +20,6 @@ const defaultSchemaContext: SchemaContextType = {
   introspect() {},
   isFetching: false,
   schema: ExampleSchema,
-  setFetchError() {},
-  setSchema() {},
   validationErrors: null,
 };
 


### PR DESCRIPTION
Spotted more stuff that should not be exposed on contexts. This time we actually did not use it anyways.