### PR TITLE
fix: fixed "Mark decorations may not be empty"  error

### DIFF
--- a/.changeset/moody-moose-sin.md
+++ b/.changeset/moody-moose-sin.md
@@ -1,0 +1,5 @@
+---
+"cm6-graphql": patch
+---
+
+fix: fixed "Mark decorations may not be empty"  error

--- a/packages/cm6-graphql/src/lint.ts
+++ b/packages/cm6-graphql/src/lint.ts
@@ -18,15 +18,22 @@ export const lint = linter(view => {
         return null;
       }
 
+      const calculatedFrom = posToOffset(
+        view.state.doc,
+        new Position(item.range.start.line, item.range.start.character),
+      );
+      const from = Math.max(0, Math.min(calculatedFrom, view.state.doc.length));
+      const calculatedRo = posToOffset(
+        view.state.doc,
+        new Position(item.range.end.line, item.range.end.character - 1),
+      );
+      const to = Math.min(
+        Math.max(from + 1, calculatedRo),
+        view.state.doc.length,
+      );
       return {
-        from: posToOffset(
-          view.state.doc,
-          new Position(item.range.start.line, item.range.start.character),
-        ),
-        to: posToOffset(
-          view.state.doc,
-          new Position(item.range.end.line, item.range.end.character - 1),
-        ),
+        from,
+        to: from !== to ? to : to + 1,
         severity: SEVERITY[item.severity - 1],
         // source: item.source, // TODO:
         message: item.message,


### PR DESCRIPTION
fix: fixed "Mark decorations may not be empty"  error in codemirror 6 lint extension.