### PR TITLE
Add user facing setting for persisting headers

### DIFF
--- a/.changeset/sweet-foxes-drive.md
+++ b/.changeset/sweet-foxes-drive.md
@@ -1,6 +1,6 @@
 ---
-'graphiql': patch
-'@graphiql/react': patch
+'graphiql': minor
+'@graphiql/react': minor
 ---
 
 Add user facing setting for persisting headers

--- a/.changeset/sweet-foxes-drive.md
+++ b/.changeset/sweet-foxes-drive.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Add user facing setting for persisting headers

--- a/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
+++ b/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
@@ -1,7 +1,10 @@
+import { StorageAPI } from '@graphiql/toolkit';
 import {
   createTab,
   fuzzyExtractOperationName,
   getDefaultTabState,
+  clearHeadersFromTabs,
+  STORAGE_KEY,
 } from '../tabs';
 
 describe('createTab', () => {
@@ -139,5 +142,31 @@ describe('getDefaultTabState', () => {
         }),
       ],
     });
+  });
+});
+
+describe('clearHeadersFromTabs', () => {
+  const createMockStorage = () => {
+    const mockStorage = new Map();
+    return mockStorage as unknown as StorageAPI;
+  };
+
+  it('preserves tab state except for headers', () => {
+    const storage = createMockStorage();
+    const stateWithoutHeaders = {
+      hash: 123,
+      response: {
+        a: 'test',
+      },
+    };
+    const stateWithHeaders = {
+      ...stateWithoutHeaders,
+      headers: `{ "authorization": "secret" }`,
+    };
+    storage.set(STORAGE_KEY, JSON.stringify(stateWithHeaders));
+
+    clearHeadersFromTabs(storage);
+
+    expect(JSON.parse(storage.get(STORAGE_KEY)!)).toEqual(stateWithoutHeaders);
   });
 });

--- a/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
+++ b/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
@@ -167,6 +167,9 @@ describe('clearHeadersFromTabs', () => {
 
     clearHeadersFromTabs(storage);
 
-    expect(JSON.parse(storage.get(STORAGE_KEY)!)).toEqual(stateWithoutHeaders);
+    expect(JSON.parse(storage.get(STORAGE_KEY)!)).toEqual({
+      ...stateWithoutHeaders,
+      headers: null,
+    });
   });
 });

--- a/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
+++ b/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
@@ -154,8 +154,9 @@ describe('clearHeadersFromTabs', () => {
   it('preserves tab state except for headers', () => {
     const storage = createMockStorage();
     const stateWithoutHeaders = {
-      hash: 123,
-      response: {
+      operationName: 'test',
+      query: 'query test {\n  test {\n    id\n  }\n}',
+      test: {
         a: 'test',
       },
     };

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -24,6 +24,7 @@ import {
   useSetEditorValues,
   useStoreTabs,
   useSynchronizeActiveTabValues,
+  clearHeadersFromTabs,
 } from './tabs';
 import { CodeMirrorEditor } from './types';
 import { STORAGE_KEY as STORAGE_KEY_VARIABLES } from './variable-editor';
@@ -270,7 +271,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
   const [persistHeadersInternal, setShouldPersistHeadersInternal] = useState(
     props.shouldPersistHeaders ??
-      storage?.get('shouldPersistHeaders') === 'true',
+      storage?.get(PERSIST_HEADERS_STORAGE_KEY) === 'true',
   );
   const userControlledShouldPersistHeaders =
     props.shouldPersistHeaders !== false;
@@ -279,11 +280,13 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     : (props.shouldPersistHeaders as boolean);
   const setShouldPersistHeaders = useCallback(
     (persist: boolean) => {
+      // clean up when setting to false
       if (!persist) {
         storage?.set(STORAGE_KEY_HEADERS, '');
+        clearHeadersFromTabs(storage);
       }
       setShouldPersistHeadersInternal(persist);
-      storage?.set('shouldPersistHeaders', persist.toString());
+      storage?.set(PERSIST_HEADERS_STORAGE_KEY, persist.toString());
     },
     [storage],
   );
@@ -519,6 +522,8 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 }
 
 export const useEditorContext = createContextHook(EditorContext);
+
+const PERSIST_HEADERS_STORAGE_KEY = 'shouldPersistHeaders';
 
 const DEFAULT_QUERY = `# Welcome to GraphiQL
 #

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -7,7 +7,14 @@ import {
   visit,
 } from 'graphql';
 import { VariableToType } from 'graphql-language-service';
-import { ReactNode, useCallback, useMemo, useState } from 'react';
+import {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { useStorageContext } from '../storage';
 import { createContextHook, createNullableContext } from '../utility/context';
@@ -335,6 +342,15 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     },
     [storage, tabState, headerEditor],
   );
+
+  const lastShouldPersistHeadersProp = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    const propValue = Boolean(props.shouldPersistHeaders);
+    if (lastShouldPersistHeadersProp.current !== propValue) {
+      setShouldPersistHeaders(propValue);
+      lastShouldPersistHeadersProp.current = propValue;
+    }
+  }, [props.shouldPersistHeaders, setShouldPersistHeaders]);
 
   const synchronizeActiveTabValues = useSynchronizeActiveTabValues({
     queryEditor,

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -273,7 +273,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       storage?.get('shouldPersistHeaders') === 'true',
   );
   const userControlledShouldPersistHeaders =
-    props.shouldPersistHeaders === undefined;
+    props.shouldPersistHeaders !== false;
   const shouldPersistHeaders = userControlledShouldPersistHeaders
     ? persistHeadersInternal
     : (props.shouldPersistHeaders as boolean);

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -146,10 +146,6 @@ export type EditorContextType = TabsState & {
    * Changes if headers should be persisted.
    */
   setShouldPersistHeaders(persist: boolean): void;
-  /**
-   * Indicates if the user can control `shouldPersistHeaders` value.
-   */
-  userControlledShouldPersistHeaders: boolean;
 };
 
 export const EditorContext =
@@ -271,15 +267,12 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     null,
   );
 
-  const userControlledShouldPersistHeaders =
-    props.shouldPersistHeaders !== false;
   const [shouldPersistHeaders, setShouldPersistHeadersInternal] = useState(
     () => {
-      const propValue = Boolean(props.shouldPersistHeaders);
       const isStored = storage?.get(PERSIST_HEADERS_STORAGE_KEY) !== null;
-      return userControlledShouldPersistHeaders && isStored
+      return props.shouldPersistHeaders !== false && isStored
         ? storage?.get(PERSIST_HEADERS_STORAGE_KEY) === 'true'
-        : propValue;
+        : Boolean(props.shouldPersistHeaders);
     },
   );
 
@@ -495,7 +488,6 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
       shouldPersistHeaders,
       setShouldPersistHeaders,
-      userControlledShouldPersistHeaders,
     }),
     [
       tabState,
@@ -518,7 +510,6 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
 
       shouldPersistHeaders,
       setShouldPersistHeaders,
-      userControlledShouldPersistHeaders,
     ],
   );
 

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -269,15 +269,17 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     null,
   );
 
-  const [persistHeadersInternal, setShouldPersistHeadersInternal] = useState(
-    props.shouldPersistHeaders ??
-      storage?.get(PERSIST_HEADERS_STORAGE_KEY) === 'true',
-  );
   const userControlledShouldPersistHeaders =
     props.shouldPersistHeaders !== false;
-  const shouldPersistHeaders = userControlledShouldPersistHeaders
-    ? persistHeadersInternal
-    : (props.shouldPersistHeaders as boolean);
+  const [shouldPersistHeaders, setShouldPersistHeadersInternal] = useState(
+    () => {
+      const propValue = Boolean(props.shouldPersistHeaders);
+      return userControlledShouldPersistHeaders
+        ? storage?.get(PERSIST_HEADERS_STORAGE_KEY) === 'true' || propValue
+        : propValue;
+    },
+  );
+
   const setShouldPersistHeaders = useCallback(
     (persist: boolean) => {
       // clean up when setting to false

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -346,7 +346,7 @@ export function clearHeadersFromTabs(storage: StorageAPI | null) {
     storage?.set(
       STORAGE_KEY,
       JSON.stringify(parsedTabs, (key, value) =>
-        key === 'headers' ? undefined : value,
+        key === 'headers' ? null : value,
       ),
     );
   }

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -339,6 +339,19 @@ export function fuzzyExtractOperationName(str: string): string | null {
   return match?.[2] ?? null;
 }
 
+export function clearHeadersFromTabs(storage: StorageAPI | null) {
+  const persistedTabs = storage?.get(STORAGE_KEY);
+  if (persistedTabs) {
+    const parsedTabs = JSON.parse(persistedTabs);
+    storage?.set(
+      STORAGE_KEY,
+      JSON.stringify(parsedTabs, (key, value) =>
+        key === 'headers' ? undefined : value,
+      ),
+    );
+  }
+}
+
 const DEFAULT_TITLE = '<untitled>';
 
-const STORAGE_KEY = 'tabState';
+export const STORAGE_KEY = 'tabState';

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -210,6 +210,19 @@ export function useSynchronizeActiveTabValues({
   );
 }
 
+export function serializeTabState(
+  tabState: TabsState,
+  shouldPersistHeaders = false,
+) {
+  return JSON.stringify(tabState, (key, value) =>
+    key === 'hash' ||
+    key === 'response' ||
+    (!shouldPersistHeaders && key === 'headers')
+      ? null
+      : value,
+  );
+}
+
 export function useStoreTabs({
   storage,
   shouldPersistHeaders,
@@ -226,15 +239,7 @@ export function useStoreTabs({
   );
   return useCallback(
     (currentState: TabsState) => {
-      store(
-        JSON.stringify(currentState, (key, value) =>
-          key === 'hash' ||
-          key === 'response' ||
-          (!shouldPersistHeaders && key === 'headers')
-            ? null
-            : value,
-        ),
-      );
+      store(serializeTabState(currentState, shouldPersistHeaders));
     },
     [shouldPersistHeaders, store],
   );

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -751,6 +751,44 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             }}
           />
         </div>
+        {editorContext.userControlledShouldPersistHeaders ? (
+          <div className="graphiql-dialog-section">
+            <div>
+              <div className="graphiql-dialog-section-title">
+                Persist headers
+              </div>
+              <div className="graphiql-dialog-section-caption">
+                Save headers upon reloading.
+              </div>
+            </div>
+            <ButtonGroup>
+              <Button
+                type="button"
+                id="enable-persist-headers"
+                className={
+                  editorContext.shouldPersistHeaders ? 'active' : undefined
+                }
+                onClick={() => {
+                  editorContext.setShouldPersistHeaders(true);
+                }}
+              >
+                On
+              </Button>
+              <Button
+                type="button"
+                id="disable-persist-headers"
+                className={
+                  !editorContext.shouldPersistHeaders ? 'active' : undefined
+                }
+                onClick={() => {
+                  editorContext.setShouldPersistHeaders(false);
+                }}
+              >
+                Off
+              </Button>
+            </ButtonGroup>
+          </div>
+        ) : null}
         <div className="graphiql-dialog-section">
           <div>
             <div className="graphiql-dialog-section-title">Theme</div>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -758,7 +758,10 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                 Persist headers
               </div>
               <div className="graphiql-dialog-section-caption">
-                Save headers upon reloading.
+                Save headers upon reloading.{' '}
+                <span className="graphiql-warning-text">
+                  Only enable if you trust this device.
+                </span>
               </div>
             </div>
             <ButtonGroup>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -158,7 +158,10 @@ export function GraphiQL({
       validationRules={validationRules}
       variables={variables}
     >
-      <GraphiQLInterface {...props} />
+      <GraphiQLInterface
+        showPersistHeadersSettings={shouldPersistHeaders !== false}
+        {...props}
+      />
     </GraphiQLProvider>
   );
 }
@@ -198,6 +201,11 @@ export type GraphiQLInterfaceProps = WriteableEditorProps &
      * editor.
      */
     toolbar?: GraphiQLToolbarConfig;
+    /**
+     * Indicates if settings for persisting headers should appear in the
+     * settings modal.
+     */
+    showPersistHeadersSettings?: boolean;
   };
 
 export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
@@ -751,7 +759,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             }}
           />
         </div>
-        {editorContext.userControlledShouldPersistHeaders ? (
+        {props.showPersistHeadersSettings ? (
           <div className="graphiql-dialog-section">
             <div>
               <div className="graphiql-dialog-section-title">

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -380,6 +380,43 @@ describe('GraphiQL', () => {
     });
   }); // panel resizing
 
+  it('allows the user to control persisting headers if it is not passed as a prop', async () => {
+    const { container, findByText } = render(
+      <GraphiQL fetcher={noOpFetcher} />,
+    );
+
+    act(() => {
+      fireEvent.click(
+        container.querySelector('[aria-label="Open settings dialog"]'),
+      );
+    });
+
+    const element = await findByText('Persist headers');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('does not allow the user to control persisting headers if it is passed as a prop', async () => {
+    const { container, findByText } = render(
+      <GraphiQL shouldPersistHeaders={false} fetcher={noOpFetcher} />,
+    );
+
+    act(() => {
+      fireEvent.click(
+        container.querySelector('[aria-label="Open settings dialog"]'),
+      );
+    });
+
+    const callback = async () => {
+      try {
+        await findByText('Persist headers');
+      } catch (e) {
+        // eslint-disable-next-line no-throw-literal
+        throw 'failed';
+      }
+    };
+    await expect(callback).rejects.toEqual('failed');
+  });
+
   describe('Tabs', () => {
     it('show tabs if there are more than one', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -380,14 +380,14 @@ describe('GraphiQL', () => {
     });
   }); // panel resizing
 
-  it('allows the user to control persisting headers if it is not passed as a prop', async () => {
+  it('allows the user to control persisting headers if it is true', async () => {
     const { container, findByText } = render(
-      <GraphiQL fetcher={noOpFetcher} />,
+      <GraphiQL shouldPersistHeaders fetcher={noOpFetcher} />,
     );
 
     act(() => {
       fireEvent.click(
-        container.querySelector('[aria-label="Open settings dialog"]'),
+        container.querySelector('[aria-label="Open settings dialog"]')!,
       );
     });
 
@@ -395,14 +395,29 @@ describe('GraphiQL', () => {
     expect(element).toBeInTheDocument();
   });
 
-  it('does not allow the user to control persisting headers if it is passed as a prop', async () => {
+  it('allows the user to control persisting headers if it is not passed in', async () => {
+    const { container, findByText } = render(
+      <GraphiQL fetcher={noOpFetcher} />,
+    );
+
+    act(() => {
+      fireEvent.click(
+        container.querySelector('[aria-label="Open settings dialog"]')!,
+      );
+    });
+
+    const element = await findByText('Persist headers');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('does not allow the user to control persisting headers is false', async () => {
     const { container, findByText } = render(
       <GraphiQL shouldPersistHeaders={false} fetcher={noOpFetcher} />,
     );
 
     act(() => {
       fireEvent.click(
-        container.querySelector('[aria-label="Open settings dialog"]'),
+        container.querySelector('[aria-label="Open settings dialog"]')!,
       );
     });
 

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -312,6 +312,11 @@ reach-portal .graphiql-dialog-section-caption {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
 }
 
+reach-portal .graphiql-warning-text {
+  color: hsl(var(--color-warning));
+  font-weight: var(--font-weight-medium);
+}
+
 reach-portal .graphiql-table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
Resolves https://github.com/graphql/graphiql/issues/2793

# Description

Adds a user control in the settings dialog for persisting headers. This is only visible if the `shouldPersistHeaders` is explicitly set as `false`.

Demo and brief explanation: https://www.loom.com/share/d72cf65025b04b1f9d6d5e518445bc25

<img width="716" alt="image" src="https://user-images.githubusercontent.com/11748696/202808224-b5410c29-6964-4664-88ac-e34a34b30f8d.png">


I also found 2 potential issues when working on this:
- https://github.com/graphql/graphiql/issues/2891 (Accessibility related, I think the ButtonGroup we use in the settings dialog doesn't have the correct accessibility behavior and attributes. I decided to keep it as a separate issue to keep this PR smaller, I'll work on that one once this one is completed)
- https://github.com/graphql/graphiql/issues/2892

**Note for the future:** I think it would be nice to somehow refactor this out into a user settings module, not the UI but the logic to store and access user settings. At the moment we have Theme and now Persist Headers, but there could be more user controlled settings going forward and having a central place for this logic (including defaults and such) could be nice.

### Questions
1. As headers are not persisted as a security measure, should we include a warning for the user in the dialog?
2. I added logic to cleanup the headers storage if this option is turned off, do we also need to do the same for tabs state?