### PR TITLE
Instantiate `isHeadersEditorEnabled` early

### DIFF
--- a/.changeset/wise-pans-hear.md
+++ b/.changeset/wise-pans-hear.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix cannot access `initialHeaders` before initialization

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -195,6 +195,8 @@ export type GraphiQLInterfaceProps = WriteableEditorProps &
   };
 
 export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
+  const isHeadersEditorEnabled = props.isHeadersEditorEnabled ?? true;
+
   const editorContext = useEditorContext({ nonNull: true });
   const executionContext = useExecutionContext({ nonNull: true });
   const schemaContext = useSchemaContext({ nonNull: true });
@@ -304,8 +306,6 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   const footer = children.find(child =>
     isChildComponentType(child, GraphiQL.Footer),
   );
-
-  const isHeadersEditorEnabled = props.isHeadersEditorEnabled ?? true;
 
   const onClickReference = () => {
     if (pluginResize.hiddenElement === 'first') {


### PR DESCRIPTION
This should fix #2698, it looks like that when there are headers in localstorage we try to access `isHeadersEditorEnabled` before it is instantiated 😊