### PR TITLE
[vscode-graphql] fix Svelte support

### DIFF
--- a/.changeset/great-mayflies-camp.md
+++ b/.changeset/great-mayflies-camp.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+add missing pieces for svelte language support

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -16,6 +16,7 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.jsx',
   '.tsx',
   '.vue',
+  '.svelte',
 ];
 
 /**

--- a/packages/vscode-graphql/src/apis/statusBar.ts
+++ b/packages/vscode-graphql/src/apis/statusBar.ts
@@ -61,6 +61,7 @@ const statusBarActivationLanguageIds = [
   'typescript',
   'typescriptreact',
   'vue',
+  'svelte',
 ];
 
 export const createStatusBar = () => {

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -57,6 +57,7 @@ export async function activate(context: ExtensionContext) {
       { scheme: 'file', language: 'typescript' },
       { scheme: 'file', language: 'typescriptreact' },
       { scheme: 'file', language: 'vue' },
+      { scheme: 'file', language: 'svelte' },
     ],
     synchronize: {
       // TODO: This should include any referenced graphql files inside the graphql-config


### PR DESCRIPTION
Fixes #2857

The LSP server wasn't registered for svelte files.

Note: the PR does not have tests