### PR TITLE
chore: use `createFetcher` in CDN example

### DIFF
--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -54,7 +54,9 @@
     <script>
       ReactDOM.render(
         React.createElement(GraphiQL, {
-          fetcher: GraphiQL.createFetcher({ url: 'https://swapi-graphql.netlify.app/.netlify/functions/index' }),
+          fetcher: GraphiQL.createFetcher({
+            url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+          }),
           defaultEditorToolsVisibility: true,
         }),
         document.getElementById('graphiql'),

--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -52,28 +52,9 @@
       type="application/javascript"
     ></script>
     <script>
-      function graphQLFetcher(graphQLParams) {
-        return fetch(
-          'https://swapi-graphql.netlify.app/.netlify/functions/index',
-          {
-            method: 'post',
-            headers: {
-              Accept: 'application/json',
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(graphQLParams),
-            credentials: 'omit',
-          },
-        ).then(function (response) {
-          return response.json().catch(function () {
-            return response.text();
-          });
-        });
-      }
-
       ReactDOM.render(
         React.createElement(GraphiQL, {
-          fetcher: graphQLFetcher,
+          fetcher: GraphiQL.createFetcher({ url: 'https://swapi-graphql.netlify.app/.netlify/functions/index' }),
           defaultEditorToolsVisibility: true,
         }),
         document.getElementById('graphiql'),


### PR DESCRIPTION
The current `graphQLFetcher` in the example doesn't support headers. But it seems easier to just use `createFetcher`?