### PR TITLE
make `@graphiql/react` a real dependency instead of a peer dependency

### DIFF
--- a/.changeset/poor-kiwis-divide.md
+++ b/.changeset/poor-kiwis-divide.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-explorer': patch
+---
+
+Make `@graphiql/react` a real dependency instead of a peer dependency

--- a/packages/graphiql-plugin-explorer/README.md
+++ b/packages/graphiql-plugin-explorer/README.md
@@ -13,7 +13,7 @@ npm i -S @graphiql/plugin-explorer
 The following packages are peer dependencies, so make sure you have them installed as well:
 
 ```sh
-npm i -S react react-dom graphql @graphiql/react
+npm i -S react react-dom graphql
 ```
 
 ## Usage

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -24,10 +24,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@graphiql/react": "^0.11.1",
     "graphiql-explorer": "^0.9.0"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.11.0",
     "graphql": "^15.5.0 || ^16.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
Otherwise changeset will always use [a major version bump](https://github.com/changesets/changesets/blob/main/docs/decisions.md) for the explorer plugin package when we change anything about `@graphiql/react`. It's also easier when installing the plugin as package.