### PR TITLE
Revert "GitHub Workflows security hardening"

### DIFF
--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -14,9 +14,6 @@ on:
 
 # TODO: test matrix?
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
 jobs:
   build:
     name: Build & Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,8 @@ on:
   push:
     branches:
       - main
-permissions: {}
 jobs:
   release:
-    permissions:
-      contents: read # to checkout the code
-
     environment: deploy
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts graphql/graphiql#2769 which breaks the release workflow (it prevents a git push)