### PR TITLE
only remove namespaced items when clearing `localStorage`

### DIFF
--- a/.changeset/twenty-walls-drive.md
+++ b/.changeset/twenty-walls-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+Only remove namespaced items when clearing `localStorage`

--- a/packages/graphiql-toolkit/src/storage/base.ts
+++ b/packages/graphiql-toolkit/src/storage/base.ts
@@ -60,9 +60,18 @@ export class StorageAPI {
     } else if (storage === null) {
       // Passing `null` creates a noop storage
       this.storage = null;
+    } else if (typeof window !== 'undefined') {
+      this.storage = window.localStorage;
+      // We only want to clear the namespaced items
+      this.storage.clear = () => {
+        for (const key in window.localStorage) {
+          if (key.indexOf(`${STORAGE_NAMESPACE}:`) === 0) {
+            window.localStorage.removeItem(key);
+          }
+        }
+      };
     } else {
-      // When passing `undefined` we default to localStorage
-      this.storage = typeof window !== 'undefined' ? window.localStorage : null;
+      this.storage = null;
     }
   }
 


### PR DESCRIPTION
Fixes #2754