### PR TITLE
[v2] make popover styles look good in dark mode

### DIFF
--- a/packages/graphiql-react/src/editor/style/hint.css
+++ b/packages/graphiql-react/src/editor/style/hint.css
@@ -3,9 +3,9 @@
 /* Popup styles */
 .CodeMirror-hints {
   background: hsl(var(--color-base));
-  border: none;
+  border: var(--popover-border);
   border-radius: var(--border-radius-8);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--popover-box-shadow);
   display: grid;
   font-family: var(--font-family);
   font-size: var(--font-size-body);

--- a/packages/graphiql-react/src/editor/style/info.css
+++ b/packages/graphiql-react/src/editor/style/info.css
@@ -1,8 +1,9 @@
 /* Popup styles */
 .CodeMirror-info {
   background-color: hsl(var(--color-base));
+  border: var(--popover-border);
   border-radius: var(--border-radius-8);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--popover-box-shadow);
   color: hsla(var(--color-neutral), 1);
   max-height: 300px;
   max-width: 400px;

--- a/packages/graphiql-react/src/editor/style/lint.css
+++ b/packages/graphiql-react/src/editor/style/lint.css
@@ -73,9 +73,9 @@
 /* Popup styles */
 .CodeMirror-lint-tooltip {
   background-color: hsl(var(--color-base));
-  border: none;
+  border: var(--popover-border);
   border-radius: var(--border-radius-8);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--popover-box-shadow);
   font-size: var(--font-size-body);
   font-family: var(--font-family);
   max-width: 600px;

--- a/packages/graphiql-react/src/explorer/components/search.css
+++ b/packages/graphiql-react/src/explorer/components/search.css
@@ -4,8 +4,9 @@
   color: hsla(var(--color-neutral), 0.6);
 
   &:not([data-state='idle']) {
+    border: var(--popover-border);
     border-radius: var(--border-radius-4);
-    box-shadow: var(--box-shadow);
+    box-shadow: var(--popover-box-shadow);
     color: hsla(var(--color-neutral), 1);
 
     & .graphiql-doc-explorer-search-input {

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -43,10 +43,11 @@ reach-portal {
   --border-radius-8: 8px;
   --border-radius-12: 12px;
 
-  /* Box shadow */
-  --box-shadow: 0px 6px 20px rgba(59, 76, 106, 0.13),
+  /* Popover styles (tooltip, dialog, etc) */
+  --popover-box-shadow: 0px 6px 20px rgba(59, 76, 106, 0.13),
     0px 1.34018px 4.46726px rgba(59, 76, 106, 0.0774939),
     0px 0.399006px 1.33002px rgba(59, 76, 106, 0.0525061);
+  --popover-border: none;
 
   /* Layout */
   --sidebar-width: 44px;
@@ -68,6 +69,9 @@ reach-portal {
     --color-error: 13, 100%, 58%;
     --color-neutral: 219, 29%, 78%;
     --color-base: 219, 29%, 18%;
+
+    --popover-box-shadow: none;
+    --popover-border: 1px solid hsl(var(--color-neutral));
   }
 }
 
@@ -84,6 +88,9 @@ body.graphiql-dark reach-portal {
   --color-error: 13, 100%, 58%;
   --color-neutral: 219, 29%, 78%;
   --color-base: 219, 29%, 18%;
+
+  --popover-box-shadow: none;
+  --popover-border: 1px solid hsl(var(--color-neutral));
 }
 
 .graphiql-container,

--- a/packages/graphiql-react/src/ui/dialog.css
+++ b/packages/graphiql-react/src/ui/dialog.css
@@ -15,8 +15,9 @@
 
 [data-reach-dialog-content] {
   background-color: hsl(var(--color-base));
+  border: var(--popover-border);
   border-radius: var(--border-radius-12);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--popover-box-shadow);
   margin: 0;
   max-height: 80vh;
   max-width: 80vw;

--- a/packages/graphiql-react/src/ui/dropdown.css
+++ b/packages/graphiql-react/src/ui/dropdown.css
@@ -4,9 +4,9 @@
 [data-reach-listbox-popover],
 [data-reach-menu-list] {
   background-color: hsl(var(--color-base));
-  box-shadow: var(--box-shadow);
-  border: none;
+  border: var(--popover-border);
   border-radius: var(--border-radius-8);
+  box-shadow: var(--popover-box-shadow);
   font-size: inherit;
   max-width: 250px;
   padding: var(--px-4);

--- a/packages/graphiql-react/src/ui/tooltip.css
+++ b/packages/graphiql-react/src/ui/tooltip.css
@@ -2,9 +2,9 @@
 
 [data-reach-tooltip] {
   background: hsl(var(--color-base));
-  border: none;
+  border: var(--popover-border);
   border-radius: var(--border-radius-4);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--popover-box-shadow);
   color: hsl(var(--color-neutral));
   font-size: inherit;
   padding: var(--px-4) var(--px-6);


### PR DESCRIPTION
A quick fix for popover styles (tooltips, dialogs, etc) in the dark theme. Box shadows only really work with a light theme, in a dark theme the subtle contrast is barely noticeable. This PR removes the box shadow in the dark theme and instead applies a light border around the popover.

| Before | After |
| --- | --- |
| <img width="1282" alt="CleanShot 2022-08-20 at 11 55 50@2x" src="https://user-images.githubusercontent.com/22288634/185740261-632615a4-eda3-4f2f-ae31-45d4d6a658f6.png"> | <img width="1286" alt="CleanShot 2022-08-20 at 11 57 14@2x" src="https://user-images.githubusercontent.com/22288634/185740307-6220ab9c-c70f-430d-a68a-e4d3153f25d4.png"> |
| <img width="351" alt="CleanShot 2022-08-20 at 11 56 03@2x" src="https://user-images.githubusercontent.com/22288634/185740262-80d51234-b3c6-40b6-ad84-4385d4c8841b.png"> | <img width="383" alt="CleanShot 2022-08-20 at 11 57 24@2x" src="https://user-images.githubusercontent.com/22288634/185740326-b7b2f13e-d742-4d0d-965b-24a00c8f13c1.png"> |
| <img width="560" alt="CleanShot 2022-08-20 at 11 56 10@2x" src="https://user-images.githubusercontent.com/22288634/185740267-cc308ab2-ac62-4d29-b800-bbc7b3eaa1d5.png"> | <img width="624" alt="CleanShot 2022-08-20 at 11 57 30@2x" src="https://user-images.githubusercontent.com/22288634/185740339-18c89ee7-0f6d-4088-8fb4-6d117a7e5fca.png"> |