### PR TITLE
🛠️ ESLint: enable `@typescript-eslint/require-await` rule to disallow `async` functions which have no `await` expression

### DIFF
--- a/.changeset/orange-starfishes-agree.md
+++ b/.changeset/orange-starfishes-agree.md
@@ -1,0 +1,8 @@
+---
+'graphql-language-service': patch
+'graphql-language-service-server': patch
+'monaco-graphql': patch
+'vscode-graphql-execution': patch
+---
+
+enable `@typescript-eslint/require-await` rule to disallow `async` functions which have no `await` expression

--- a/.eslintignore
+++ b/.eslintignore
@@ -66,3 +66,8 @@ working-group/
 
 .changeset
 storybook-static/
+
+# Followed are located in .gitignore
+packages/graphiql-react/types/
+packages/graphiql-plugin-explorer/types/
+packages/graphiql-plugin-code-exporter/types/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,11 @@ module.exports = {
     ecmaFeatures: {
       jsx: true,
     },
+    project: [
+      'packages/*/tsconfig.json',
+      'examples/*/tsconfig.json',
+      'tsconfig.eslint.json',
+    ],
   },
   settings: {
     react: {
@@ -118,8 +123,10 @@ module.exports = {
     'no-warning-comments': 0,
     radix: 1,
     '@typescript-eslint/prefer-as-const': 'error',
-    'require-await': 0,
-    // 'require-await': 1,
+    'require-await': 'off',
+    // Disallow async functions which have no await expression
+    // https://typescript-eslint.io/rules/require-await/
+    '@typescript-eslint/require-await': 'error',
     'vars-on-top': 0,
     yoda: 1,
     '@typescript-eslint/no-inferrable-types': 'error',

--- a/examples/monaco-graphql-webpack/src/schema.ts
+++ b/examples/monaco-graphql-webpack/src/schema.ts
@@ -64,7 +64,7 @@ class MySchemaFetcher {
     }
     return this.loadSchema();
   }
-  async setApiToken(token: string) {
+  setApiToken(token: string) {
     this._currentSchema.headers.authorization = `Bearer ${token}`;
     localStorage.setItem(localStorageKey, token);
   }

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
@@ -38,7 +38,7 @@ describe('createGraphiQLFetcher', () => {
   });
 
   it('returns simple fetcher for introspection', async () => {
-    createSimpleFetcher.mockReturnValue(async () => 'hey!');
+    createSimpleFetcher.mockReturnValue(() => 'hey!');
     const fetcher = createGraphiQLFetcher({ url: serverURL });
     expect(createWebsocketsFetcherFromUrl.mock.calls).toEqual([]);
     expect(createMultipartFetcher.mock.calls).toEqual([

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -128,10 +128,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
     }
   };
 
-  getFragmentDependencies = async (
+  getFragmentDependencies = (
     query: string,
     fragmentDefinitions?: Map<string, FragmentInfo> | null,
-  ): Promise<FragmentInfo[]> => {
+  ): FragmentInfo[] => {
     // If there isn't context for fragment references,
     // return an empty array.
     if (!fragmentDefinitions) {
@@ -148,10 +148,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
     return this.getFragmentDependenciesForAST(parsedQuery, fragmentDefinitions);
   };
 
-  getFragmentDependenciesForAST = async (
+  getFragmentDependenciesForAST = (
     parsedQuery: ASTNode,
     fragmentDefinitions: Map<string, FragmentInfo>,
-  ): Promise<FragmentInfo[]> => {
+  ): FragmentInfo[] => {
     if (!fragmentDefinitions) {
       return [];
     }
@@ -220,10 +220,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
     return fragmentDefinitions;
   };
 
-  getObjectTypeDependencies = async (
+  getObjectTypeDependencies = (
     query: string,
     objectTypeDefinitions?: Map<string, ObjectTypeInfo>,
-  ): Promise<Array<ObjectTypeInfo>> => {
+  ): Array<ObjectTypeInfo> => {
     // If there isn't context for object type references,
     // return an empty array.
     if (!objectTypeDefinitions) {
@@ -243,10 +243,10 @@ export class GraphQLCache implements GraphQLCacheInterface {
     );
   };
 
-  getObjectTypeDependenciesForAST = async (
+  getObjectTypeDependenciesForAST = (
     parsedQuery: ASTNode,
     objectTypeDefinitions: Map<string, ObjectTypeInfo>,
-  ): Promise<Array<ObjectTypeInfo>> => {
+  ): Array<ObjectTypeInfo> => {
     if (!objectTypeDefinitions) {
       return [];
     }
@@ -414,11 +414,11 @@ export class GraphQLCache implements GraphQLCacheInterface {
     return graphQLFileMap;
   }
 
-  async updateFragmentDefinition(
+  updateFragmentDefinition(
     rootDir: Uri,
     filePath: Uri,
     contents: Array<CachedContent>,
-  ): Promise<void> {
+  ): void {
     const cache = this._fragmentDefinitionsCache.get(rootDir);
     const asts = contents.map(({ query }) => {
       try {
@@ -476,11 +476,11 @@ export class GraphQLCache implements GraphQLCacheInterface {
     }
   }
 
-  async updateObjectTypeDefinition(
+  updateObjectTypeDefinition(
     rootDir: Uri,
     filePath: Uri,
     contents: Array<CachedContent>,
-  ): Promise<void> {
+  ): void {
     const cache = this._typeDefinitionsCache.get(rootDir);
     const asts = contents.map(({ query }) => {
       try {

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -519,7 +519,7 @@ export class GraphQLLanguageService {
 
     return result;
   }
-  async getOutline(documentText: string): Promise<Outline | null> {
+  getOutline(documentText: string): Outline | null {
     return getOutline(documentText);
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -161,11 +161,11 @@ export class MessageProcessor {
     this._connection = connection;
   }
 
-  async handleInitializeRequest(
+  handleInitializeRequest(
     params: InitializeParams,
     _token?: CancellationToken,
     configDir?: string,
-  ): Promise<InitializeResult> {
+  ): InitializeResult {
     if (!params) {
       throw new Error('`params` argument is required to initialize.');
     }
@@ -935,7 +935,7 @@ export class MessageProcessor {
       this._logger.error(String(err));
     }
   }
-  async _cacheSchemaFile(
+  _cacheSchemaFile(
     uri: UnnormalizedTypeDefPointer,
     project: GraphQLProjectConfig,
   ) {
@@ -1195,11 +1195,11 @@ export class MessageProcessor {
 
     return null;
   }
-  async _invalidateCache(
+  _invalidateCache(
     textDocument: VersionedTextDocumentIdentifier,
     uri: Uri,
     contents: CachedContent[],
-  ): Promise<Map<string, CachedDocumentType> | null> {
+  ): Map<string, CachedDocumentType> | null {
     if (this._textDocumentCache.has(uri)) {
       const cachedDocument = this._textDocumentCache.get(uri);
       if (

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
@@ -25,7 +25,7 @@ const MOCK_CONFIG = {
 
 describe('GraphQLLanguageService', () => {
   const mockCache = {
-    async getSchema() {
+    getSchema() {
       const config = this.getGraphQLConfig();
       return config.getDefault()!.getSchema();
     },

--- a/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/Logger-test.ts
@@ -14,7 +14,7 @@ describe('Logger', () => {
   let mockedStdoutWrite: jest.SpyInstance = null;
   let mockedStderrWrite: jest.SpyInstance = null;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     mockedStdoutWrite = jest
       .spyOn(process.stdout, 'write')
       .mockImplementation(() => true);

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -67,7 +67,7 @@ describe('MessageProcessor', () => {
       getDiagnostics: (_query, _uri) => {
         return [];
       },
-      getDocumentSymbols: async (_query: string, uri: string) => {
+      getDocumentSymbols: (_query: string, uri: string) => {
         return [
           {
             name: 'item',
@@ -82,7 +82,7 @@ describe('MessageProcessor', () => {
           },
         ];
       },
-      getOutline: async (_query: string): Promise<Outline> => {
+      getOutline: (_query: string): Outline => {
         return {
           outlineTrees: [
             {
@@ -95,11 +95,7 @@ describe('MessageProcessor', () => {
           ],
         };
       },
-      getDefinition: async (
-        _query,
-        position,
-        uri,
-      ): Promise<DefinitionQueryResult> => {
+      getDefinition: (_query, position, uri): DefinitionQueryResult => {
         return {
           queryRange: [new Range(position, position)],
           definitions: [
@@ -119,7 +115,7 @@ describe('MessageProcessor', () => {
     // @ts-ignore
     get workspace() {
       return {
-        getConfiguration: async () => {
+        getConfiguration: () => {
           return [getConfigurationReturnValue];
         },
       };
@@ -373,7 +369,7 @@ describe('MessageProcessor', () => {
     });
   });
 
-  it('parseDocument finds queries in tagged templates', async () => {
+  it('parseDocument finds queries in tagged templates', () => {
     const text = `
 // @flow
 import {gql} from 'react-apollo';
@@ -403,7 +399,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in tagged templates using typescript', async () => {
+  it('parseDocument finds queries in tagged templates using typescript', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -432,7 +428,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in tagged templates using tsx', async () => {
+  it('parseDocument finds queries in tagged templates using tsx', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -463,7 +459,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in multi-expression tagged templates using tsx', async () => {
+  it('parseDocument finds queries in multi-expression tagged templates using tsx', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -495,7 +491,7 @@ query Test {
 }`);
   });
   // TODO: why an extra line here?
-  it('parseDocument finds queries in multi-expression tagged template with declarations with using tsx', async () => {
+  it('parseDocument finds queries in multi-expression tagged template with declarations with using tsx', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -528,7 +524,7 @@ query Test {
 }`);
   });
 
-  it('parseDocument finds queries in multi-expression template strings using tsx', async () => {
+  it('parseDocument finds queries in multi-expression template strings using tsx', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -563,7 +559,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in call expressions with template literals', async () => {
+  it('parseDocument finds queries in call expressions with template literals', () => {
     const text = `
 // @flow
 import {gql} from 'react-apollo';
@@ -593,7 +589,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in #graphql-annotated templates', async () => {
+  it('parseDocument finds queries in #graphql-annotated templates', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -622,7 +618,7 @@ query Test {
 `);
   });
 
-  it('parseDocument finds queries in /*GraphQL*/-annotated templates', async () => {
+  it('parseDocument finds queries in /*GraphQL*/-annotated templates', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -651,7 +647,7 @@ query Test {
 `);
   });
 
-  it('parseDocument ignores non gql tagged templates', async () => {
+  it('parseDocument ignores non gql tagged templates', () => {
     const text = `
 // @flow
 import randomThing from 'package';
@@ -674,7 +670,7 @@ export function Example(arg: string) {}`;
     expect(contents.length).toEqual(0);
   });
 
-  it('parseDocument ignores non gql call expressions with template literals', async () => {
+  it('parseDocument ignores non gql call expressions with template literals', () => {
     const text = `
 // @flow
 import randomthing from 'package';
@@ -697,7 +693,7 @@ export function Example(arg: string) {}`;
     expect(contents.length).toEqual(0);
   });
 
-  it('an unparsable JS/TS file does not throw and bring down the server', async () => {
+  it('an unparsable JS/TS file does not throw and bring down the server', () => {
     const text = `
 // @flow
 import type randomThing fro 'package';

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -19,7 +19,7 @@ describe('findGraphQLTags', () => {
   const findGraphQLTags = (text: string, ext: string) =>
     baseFindGraphQLTags(text, ext, '', logger);
 
-  it('finds queries in tagged templates', async () => {
+  it('finds queries in tagged templates', () => {
     const text = `
 // @flow
 import {gql} from 'react-apollo';
@@ -49,7 +49,7 @@ query Test {
 `);
   });
 
-  it('finds queries in call expressions with template literals', async () => {
+  it('finds queries in call expressions with template literals', () => {
     const text = `
     // @flow
     import {gql} from 'react-apollo';
@@ -79,7 +79,7 @@ query Test {
     `);
   });
 
-  it('finds queries in #graphql-annotated templates', async () => {
+  it('finds queries in #graphql-annotated templates', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -108,7 +108,7 @@ query Test {
 `);
   });
 
-  it('finds queries in /* GraphQL */ prefixed templates', async () => {
+  it('finds queries in /* GraphQL */ prefixed templates', () => {
     const text = `
 import {gql} from 'react-apollo';
 import {B} from 'B';
@@ -140,14 +140,14 @@ query Test {
 `);
   });
 
-  it('finds queries with nested graphql.experimental template tag expression', async () => {
+  it('finds queries with nested graphql.experimental template tag expression', () => {
     const text = `const query = graphql.experimental\` query {} \``;
 
     const contents = findGraphQLTags(text, '.ts');
     expect(contents[0].template).toEqual(` query {} `);
   });
 
-  it('finds queries with nested template tag expressions', async () => {
+  it('finds queries with nested template tag expressions', () => {
     const text = `export default {
   else: () => gql\` query {} \`
 }`;
@@ -156,7 +156,7 @@ query Test {
     expect(contents[0].template).toEqual(` query {} `);
   });
 
-  it('finds queries with template tags inside call expressions', async () => {
+  it('finds queries with template tags inside call expressions', () => {
     const text = `something({
   else: () => graphql\` query {} \`
 })`;
@@ -165,7 +165,7 @@ query Test {
     expect(contents[0].template).toEqual(` query {} `);
   });
 
-  it('finds queries in tagged templates in Vue SFC using <script setup>', async () => {
+  it('finds queries in tagged templates in Vue SFC using <script setup>', () => {
     const text = `
 <script setup lang="ts">
 gql\`
@@ -178,7 +178,7 @@ query {id}
 query {id}`);
   });
 
-  it('finds queries in tagged templates in Vue SFC using normal <script>', async () => {
+  it('finds queries in tagged templates in Vue SFC using normal <script>', () => {
     const text = `
 <script lang="ts">
 gql\`
@@ -191,7 +191,7 @@ query {id}
 query {id}`);
   });
 
-  it('finds queries in tagged templates in Vue SFC using <script lang="tsx">', async () => {
+  it('finds queries in tagged templates in Vue SFC using <script lang="tsx">', () => {
     const text = `
 <script lang="tsx">
 import { defineComponent } from 'vue';
@@ -213,7 +213,7 @@ export default defineComponent({
 query {id}`);
   });
 
-  it('finds queries in tagged templates in Svelte using normal <script>', async () => {
+  it('finds queries in tagged templates in Svelte using normal <script>', () => {
     const text = `
 <script>
 gql\`
@@ -226,7 +226,7 @@ query {id}
 query {id}`);
   });
 
-  it('finds multiple queries in a single file', async () => {
+  it('finds multiple queries in a single file', () => {
     const text = `something({
   else: () => gql\` query {} \`
 })
@@ -252,7 +252,7 @@ const query = graphql\`query myQuery {}\``;
     expect(contents[1].template).toEqual(`query myQuery {}`);
   });
 
-  it('ignores non gql tagged templates', async () => {
+  it('ignores non gql tagged templates', () => {
     const text = `
 // @flow
 import randomthing from 'package';
@@ -275,7 +275,7 @@ export function Example(arg: string) {}`;
     expect(contents.length).toEqual(0);
   });
 
-  it('ignores non gql call expressions with template literals', async () => {
+  it('ignores non gql call expressions with template literals', () => {
     const text = `
 // @flow
 import randomthing from 'package';

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -270,7 +270,7 @@ type HandlerOptions = {
  *
  * @param options {HandlerOptions}
  */
-async function addHandlers({
+function addHandlers({
   connection,
   logger,
   config,
@@ -279,7 +279,7 @@ async function addHandlers({
   graphqlFileExtensions,
   tmpDir,
   loadConfigOptions,
-}: HandlerOptions): Promise<void> {
+}: HandlerOptions): void {
   const messageProcessor = new MessageProcessor({
     logger,
     config,

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
@@ -59,7 +59,7 @@ const suggestionCommand = {
 
 describe('getAutocompleteSuggestions', () => {
   let schema: GraphQLSchema;
-  beforeEach(async () => {
+  beforeEach(() => {
     // graphQLVersion = pkg.version;
     const schemaIDL = fs.readFileSync(
       path.join(__dirname, '__schema__/StarWarsSchema.graphql'),

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
@@ -28,7 +28,7 @@ import {
 
 describe('getDiagnostics', () => {
   let schema: GraphQLSchema;
-  beforeEach(async () => {
+  beforeEach(() => {
     const schemaIDL = fs.readFileSync(
       path.join(__dirname, '__schema__/StarWarsSchema.graphql'),
       'utf8',

--- a/packages/graphql-language-service/src/interface/__tests__/getHoverInformation-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getHoverInformation-test.ts
@@ -19,7 +19,7 @@ import { getHoverInformation } from '../getHoverInformation';
 
 describe('getHoverInformation', () => {
   let schema: GraphQLSchema;
-  beforeEach(async () => {
+  beforeEach(() => {
     const schemaIDL = fs.readFileSync(
       path.join(__dirname, '__schema__/HoverTestSchema.graphql'),
       'utf8',

--- a/packages/graphql-language-service/src/interface/getDefinition.ts
+++ b/packages/graphql-language-service/src/interface/getDefinition.ts
@@ -48,11 +48,11 @@ function getPosition(text: string, node: ASTNode): Position {
   return offsetToPosition(text, location.start);
 }
 
-export async function getDefinitionQueryResultForNamedType(
+export function getDefinitionQueryResultForNamedType(
   text: string,
   node: NamedTypeNode,
   dependencies: Array<ObjectTypeInfo>,
-): Promise<DefinitionQueryResult> {
+): DefinitionQueryResult {
   const name = node.name.value;
   const defNodes = dependencies.filter(
     ({ definition }) => definition.name && definition.name.value === name,
@@ -72,11 +72,11 @@ export async function getDefinitionQueryResultForNamedType(
   };
 }
 
-export async function getDefinitionQueryResultForField(
+export function getDefinitionQueryResultForField(
   fieldName: string,
   typeName: string,
   dependencies: Array<ObjectTypeInfo>,
-): Promise<DefinitionQueryResult> {
+): DefinitionQueryResult {
   const defNodes = dependencies.filter(
     ({ definition }) => definition.name && definition.name.value === typeName,
   );
@@ -108,11 +108,11 @@ export async function getDefinitionQueryResultForField(
   };
 }
 
-export async function getDefinitionQueryResultForFragmentSpread(
+export function getDefinitionQueryResultForFragmentSpread(
   text: string,
   fragment: FragmentSpreadNode,
   dependencies: Array<FragmentInfo>,
-): Promise<DefinitionQueryResult> {
+): DefinitionQueryResult {
   const name = fragment.name.value;
   const defNodes = dependencies.filter(
     ({ definition }) => definition.name.value === name,

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -56,12 +56,12 @@ export interface GraphQLCache {
   getObjectTypeDependencies: (
     query: string,
     fragmentDefinitions: Map<string, ObjectTypeInfo>,
-  ) => Promise<ObjectTypeInfo[]>;
+  ) => Promise<ObjectTypeInfo[]> | ObjectTypeInfo[];
 
   getObjectTypeDependenciesForAST: (
     parsedQuery: ASTNode,
     fragmentDefinitions: Map<string, ObjectTypeInfo>,
-  ) => Promise<ObjectTypeInfo[]>;
+  ) => Promise<ObjectTypeInfo[]> | ObjectTypeInfo[];
 
   getObjectTypeDefinitions: (
     graphQLConfig: GraphQLProjectConfig,
@@ -71,7 +71,7 @@ export interface GraphQLCache {
     rootDir: Uri,
     filePath: Uri,
     contents: CachedContent[],
-  ) => Promise<void>;
+  ) => Promise<void> | void;
 
   updateObjectTypeDefinitionCache: (
     rootDir: Uri,
@@ -82,12 +82,12 @@ export interface GraphQLCache {
   getFragmentDependencies: (
     query: string,
     fragmentDefinitions: Maybe<Map<string, FragmentInfo>>,
-  ) => Promise<FragmentInfo[]>;
+  ) => Promise<FragmentInfo[]> | FragmentInfo[];
 
   getFragmentDependenciesForAST: (
     parsedQuery: ASTNode,
     fragmentDefinitions: Map<string, FragmentInfo>,
-  ) => Promise<FragmentInfo[]>;
+  ) => Promise<FragmentInfo[]> | FragmentInfo[];
 
   getFragmentDefinitions: (
     graphQLConfig: GraphQLProjectConfig,
@@ -97,7 +97,7 @@ export interface GraphQLCache {
     rootDir: Uri,
     filePath: Uri,
     contents: CachedContent[],
-  ) => Promise<void>;
+  ) => Promise<void> | void;
 
   updateFragmentDefinitionCache: (
     rootDir: Uri,

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -35,7 +35,7 @@ export class GraphQLWorker {
     this._formattingOptions = createData.formattingOptions;
   }
 
-  public async doValidation(uri: string) {
+  public doValidation(uri: string) {
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
@@ -53,10 +53,10 @@ export class GraphQLWorker {
     }
   }
 
-  public async doComplete(
+  public doComplete(
     uri: string,
     position: Position,
-  ): Promise<GraphQLWorkerCompletionItem[]> {
+  ): GraphQLWorkerCompletionItem[] {
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
@@ -76,7 +76,7 @@ export class GraphQLWorker {
     }
   }
 
-  public async doHover(uri: string, position: Position) {
+  public doHover(uri: string, position: Position) {
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
@@ -109,7 +109,7 @@ export class GraphQLWorker {
     }
   }
 
-  public async doGetVariablesJSONSchema(uri: string): Promise<unknown> {
+  public doGetVariablesJSONSchema(uri: string): unknown {
     const documentModel = this._getTextModel(uri);
     const document = documentModel?.getValue();
     if (!documentModel || !document) {

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -155,7 +155,7 @@ export class LanguageService {
    * override `schemas` config entirely
    * @param schema {schemaString}
    */
-  public async updateSchemas(schemas: SchemaConfig[]): Promise<void> {
+  public updateSchemas(schemas: SchemaConfig[]): void {
     this._schemas = schemas;
     this._cacheSchemas();
   }

--- a/packages/vscode-graphql-execution/src/helpers/network.ts
+++ b/packages/vscode-graphql-execution/src/helpers/network.ts
@@ -135,7 +135,7 @@ export class NetworkHelper {
       ${literal.content}
     `;
     return Promise.all(
-      operationTypes.map(async operation => {
+      operationTypes.map(operation => {
         const subscriber = this.buildSubscribeConsumer(
           updateCallback,
           operation,

--- a/packages/vscode-graphql-execution/src/helpers/source.ts
+++ b/packages/vscode-graphql-execution/src/helpers/source.ts
@@ -237,10 +237,10 @@ export interface ExtractedTemplateLiteral {
   definition: OperationDefinitionNode;
 }
 
-export const getFragmentDependencies = async (
+export const getFragmentDependencies = (
   query: string,
   fragmentDefinitions?: Map<string, FragmentInfo> | null,
-): Promise<FragmentInfo[]> => {
+): FragmentInfo[] => {
   // If there isn't context for fragment references,
   // return an empty array.
   if (!fragmentDefinitions) {
@@ -257,10 +257,10 @@ export const getFragmentDependencies = async (
   return getFragmentDependenciesForAST(parsedQuery, fragmentDefinitions);
 };
 
-export const getFragmentDependenciesForAST = async (
+export const getFragmentDependenciesForAST = (
   parsedQuery: ASTNode,
   fragmentDefinitions: Map<string, FragmentInfo>,
-): Promise<FragmentInfo[]> => {
+): FragmentInfo[] => {
   if (!fragmentDefinitions) {
     return [];
   }

--- a/packages/vscode-graphql-execution/src/providers/exec-content.ts
+++ b/packages/vscode-graphql-execution/src/providers/exec-content.ts
@@ -61,7 +61,7 @@ export class GraphQLContentProvider implements TextDocumentContentProvider {
           (await window.showInputBox({
             ignoreFocusOut: true,
             placeHolder: `Please enter the value for ${node.variable.name.value}`,
-            validateInput: async (value: string) =>
+            validateInput: (value: string) =>
               this.sourceHelper.validate(value, variableType),
           })) as string,
           variableType,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -23,7 +23,7 @@
     "packages/graphiql/cypress/plugins/*.js",
     "packages/cm6-graphql/rollup.config.js",
     "packages/graphiql-plugin-code-exporter/postcss.config.js",
-    "packages/graphiql-react/mocks/svg.js",
+    "packages/graphiql-react/mocks/svg.jsx",
     "packages/graphiql-react/postcss.config.js",
     "packages/graphql-language-service/src/utils/__tests__/__fixtures__/file.js",
     "packages/graphiql/__mocks__/codemirror.ts",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,44 @@
+{
+  // https://typescript-eslint.io/docs/linting/typed-linting/monorepos/#one-root-tsconfigjson
+  // extend your base config to share compilerOptions, etc
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // ensure that nobody can accidentally use this config for a build
+    "noEmit": true
+  },
+  "include": [
+    "scripts/*.js",
+    "resources/*.js",
+    "packages/*/esbuild.js",
+    "packages/*/jest.config.js",
+    "packages/*/babel.config.js",
+    "packages/*/vite.config.ts",
+    "packages/graphql-language-service/benchmark/index.ts",
+    "packages/graphql-language-service-cli/bin/graphql.js",
+    "packages/graphiql/test/*.js",
+    "packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx",
+    "packages/graphiql/resources/webpack.config.js",
+    "packages/graphiql/postcss.config.js",
+    "packages/graphiql/cypress/support/*.js",
+    "packages/graphiql/cypress/plugins/*.js",
+    "packages/cm6-graphql/rollup.config.js",
+    "packages/graphiql-plugin-code-exporter/postcss.config.js",
+    "packages/graphiql-react/mocks/svg.js",
+    "packages/graphiql-react/postcss.config.js",
+    "packages/graphql-language-service/src/utils/__tests__/__fixtures__/file.js",
+    "packages/graphiql/__mocks__/codemirror.ts",
+    "packages/graphiql/__mocks__/@graphiql/react.tsx",
+    "examples/*/babel.config.js",
+    "examples/*/webpack.config.js",
+    "examples/graphiql-explorer/src/vite-env.d.ts",
+    "examples/graphiql-webpack/src/index.jsx",
+    "examples/monaco-graphql-react-vite/vite.config.ts",
+    "functions/schema-demo.js",
+    "**/__test__/**/*.ts",
+    "**/__tests__/*.ts",
+    "**/*.spec.ts",
+    ".eslintrc.js",
+    "babel.config.js",
+    "jest.config.js"
+  ]
+}


### PR DESCRIPTION
added changeset for packages where source code (not tests) was modified

**UPDATE**:
locally lint command passes, but fails in ci with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` because `@typescript-eslint/require-await` rule requires types information to run, any idea how to fix ci?