### PR TITLE
expose PluginContextProvider

### DIFF
--- a/.changeset/happy-cherries-add.md
+++ b/.changeset/happy-cherries-add.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Export the `PluginContextProvider` component

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -50,6 +50,7 @@ export {
   DOC_EXPLORER_PLUGIN,
   HISTORY_PLUGIN,
   PluginContext,
+  PluginContextProvider,
   usePluginContext,
 } from './plugin';
 export { GraphiQLProvider } from './provider';

--- a/packages/graphiql/__mocks__/@graphiql/react.tsx
+++ b/packages/graphiql/__mocks__/@graphiql/react.tsx
@@ -62,7 +62,7 @@ export {
   PenIcon,
   PlayIcon,
   PluginContext,
-  PluginContextProfider,
+  PluginContextProvider,
   PlusIcon,
   PrettifyIcon,
   ReloadIcon,

--- a/packages/graphiql/__mocks__/@graphiql/react.tsx
+++ b/packages/graphiql/__mocks__/@graphiql/react.tsx
@@ -62,6 +62,7 @@ export {
   PenIcon,
   PlayIcon,
   PluginContext,
+  PluginContextProfider,
   PlusIcon,
   PrettifyIcon,
   ReloadIcon,


### PR DESCRIPTION
Any other ContextProvider are exposed, with exception PluginContextProvider.

So in my opinion https://github.com/graphql/graphiql/pull/2674 only miss this expose