### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -14,6 +14,9 @@ on:
 
 # TODO: test matrix?
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build:
     name: Build & Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches:
       - main
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write # for changesets/action to git push 
     environment: deploy
     name: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a re-fix of https://github.com/graphql/graphiql/pull/2769

After the analysis of https://github.com/graphql/graphiql/actions/runs/3217885196/jobs/5261386138 I believe the root cause is that https://github.com/changesets/action/blob/398d7edfb130ad2d4e076a573724f435ea87cea6/src/index.ts#L30-L34 doesn't work as expected. I.e. it is supposed to set the dedicated [`secrets.GH_TOKEN`](https://github.com/graphql/graphiql/blob/082da7dce63f188dc71ec1938add0a97c825d3a6/.github/workflows/release.yml#L31) as the default repository token used by git, but it fails as git still uses the temporary `GITHUB_TOKEN` instead - the one that is set up in the `actions/checkout@v3` step with:
```
Setting up auth
  /usr/bin/git config --local --name-only --get-regexp core\.sshCommand
  /usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :
  /usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
  /usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :
  /usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
```

This way while `GITHUB_TOKEN` doesn't need `pull-requests: write` permissions (because the `secrets.GH_TOKEN` is used for that) it still needs `contents: write` for git push.

@acao Could you give it a try?