### PR TITLE
feat: pass subscription Headers as connection_init payload

### DIFF
--- a/.changeset/late-queens-visit.md
+++ b/.changeset/late-queens-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': minor
+---
+
+Allow passing Headers for subscriptions into connection_init payload

--- a/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
@@ -35,7 +35,6 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
   // simpler fetcher for schema requests
   const simpleFetcher = createSimpleFetcher(options, httpFetch);
 
-  const wsFetcher = getWsFetcher(options);
   const httpFetcher = options.enableIncrementalDelivery
     ? createMultipartFetcher(options, httpFetch)
     : simpleFetcher;
@@ -52,6 +51,8 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
       graphQLParams.operationName || undefined,
     );
     if (isSubscription) {
+      const wsFetcher = getWsFetcher(options, fetcherOpts);
+
       if (!wsFetcher) {
         throw Error(
           `Your GraphiQL createFetcher is not properly configured for websocket subscriptions yet. ${

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -193,15 +193,18 @@ export const createMultipartFetcher = (
  * @param options {CreateFetcherOptions}
  * @returns
  */
-export const getWsFetcher = (options: CreateFetcherOptions) => {
+export const getWsFetcher = (
+  options: CreateFetcherOptions,
+  fetcherOpts: FetcherOpts | undefined,
+) => {
   if (options.wsClient) {
     return createWebsocketsFetcherFromClient(options.wsClient);
   }
   if (options.subscriptionUrl) {
-    return createWebsocketsFetcherFromUrl(
-      options.subscriptionUrl,
-      options.wsConnectionParams,
-    );
+    return createWebsocketsFetcherFromUrl(options.subscriptionUrl, {
+      ...options.wsConnectionParams,
+      ...fetcherOpts?.headers,
+    });
   }
   const legacyWebsocketsClient = options.legacyClient || options.legacyWsClient;
   if (legacyWebsocketsClient) {


### PR DESCRIPTION
Fixes #2181 

This matches the behavior of graphql-playground by allowing to use `Headers` to configure the payload of the `connection_init` frame.

<img width="1463" alt="Screenshot 2022-08-28 at 18 11 57" src="https://user-images.githubusercontent.com/697707/187081149-45b3216c-8144-4f5c-92d4-f41c7a0bcd7e.png">

