### PR TITLE
Do not show dropdown for execute button if an operation is currently running

### DIFF
--- a/.changeset/poor-vans-kiss.md
+++ b/.changeset/poor-vans-kiss.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Fix stop execution button showing a dropdown

--- a/packages/graphiql-react/src/toolbar/execute.tsx
+++ b/packages/graphiql-react/src/toolbar/execute.tsx
@@ -26,7 +26,7 @@ export function ExecuteButton() {
     'aria-label': label,
   };
 
-  return hasOptions ? (
+  return hasOptions && !isFetching ? (
     <Menu>
       <Tooltip label={label}>
         <Menu.Button {...buttonProps} />


### PR DESCRIPTION
If you have multiple operations defined in the editor, clicking the execute button will show a dropdown to choose which operation to run.

If an operation is running, the stop button still shows the dropdown. Since only one operation can be running at any point in time, showing the dropdown is useless. This merge request makes sure that the dropdown is only shown, if no operation is currently running