### PR TITLE
fix publishing canary versions from PRs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,11 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 'current'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     paths:
       - 'yarn.lock'
-      
+
 jobs:
   check:
     name: License Check
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,5 +1,5 @@
 name: Lint & Build PR
-on: 
+on:
   pull_request:
     types: [opened, synchronize]
     # TODO: ignore this after setting up a separate task to link markdown
@@ -9,7 +9,6 @@ on:
     #   - 'examples'
     #   - '!examples/monaco-graphql-webpack'
 
-      
 jobs:
   lint:
     name: Lint
@@ -19,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 
@@ -37,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -28,11 +28,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: 'yarn'
-          node-version: '16.x'
+          node-version: 16
 
       - name: Force GraphQL ${{ matrix.release }} solution
         run: yarn repo:resolve graphql@${{ matrix.release }}
-    
+
       - run: yarn install --frozen-lockfile --immutable
 
       - name: Typescript Build

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 'current'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          # TODO: fix vite bug for node 18 current
           node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           # TODO: fix vite bug for node 18 current
-          node-version: '16.x'
+          node-version: 16
           cache: 'yarn'
       - run: yarn install --frozen-lockfile --immutable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           # TODO: fix vite bug for node 18 current


### PR DESCRIPTION
This fixes a regressions around publishing canary versions for PRs that might have come in with #2626. I also switched back to Node 16 for now as some parts of the build are not working properly.