### PR TITLE
correctly handle `null` when type-guarding promises and observables

### DIFF
--- a/.changeset/quick-bulldogs-impress.md
+++ b/.changeset/quick-bulldogs-impress.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+Correctly handle `null` in type-guard functions for `Promise` and `Observable`

--- a/packages/graphiql-toolkit/src/async-helpers/index.ts
+++ b/packages/graphiql-toolkit/src/async-helpers/index.ts
@@ -6,7 +6,11 @@ import {
 
 // Duck-type promise detection.
 export function isPromise<T>(value: Promise<T> | any): value is Promise<T> {
-  return typeof value === 'object' && typeof value.then === 'function';
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.then === 'function'
+  );
 }
 
 // Duck-type Observable.take(1).toPromise()
@@ -29,6 +33,7 @@ function observableToPromise<T>(observable: Observable<T>): Promise<T> {
 export function isObservable<T>(value: any): value is Observable<T> {
   return (
     typeof value === 'object' &&
+    value !== null &&
     'subscribe' in value &&
     typeof value.subscribe === 'function'
   );


### PR DESCRIPTION
Ran into this when trying to reproduce an issue. Passing `null` values into these functions caused them to throw.