### PR TITLE
[vscode-graphql] fix Svelte support

### DIFF
--- a/packages/vscode-graphql/src/apis/statusBar.ts
+++ b/packages/vscode-graphql/src/apis/statusBar.ts
@@ -61,6 +61,7 @@ const statusBarActivationLanguageIds = [
   'typescript',
   'typescriptreact',
   'vue',
+  'svelte',
 ];
 
 export const createStatusBar = () => {

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -57,6 +57,7 @@ export async function activate(context: ExtensionContext) {
       { scheme: 'file', language: 'typescript' },
       { scheme: 'file', language: 'typescriptreact' },
       { scheme: 'file', language: 'vue' },
+      { scheme: 'file', language: 'svelte' },
     ],
     synchronize: {
       // TODO: This should include any referenced graphql files inside the graphql-config


### PR DESCRIPTION
Fixes #2857

The LSP server wasn't registered for svelte files.

Note: the PR does not have tests