### PR TITLE
Add Cristina Shaver as co-maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Maintainers who are currently active (to varying degrees, please contact us via 
 - [@dotansimha](https://github.com/dotansimha)
 - [@saihaj](https://github.com/saihaj)
 - [@jonathanawesome](https://github.com/jonathanawesome)
+- [@cshaver](https://github.com/cshaver)
 
 > Thank you graphql community for all the help & support! I did it all for you, and I couldn't have done it without you ❤️ - @acao
 


### PR DESCRIPTION
Cristina (@cshaver) began helping with `monaco-graphql` and `graphiql` in late 2019 or 2020, providing some of the implementation that's in both `@graphiql/react` and `monaco-graphql` today. She has also helped with issue triage in the past.

She would like to help us advance`monaco-graphql` and `graphiql` and `@graphiql/react`. Her eye for a11y and both DX and UX will help so much!