### PR TITLE
fix peer dependency versions

### DIFF
--- a/.changeset/fuzzy-seahorses-exist.md
+++ b/.changeset/fuzzy-seahorses-exist.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-explorer': patch
+---
+
+Fix peer dependency versions

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -26,10 +26,10 @@
     "graphiql-explorer": "^0.9.0"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.11.1",
-    "graphql": "^16.4.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@graphiql/react": "^0.11.0",
+    "graphql": "^15.5.0 || ^16.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^1.3.0",


### PR DESCRIPTION
Oversight from my end, the peer dependency versions should be more loose and align with the ones we declare for the other packages.