### PR TITLE
docs: typo - `/* GraphQL */` not `/* GraphiQL */`!

### DIFF
--- a/.changeset/spicy-ducks-fail.md
+++ b/.changeset/spicy-ducks-fail.md
@@ -1,0 +1,6 @@
+---
+"vscode-graphql-syntax": patch
+"vscode-graphql": patch
+---
+
+docs typo bug - `/* GraphQL */` (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` & `vscode-graphql` language support

--- a/packages/vscode-graphql-syntax/README.md
+++ b/packages/vscode-graphql-syntax/README.md
@@ -85,7 +85,7 @@ Note, inline `""` and `''` string literals could also be delimited if needed, bu
 #### Comment-Delimited patterns
 
 ```ts
-/* GraphiQL */
+/* GraphQL */
 const query = `
  { id }
 `;


### PR DESCRIPTION
huge typo. caused this user bug https://github.com/graphql/graphiql/issues/2843#issuecomment-1294685543