### PR TITLE
add CSS variables for color shades

### DIFF
--- a/.changeset/fair-gifts-smell.md
+++ b/.changeset/fair-gifts-smell.md
@@ -1,0 +1,8 @@
+---
+'@graphiql/react': minor
+---
+
+Add CSS variables for color alpha values:
+- `--alpha-secondary`: A color for supplementary text that should be read but not be the main focus
+- `--alpha-tertiary`: A color for supplementary text which is optional to read, i.e. the UI would function without the user reading this text
+- `--alpha-background-light`, `--alpha-background-medium` and `--alpha-background-heavy`: Three alpha values used for backgrounds and borders that have different intensity

--- a/.changeset/sweet-terms-fold.md
+++ b/.changeset/sweet-terms-fold.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/plugin-explorer': patch
+---
+
+Use the new CSS variables for color alpha values defined in `@graphiql/react` in style definitions

--- a/packages/graphiql-plugin-explorer/src/index.css
+++ b/packages/graphiql-plugin-explorer/src/index.css
@@ -29,7 +29,7 @@
 
 .graphiql-explorer-root select {
   background-color: hsl(var(--color-base));
-  border: 1px solid hsla(var(--color-neutral), 0.6);
+  border: 1px solid hsla(var(--color-neutral), var(--alpha-secondary));
   border-radius: var(--border-radius-4);
   color: hsl(var(--color-neutral));
   margin: 0 var(--px-4);

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -42,7 +42,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         <svg
           viewBox="0 -4 13 15"
           style={{
-            color: 'hsla(var(--color-neutral), 0.4)',
+            color: 'hsla(var(--color-neutral), var(--alpha-tertiary, 0.4))',
             marginRight: 'var(--px-4)',
             height: 'var(--px-16)',
             width: 'var(--px-16)',
@@ -58,7 +58,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         <svg
           viewBox="0 -2 13 15"
           style={{
-            color: 'hsla(var(--color-neutral), 0.4)',
+            color: 'hsla(var(--color-neutral), var(--alpha-tertiary, 0.4))',
             marginRight: 'var(--px-4)',
             height: 'var(--px-16)',
             width: 'var(--px-16)',
@@ -74,7 +74,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         <svg
           viewBox="0 0 15 15"
           style={{
-            color: 'hsla(var(--color-neutral), 0.4)',
+            color: 'hsla(var(--color-neutral), var(--alpha-tertiary, 0.4))',
             marginRight: 'var(--px-4)',
             height: 'var(--px-16)',
             width: 'var(--px-16)',
@@ -106,7 +106,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         buttonStyle: {
           backgroundColor: 'transparent',
           border: 'none',
-          color: 'hsla(var(--color-neutral), 0.6)',
+          color: 'hsla(var(--color-neutral), var(--alpha-secondary, 0.6))',
           cursor: 'pointer',
           fontSize: '1em',
         },
@@ -116,7 +116,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         actionButtonStyle: {
           backgroundColor: 'transparent',
           border: 'none',
-          color: 'hsla(var(--color-neutral), 0.6)',
+          color: 'hsla(var(--color-neutral), var(--alpha-secondary, 0.6))',
           cursor: 'pointer',
           fontSize: '1em',
         },

--- a/packages/graphiql-react/src/editor/style/auto-insertion.css
+++ b/packages/graphiql-react/src/editor/style/auto-insertion.css
@@ -13,6 +13,6 @@
 
   15%,
   85% {
-    background-color: hsla(var(--color-warning), 0.07);
+    background-color: hsla(var(--color-warning), var(--alpha-background-light));
   }
 }

--- a/packages/graphiql-react/src/editor/style/codemirror.css
+++ b/packages/graphiql-react/src/editor/style/codemirror.css
@@ -35,7 +35,7 @@
 
 .cm-s-graphiql {
   /* Default to punctuation */
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
 
   /* OperationType, `fragment`, `on` */
   & .cm-keyword {
@@ -47,7 +47,7 @@
   }
   /* Punctuator (except `$` and `@`) */
   & .cm-punctuation {
-    color: hsla(var(--color-neutral), 0.6);
+    color: hsla(var(--color-neutral), var(--alpha-secondary));
   }
   /* Variable */
   & .cm-variable {
@@ -91,11 +91,11 @@
   }
   /* Comment */
   & .cm-comment {
-    color: hsla(var(--color-neutral), 0.4);
+    color: hsla(var(--color-neutral), var(--alpha-tertiary));
   }
   /* Whitespace */
   & .cm-ws {
-    color: hsla(var(--color-neutral), 0.4);
+    color: hsla(var(--color-neutral), var(--alpha-tertiary));
   }
   /* Invalid characters */
   & .cm-invalidchar {
@@ -104,25 +104,25 @@
 
   /* Cursor */
   & .CodeMirror-cursor {
-    border-left: 2px solid hsla(var(--color-neutral), 0.6);
+    border-left: 2px solid hsla(var(--color-neutral), var(--alpha-secondary));
   }
 
   /* Color for line numbers and fold-gutters */
   & .CodeMirror-linenumber {
-    color: hsla(var(--color-neutral), 0.4);
+    color: hsla(var(--color-neutral), var(--alpha-tertiary));
   }
 }
 
 /* Matching bracket colors */
 div.CodeMirror span.CodeMirror-matchingbracket,
 div.CodeMirror span.CodeMirror-nonmatchingbracket {
-  color: hsla(var(--color-neutral), 0.4);
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
 }
 
 /* Selected text blocks */
 .CodeMirror-selected,
 .CodeMirror-focused .CodeMirror-selected {
-  background: hsla(var(--color-neutral), 0.15);
+  background: hsla(var(--color-neutral), var(--alpha-background-heavy));
 }
 
 /* Position the search dialog */
@@ -137,12 +137,14 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
   z-index: 6;
 }
 .CodeMirror-dialog-top {
-  border-bottom: 1px solid hsla(var(--color-neutral), 0.15);
+  border-bottom: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   padding-bottom: var(--px-12);
   top: 0;
 }
 .CodeMirror-dialog-bottom {
-  border-top: 1px solid hsla(var(--color-neutral), 0.15);
+  border-top: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   bottom: 0;
   padding-top: var(--px-12);
 }
@@ -154,7 +156,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 
 /* Style the input field for searching */
 .CodeMirror-dialog input {
-  border: 1px solid hsla(var(--color-neutral), 0.15);
+  border: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   border-radius: var(--border-radius-4);
   padding: var(--px-4);
 }
@@ -164,7 +166,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {
 
 /* Set the highlight color for search results */
 .cm-searching {
-  background-color: hsla(var(--color-warning), 0.07);
+  background-color: hsla(var(--color-warning), var(--alpha-background-light));
   /**
    * When cycling through search results, CodeMirror overlays the current 
    * selection with another element that has the .CodeMirror-selected class

--- a/packages/graphiql-react/src/editor/style/fold.css
+++ b/packages/graphiql-react/src/editor/style/fold.css
@@ -16,7 +16,7 @@
 
 .CodeMirror-foldgutter-open,
 .CodeMirror-foldgutter-folded {
-  color: hsla(var(--color-neutral), 0.4);
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
 
   &::after {
     margin: 0 var(--px-2);

--- a/packages/graphiql-react/src/editor/style/hint.css
+++ b/packages/graphiql-react/src/editor/style/hint.css
@@ -18,7 +18,7 @@
 /* Autocomplete items */
 .CodeMirror-hint {
   border-radius: var(--border-radius-4);
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   grid-column: 1 / 2;
   margin: var(--px-4);
   /* Override element style added by codemirror */
@@ -29,13 +29,14 @@
   }
 }
 li.CodeMirror-hint-active {
-  background: hsla(var(--color-primary), 0.1);
+  background: hsla(var(--color-primary), var(--alpha-background-medium));
   color: hsl(var(--color-primary));
 }
 
 /* Sidebar with additional information */
 .CodeMirror-hint-information {
-  border-left: 1px solid hsla(var(--color-neutral), 0.15);
+  border-left: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   grid-column: 2 / 3;
   grid-row: 1 / 99999;
   /* Same as the popup as a whole minus padding */
@@ -52,9 +53,9 @@ li.CodeMirror-hint-active {
   font-weight: var(--font-weight-medium);
 }
 .CodeMirror-hint-information-type-name-pill {
-  border: 1px solid hsla(var(--color-neutral), 0.4);
+  border: 1px solid hsla(var(--color-neutral), var(--alpha-tertiary));
   border-radius: var(--border-radius-4);
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   margin-left: var(--px-6);
   padding: var(--px-4);
 }
@@ -67,6 +68,6 @@ li.CodeMirror-hint-active {
   }
 }
 .CodeMirror-hint-information-description {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   margin-top: var(--px-12);
 }

--- a/packages/graphiql-react/src/editor/style/info.css
+++ b/packages/graphiql-react/src/editor/style/info.css
@@ -43,16 +43,16 @@
 
   /* Type names */
   & .type-name-pill {
-    border: 1px solid hsla(var(--color-neutral), 0.4);
+    border: 1px solid hsla(var(--color-neutral), var(--alpha-tertiary));
     border-radius: var(--border-radius-4);
-    color: hsla(var(--color-neutral), 0.6);
+    color: hsla(var(--color-neutral), var(--alpha-secondary));
     margin-left: var(--px-6);
     padding: var(--px-4);
   }
 
   /* Descriptions */
   & .info-description {
-    color: hsla(var(--color-neutral), 0.6);
+    color: hsla(var(--color-neutral), var(--alpha-secondary));
     margin-top: var(--px-12);
     overflow: hidden;
   }

--- a/packages/graphiql-react/src/explorer/components/argument.css
+++ b/packages/graphiql-react/src/explorer/components/argument.css
@@ -9,7 +9,7 @@
 }
 
 .graphiql-doc-explorer-argument-deprecation {
-  background-color: hsla(var(--color-warning), 0.07);
+  background-color: hsla(var(--color-warning), var(--alpha-background-light));
   border: 1px solid hsl(var(--color-warning));
   border-radius: var(--border-radius-4);
   color: hsl(var(--color-warning));

--- a/packages/graphiql-react/src/explorer/components/deprecation-reason.css
+++ b/packages/graphiql-react/src/explorer/components/deprecation-reason.css
@@ -1,5 +1,5 @@
 .graphiql-doc-explorer-deprecation {
-  background-color: hsla(var(--color-warning), 0.07);
+  background-color: hsla(var(--color-warning), var(--alpha-background-light));
   border: 1px solid hsl(var(--color-warning));
   border-radius: var(--px-4);
   color: hsl(var(--color-warning));

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -50,7 +50,7 @@
 /* The back-button in the doc explorer */
 a.graphiql-doc-explorer-back {
   align-items: center;
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: flex;
   text-decoration: none;
 
@@ -59,7 +59,7 @@ a.graphiql-doc-explorer-back {
   }
 
   &:focus {
-    outline: hsla(var(--color-neutral), 0.6) auto 1px;
+    outline: hsla(var(--color-neutral), var(--alpha-secondary)) auto 1px;
 
     & + .graphiql-doc-explorer-title {
       /* Don't hide the header when focussing the back link */
@@ -89,13 +89,13 @@ a.graphiql-doc-explorer-back {
 
 /* The contents of the currently active page in the doc explorer */
 .graphiql-doc-explorer-content > * {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   margin-top: var(--px-20);
 }
 
 /* Error message */
 .graphiql-doc-explorer-error {
-  background-color: hsla(var(--color-error), 0.15);
+  background-color: hsla(var(--color-error), var(--alpha-background-heavy));
   border: 1px solid hsl(var(--color-error));
   border-radius: var(--border-radius-8);
   color: hsl(var(--color-error));

--- a/packages/graphiql-react/src/explorer/components/search.css
+++ b/packages/graphiql-react/src/explorer/components/search.css
@@ -1,7 +1,7 @@
 @import url('@reach/combobox/styles.css');
 
 [data-reach-combobox] {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
 
   &:not([data-state='idle']) {
     border: var(--popover-border);
@@ -19,7 +19,7 @@
 
 .graphiql-doc-explorer-search-input {
   align-items: center;
-  background-color: hsla(var(--color-neutral), 0.07);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   border-radius: var(--border-radius-4);
   display: flex;
   padding: var(--px-8) var(--px-12);
@@ -41,7 +41,8 @@
   border: none;
   border-bottom-left-radius: var(--border-radius-4);
   border-bottom-right-radius: var(--border-radius-4);
-  border-top: 1px solid hsla(var(--color-neutral), 0.15);
+  border-top: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   max-height: 400px;
   overflow-y: auto;
 
@@ -59,22 +60,25 @@
 
 [data-reach-combobox-option] {
   border-radius: var(--border-radius-4);
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   overflow-x: hidden;
   padding: var(--px-8) var(--px-12);
   text-overflow: ellipsis;
   white-space: nowrap;
 
   &[data-highlighted] {
-    background-color: hsla(var(--color-neutral), 0.07);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   }
 
   &:hover {
-    background-color: hsla(var(--color-neutral), 0.1);
+    background-color: hsla(
+      var(--color-neutral),
+      var(--alpha-background-medium)
+    );
   }
 
   &[data-highlighted]:hover {
-    background-color: hsla(var(--color-neutral), 0.15);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-heavy));
   }
 
   & + & {
@@ -95,7 +99,7 @@
 }
 
 .graphiql-doc-explorer-search-divider {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   font-size: var(--font-size-hint);
   font-weight: var(--font-weight-medium);
   margin-top: var(--px-8);
@@ -103,6 +107,6 @@
 }
 
 .graphiql-doc-explorer-search-empty {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   padding: var(--px-8) var(--px-12);
 }

--- a/packages/graphiql-react/src/history/style.css
+++ b/packages/graphiql-react/src/history/style.css
@@ -11,7 +11,7 @@
 
 .graphiql-history-item {
   border-radius: var(--border-radius-4);
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: flex;
   font-size: var(--font-size-inline-code);
   font-family: var(--font-family-mono);
@@ -19,7 +19,7 @@
 
   &:hover {
     color: hsla(var(--color-neutral), 1);
-    background-color: hsla(var(--color-neutral), 0.07);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   }
 
   &:not(:first-child) {
@@ -27,7 +27,10 @@
   }
 
   &.editable {
-    background-color: hsla(var(--color-primary), 0.1);
+    background-color: hsla(
+      var(--color-primary),
+      var(--alpha-background-medium)
+    );
 
     & > input {
       background: transparent;
@@ -39,7 +42,7 @@
       width: 100%;
 
       &::placeholder {
-        color: hsla(var(--color-neutral), 0.6);
+        color: hsla(var(--color-neutral), var(--alpha-secondary));
       }
     }
 
@@ -48,7 +51,10 @@
       padding: 0 var(--px-10);
 
       &:active {
-        background-color: hsla(var(--color-primary), 0.15);
+        background-color: hsla(
+          var(--color-primary),
+          var(--alpha-background-heavy)
+        );
       }
 
       &:focus {
@@ -72,7 +78,7 @@ button.graphiql-history-item-label {
 
 button.graphiql-history-item-action {
   align-items: center;
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: flex;
   padding: var(--px-8) var(--px-6);
 

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -13,6 +13,13 @@ reach-portal {
   --color-neutral: 219, 28%, 32%;
   --color-base: 219, 28%, 100%;
 
+  /* Color alpha values */
+  --alpha-secondary: 0.6;
+  --alpha-tertiary: 0.4;
+  --alpha-background-heavy: 0.15;
+  --alpha-background-medium: 0.1;
+  --alpha-background-light: 0.07;
+
   /* Font */
   --font-family: 'Roboto', sans-serif;
   --font-family-mono: 'Fira Code', monospace;
@@ -112,7 +119,7 @@ reach-portal {
     font-size: var(--font-size-caption);
 
     &::placeholder {
-      color: hsla(var(--color-neutral), 0.6);
+      color: hsla(var(--color-neutral), var(--alpha-secondary));
     }
   }
 

--- a/packages/graphiql-react/src/toolbar/button.css
+++ b/packages/graphiql-react/src/toolbar/button.css
@@ -4,6 +4,6 @@ button.graphiql-toolbar-button {
   width: var(--toolbar-width);
 
   &.error {
-    background: hsla(var(--color-error), 0.15);
+    background: hsla(var(--color-error), var(--alpha-background-heavy));
   }
 }

--- a/packages/graphiql-react/src/ui/button-group.css
+++ b/packages/graphiql-react/src/ui/button-group.css
@@ -1,5 +1,5 @@
 .graphiql-button-group {
-  background-color: hsla(var(--color-neutral), 0.07);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   /* Border radius of button plus padding */
   border-radius: calc(var(--border-radius-4) + var(--px-4));
   display: flex;
@@ -8,7 +8,10 @@
   & > button.graphiql-button {
     background-color: transparent;
     &:hover {
-      background-color: hsla(var(--color-neutral), 0.07);
+      background-color: hsla(
+        var(--color-neutral),
+        var(--alpha-background-light)
+      );
     }
     &.active {
       background-color: hsl(var(--color-base));

--- a/packages/graphiql-react/src/ui/button.css
+++ b/packages/graphiql-react/src/ui/button.css
@@ -5,21 +5,24 @@ button.graphiql-un-styled {
   cursor: pointer;
 
   &:hover {
-    background-color: hsla(var(--color-neutral), 0.07);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   }
 
   &:active {
-    background-color: hsla(var(--color-neutral), 0.1);
+    background-color: hsla(
+      var(--color-neutral),
+      var(--alpha-background-medium)
+    );
   }
 
   &:focus {
-    outline: hsla(var(--color-neutral), 0.15) auto 1px;
+    outline: hsla(var(--color-neutral), var(--alpha-background-heavy)) auto 1px;
   }
 }
 
 .graphiql-button,
 button.graphiql-button {
-  background-color: hsla(var(--color-neutral), 0.07);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   border: none;
   border-radius: var(--border-radius-4);
   color: hsla(var(--color-neutral), 1);
@@ -29,17 +32,20 @@ button.graphiql-button {
 
   &:hover,
   &:active {
-    background-color: hsla(var(--color-neutral), 0.1);
+    background-color: hsla(
+      var(--color-neutral),
+      var(--alpha-background-medium)
+    );
   }
 
   &:focus {
-    outline: hsla(var(--color-neutral), 0.15) auto 1px;
+    outline: hsla(var(--color-neutral), var(--alpha-background-heavy)) auto 1px;
   }
 
   &.graphiql-button-success {
-    background-color: hsla(var(--color-success), 0.15);
+    background-color: hsla(var(--color-success), var(--alpha-background-heavy));
   }
   &.graphiql-button-error {
-    background-color: hsla(var(--color-error), 0.15);
+    background-color: hsla(var(--color-error), var(--alpha-background-heavy));
   }
 }

--- a/packages/graphiql-react/src/ui/dialog.css
+++ b/packages/graphiql-react/src/ui/dialog.css
@@ -2,7 +2,7 @@
 
 [data-reach-dialog-overlay] {
   align-items: center;
-  background-color: hsla(var(--color-neutral), 0.15);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-heavy));
   display: flex;
   justify-content: center;
   /**
@@ -27,7 +27,7 @@
 }
 
 .graphiql-dialog-close > svg {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: block;
   height: var(--px-12);
   padding: var(--px-12);

--- a/packages/graphiql-react/src/ui/dropdown.css
+++ b/packages/graphiql-react/src/ui/dropdown.css
@@ -25,7 +25,7 @@
   &[data-selected],
   &[data-current-nav],
   &:hover {
-    background-color: hsla(var(--color-neutral), 0.07);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
     color: inherit;
   }
 

--- a/packages/graphiql-react/src/ui/markdown.css
+++ b/packages/graphiql-react/src/ui/markdown.css
@@ -81,12 +81,12 @@
   }
 
   & blockquote {
-    border-left: 1.5px solid hsla(var(--color-neutral), 0.4);
+    border-left: 1.5px solid hsla(var(--color-neutral), var(--alpha-tertiary));
   }
 
   & code,
   & pre {
-    background-color: hsla(var(--color-neutral), 0.07);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
     color: hsla(var(--color-neutral), 1);
   }
 
@@ -109,7 +109,7 @@
 
   & code,
   & pre {
-    background-color: hsla(var(--color-warning), 0.15);
+    background-color: hsla(var(--color-warning), var(--alpha-background-heavy));
   }
 
   & > * {
@@ -129,7 +129,7 @@
 
 .CodeMirror-hint-information-deprecation,
 .CodeMirror-info .info-deprecation {
-  background-color: hsla(var(--color-warning), 0.07);
+  background-color: hsla(var(--color-warning), var(--alpha-background-light));
   border: 1px solid hsl(var(--color-warning));
   border-radius: var(--border-radius-4);
   color: hsl(var(--color-warning));

--- a/packages/graphiql-react/src/ui/spinner.css
+++ b/packages/graphiql-react/src/ui/spinner.css
@@ -8,7 +8,7 @@
     animation: rotation 0.8s linear 0s infinite;
     border: 4px solid transparent;
     border-radius: 100%;
-    border-top: 4px solid hsla(var(--color-neutral), 0.4);
+    border-top: 4px solid hsla(var(--color-neutral), var(--alpha-tertiary));
     content: '';
     display: inline-block;
     height: 46px;

--- a/packages/graphiql-react/src/ui/tabs.css
+++ b/packages/graphiql-react/src/ui/tabs.css
@@ -11,7 +11,7 @@
 .graphiql-tab {
   align-items: stretch;
   border-radius: var(--border-radius-8);
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: flex;
 
   & > button.graphiql-tab-close {
@@ -24,7 +24,7 @@
   }
 
   &.graphiql-tab-active {
-    background-color: hsla(var(--color-neutral), 0.15);
+    background-color: hsla(var(--color-neutral), var(--alpha-background-heavy));
     color: hsla(var(--color-neutral), 1);
   }
 }

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -17,7 +17,7 @@
   width: var(--sidebar-width);
 }
 .graphiql-container .graphiql-sidebar button {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   height: var(--sidebar-width);
   width: var(--sidebar-width);
 }
@@ -41,7 +41,7 @@
 
 /* The current session and tabs */
 .graphiql-container .graphiql-sessions {
-  background-color: hsla(var(--color-neutral), 0.07);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
   /* Adding the 8px of padding to the inner border radius of the query editor */
   border-radius: calc(var(--border-radius-12) + var(--px-8));
   display: flex;
@@ -66,7 +66,7 @@ button.graphiql-tab-add {
   padding: 0 var(--px-4);
 }
 button.graphiql-tab-add > svg {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: block;
   height: var(--px-16);
   width: var(--px-16);
@@ -83,7 +83,7 @@ button.graphiql-tab-add > svg {
 
 /* The GraphiQL logo */
 .graphiql-container .graphiql-logo {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   font-size: var(--font-size-h4);
   font-weight: var(--font-weight-medium);
   padding: var(--px-12) var(--px-16);
@@ -91,7 +91,7 @@ button.graphiql-tab-add > svg {
 
 /* Undo default link styling for the default GraphiQL logo link */
 .graphiql-container .graphiql-logo .graphiql-logo-link {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
   text-decoration: none;
 }
 
@@ -116,7 +116,8 @@ button.graphiql-tab-add > svg {
 
 /* The query editor and the toolbar */
 .graphiql-container .graphiql-query-editor {
-  border-bottom: 1px solid hsla(var(--color-neutral), 0.15);
+  border-bottom: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   display: flex;
   flex: 1;
   padding: var(--px-16);
@@ -139,7 +140,7 @@ button.graphiql-tab-add > svg {
 
 /* The toolbar icons */
 .graphiql-toolbar-icon {
-  color: hsla(var(--color-neutral), 0.4);
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: calc(var(--toolbar-width) - (var(--px-8) * 2));
   padding: var(--px-8);
@@ -155,7 +156,7 @@ button.graphiql-tab-add > svg {
   padding: var(--px-8);
 }
 .graphiql-container .graphiql-editor-tools button {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
 }
 .graphiql-container .graphiql-editor-tools button.active {
   color: hsla(var(--color-neutral), 1);
@@ -208,12 +209,14 @@ button.graphiql-tab-add > svg {
 
 /* The footer below the response view */
 .graphiql-container .graphiql-footer {
-  border-top: 1px solid hsla(var(--color-neutral), 0.15);
+  border-top: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
 }
 
 /* The plugin container */
 .graphiql-container .graphiql-plugin {
-  border-left: 1px solid hsla(var(--color-neutral), 0.15);
+  border-left: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   flex: 1;
   max-width: calc(100% - 2 * var(--px-16));
   overflow-y: auto;
@@ -226,7 +229,8 @@ button.graphiql-tab-add > svg {
   cursor: col-resize;
 }
 .graphiql-container .graphiql-horizontal-drag-bar:hover::after {
-  border: var(--px-2) solid hsla(var(--color-neutral), 0.15);
+  border: var(--px-2) solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   border-radius: var(--border-radius-2);
   content: '';
   display: block;
@@ -240,7 +244,7 @@ button.graphiql-tab-add > svg {
 
 /* Generic icon style */
 .graphiql-container .graphiql-chevron-icon {
-  color: hsla(var(--color-neutral), 0.4);
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: var(--px-12);
   padding: var(--px-12);
@@ -277,7 +281,8 @@ reach-portal .graphiql-dialog-title {
 /* A section inside the settings dialog */
 reach-portal .graphiql-dialog-section {
   align-items: center;
-  border-top: 1px solid hsla(var(--color-neutral), 0.15);
+  border-top: 1px solid
+    hsla(var(--color-neutral), var(--alpha-background-heavy));
   display: flex;
   justify-content: space-between;
   padding: var(--px-24);
@@ -294,7 +299,7 @@ reach-portal .graphiql-dialog-section-title {
 
 /* The section caption in the settings dialog */
 reach-portal .graphiql-dialog-section-caption {
-  color: hsla(var(--color-neutral), 0.6);
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
 }
 
 reach-portal .graphiql-table {
@@ -302,13 +307,13 @@ reach-portal .graphiql-table {
   width: 100%;
 }
 reach-portal .graphiql-table :is(th, td) {
-  border: 1px solid hsla(var(--color-neutral), 0.15);
+  border: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   padding: var(--px-8) var(--px-12);
 }
 
 /* A single key the short-key dialog */
 reach-portal .graphiql-key {
-  background-color: hsla(var(--color-neutral), 0.1);
+  background-color: hsla(var(--color-neutral), var(--alpha-background-medium));
   border-radius: var(--border-radius-4);
   padding: var(--px-4);
 }


### PR DESCRIPTION
This refactoring is a preparation for iterating over the color contrasts. Currently we always define the alpha values inline, so we can't ensure consistency and we have to change a bunch of files if we'd ever like to change one of these values. These set of variables should help with that (in fact this will help with a PR I'm gonna open later today 😜 )