### PR TITLE
fix: fix fetchError persisting across different fetchers

### DIFF
--- a/.changeset/friendly-flies-battle.md
+++ b/.changeset/friendly-flies-battle.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Fix `fetchError` not being cleared when a new `fetcher` is used

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -168,7 +168,6 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
       }
 
       setIsFetching(true);
-      // clear any previous fetch errors
       setFetchError(null);
 
       let result = await fetch;

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -168,6 +168,8 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
       }
 
       setIsFetching(true);
+      // clear any previous fetch errors
+      setFetchError(null);
 
       let result = await fetch;
 

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -98,7 +98,7 @@ describe('GraphiQL', () => {
     expect(secondCalled).toEqual(true);
   });
 
-  it('should refetch schema after a fetchError', async () => {
+  it('should refresh schema with new fetcher after a fetchError', async () => {
     function firstFetcher() {
       return Promise.reject('Schema Error');
     }

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -98,6 +98,31 @@ describe('GraphiQL', () => {
     expect(secondCalled).toEqual(true);
   });
 
+  it('should refetch schema after a fetchError', async () => {
+    function firstFetcher() {
+      return Promise.reject('Schema Error');
+    }
+    function secondFetcher() {
+      return Promise.resolve(simpleIntrospection);
+    }
+
+    // Use a bad fetcher for our initial render
+    const { rerender, container } = render(<GraphiQL fetcher={firstFetcher} />);
+    await wait();
+
+    expect(
+      container.querySelector('.doc-explorer-contents .error-container'),
+    ).toBeTruthy();
+
+    // Re-render with valid fetcher
+    rerender(<GraphiQL fetcher={secondFetcher} />);
+    await wait();
+
+    expect(
+      container.querySelector('.doc-explorer-contents .error-container'),
+    ).not.toBeTruthy();
+  });
+
   it('should not throw error if schema missing and query provided', () => {
     expect(() =>
       render(<GraphiQL fetcher={noOpFetcher} query="{}" />),


### PR DESCRIPTION
If you construct a `GraphiQL` instance with a bad fetcher `fetchError` gets persisted in `SchemaContextType` forever. You can still fetch a new schema but the `DocExplorer` will always show "Error fetching schema"