### PR TITLE
Support Default values in lint variables

### DIFF
--- a/packages/codemirror-graphql/src/variables/lint.ts
+++ b/packages/codemirror-graphql/src/variables/lint.ts
@@ -170,9 +170,9 @@ function validateValue(
 
     // Look for missing non-nullable fields.
     Object.keys(type.getFields()).forEach(fieldName => {
+      const field = type.getFields()[fieldName];
       if (!providedFields[fieldName]) {
-        const fieldType = type.getFields()[fieldName].type;
-        if (fieldType instanceof GraphQLNonNull) {
+        if (field.type instanceof GraphQLNonNull && !field.defaultValue) {
           fieldErrors.push([
             valueAST,
             `Object of type "${type}" is missing required field "${fieldName}".`,


### PR DESCRIPTION
At least variable section do a big red warning for missing values of field with a default value, 

this intend to silence that. 
