### PR TITLE
add missing changeset for cm6-graphql

### DIFF
--- a/.changeset/calm-poets-invite.md
+++ b/.changeset/calm-poets-invite.md
@@ -1,0 +1,5 @@
+---
+'cm6-graphql': patch
+---
+
+First release of a modern codemirror 6 mode for graphql by @imolorhe!

--- a/.changeset/curly-guests-heal.md
+++ b/.changeset/curly-guests-heal.md
@@ -1,0 +1,5 @@
+---
+'codemirror-graphql': patch
+---
+
+increment @codemirror/language peer dependency to 6.0.0


### PR DESCRIPTION
Forgot this detail in your pr @imolorhe my bad! Otherwise there won't be a release. We don't use conventional commits anymore, we use atlassian changesets now.

This will attribute the mode to me now in the changelog which is unfortunate. Do you want to re-create this PR yourself so it gives you credit? It will still link just to the changeset commit, and not the PR where you added this mode, but you can link to that from the changelog entry at least!