### PR TITLE
change severity of `no-console` rule to `error` to clean up eslint output

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
 
   rules: {
     // Possible Errors (http://eslint.org/docs/rules/#possible-errors)
-    'no-console': 1,
+    'no-console': 'error',
     'no-constant-binary-expression': 2,
     'no-empty': [1, { allowEmptyCatch: true }],
     'no-extra-parens': 0,
@@ -304,10 +304,9 @@ module.exports = {
     },
     {
       // Resources are typically our helper scripts; make life easier there
-      files: ['resources/*.js', '**/resources/*.js'],
+      files: ['resources/**', 'scripts/**'],
       rules: {
-        'no-console': 0,
-        'no-await-in-loop': 0,
+        'no-console': 'off',
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -317,5 +317,12 @@ module.exports = {
         'no-undef': 'off', // ts(2304)
       },
     },
+    {
+      // Disable rules for examples folder
+      files: ['examples/**'],
+      rules: {
+        'no-console': 'off',
+      },
+    }
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -304,7 +304,7 @@ module.exports = {
     },
     {
       // Resources are typically our helper scripts; make life easier there
-      files: ['resources/**', 'scripts/**'],
+      files: ['resources/**', '**/resources/**', 'scripts/**'],
       rules: {
         'no-console': 'off',
       },
@@ -323,6 +323,6 @@ module.exports = {
       rules: {
         'no-console': 'off',
       },
-    }
+    },
   ],
 };

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -61,7 +61,6 @@ async function render() {
 
     const schema = await schemaFetcher.loadSchema();
     if (schema) {
-      // eslint-disable-next-line no-console
       console.log('loaded schema', schema);
       monacoGraphQLAPI.setSchemaConfig([
         { ...schema, fileMatch: [operationUri, schemaModel.uri.toString()] },
@@ -321,7 +320,6 @@ export function renderGithubLoginButton() {
       { provider: 'github', scope: ['user'] },
       async (err: Error, data: { token: string }) => {
         if (err) {
-          // eslint-disable-next-line no-console
           console.error('Error authenticating with GitHub:', err);
         } else {
           schemaFetcher.setApiToken(data.token);

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -61,6 +61,7 @@ async function render() {
 
     const schema = await schemaFetcher.loadSchema();
     if (schema) {
+      // eslint-disable-next-line no-console
       console.log('loaded schema', schema);
       monacoGraphQLAPI.setSchemaConfig([
         { ...schema, fileMatch: [operationUri, schemaModel.uri.toString()] },
@@ -320,7 +321,8 @@ export function renderGithubLoginButton() {
       { provider: 'github', scope: ['user'] },
       async (err: Error, data: { token: string }) => {
         if (err) {
-          console.error('Error Authenticating with GitHub: ' + err);
+          // eslint-disable-next-line no-console
+          console.error('Error authenticating with GitHub:', err);
         } else {
           schemaFetcher.setApiToken(data.token);
           await render();

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -94,7 +94,8 @@ export const createWebsocketsFetcherFromUrl = (
         );
       }
     }
-    console.error(`Error creating websocket client for:\n${url}\n\n${err}`);
+    // eslint-disable-next-line no-console
+    console.error(`Error creating websocket client for ${url}`, err);
   }
 };
 

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -696,6 +696,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       const promises = chunk.map(fileInfo =>
         this.promiseToReadGraphQLFile(fileInfo.filePath)
           .catch(error => {
+            // eslint-disable-next-line no-console
             console.log('pro', error);
             /**
              * fs emits `EMFILE | ENFILE` error when there are too many

--- a/packages/graphql-language-service-server/src/Logger.ts
+++ b/packages/graphql-language-service-server/src/Logger.ts
@@ -74,7 +74,10 @@ export class Logger implements VSCodeLogger {
     // @TODO: enable with debugging
     if (severityKey !== SEVERITY.Hint) {
       this._getOutputStream(severity).write(logMessage, err => {
-        err && console.error(err);
+        if (err) {
+          // eslint-disable-next-line no-console
+          console.error(err);
+        }
       });
     }
   }

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -48,6 +48,7 @@ export class GraphQLWorker {
       );
       return graphqlDiagnostics.map(toMarkerData);
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error(err);
       return [];
     }
@@ -71,6 +72,7 @@ export class GraphQLWorker {
       );
       return suggestions.map(suggestion => toCompletion(suggestion));
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error(err);
       return [];
     }
@@ -104,6 +106,7 @@ export class GraphQLWorker {
         ),
       };
     } catch (err) {
+      // eslint-disable-next-line
       console.error(err);
       return null;
     }

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -167,6 +167,7 @@ export class LanguageService {
   public updateSchema(schema: SchemaConfig): void {
     const schemaIndex = this._schemas.findIndex(c => c.uri === schema.uri);
     if (schemaIndex < 0) {
+      // eslint-disable-next-line no-console
       console.warn(
         'updateSchema could not find a schema in your config by that URI',
         schema.uri,

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -250,7 +250,8 @@ export class CompletionAdapter
         suggestions: completionItems.map(toCompletion),
       };
     } catch (err) {
-      console.error(`Error fetching completion items\n\n${err}`);
+      // eslint-disable-next-line no-console
+      console.error('Error fetching completion items', err);
       return { suggestions: [] };
     }
   }

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -91,6 +91,7 @@ export class WorkerManager {
         });
         this._client = await this._worker.getProxy();
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.error('error loading worker', error);
       }
     }

--- a/packages/vscode-graphql-execution/src/extension.ts
+++ b/packages/vscode-graphql-execution/src/extension.ts
@@ -23,7 +23,6 @@ function getConfig() {
 }
 
 export function activate(context: ExtensionContext) {
-  console.log('activated!');
   const outputChannel: OutputChannel = window.createOutputChannel(
     'GraphQL Operation Execution',
   );
@@ -31,6 +30,7 @@ export function activate(context: ExtensionContext) {
   const { debug } = config;
 
   if (debug) {
+    // eslint-disable-next-line no-console
     console.log('Extension "vscode-graphql" is now active!');
   }
 
@@ -102,5 +102,6 @@ export function activate(context: ExtensionContext) {
 }
 
 export function deactivate() {
+  // eslint-disable-next-line no-console
   console.log('Extension "vscode-graphql-execution" is now de-active!');
 }

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -27,6 +27,7 @@ export async function activate(context: ExtensionContext) {
   const config = getConfig();
   const { debug } = config;
   if (debug) {
+    // eslint-disable-next-line no-console
     console.log('Extension "vscode-graphql" is now active!');
   }
 
@@ -127,9 +128,10 @@ export async function activate(context: ExtensionContext) {
 
 export function deactivate() {
   if (!client) {
-    return undefined;
+    return;
   }
-  console.log('Extension "vscode-graphql" will be de-activated!!');
+  // eslint-disable-next-line no-console
+  console.log('Extension "vscode-graphql" will be de-activated!');
   return client.stop();
 }
 

--- a/packages/vscode-graphql/src/server/index.ts
+++ b/packages/vscode-graphql/src/server/index.ts
@@ -7,13 +7,10 @@ import { startServer } from 'graphql-language-service-server';
 // watching the extension, so please restart the extension debugger for changes!
 
 const start = () => {
-  startServer({
-    method: 'node',
-  })
-    .then(() => {})
-    .catch(err => {
-      console.error(err);
-    });
+  startServer({ method: 'node' }).catch(err => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  });
 };
 
 start();


### PR DESCRIPTION
explicitly disable them with `eslint-disable-next-line`