### PR TITLE
better color contrasts

### DIFF
--- a/packages/graphiql-react/src/editor/style/codemirror.css
+++ b/packages/graphiql-react/src/editor/style/codemirror.css
@@ -35,7 +35,7 @@
 
 .cm-s-graphiql {
   /* Default to punctuation */
-  color: hsla(var(--color-neutral), var(--alpha-secondary));
+  color: hsla(var(--color-neutral), var(--alpha-tertiary));
 
   /* OperationType, `fragment`, `on` */
   & .cm-keyword {
@@ -47,7 +47,7 @@
   }
   /* Punctuator (except `$` and `@`) */
   & .cm-punctuation {
-    color: hsla(var(--color-neutral), var(--alpha-secondary));
+    color: hsla(var(--color-neutral), var(--alpha-tertiary));
   }
   /* Variable */
   & .cm-variable {
@@ -91,7 +91,7 @@
   }
   /* Comment */
   & .cm-comment {
-    color: hsla(var(--color-neutral), var(--alpha-tertiary));
+    color: hsla(var(--color-neutral), var(--alpha-secondary));
   }
   /* Whitespace */
   & .cm-ws {
@@ -116,7 +116,7 @@
 /* Matching bracket colors */
 div.CodeMirror span.CodeMirror-matchingbracket,
 div.CodeMirror span.CodeMirror-nonmatchingbracket {
-  color: hsla(var(--color-neutral), var(--alpha-tertiary));
+  color: hsl(var(--color-warning));
 }
 
 /* Selected text blocks */

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -14,8 +14,8 @@ reach-portal {
   --color-base: 219, 28%, 100%;
 
   /* Color alpha values */
-  --alpha-secondary: 0.6;
-  --alpha-tertiary: 0.4;
+  --alpha-secondary: 0.76;
+  --alpha-tertiary: 0.5;
   --alpha-background-heavy: 0.15;
   --alpha-background-medium: 0.1;
   --alpha-background-light: 0.07;

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -106,6 +106,7 @@ button.graphiql-tab-add > svg {
 .graphiql-container .graphiql-editors {
   background-color: hsl(var(--color-base));
   border-radius: calc(var(--border-radius-12));
+  box-shadow: var(--popover-box-shadow);
   display: flex;
   flex: 1;
   flex-direction: column;


### PR DESCRIPTION
This tries to improve the color contrasts for GraphiQL:
- Increasing the alpha for secondary and tertiary neutral colors
- Adding the box shadow from the design around the main editor card
- Using a yellow color for matching brackets

| Before | After |
| --- | --- |
| ![CleanShot 2022-09-02 at 17 39 29@2x](https://user-images.githubusercontent.com/22288634/188190245-3487028a-f54b-4dc7-b4da-5215972dcaec.png) | ![CleanShot 2022-09-02 at 17 37 37@2x](https://user-images.githubusercontent.com/22288634/188190329-dcc162d1-3d60-4b9b-9bbd-48c4e8d83564.png) |
| ![CleanShot 2022-09-02 at 17 39 18@2x](https://user-images.githubusercontent.com/22288634/188190305-4cfe523c-8e77-4e82-bf44-4966e1fe76c0.png) | ![CleanShot 2022-09-02 at 17 38 35@2x](https://user-images.githubusercontent.com/22288634/188190324-b8f18a8e-9bd5-4384-aaff-ac9820587cef.png) |