### PR TITLE
make `@graphiql/plugin-explorer` package public

### DIFF
--- a/.changeset/tricky-seas-flash.md
+++ b/.changeset/tricky-seas-flash.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-explorer': minor
+---
+
+Add a package that exports a plugin to use the GraphiQL Explorer from OneGraph

--- a/packages/graphiql-plugin-explorer/CHANGELOG.md
+++ b/packages/graphiql-plugin-explorer/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @graphiql/plugin-explorer
-
-## 0.1.0
-
-### Minor Changes
-
-- [#2715](https://github.com/graphql/graphiql/pull/2715) [`c922719e`](https://github.com/graphql/graphiql/commit/c922719e6b960776cd0a71f14d2b86c6bb69373c) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a package that exports a plugin to use the GraphiQL Explorer from OneGraph

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@graphiql/plugin-explorer",
-  "private": true,
-  "version": "0.1.0",
+  "version": "0.0.0",
   "main": "dist/graphiql-plugin-explorer.cjs.js",
   "module": "dist/graphiql-plugin-explorer.es.js",
   "types": "types/index.d.ts",


### PR DESCRIPTION
I forgot to remove the `private` field from the `package.json` after moving the explorer plugin code from an example to a package in #2715. This fixes that and reverts the version so that CI will hopefully publish it in the next run.