### PR TITLE
[language-services] Improve autocomplete suggestions when editing type system definitions

### DIFF
--- a/.changeset/chatty-timers-heal.md
+++ b/.changeset/chatty-timers-heal.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': minor
+---
+
+Provide autocomplete suggestions for documents with type definitions

--- a/.changeset/smart-cats-marry.md
+++ b/.changeset/smart-cats-marry.md
@@ -1,0 +1,5 @@
+---
+'example-monaco-graphql-webpack': minor
+---
+
+Add schema SDL editor populated with the test schema

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,7 +131,8 @@ module.exports = {
     'no-catch-shadow': 1,
     'no-label-var': 1,
     'no-restricted-globals': 0,
-    'no-shadow': 1,
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
     'no-undef-init': 0,
     'no-undefined': 0,
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,23 @@
       ],
       "sourceMaps": true,
       "preLaunchTask": "watch-vscode"
+    },
+    {
+      "type": "node",
+      "name": "jest watch",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": [
+        "--config",
+        "jest.config.js",
+        "--color",
+        "--runInBand",
+        "--watch",
+        "${relativeFile}"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/examples/monaco-graphql-webpack/babel.config.js
+++ b/examples/monaco-graphql-webpack/babel.config.js
@@ -4,5 +4,8 @@ module.exports = {
     require.resolve('@babel/preset-typescript'),
     require.resolve('@babel/preset-react'),
   ],
-  plugins: [require.resolve('@babel/plugin-proposal-class-properties')],
+  plugins: [
+    require.resolve('@babel/plugin-proposal-class-properties'),
+    require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+  ],
 };

--- a/examples/monaco-graphql-webpack/src/editors.ts
+++ b/examples/monaco-graphql-webpack/src/editors.ts
@@ -42,12 +42,14 @@ query Example(
 
 const variablesString =
   localStorage.getItem('variables') ??
-  `{ 
-  "reviewEvent": "graphql", 
+  `{
+  "reviewEvent": "graphql",
   "name": true
 }`;
 
 const resultsString = `{}`;
+
+const schemaSdlString = localStorage.getItem('schema-sdl') ?? ``;
 
 const THEME = 'vs-dark';
 
@@ -91,6 +93,24 @@ export function createEditors() {
     },
   );
 
+  const schemaModel = monaco.editor.createModel(
+    schemaSdlString,
+    GRAPHQL_LANGUAGE_ID,
+    monaco.Uri.file('/1/schema.graphqls'),
+  );
+
+  const schemaEditor = monaco.editor.create(
+    document.getElementById('schema-sdl') as HTMLElement,
+    {
+      model: schemaModel,
+      formatOnPaste: true,
+      formatOnType: true,
+      folding: true,
+      theme: THEME,
+      language: GRAPHQL_LANGUAGE_ID,
+    },
+  );
+
   const resultsModel = monaco.editor.createModel(
     resultsString,
     'json',
@@ -113,7 +133,9 @@ export function createEditors() {
     operationEditor,
     variablesEditor,
     resultsEditor,
+    schemaEditor,
     operationModel,
     variablesModel,
+    schemaModel,
   };
 }

--- a/examples/monaco-graphql-webpack/src/index.html.ejs
+++ b/examples/monaco-graphql-webpack/src/index.html.ejs
@@ -23,6 +23,7 @@
             aria-atomic="true"
             id="results"
           ></div>
+          <div id="schema-sdl"></div>
         </div>
       </div>
     </div>

--- a/examples/monaco-graphql-webpack/src/schema.ts
+++ b/examples/monaco-graphql-webpack/src/schema.ts
@@ -3,6 +3,7 @@ import {
   getIntrospectionQuery,
   printSchema,
   parse,
+  buildASTSchema,
 } from 'graphql';
 import type { SchemaConfig } from 'monaco-graphql/src/typings';
 import { Uri } from 'monaco-editor';
@@ -135,7 +136,8 @@ class MySchemaFetcher {
 
 function isValid(sdl: string) {
   try {
-    parse(sdl);
+    const ast = parse(sdl);
+    buildASTSchema(ast);
     return true;
   } catch {
     return false;

--- a/examples/monaco-graphql-webpack/src/style.css
+++ b/examples/monaco-graphql-webpack/src/style.css
@@ -48,7 +48,11 @@ body {
 }
 #results {
   align-items: stretch;
-  height: 90vh;
+  height: 45vh;
+}
+#schema-sdl {
+  align-items: stretch;
+  height: 45vh;
 }
 
 /* Toolbar */

--- a/packages/codemirror-graphql/src/__tests__/hint-test.ts
+++ b/packages/codemirror-graphql/src/__tests__/hint-test.ts
@@ -17,10 +17,6 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLString,
-  __Directive,
-  __EnumValue,
-  __Field,
-  __InputValue,
   __Schema,
   __Type,
 } from 'graphql';
@@ -614,30 +610,6 @@ describe('graphql-hint', () => {
       {
         text: 'SubscriptionType',
         description: 'This is a simple subscription type',
-      },
-      {
-        text: '__Schema',
-        description: __Schema.description,
-      },
-      {
-        text: '__Type',
-        description: __Type.description,
-      },
-      {
-        text: '__Field',
-        description: __Field.description,
-      },
-      {
-        text: '__InputValue',
-        description: __InputValue.description,
-      },
-      {
-        text: '__EnumValue',
-        description: __EnumValue.description,
-      },
-      {
-        text: '__Directive',
-        description: __Directive.description,
       },
     ];
     const expectedSuggestions = getExpectedSuggestions(list);

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -164,8 +164,8 @@ export const createMultipartFetcher = (
         // the static provided headers
         ...fetcherOpts?.headers,
       },
-    }).then(response =>
-      meros<Extract<ExecutionResultPayload, { hasNext: boolean }>>(response, {
+    }).then(r =>
+      meros<Extract<ExecutionResultPayload, { hasNext: boolean }>>(r, {
         multiple: true,
       }),
     );

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -262,6 +262,7 @@ export class GraphQLLanguageService {
         position,
         undefined,
         fragmentInfo,
+        { uri: filePath },
       );
     }
     return [];

--- a/packages/graphql-language-service/src/interface/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/interface/__tests__/__schema__/StarWarsSchema.graphql
@@ -71,3 +71,5 @@ type Query {
   inputTypeTest(args: InputType = {key: "key"}): TestType
   deprecatedField: TestType @deprecated(reason: "Use test instead.")
 }
+
+union TestUnion = Droid | TestType

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
@@ -581,13 +581,13 @@ describe('getAutocompleteSuggestions', () => {
     });
 
     it('provides interfaces to be extended', () => {
-      expect(
-        testSuggestions('extend interface ', new Position(0, 17)),
-      ).toEqual([
-        { label: 'AnotherInterface' },
-        { label: 'Character' },
-        { label: 'TestInterface' },
-      ]);
+      expect(testSuggestions('extend interface ', new Position(0, 17))).toEqual(
+        [
+          { label: 'AnotherInterface' },
+          { label: 'Character' },
+          { label: 'TestInterface' },
+        ],
+      );
     });
 
     it('provides unions to be extended', () => {

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
@@ -614,12 +614,49 @@ describe('getAutocompleteSuggestions', () => {
       ]));
     it('provides correct suggestions on object fields', () =>
       expect(
-        testSuggestions(`type Type {\n  aField: s`, new Position(0, 23)),
-        // FIXME: these are just input types, should suggest output types and [
-      ).toEqual([{ label: 'Episode' }, { label: 'String' }]));
+        testSuggestions(
+          `type Type {\n  aField: s`,
+          new Position(0, 23),
+          [],
+          'schema.graphqls',
+        ),
+      ).toEqual([
+        { label: 'Episode' },
+        { label: 'String' },
+        { label: 'TestInterface' },
+        { label: 'TestType' },
+        { label: 'TestUnion' },
+      ]));
+    it('provides correct suggestions on object fields that are arrays', () =>
+      expect(
+        testSuggestions(
+          `type Type {\n  aField: []`,
+          new Position(0, 25),
+          [],
+          'schema.graphqls',
+        ),
+      ).toEqual([
+        { label: 'AnotherInterface' },
+        { label: 'Boolean' },
+        { label: 'Character' },
+        { label: 'Droid' },
+        { label: 'Episode' },
+        { label: 'Human' },
+        { label: 'Int' },
+        { label: 'Query' },
+        { label: 'String' },
+        { label: 'TestInterface' },
+        { label: 'TestType' },
+        { label: 'TestUnion' },
+      ]));
     it('provides correct suggestions on input object fields', () =>
       expect(
-        testSuggestions(`input Type {\n  aField: s`, new Position(0, 23)),
+        testSuggestions(
+          `input Type {\n  aField: s`,
+          new Position(0, 23),
+          [],
+          'schema.graphqls',
+        ),
       ).toEqual([{ label: 'Episode' }, { label: 'String' }]));
     it('provides correct directive suggestions on args definitions', () =>
       expect(

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -1310,12 +1310,14 @@ function unwrapType(state: State): State {
   if (
     state.prevState &&
     state.kind &&
-    ([
-      RuleKinds.NAMED_TYPE,
-      RuleKinds.LIST_TYPE,
-      RuleKinds.TYPE,
-      RuleKinds.NON_NULL_TYPE,
-    ] as RuleKind[]).includes(state.kind)
+    (
+      [
+        RuleKinds.NAMED_TYPE,
+        RuleKinds.LIST_TYPE,
+        RuleKinds.TYPE,
+        RuleKinds.NON_NULL_TYPE,
+      ] as RuleKind[]
+    ).includes(state.kind)
   ) {
     return unwrapType(state.prevState);
   }

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -1271,7 +1271,7 @@ export function getTypeInfo(
   };
 }
 
-enum GraphQLDocumentMode {
+export enum GraphQLDocumentMode {
   TYPE_SYSTEM = 'TYPE_SYSTEM',
   EXECUTABLE = 'EXECUTABLE',
 }

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -303,7 +303,32 @@ export const ParseRules: { [name: string]: ParseRule } = {
     list('InputValueDef'),
     p('}'),
   ],
-  ExtendDef: [word('extend'), 'ObjectTypeDef'],
+  ExtendDef: [word('extend'), 'ExtensionDefinition'],
+  ExtensionDefinition(token: Token): RuleKind | void {
+    switch (token.value) {
+      case 'schema':
+        return Kind.SCHEMA_EXTENSION;
+      case 'scalar':
+        return Kind.SCALAR_TYPE_EXTENSION;
+      case 'type':
+        return Kind.OBJECT_TYPE_EXTENSION;
+      case 'interface':
+        return Kind.INTERFACE_TYPE_EXTENSION;
+      case 'union':
+        return Kind.UNION_TYPE_EXTENSION;
+      case 'enum':
+        return Kind.ENUM_TYPE_EXTENSION;
+      case 'input':
+        return Kind.INPUT_OBJECT_TYPE_EXTENSION;
+    }
+  },
+  [Kind.SCHEMA_EXTENSION]: ['SchemaDef'],
+  [Kind.SCALAR_TYPE_EXTENSION]: ['ScalarDef'],
+  [Kind.OBJECT_TYPE_EXTENSION]: ['ObjectTypeDef'],
+  [Kind.INTERFACE_TYPE_EXTENSION]: ['InterfaceDef'],
+  [Kind.UNION_TYPE_EXTENSION]: ['UnionDef'],
+  [Kind.ENUM_TYPE_EXTENSION]: ['EnumDef'],
+  [Kind.INPUT_OBJECT_TYPE_EXTENSION]: ['InputDef'],
 };
 
 // A keyword Token.

--- a/packages/graphql-language-service/src/parser/types.ts
+++ b/packages/graphql-language-service/src/parser/types.ts
@@ -79,6 +79,7 @@ export const AdditionalRuleKinds: _AdditionalRuleKinds = {
   INPUT_VALUE_DEF: 'InputValueDef',
   ARGUMENTS_DEF: 'ArgumentsDef',
   EXTEND_DEF: 'ExtendDef',
+  EXTENSION_DEFINITION: 'ExtensionDefinition',
   DIRECTIVE_DEF: 'DirectiveDef',
   IMPLEMENTS: 'Implements',
   VARIABLE_DEFINITIONS: 'VariableDefinitions',
@@ -109,6 +110,7 @@ export type _AdditionalRuleKinds = {
   INPUT_VALUE_DEF: 'InputValueDef';
   ARGUMENTS_DEF: 'ArgumentsDef';
   EXTEND_DEF: 'ExtendDef';
+  EXTENSION_DEFINITION: 'ExtensionDefinition';
   DIRECTIVE_DEF: 'DirectiveDef';
   IMPLEMENTS: 'Implements';
   VARIABLE_DEFINITIONS: 'VariableDefinitions';

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -213,6 +213,7 @@ export class LanguageService {
       position,
       undefined,
       this.getExternalFragmentDefinitions(),
+      { uri },
     );
   };
   /**


### PR DESCRIPTION
When editing type system definitions, the autocomplete suggestions aren't super helpful (and kinda hard not to accidentally trigger at the top-level of the document):
<img width="518" alt="image" src="https://user-images.githubusercontent.com/2136754/183767357-28b47446-687f-4105-b75b-f8e7635335cc.png">

In this PR I've updated one of the examples (so I could play with this behavior) to have an editor for the SDL that gets loaded in, which is applied to the query editor upon editing (I've added `fakeField` in the screenshot):
<details><summary>🖼 Screenshot of modified example</summary><img src="https://user-images.githubusercontent.com/2136754/183768056-c911ac13-da30-4ba8-8cfb-ffc9740a0ee0.png" width="1792" alt="" /></details>

And I've added some autocomplete suggestions for the right keywords at the top-level, plus keywords that go after `extend`:
<details>
<summary>🖼 Gif </summary><img src="https://user-images.githubusercontent.com/2136754/183767846-ccc5c1ff-3a3d-4187-8017-a0e872b05203.gif" width="676" alt="" /></details>

This is still rough, but I wanted to get some feedback on distinguishing between documents that contain documents executable and type system.

@acao (not sure who else to tag!)