### PR TITLE
Simple box model reset

### DIFF
--- a/.changeset/tricky-glasses-try.md
+++ b/.changeset/tricky-glasses-try.md
@@ -3,4 +3,4 @@
 "graphiql": patch
 ---
 
-Adds a box-model reset for all children of the .graphiql-container class. This change facilitated another change to the --sidebar-width variable. 
+Adds a box-model reset for all children of the `.graphiql-container` class. This change facilitated another change to the `--sidebar-width` variable. 

--- a/.changeset/tricky-glasses-try.md
+++ b/.changeset/tricky-glasses-try.md
@@ -1,0 +1,6 @@
+---
+"@graphiql/react": patch
+"graphiql": patch
+---
+
+Adds a box-model reset for all children of the .graphiql-container class. This change facilitated another change to the --sidebar-width variable. 

--- a/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
@@ -14,13 +14,12 @@ const defaultSchemaContext: SchemaContextType = {
 };
 
 const withErrorSchemaContext: SchemaContextType = {
-  fetchError: "Error fetching schema",
+  fetchError: 'Error fetching schema',
   introspect() {},
   isFetching: false,
   schema: new GraphQLSchema({ description: 'GraphQL Schema for testing' }),
   validationErrors: [],
 };
-
 
 function DocExplorerWithContext() {
   return (
@@ -75,8 +74,6 @@ describe('DocExplorer', () => {
       </SchemaContext.Provider>,
     );
     const error = container.querySelector('.graphiql-doc-explorer-error');
-    expect(
-      error,
-    ).toHaveTextContent('Error fetching schema');
-  });  
+    expect(error).toHaveTextContent('Error fetching schema');
+  });
 });

--- a/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
@@ -68,12 +68,23 @@ describe('DocExplorer', () => {
     ).toHaveTextContent('GraphQL Schema for testing');
   });
   it('renders correctly with schema error', () => {
-    const { container } = render(
+    const { rerender, container } = render(
       <SchemaContext.Provider value={withErrorSchemaContext}>
         <DocExplorerWithContext />,
       </SchemaContext.Provider>,
     );
+
     const error = container.querySelector('.graphiql-doc-explorer-error');
+
     expect(error).toHaveTextContent('Error fetching schema');
+
+    rerender(
+      <SchemaContext.Provider value={defaultSchemaContext}>
+        <DocExplorerWithContext />,
+      </SchemaContext.Provider>,
+    );
+
+    const errors = container.querySelectorAll('.graphiql-doc-explorer-error');
+    expect(errors).toHaveLength(0);
   });
 });

--- a/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/doc-explorer.spec.tsx
@@ -13,6 +13,15 @@ const defaultSchemaContext: SchemaContextType = {
   validationErrors: [],
 };
 
+const withErrorSchemaContext: SchemaContextType = {
+  fetchError: "Error fetching schema",
+  introspect() {},
+  isFetching: false,
+  schema: new GraphQLSchema({ description: 'GraphQL Schema for testing' }),
+  validationErrors: [],
+};
+
+
 function DocExplorerWithContext() {
   return (
     <ExplorerContextProvider>
@@ -59,4 +68,15 @@ describe('DocExplorer', () => {
       container.querySelector('.graphiql-markdown-description'),
     ).toHaveTextContent('GraphQL Schema for testing');
   });
+  it('renders correctly with schema error', () => {
+    const { container } = render(
+      <SchemaContext.Provider value={withErrorSchemaContext}>
+        <DocExplorerWithContext />,
+      </SchemaContext.Provider>,
+    );
+    const error = container.querySelector('.graphiql-doc-explorer-error');
+    expect(
+      error,
+    ).toHaveTextContent('Error fetching schema');
+  });  
 });

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -1,3 +1,8 @@
+/* a very simple box-model reset, intentionally does not include pseudo elements */
+.graphiql-container * {
+  box-sizing: border-box;
+}
+
 .graphiql-container,
 .CodeMirror-info,
 .CodeMirror-lint-tooltip,
@@ -57,7 +62,7 @@ reach-portal {
   --popover-border: none;
 
   /* Layout */
-  --sidebar-width: 44px;
+  --sidebar-width: 60px;
   --toolbar-width: 40px;
   --session-header-height: 51px;
 }

--- a/packages/graphiql-react/src/toolbar/button.css
+++ b/packages/graphiql-react/src/toolbar/button.css
@@ -1,5 +1,7 @@
 button.graphiql-toolbar-button {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: var(--toolbar-width);
   width: var(--toolbar-width);
 

--- a/packages/graphiql-react/src/vite-env.d.ts
+++ b/packages/graphiql-react/src/vite-env.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line spaced-comment
 /// <reference types="vite/client" />

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -323,7 +323,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   return (
     <div data-testid="graphiql-container" className="graphiql-container">
       <div className="graphiql-sidebar">
-        <div>
+        <div className="graphiql-sidebar-section">
           {pluginContext
             ? pluginContext?.plugins.map(plugin => {
                 const isVisible = plugin === pluginContext.visiblePlugin;
@@ -352,7 +352,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
               })
             : null}
         </div>
-        <div>
+        <div className="graphiql-sidebar-section">
           <Tooltip label="Re-fetch GraphQL schema">
             <UnStyledButton
               type="button"

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -108,11 +108,13 @@ describe('GraphiQL', () => {
     }
 
     // Use a bad fetcher for our initial render
-    const { rerender, container } = render(<GraphiQL fetcher={firstFetcher} />);
+    const { rerender, container, getByLabelText } = render(<GraphiQL fetcher={firstFetcher} />);
     await wait();
 
+    fireEvent.click(getByLabelText('Show Documentation Explorer'));
+
     expect(
-      container.querySelector('.doc-explorer-contents .error-container'),
+      container.querySelector('.graphiql-doc-explorer-error')
     ).toBeTruthy();
 
     // Re-render with valid fetcher
@@ -120,7 +122,7 @@ describe('GraphiQL', () => {
     await wait();
 
     expect(
-      container.querySelector('.doc-explorer-contents .error-container'),
+      container.querySelector('.graphiql-doc-explorer-error'),
     ).not.toBeTruthy();
   });
 

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -108,13 +108,15 @@ describe('GraphiQL', () => {
     }
 
     // Use a bad fetcher for our initial render
-    const { rerender, container, getByLabelText } = render(<GraphiQL fetcher={firstFetcher} />);
+    const { rerender, container, getByLabelText } = render(
+      <GraphiQL fetcher={firstFetcher} />,
+    );
     await wait();
 
     fireEvent.click(getByLabelText('Show Documentation Explorer'));
 
     expect(
-      container.querySelector('.graphiql-doc-explorer-error')
+      container.querySelector('.graphiql-doc-explorer-error'),
     ).toBeTruthy();
 
     // Re-render with valid fetcher

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -16,11 +16,22 @@
   padding: var(--px-8);
   width: var(--sidebar-width);
 }
-.graphiql-container .graphiql-sidebar button {
-  color: hsla(var(--color-neutral), var(--alpha-secondary));
-  height: var(--sidebar-width);
-  width: var(--sidebar-width);
+
+.graphiql-container .graphiql-sidebar .graphiql-sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-8);
 }
+
+.graphiql-container .graphiql-sidebar button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: hsla(var(--color-neutral), var(--alpha-secondary));
+  height: calc(var(--sidebar-width) - (2 * var(--px-8)));
+  width: calc(var(--sidebar-width) - (2 * var(--px-8)));
+}
+
 .graphiql-container .graphiql-sidebar button.active {
   color: hsla(var(--color-neutral), 1);
 }
@@ -28,9 +39,8 @@
   margin-top: var(--px-4);
 }
 .graphiql-container .graphiql-sidebar button > svg {
-  height: calc(var(--sidebar-width) - (2 * var(--px-12)));
-  padding: var(--px-12);
-  width: calc(var(--sidebar-width) - (2 * var(--px-12)));
+  height: var(--px-20);
+  width: var(--px-20);
 }
 
 /* The main content, i.e. everything except the sidebar */
@@ -144,7 +154,6 @@ button.graphiql-tab-add > svg {
   color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: calc(var(--toolbar-width) - (var(--px-8) * 2));
-  padding: var(--px-8);
   width: calc(var(--toolbar-width) - (var(--px-8) * 2));
 }
 


### PR DESCRIPTION
This PR address the issues described in #2777 by adding the well-known box model reset to all children of the container into which we render GraphiQL.

A new class and associated styles are added to contain the sidebar controls, and adjustments are made to the toolbar button css to fit the new box model.

