### PR TITLE
fix throwing an error inside the fetcher when there is no AST

### DIFF
--- a/.changeset/modern-queens-compare.md
+++ b/.changeset/modern-queens-compare.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+Handle execution when there is no document AST (because the query editor is empty or the query string contains syntax errors)

--- a/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
@@ -47,10 +47,12 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
         fetcherOpts,
       );
     }
-    const isSubscription = isSubscriptionWithName(
-      fetcherOpts?.documentAST!,
-      graphQLParams.operationName || undefined,
-    );
+    const isSubscription = fetcherOpts?.documentAST
+      ? isSubscriptionWithName(
+          fetcherOpts.documentAST,
+          graphQLParams.operationName || undefined,
+        )
+      : false;
     if (isSubscription) {
       if (!wsFetcher) {
         throw Error(


### PR DESCRIPTION
Fixes #2721

Avoid throwing an error in the fetcher if there is no document AST. This can happen when the query string is empty, it just contains comments or when there is a syntax error. In any case, we always want to actually send the request to the server and let the final parsing and validation take place there.