### PR TITLE
use nohoist in exec extension

### DIFF
--- a/.changeset/eight-rockets-run.md
+++ b/.changeset/eight-rockets-run.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-execution': patch
+---
+
+ensure all node_modules resolve for exec extension with nohoist

--- a/packages/vscode-graphql-execution/package.json
+++ b/packages/vscode-graphql-execution/package.json
@@ -111,10 +111,24 @@
     "graphql-ws": "5.10.0",
     "@whatwg-node/fetch": "0.2.8",
     "ws": "8.8.1",
-    "graphql": "^16.4.0",
-    "nullthrows": "^1.1.1"
+    "graphql": "16.6.0",
+    "nullthrows": "1.1.1"
   },
   "resolutions": {
     "cosmiconfig": "^5.0.1"
+  },
+  "workspaces": {
+    "nohoist": [
+      "graphql",
+      "graphql-config",
+      "dotenv",
+      "graphql-ws",
+      "graphql-tag",
+      "@urql/core",
+      "ws",
+      "nullthrows",
+      "capitalize",
+      "@whatwg-node/fetch"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10648,6 +10648,11 @@ graphql-ws@^5.4.1, graphql-ws@^5.5.5:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.5.5.tgz#f375486d3f196e2a2527b503644693ae3a8670a9"
   integrity sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw==
 
+graphql@16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+
 graphql@^16.1.0, graphql@^16.4.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.5.0.tgz#41b5c1182eaac7f3d47164fb247f61e4dfb69c85"
@@ -13787,7 +13792,7 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nullthrows@^1.0.0, nullthrows@^1.1.1:
+nullthrows@1.1.1, nullthrows@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==


### PR DESCRIPTION
use `workspaces.nohoist` to ensure the workspace has everything we need to bundle `node_modules` with `vsce`!

I had too many issues with `esbuild` and the exec extension, so I had to opt out from bundling, but it's not to bad if we keep `nohoist` in check I guess?