### PR TITLE
don't pass `shouldPersistHeaders` to fetcher anymore

### DIFF
--- a/.changeset/ninety-tips-thank.md
+++ b/.changeset/ninety-tips-thank.md
@@ -1,0 +1,13 @@
+---
+'@graphiql/toolkit': minor
+---
+
+BREAKING: Don't pass `shouldPersistHeaders` anymore when invoking the fetcher function. This value can be looked up by consuming the `EditorContext`:
+```js
+import { useEditorContext } from '@graphiql/react';
+
+function MyComponent() {
+  const { shouldPersistHeaders } = useEditorContext();
+  // Do things...
+}
+```

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -75,7 +75,6 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     headerEditor,
     queryEditor,
     responseEditor,
-    shouldPersistHeaders,
     variableEditor,
     updateActiveTabValues,
   } = useEditorContext({ nonNull: true, caller: ExecutionContextProvider });
@@ -250,7 +249,6 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
         },
         {
           headers: headers ?? undefined,
-          shouldPersistHeaders,
           documentAST: queryEditor.documentAST ?? undefined,
         },
       );
@@ -311,7 +309,6 @@ export function ExecutionContextProvider(props: ExecutionContextProviderProps) {
     props.operationName,
     queryEditor,
     responseEditor,
-    shouldPersistHeaders,
     stop,
     subscription,
     updateActiveTabValues,

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
@@ -49,10 +49,7 @@ describe('createGraphiQLFetcher', () => {
     ]);
     const res = await fetcher(
       { query: getIntrospectionQuery(), operationName: 'IntrospectionQuery' },
-      {
-        documentAST: exampleIntrospectionDocument,
-        shouldPersistHeaders: false,
-      },
+      { documentAST: exampleIntrospectionDocument },
     );
     expect(res).toEqual('hey!');
   });

--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -32,12 +32,6 @@ export type FetcherParams = {
 
 export type FetcherOpts = {
   headers?: { [key: string]: any };
-  /**
-   * @deprecated This property will be removed in the next major version of
-   * `graphiql`, it just echoes back the value passed as prop to the `GraphiQL`
-   * component with a default value of `false`
-   */
-  shouldPersistHeaders?: boolean;
   documentAST?: DocumentNode;
 };
 


### PR DESCRIPTION
This has been deprecated for a while now. If users are interested in this value they can look it up in the `EditorContext` instead.