### PR TITLE
add `.svelte` to list of supported extensions

### DIFF
--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -16,6 +16,7 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.jsx',
   '.tsx',
   '.vue',
+  '.svelte'
 ];
 
 /**


### PR DESCRIPTION
fixes #2857, a small oversight, should fix .svelte language features until other parsing errors arise