### PR TITLE
package.json license field for graphiql-explorer

### DIFF
--- a/.changeset/calm-falcons-arrive.md
+++ b/.changeset/calm-falcons-arrive.md
@@ -1,0 +1,6 @@
+---
+"@graphiql/plugin-explorer": patch
+"graphiql": patch
+---
+
+Specify MIT license for `@graphiql/plugin-explorer` `package.json` 

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -4,6 +4,7 @@
   "main": "dist/graphiql-plugin-explorer.cjs.js",
   "module": "dist/graphiql-plugin-explorer.es.js",
   "types": "types/index.d.ts",
+  "license": "MIT",
   "keywords": [
     "react",
     "graphql",


### PR DESCRIPTION
Specify `MIT` `license` in `package.json` for the new `graphiql-explorer` plugin so that it passes our own and user checks!