### PR TITLE
removes stack trace from Jest output

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "start-graphiql": "yarn workspace graphiql dev",
     "start-monaco": "yarn workspace example-monaco-graphql-webpack start",
     "t": "yarn run testonly",
-    "test": "yarn jest",
+    "test": "yarn jest --noStackTrace",
     "test:coverage": "yarn jest --coverage",
     "test:watch": "yarn jest --watch",
     "testonly": "jest && yarn workspace codemirror-graphql run test",


### PR DESCRIPTION
The wall of text while running tests is a stack trace via Jest, which is unusable as a stack trace because it's all minified/transformed code. This PR adds the [--noStackTrace](https://jestjs.io/docs/cli#--nostacktrace) CLI option to remove the wall of text.