### PR TITLE
fix(@graphiql/react): show info overlay over scrollbar

### DIFF
--- a/.changeset/selfish-terms-sing.md
+++ b/.changeset/selfish-terms-sing.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Make sure that the info overlay in editors is shown above the vertical scrollbar

--- a/packages/graphiql-react/src/editor/style/info.css
+++ b/packages/graphiql-react/src/editor/style/info.css
@@ -12,6 +12,7 @@
   padding: var(--px-12);
   position: fixed;
   transition: opacity 0.15s;
+  z-index: 10;
 
   /* Link styles */
   & a {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="428" alt="CleanShot 2022-10-05 at 12 32 49@2x" src="https://user-images.githubusercontent.com/22288634/194042487-579f6746-f3f9-4d81-bef4-4b48bca9b242.png"> | <img width="424" alt="CleanShot 2022-10-05 at 12 32 34@2x" src="https://user-images.githubusercontent.com/22288634/194042490-36bf1fc4-8c30-4a65-888b-75af47f5be2f.png"> |
