### PR TITLE
[plugin-explorer] Fix an error in `graphiql-explorer.d.ts` and import it in `types/index.d.ts`

### DIFF
--- a/.changeset/friendly-seals-develop.md
+++ b/.changeset/friendly-seals-develop.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-explorer': patch
+---
+
+Expose typings for graphiql-explorer

--- a/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
+++ b/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
@@ -51,7 +51,7 @@ declare module 'graphiql-explorer' {
       explorerActionsStyle?: CSSProperties;
       buttonStyle?: CSSProperties;
       actionButtonStyle?: CSSProperties;
-    };
+    } | null;
     showAttribution: boolean;
     hideActions?: boolean;
     externalFragments?: FragmentDefinitionNode[];

--- a/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
+++ b/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
@@ -9,7 +9,7 @@ declare module 'graphiql-explorer' {
     GraphQLSchema,
     ValueNode,
   } from 'graphql';
-  import { ComponentType, ReactNode } from 'react';
+  import { ComponentType, ReactNode, CSSProperties } from 'react';
 
   export type GraphiQLExplorerProps = {
     query: string;
@@ -47,10 +47,10 @@ declare module 'graphiql-explorer' {
     arrowClosed?: ReactNode | null;
     checkboxChecked?: ReactNode | null;
     checkboxUnchecked?: ReactNode | null;
-    styles?: ?{
-      explorerActionsStyle?: { [key: string]: any };
-      buttonStyle?: { [key: string]: any };
-      actionButtonStyle?: { [key: string]: any };
+    styles?: {
+      explorerActionsStyle?: CSSProperties;
+      buttonStyle?: CSSProperties;
+      actionButtonStyle?: CSSProperties;
     };
     showAttribution: boolean;
     hideActions?: boolean;

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -7,6 +7,7 @@ import {
 import GraphiQLExplorer, { GraphiQLExplorerProps } from 'graphiql-explorer';
 import { useMemo, useRef } from 'react';
 
+import './graphiql-explorer.d.ts';
 import './index.css';
 
 function ExplorerPlugin(props: GraphiQLExplorerProps) {


### PR DESCRIPTION
I've imported _graphiql-explorer.d.ts_ so the types for `graphiql-explorer` are visible in user projects and I've solved the _ts(8020)_ JSDoc type error in it — probably a leftover of some Flow code?

Closes https://github.com/graphql/graphiql/issues/2730 and https://github.com/graphql/graphiql/issues/2729.