### PR TITLE
avoid CodeMirror overlapping with other parts of the UI

### DIFF
--- a/.changeset/pink-weeks-fetch.md
+++ b/.changeset/pink-weeks-fetch.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix CodeMirror editors overlapping other parts of the UI on certain browser-OS-combinations (e.g. Chrome on Windows)

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -179,6 +179,18 @@ button.graphiql-tab-add > svg {
   padding: var(--px-16);
 }
 
+/**
+   * The way CodeMirror editors are styled they overflow their containing
+   * element. For some OS-browser-combinations this might cause overlap issues,
+   * setting the position of this to `relative` makes sure this element will
+   * always be on top of any editors.
+   */
+.graphiql-container .graphiql-toolbar,
+.graphiql-container .graphiql-editor-tools,
+.graphiql-container .graphiql-editor-tool {
+  position: relative;
+}
+
 /* The response view */
 .graphiql-container .graphiql-response {
   --editor-background: transparent;


### PR DESCRIPTION
Fixes #2743. I left a code comment that explains why we need these styles.