### PR TITLE
fix minor style issues

### DIFF
--- a/.changeset/eight-wombats-refuse.md
+++ b/.changeset/eight-wombats-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Make sure the back link and title are hidden when focussing the input field for searching the docs

--- a/.changeset/sweet-tomatoes-protect.md
+++ b/.changeset/sweet-tomatoes-protect.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Make sure hidden editors don't overflow

--- a/packages/graphiql-react/src/editor/style/editor.css
+++ b/packages/graphiql-react/src/editor/style/editor.css
@@ -5,7 +5,9 @@
 
   &.hidden {
     /* Just setting `display: none;` would break the editor gutters */
+    left: -9999px;
     position: absolute;
+    top: -9999px;
     visibility: hidden;
   }
 }

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -4,9 +4,20 @@
   justify-content: space-between;
   position: relative;
 
-  &:focus-within .graphiql-doc-explorer-title {
-    /* Hide the header when focussing the search input */
-    visibility: hidden;
+  &:focus-within {
+    & .graphiql-doc-explorer-title {
+      /* Hide the header when focussing the search input */
+      visibility: hidden;
+    }
+
+    & .graphiql-doc-explorer-back:not(:focus) {
+      /**
+        * Make the back link invisible when focussing the search input. Hiding
+        * it in any other way makes it impossible to focus the link by pressing
+        * Shift-Tab while the input is focussed.
+        */
+      color: transparent;
+    }
   }
 }
 .graphiql-doc-explorer-header-content {


### PR DESCRIPTION
This fixes two small issues:
- Make sure that invisible editors are hidden off screen so they don't cause overflow that makes scrollbars visible. (Can happen depending on how you define the height of the container element.)
- Properly hide the back link and the title when focussing the search field in the docs. (Currently the back link stays visible because the background of the input field is a transparent color.)