### PR TITLE
disable exec for now until vsce issues are resolved

### DIFF
--- a/.changeset/sweet-peaches-tap.md
+++ b/.changeset/sweet-peaches-tap.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql': patch
+---
+
+disable exec extension in vscode-graphql until stable

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -51,8 +51,7 @@
   ],
   "main": "./out/extension",
   "extensionDependencies": [
-    "GraphQL.vscode-graphql-syntax",
-    "GraphQL.vscode-graphql-execution"
+    "GraphQL.vscode-graphql-syntax"
   ],
   "contributes": {
     "snippets": [


### PR DESCRIPTION
so many `vsce` unknowns, lets just skip his for now...

until I can figure out how to bundle `graphql.vscode-graphql-execution` with `vsce` in a yarn monorepo context! worked fine before outside of the monorepo.