### PR TITLE
use different colors for field names and argument names

### DIFF
--- a/.changeset/violet-mangos-explain.md
+++ b/.changeset/violet-mangos-explain.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/plugin-explorer': patch
+'@graphiql/react': patch
+---
+
+Use different colors for field names and argument names

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -30,7 +30,7 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
         def: 'hsl(var(--color-tertiary))',
         property: 'hsl(var(--color-info))',
         qualifier: 'hsl(var(--color-secondary))',
-        attribute: 'hsl(var(--color-info))',
+        attribute: 'hsl(var(--color-tertiary))',
         number: 'hsl(var(--color-success))',
         string: 'hsl(var(--color-warning))',
         builtin: 'hsl(var(--color-success))',

--- a/packages/graphiql-react/src/editor/style/codemirror.css
+++ b/packages/graphiql-react/src/editor/style/codemirror.css
@@ -75,7 +75,7 @@
   }
   /* Name (ObjectField, Argument) */
   & .cm-attribute {
-    color: hsl(var(--color-info));
+    color: hsl(var(--color-tertiary));
   }
   /* Name (Directive) */
   & .cm-meta {


### PR DESCRIPTION
[It was noted](https://twitter.com/alexey_rodionov/status/1567227215234072576) that we use the same colors for field and argument names in the explorer plugin. This stems from the colors we chose for the editor theme. To avoid using the same color in the explorer and also keep it consistent with the editor theme, we update the color for argument names. (I double-checked that this introduces no "color conflicts" where we would show two different adjacent tokens in the same color.)