### PR TITLE
Fix react testling library context errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@cypress/webpack-preprocessor": "^5.5.0",
     "@manypkg/get-packages": "^1.1.3",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.3.1",
-    "@testing-library/jest-dom": "^5.4.0",
+    "@testing-library/jest-dom": "5.16.5",
     "@types/aws-serverless-express": "^3.3.3",
     "@types/codemirror": "^0.0.90",
     "@types/express": "^4.17.11",

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -51,7 +51,7 @@
     "set-value": "^4.1.0"
   },
   "devDependencies": {
-    "@testing-library/react": "9.4.1",
+    "@testing-library/react": "12.1.5",
     "@types/codemirror": "^5.60.5",
     "@types/set-value": "^4.0.1",
     "@vitejs/plugin-react": "^1.3.0",

--- a/packages/graphiql-react/src/explorer/components/__tests__/field-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/field-documentation.spec.tsx
@@ -1,5 +1,4 @@
 import {
-  // @ts-expect-error
   fireEvent,
   render,
 } from '@testing-library/react';

--- a/packages/graphiql-react/src/explorer/components/__tests__/field-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/field-documentation.spec.tsx
@@ -1,7 +1,4 @@
-import {
-  fireEvent,
-  render,
-} from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { GraphQLString, GraphQLObjectType, Kind } from 'graphql';
 
 import { ExplorerContext, ExplorerFieldDef } from '../../context';

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
@@ -1,7 +1,4 @@
-import {
-  fireEvent,
-  render,
-} from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import {
   GraphQLBoolean,
   GraphQLEnumType,

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
@@ -1,5 +1,4 @@
 import {
-  // @ts-expect-error
   fireEvent,
   render,
 } from '@testing-library/react';
@@ -89,7 +88,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title.removeChild(title.childNodes[0]);
+    title?.removeChild(title?.childNodes[0]);
     expect(title).toHaveTextContent('Possible Types');
   });
 
@@ -100,7 +99,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title.removeChild(title.childNodes[0]);
+    title?.removeChild(title?.childNodes[0]);
     expect(title).toHaveTextContent('Enum Values');
     const enums = container.querySelectorAll(
       '.graphiql-doc-explorer-enum-value',
@@ -119,7 +118,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title.removeChild(title.childNodes[0]);
+    title?.removeChild(title?.childNodes[0]);
     expect(title).toHaveTextContent('Enum Values');
 
     let enums = container.querySelectorAll('.graphiql-doc-explorer-enum-value');

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-link.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-link.spec.tsx
@@ -1,5 +1,4 @@
 import {
-  // @ts-expect-error
   fireEvent,
   render,
 } from '@testing-library/react';

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-link.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-link.spec.tsx
@@ -1,7 +1,4 @@
-import {
-  fireEvent,
-  render,
-} from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { GraphQLNonNull, GraphQLList, GraphQLString } from 'graphql';
 import { ComponentProps } from 'react';
 

--- a/packages/graphiql-react/src/history/__tests__/components.spec.tsx
+++ b/packages/graphiql-react/src/history/__tests__/components.spec.tsx
@@ -1,5 +1,4 @@
 import {
-  // @ts-expect-error
   fireEvent,
   render,
 } from '@testing-library/react';

--- a/packages/graphiql-react/src/history/__tests__/components.spec.tsx
+++ b/packages/graphiql-react/src/history/__tests__/components.spec.tsx
@@ -1,7 +1,4 @@
-import {
-  fireEvent,
-  render,
-} from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { ComponentProps } from 'react';
 import { formatQuery, HistoryItem } from '../components';
 import { HistoryContextProvider } from '../context';

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -62,12 +62,12 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.4.0",
-    "@testing-library/react": "9.4.1",
+    "@testing-library/jest-dom": "5.16.5",
+    "@testing-library/react": "12.1.5",
     "@types/codemirror": "^5.60.5",
     "@types/markdown-it": "^12.2.3",
     "@types/node": "^14.14.22",
-    "@types/testing-library__jest-dom": "^5.0.1",
+    "@types/testing-library__jest-dom": "5.14.5",
     "babel-loader": "^8.1.0",
     "babel-plugin-macros": "^2.8.0",
     "cross-env": "^7.0.2",

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom';
 import { act, render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { GraphiQL } from '../GraphiQL';
-import { Fetcher } from '@graphiql/toolkit'
+import { Fetcher } from '@graphiql/toolkit';
 import { ToolbarButton } from '@graphiql/react';
 
 import {
@@ -39,7 +39,6 @@ const simpleIntrospection = {
   },
 };
 
-
 beforeEach(() => {
   window.localStorage.clear();
 });
@@ -60,7 +59,7 @@ describe('GraphiQL', () => {
     });
 
     it('should construct correctly with fetcher', async () => {
-      await act( async () => {
+      await act(async () => {
         expect(() => render(<GraphiQL fetcher={noOpFetcher} />)).not.toThrow();
       });
     });
@@ -85,26 +84,26 @@ describe('GraphiQL', () => {
 
       await waitFor(() => {
         expect(firstCalled).toEqual(true);
-      });  
+      });
 
       // Re-render does not call fetcher again
       firstCalled = false;
-      await act( async () => {
+      await act(async () => {
         rerender(<GraphiQL fetcher={firstFetcher} />);
       });
 
       await waitFor(() => {
         expect(firstCalled).toEqual(false);
-      });  
+      });
 
       // Re-render with new fetcher is called.
-      await act( async () => {
+      await act(async () => {
         rerender(<GraphiQL fetcher={secondFetcher} />);
-      });    
+      });
 
       await waitFor(() => {
         expect(secondCalled).toEqual(true);
-      });      
+      });
     });
 
     it('should refresh schema with new fetcher after a fetchError', async () => {
@@ -120,35 +119,43 @@ describe('GraphiQL', () => {
         <GraphiQL fetcher={firstFetcher} />,
       );
 
-      const showDocExplorerButton = getByLabelText('Show Documentation Explorer');
+      const showDocExplorerButton = getByLabelText(
+        'Show Documentation Explorer',
+      );
 
       await waitFor(() => {
         expect(showDocExplorerButton).not.toBe(null);
-      });  
+      });
 
       act(() => {
         fireEvent.click(showDocExplorerButton);
       });
 
       await waitFor(() => {
-        expect(container.querySelector('.graphiql-doc-explorer-error')).not.toBe(null);
-      });  
+        expect(
+          container.querySelector('.graphiql-doc-explorer-error'),
+        ).not.toBe(null);
+      });
 
       // Re-render with valid fetcher
-      await act( async () => {
+      await act(async () => {
         rerender(<GraphiQL fetcher={secondFetcher} />);
       });
 
       await waitFor(() => {
-        expect(container.querySelector('.graphiql-doc-explorer-error')).toBe(null);
-      });  
+        expect(container.querySelector('.graphiql-doc-explorer-error')).toBe(
+          null,
+        );
+      });
     });
   }); // fetcher
 
   describe('schema', () => {
     it('should not throw error if schema missing and query provided', async () => {
-      await act( async () => {
-        expect(() => render(<GraphiQL fetcher={noOpFetcher} query="{}" />)).not.toThrow();
+      await act(async () => {
+        expect(() =>
+          render(<GraphiQL fetcher={noOpFetcher} query="{}" />),
+        ).not.toThrow();
       });
     });
   }); // schema
@@ -156,14 +163,15 @@ describe('GraphiQL', () => {
   describe('default query', () => {
     it('defaults to the built-in default query', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-      
-      await waitFor(() => {
-        const mockEditor = container.querySelector('[data-testid="query-editor"] .mockCodeMirror') as HTMLTextAreaElement;
-        expect(mockEditor.value).toContain('# Welcome to GraphiQL');
-      });  
 
+      await waitFor(() => {
+        const mockEditor = container.querySelector(
+          '[data-testid="query-editor"] .mockCodeMirror',
+        ) as HTMLTextAreaElement;
+        expect(mockEditor.value).toContain('# Welcome to GraphiQL');
+      });
     });
-  
+
     it('accepts a custom default query', async () => {
       const { container } = render(
         <GraphiQL fetcher={noOpFetcher} defaultQuery="GraphQL Party!!" />,
@@ -171,10 +179,11 @@ describe('GraphiQL', () => {
 
       await waitFor(() => {
         expect(
-          container.querySelector('[data-testid="query-editor"] .mockCodeMirror'),
+          container.querySelector(
+            '[data-testid="query-editor"] .mockCodeMirror',
+          ),
         ).toHaveValue('GraphQL Party!!');
-      });  
-
+      });
     });
   }); // default query
 
@@ -182,46 +191,52 @@ describe('GraphiQL', () => {
   describe('plugins', () => {
     it('displays correct plugin when visiblePlugin prop is used', async () => {
       const { container } = render(
-        <GraphiQL fetcher={noOpFetcher} visiblePlugin="Documentation Explorer" />,
+        <GraphiQL
+          fetcher={noOpFetcher}
+          visiblePlugin="Documentation Explorer"
+        />,
       );
       await waitFor(() => {
-        expect(container.querySelector('.graphiql-doc-explorer')).toBeInTheDocument();
-      });  
+        expect(
+          container.querySelector('.graphiql-doc-explorer'),
+        ).toBeInTheDocument();
+      });
     });
-    
+
     it('defaults to not displaying plugin pane', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
       await waitFor(() => {
         expect(container.querySelector('.graphiql-plugin')).not.toBeVisible();
-      });        
+      });
     });
   }); // plugins
-  
+
   describe('editor tools', () => {
     it('can control the default editor tools visibility', async () => {
-      
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-      
-      const editorToolTabPanelWrap = container.querySelector('.graphiql-editor-tool');
+
+      const editorToolTabPanelWrap = container.querySelector(
+        '.graphiql-editor-tool',
+      );
 
       await waitFor(() => {
         expect(editorToolTabPanelWrap).not.toBeVisible();
-      });         
+      });
 
       const secondaryEditorTitle = container.querySelector(
         '.graphiql-editor-tools',
       ) as Element;
-      
+
       // drag the editor tools handle up
       act(() => {
         fireEvent.mouseDown(secondaryEditorTitle);
         fireEvent.mouseMove(secondaryEditorTitle, { buttons: 1, clientY: 50 });
       });
-      
+
       await waitFor(() => {
         expect(editorToolTabPanelWrap).toBeVisible();
-      });   
+      });
     });
 
     it('correctly displays variables editor when using defaultEditorToolsVisibility prop', async () => {
@@ -232,8 +247,10 @@ describe('GraphiQL', () => {
         />,
       );
       await waitFor(() => {
-        expect(container.querySelector('[aria-label="Variables"]')).toBeVisible();
-      });  
+        expect(
+          container.querySelector('[aria-label="Variables"]'),
+        ).toBeVisible();
+      });
     });
 
     it('correctly displays headers editor when using defaultEditorToolsVisibility prop', async () => {
@@ -245,7 +262,7 @@ describe('GraphiQL', () => {
       );
       await waitFor(() => {
         expect(container.querySelector('[aria-label="Headers"]')).toBeVisible();
-      });  
+      });
     });
 
     it('correctly hides editor tools when using defaultEditorToolsVisibility prop is false but either of the editors has a value', async () => {
@@ -257,18 +274,17 @@ describe('GraphiQL', () => {
         />,
       );
 
-      const editorToolTabPanelWrap = container.querySelector('.graphiql-editor-tool');
+      const editorToolTabPanelWrap = container.querySelector(
+        '.graphiql-editor-tool',
+      );
 
       await waitFor(() => {
         expect(editorToolTabPanelWrap).not.toBeVisible();
-      });  
+      });
     });
-
-  }); // editor tools 
-
+  }); // editor tools
 
   describe('panel resizing', () => {
-
     it('readjusts the query wrapper flex style field when the result panel is resized', async () => {
       // Mock the drag bar width
       const clientWidthSpy = jest
@@ -282,7 +298,9 @@ describe('GraphiQL', () => {
 
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
-      const dragBar = container.querySelector('.graphiql-horizontal-drag-bar') as Element;
+      const dragBar = container.querySelector(
+        '.graphiql-horizontal-drag-bar',
+      ) as Element;
       const editors = container.querySelector('.graphiql-editors') as Element;
 
       act(() => {
@@ -290,19 +308,21 @@ describe('GraphiQL', () => {
           button: 0,
           ctrlKey: false,
         });
-        
+
         fireEvent.mouseMove(dragBar, {
           buttons: 1,
           clientX: 700,
         });
-        
+
         fireEvent.mouseUp(dragBar);
       });
-        
+
       await waitFor(() => {
         // 700 / (900 - 700) = 3.5
-        expect((editors.parentElement as HTMLElement).style.flex).toEqual('3.5');
-      });  
+        expect((editors.parentElement as HTMLElement).style.flex).toEqual(
+          '3.5',
+        );
+      });
 
       clientWidthSpy.mockRestore();
       boundingClientRectSpy.mockRestore();
@@ -323,10 +343,12 @@ describe('GraphiQL', () => {
 
       act(() => {
         fireEvent.click(
-          container.querySelector('[aria-label="Show Documentation Explorer"]') as Element,
+          container.querySelector(
+            '[aria-label="Show Documentation Explorer"]',
+          ) as Element,
         );
       });
-      
+
       const dragBar = container.querySelectorAll(
         '.graphiql-horizontal-drag-bar',
       )[0];
@@ -335,7 +357,7 @@ describe('GraphiQL', () => {
         fireEvent.mouseDown(dragBar, {
           clientX: 3,
         });
-        
+
         fireEvent.mouseMove(dragBar, {
           buttons: 1,
           clientX: 800,
@@ -346,9 +368,12 @@ describe('GraphiQL', () => {
       await waitFor(() => {
         // 797 / (1200 - 797) = 1.977667493796526
         expect(
-          (container.querySelector('.graphiql-plugin')?.parentElement as HTMLElement).style.flex,
+          (
+            container.querySelector('.graphiql-plugin')
+              ?.parentElement as HTMLElement
+          ).style.flex,
         ).toBe('1.977667493796526');
-      }); 
+      });
 
       clientWidthSpy.mockRestore();
       boundingClientRectSpy.mockRestore();
@@ -363,27 +388,31 @@ describe('GraphiQL', () => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
         ).toHaveLength(0);
-      }); 
+      });
 
       act(() => {
-        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+        fireEvent.click(
+          container.querySelector('.graphiql-tab-add') as Element,
+        );
       });
 
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
         ).toHaveLength(2);
-      }); 
+      });
 
       act(() => {
-        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+        fireEvent.click(
+          container.querySelector('.graphiql-tab-add') as Element,
+        );
       });
-      
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
         ).toHaveLength(3);
-      });       
+      });
     });
 
     it('each tab has a close button when multiple tabs are open', async () => {
@@ -393,45 +422,53 @@ describe('GraphiQL', () => {
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(0);
-      }); 
+      });
 
       act(() => {
-        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+        fireEvent.click(
+          container.querySelector('.graphiql-tab-add') as Element,
+        );
       });
 
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(2);
-      });       
+      });
 
       act(() => {
-        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+        fireEvent.click(
+          container.querySelector('.graphiql-tab-add') as Element,
+        );
       });
 
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(3);
-      });         
+      });
     });
 
     it('close button removes a tab', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
       act(() => {
-        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+        fireEvent.click(
+          container.querySelector('.graphiql-tab-add') as Element,
+        );
       });
 
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(2);
-      });  
+      });
 
       act(() => {
         fireEvent.click(
-          container.querySelector('.graphiql-tab .graphiql-tab-close') as Element,
+          container.querySelector(
+            '.graphiql-tab .graphiql-tab-close',
+          ) as Element,
         );
       });
 
@@ -442,7 +479,7 @@ describe('GraphiQL', () => {
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(0);
-      });        
+      });
     });
 
     it('shows initial tabs', async () => {
@@ -464,7 +501,7 @@ describe('GraphiQL', () => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
         ).toHaveLength(2);
-      });        
+      });
     });
   });
 
@@ -472,7 +509,7 @@ describe('GraphiQL', () => {
     const MyFunctionalComponent = () => {
       return null;
     };
-  
+
     it('properly ignores fragments', async () => {
       const myFragment = (
         <React.Fragment>
@@ -480,53 +517,59 @@ describe('GraphiQL', () => {
           <MyFunctionalComponent />
         </React.Fragment>
       );
-  
+
       const { container, getByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>{myFragment}</GraphiQL>,
       );
-  
+
       await waitFor(() => {
-        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+        expect(
+          container.querySelector('.graphiql-container'),
+        ).toBeInTheDocument();
         expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
         expect(getByRole('toolbar')).toBeInTheDocument();
-      });  
+      });
     });
-  
+
     it('properly ignores non-override children components', async () => {
       const { container, getByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>
           <MyFunctionalComponent />
         </GraphiQL>,
       );
-  
-      await waitFor(() => {      
-        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(
+          container.querySelector('.graphiql-container'),
+        ).toBeInTheDocument();
         expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
         expect(getByRole('toolbar')).toBeInTheDocument();
-      });  
+      });
     });
-  
-    it('properly ignores non-override class components',async () => {
+
+    it('properly ignores non-override class components', async () => {
       // eslint-disable-next-line react/prefer-stateless-function
       class MyClassComponent extends React.Component {
         render() {
           return null;
         }
-      } 
-  
+      }
+
       const { container, getByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>
           <MyClassComponent />
         </GraphiQL>,
       );
-  
-      await waitFor(() => {      
-        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(
+          container.querySelector('.graphiql-container'),
+        ).toBeInTheDocument();
         expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
         expect(getByRole('toolbar')).toBeInTheDocument();
-      });  
+      });
     });
-  
+
     describe('GraphiQL.Logo', () => {
       it('can be overridden using the exported type', async () => {
         const { getByText } = render(
@@ -534,35 +577,35 @@ describe('GraphiQL', () => {
             <GraphiQL.Logo>My Exported Type Logo</GraphiQL.Logo>
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
+
+        await waitFor(() => {
           expect(getByText('My Exported Type Logo')).toBeInTheDocument();
-        });  
+        });
       });
-  
-      it('can be overridden using a named component', async() => {
+
+      it('can be overridden using a named component', async () => {
         const WrappedLogo = () => {
           return (
             <div className="test-wrapper">
               <GraphiQL.Logo>My Named Component Logo</GraphiQL.Logo>
             </div>
-          )
+          );
         };
         WrappedLogo.displayName = 'GraphiQLLogo';
-  
+
         const { container, getByText } = render(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedLogo />
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
+
+        await waitFor(() => {
           expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
           expect(getByText('My Named Component Logo')).toBeInTheDocument();
-        });  
+        });
       });
     });
-  
+
     describe('GraphiQL.Toolbar', () => {
       it('can be overridden using the exported type', async () => {
         const { container } = render(
@@ -572,38 +615,46 @@ describe('GraphiQL', () => {
             </GraphiQL.Toolbar>
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
-          expect(container.querySelectorAll('[role="toolbar"] .graphiql-toolbar-button')).toHaveLength(1);
-        });  
+
+        await waitFor(() => {
+          expect(
+            container.querySelectorAll(
+              '[role="toolbar"] .graphiql-toolbar-button',
+            ),
+          ).toHaveLength(1);
+        });
       });
-  
+
       it('can be overridden using a named component', async () => {
         const WrappedToolbar = () => {
           return (
             <div className="test-wrapper">
               <GraphiQL.Toolbar>
                 <ToolbarButton label="My Fun Label" />
-              </GraphiQL.Toolbar>,            
+              </GraphiQL.Toolbar>
+              ,
             </div>
-          )
+          );
         };
         WrappedToolbar.displayName = 'GraphiQLToolbar';
-  
-  
+
         const { container } = render(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedToolbar />
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
+
+        await waitFor(() => {
           expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
-          expect(container.querySelectorAll('[role="toolbar"] .graphiql-toolbar-button')).toHaveLength(1);
-        });  
+          expect(
+            container.querySelectorAll(
+              '[role="toolbar"] .graphiql-toolbar-button',
+            ),
+          ).toHaveLength(1);
+        });
       });
     });
-  
+
     describe('GraphiQL.Footer', () => {
       it('can be overridden using the exported type', async () => {
         const { container } = render(
@@ -613,53 +664,54 @@ describe('GraphiQL', () => {
             </GraphiQL.Footer>
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
+
+        await waitFor(() => {
           expect(
             container.querySelectorAll('.graphiql-footer button'),
-            ).toHaveLength(1);
-        }); 
+          ).toHaveLength(1);
+        });
       });
-  
+
       it('can be overridden using a named component', async () => {
         const WrappedFooter = () => {
           return (
             <div className="test-wrapper">
               <GraphiQL.Footer data-test-selector="override-footer">
                 <ToolbarButton label="My Fun Label" />
-              </GraphiQL.Footer>,        
+              </GraphiQL.Footer>
+              ,
             </div>
-          )
+          );
         };
-        WrappedFooter.displayName = 'GraphiQLFooter';      
-  
+        WrappedFooter.displayName = 'GraphiQLFooter';
+
         const { container } = render(
           <GraphiQL fetcher={noOpFetcher}>
             <WrappedFooter />
           </GraphiQL>,
         );
-  
-        await waitFor(() => {      
+
+        await waitFor(() => {
           expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
           expect(
             container.querySelectorAll('.graphiql-footer button'),
-            ).toHaveLength(1);
-        });  
+          ).toHaveLength(1);
+        });
       });
     });
-  });  
+  });
 
   describe('history', () => {
     it('defaults to closed history panel', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-  
+
       await waitFor(() => {
         expect(
           container.querySelector('.graphiql-history'),
         ).not.toBeInTheDocument();
-      });  
+      });
     });
-  
+
     it('will save history item even when history panel is closed', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL
@@ -670,20 +722,19 @@ describe('GraphiQL', () => {
           fetcher={noOpFetcher}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
         fireEvent.click(getByLabelText('Show History'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(1);
-      });  
-  
+      });
     });
-  
+
     it('adds a history item when the execute query function button is clicked', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL
@@ -694,36 +745,36 @@ describe('GraphiQL', () => {
           fetcher={noOpFetcher}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
         fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(1);
       });
     });
-  
+
     it('will not save invalid queries', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL query={mockBadQuery} fetcher={noOpFetcher} />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
         fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(0);
       });
     });
-  
+
     it('will save if there was not a previously saved query', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL
@@ -734,19 +785,19 @@ describe('GraphiQL', () => {
           headers={mockHeaders1}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
         fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(1);
       });
     });
-  
+
     it('will not save a query if the query is the same as previous query', async () => {
       const { getByLabelText, findByLabelText, container } = render(
         <GraphiQL
@@ -757,30 +808,29 @@ describe('GraphiQL', () => {
           headers={mockHeaders1}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
         fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(1);
       });
-        
+
       await act(async () => {
         fireEvent.click(await findByLabelText('Execute query (Ctrl-Enter)'));
       });
-  
+
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-history-items li'),
         ).toHaveLength(1);
       });
-  
     });
-  
+
     it('will save if new query is different than previous query', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL
@@ -791,42 +841,45 @@ describe('GraphiQL', () => {
           headers={mockHeaders1}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
       });
-  
+
       const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-  
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-  
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(1);
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(1);
       });
-  
+
       act(() => {
         fireEvent.change(
-          container.querySelector('[data-testid="query-editor"] .mockCodeMirror') as Element,
+          container.querySelector(
+            '[data-testid="query-editor"] .mockCodeMirror',
+          ) as Element,
           {
             target: { value: mockQuery2 },
           },
         );
       });
-  
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-  
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-          2,
-        );
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(2);
       });
-  
     });
-  
+
     it('will save query if variables are different', async () => {
       const { getByLabelText, container } = render(
         <GraphiQL
@@ -837,44 +890,45 @@ describe('GraphiQL', () => {
           headers={mockHeaders1}
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
       });
-  
+
       const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-      
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-  
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-          1,
-        );
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(1);
       });
-  
+
       act(() => {
         fireEvent.change(
-          container.querySelector('[aria-label="Variables"] .mockCodeMirror') as Element,
+          container.querySelector(
+            '[aria-label="Variables"] .mockCodeMirror',
+          ) as Element,
           {
             target: { value: mockVariables2 },
           },
         );
       });
-  
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-  
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-          2,
-        );
-      });      
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(2);
+      });
     });
-  
-  
+
     it('will save query if headers are different', async () => {
       const { getByLabelText, getByText, container } = render(
         <GraphiQL
@@ -886,47 +940,47 @@ describe('GraphiQL', () => {
           isHeadersEditorEnabled
         />,
       );
-  
+
       act(() => {
         fireEvent.click(getByLabelText('Show History'));
       });
-  
+
       const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-      
-        
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-      
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-          1,
-        );
-      });   
-  
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(1);
+      });
+
       act(() => {
         fireEvent.click(getByText('Headers'));
       });
-  
+
       act(() => {
         fireEvent.change(
-          container.querySelector('[aria-label="Headers"] .mockCodeMirror') as Element,
+          container.querySelector(
+            '[aria-label="Headers"] .mockCodeMirror',
+          ) as Element,
           {
             target: { value: mockHeaders2 },
           },
         );
       });
-  
+
       act(() => {
         fireEvent.click(executeQueryButton);
       });
-  
+
       await waitFor(() => {
-        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-          2,
-        );
-      });   
+        expect(
+          container.querySelectorAll('.graphiql-history-item'),
+        ).toHaveLength(2);
+      });
     });
-  
-  }); // history  
+  }); // history
 });

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -1,15 +1,16 @@
-// @ts-nocheck
-
 /**
  *  Copyright (c) 2021 GraphQL Contributors.
  *
  *  This source code is licensed under the MIT license found in the
  *  LICENSE file in the root directory of this source tree.
  */
-import { ToolbarButton } from '@graphiql/react';
-import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { act, render, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { GraphiQL, Fetcher } from '../GraphiQL';
+import { GraphiQL } from '../GraphiQL';
+import { Fetcher } from '@graphiql/toolkit'
+import { ToolbarButton } from '@graphiql/react';
+
 import {
   mockQuery1,
   mockVariables1,
@@ -38,659 +39,413 @@ const simpleIntrospection = {
   },
 };
 
-// Spins the promise loop a few times before continuing.
-const wait = () =>
-  Promise.resolve()
-    .then(() => Promise.resolve())
-    .then(() => Promise.resolve())
-    .then(() => Promise.resolve());
-
-const sleep = (delay = 600) => new Promise(res => setTimeout(res, delay));
 
 beforeEach(() => {
   window.localStorage.clear();
 });
 
 describe('GraphiQL', () => {
+  // @ts-expect-error fake Fetcher
   const noOpFetcher: Fetcher = () => {};
 
-  it('should throw error without fetcher', () => {
-    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => render(<GraphiQL />)).toThrowError(
-      'The `GraphiQL` component requires a `fetcher` function to be passed as prop.',
-    );
-    spy.mockRestore();
-  });
+  describe('fetcher', () => {
+    it('should throw error without fetcher', () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-  it('should construct correctly with fetcher', () => {
-    expect(() => render(<GraphiQL fetcher={noOpFetcher} />)).not.toThrow();
-  });
-
-  it('should refetch schema with new fetcher', async () => {
-    let firstCalled = false;
-
-    function firstFetcher() {
-      firstCalled = true;
-      return Promise.resolve(simpleIntrospection);
-    }
-
-    let secondCalled = false;
-
-    function secondFetcher() {
-      secondCalled = true;
-      return Promise.resolve(simpleIntrospection);
-    }
-
-    // Initial render calls fetcher
-    const { rerender } = render(<GraphiQL fetcher={firstFetcher} />);
-    expect(firstCalled).toEqual(true);
-
-    await wait();
-
-    // Re-render does not call fetcher again
-    firstCalled = false;
-    rerender(<GraphiQL fetcher={firstFetcher} />);
-    expect(firstCalled).toEqual(false);
-
-    await wait();
-
-    // Re-render with new fetcher is called.
-    rerender(<GraphiQL fetcher={secondFetcher} />);
-    expect(secondCalled).toEqual(true);
-  });
-
-  it('should refresh schema with new fetcher after a fetchError', async () => {
-    function firstFetcher() {
-      return Promise.reject('Schema Error');
-    }
-    function secondFetcher() {
-      return Promise.resolve(simpleIntrospection);
-    }
-
-    // Use a bad fetcher for our initial render
-    const { rerender, container, getByLabelText } = render(
-      <GraphiQL fetcher={firstFetcher} />,
-    );
-    await wait();
-
-    fireEvent.click(getByLabelText('Show Documentation Explorer'));
-
-    expect(
-      container.querySelector('.graphiql-doc-explorer-error'),
-    ).toBeTruthy();
-
-    // Re-render with valid fetcher
-    rerender(<GraphiQL fetcher={secondFetcher} />);
-    await wait();
-
-    expect(
-      container.querySelector('.graphiql-doc-explorer-error'),
-    ).not.toBeTruthy();
-  });
-
-  it('should not throw error if schema missing and query provided', () => {
-    expect(() =>
-      render(<GraphiQL fetcher={noOpFetcher} query="{}" />),
-    ).not.toThrow();
-  });
-
-  it('defaults to the built-in default query', async () => {
-    const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-    await wait();
-    expect(
-      container.querySelector('[data-testid="query-editor"] .mockCodeMirror')
-        .value,
-    ).toContain('# Welcome to GraphiQL');
-  });
-
-  it('accepts a custom default query', async () => {
-    const { container } = render(
-      <GraphiQL fetcher={noOpFetcher} defaultQuery="GraphQL Party!!" />,
-    );
-    await wait();
-    expect(
-      container.querySelector('[data-testid="query-editor"] .mockCodeMirror'),
-    ).toHaveValue('GraphQL Party!!');
-  });
-  it('accepts a docExplorerOpen prop', () => {
-    const { container } = render(
-      <GraphiQL fetcher={noOpFetcher} docExplorerOpen />,
-    );
-    expect(container.querySelector('.graphiql-plugin')).toBeInTheDocument();
-  });
-  it('defaults to closed docExplorer', () => {
-    const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-    expect(container.querySelector('.graphiql-plugin')).not.toBeVisible();
-  });
-
-  it('can control the default editor tools visibility', () => {
-    const { container: container1 } = render(
-      <GraphiQL fetcher={noOpFetcher} />,
-    );
-    const queryVariables = container1.querySelector('.graphiql-editor-tool');
-
-    expect(queryVariables).not.toBeVisible();
-
-    const secondaryEditorTitle = container1.querySelector(
-      '.graphiql-editor-tools',
-    );
-    fireEvent.mouseDown(secondaryEditorTitle);
-    fireEvent.mouseMove(secondaryEditorTitle, { buttons: 1, clientY: 50 });
-    expect(queryVariables).toBeVisible();
-
-    const { container: container2 } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        defaultEditorToolsVisibility="variables"
-      />,
-    );
-    expect(container2.querySelector('[aria-label="Variables"]')).toBeVisible();
-
-    const { container: container3 } = render(
-      <GraphiQL fetcher={noOpFetcher} defaultEditorToolsVisibility="headers" />,
-    );
-    expect(container3.querySelector('[aria-label="Headers"]')).toBeVisible();
-
-    const { container: container4 } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        variables="{test: 'value'}"
-        defaultEditorToolsVisibility={false}
-      />,
-    );
-    const queryVariables3 = container4.querySelector('.graphiql-editor-tool');
-    expect(queryVariables3).not.toBeVisible();
-  });
-
-  it('defaults to closed history panel', () => {
-    const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-    expect(
-      container.querySelector('.graphiql-history'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('will save history item even when history panel is closed', () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-        operationName={mockOperationName1}
-        fetcher={noOpFetcher}
-      />,
-    );
-    fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
-    fireEvent.click(getByLabelText('Show History'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(1);
-  });
-
-  it('adds a history item when the execute query function button is clicked', () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-        operationName={mockOperationName1}
-        fetcher={noOpFetcher}
-      />,
-    );
-    fireEvent.click(getByLabelText('Show History'));
-    fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(1);
-  });
-
-  it('will not save invalid queries', () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL query={mockBadQuery} fetcher={noOpFetcher} />,
-    );
-    fireEvent.click(getByLabelText('Show History'));
-    fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(0);
-  });
-
-  it('will save if there was not a previously saved query', () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        operationName={mockOperationName1}
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-      />,
-    );
-    fireEvent.click(getByLabelText('Show History'));
-    fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(1);
-  });
-
-  it('will not save a query if the query is the same as previous query', async () => {
-    const { getByLabelText, findByLabelText, container } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        operationName={mockOperationName1}
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-      />,
-    );
-    fireEvent.click(getByLabelText('Show History'));
-    fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(1);
-    fireEvent.click(await findByLabelText('Execute query (Ctrl-Enter)'));
-    expect(
-      container.querySelectorAll('.graphiql-history-items li'),
-    ).toHaveLength(1);
-  });
-
-  it('will save if new query is different than previous query', async () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        operationName={mockOperationName1}
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-      />,
-    );
-    await wait();
-    fireEvent.click(getByLabelText('Show History'));
-    const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      1,
-    );
-
-    fireEvent.change(
-      container.querySelector('[data-testid="query-editor"] .mockCodeMirror'),
-      {
-        target: { value: mockQuery2 },
-      },
-    );
-
-    // wait for onChange debounce
-    await sleep(150);
-
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      2,
-    );
-  });
-
-  it('will save query if variables are different', async () => {
-    const { getByLabelText, container } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        operationName={mockOperationName1}
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-      />,
-    );
-    await wait();
-    fireEvent.click(getByLabelText('Show History'));
-    const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      1,
-    );
-    await wait();
-
-    fireEvent.change(
-      container.querySelector('[aria-label="Variables"] .mockCodeMirror'),
-      {
-        target: { value: mockVariables2 },
-      },
-    );
-
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      2,
-    );
-  });
-
-  it('will save query if headers are different', async () => {
-    const { getByLabelText, getByText, container } = render(
-      <GraphiQL
-        fetcher={noOpFetcher}
-        operationName={mockOperationName1}
-        query={mockQuery1}
-        variables={mockVariables1}
-        headers={mockHeaders1}
-        headerEditorEnabled
-      />,
-    );
-    await wait();
-
-    fireEvent.click(getByLabelText('Show History'));
-    const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      1,
-    );
-    await wait();
-
-    fireEvent.click(getByText('Headers'));
-
-    fireEvent.change(
-      container.querySelector('[aria-label="Headers"] .mockCodeMirror'),
-      {
-        target: { value: mockHeaders2 },
-      },
-    );
-
-    fireEvent.click(executeQueryButton);
-    expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
-      2,
-    );
-  });
-
-  describe('children overrides', () => {
-    const MyFunctionalComponent = () => {
-      return null;
-    };
-    const wrap = component => () =>
-      <div className="test-wrapper">{component}</div>;
-
-    it('properly ignores fragments', () => {
-      const myFragment = (
-        <React.Fragment>
-          <MyFunctionalComponent />
-          <MyFunctionalComponent />
-        </React.Fragment>
+      // @ts-expect-error fetcher is a required prop to GraphiQL
+      expect(() => render(<GraphiQL />)).toThrowError(
+        'The `GraphiQL` component requires a `fetcher` function to be passed as prop.',
       );
-
-      const { container, getByRole } = render(
-        <GraphiQL fetcher={noOpFetcher}>{myFragment}</GraphiQL>,
-      );
-
-      expect(
-        container.querySelector('.graphiql-container'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-      expect(getByRole('toolbar')).toBeInTheDocument();
+      spy.mockRestore();
     });
 
-    it('properly ignores non-override children components', () => {
-      const { container, getByRole } = render(
-        <GraphiQL fetcher={noOpFetcher}>
-          <MyFunctionalComponent />
-        </GraphiQL>,
-      );
-
-      expect(
-        container.querySelector('.graphiql-container'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-      expect(getByRole('toolbar')).toBeInTheDocument();
+    it('should construct correctly with fetcher', async () => {
+      await act( async () => {
+        expect(() => render(<GraphiQL fetcher={noOpFetcher} />)).not.toThrow();
+      });
     });
 
-    it('properly ignores non-override class components', () => {
-      class MyClassComponent {
-        render() {
-          return null;
-        }
+    it('should refetch schema with new fetcher', async () => {
+      let firstCalled = false;
+
+      function firstFetcher() {
+        firstCalled = true;
+        return Promise.resolve(simpleIntrospection);
       }
 
-      const { container, getByRole } = render(
-        <GraphiQL fetcher={noOpFetcher}>
-          <MyClassComponent />
-        </GraphiQL>,
+      let secondCalled = false;
+
+      function secondFetcher() {
+        secondCalled = true;
+        return Promise.resolve(simpleIntrospection);
+      }
+
+      // Initial render calls fetcher
+      const { rerender } = render(<GraphiQL fetcher={firstFetcher} />);
+
+      await waitFor(() => {
+        expect(firstCalled).toEqual(true);
+      });  
+
+      // Re-render does not call fetcher again
+      firstCalled = false;
+      await act( async () => {
+        rerender(<GraphiQL fetcher={firstFetcher} />);
+      });
+
+      await waitFor(() => {
+        expect(firstCalled).toEqual(false);
+      });  
+
+      // Re-render with new fetcher is called.
+      await act( async () => {
+        rerender(<GraphiQL fetcher={secondFetcher} />);
+      });    
+
+      await waitFor(() => {
+        expect(secondCalled).toEqual(true);
+      });      
+    });
+
+    it('should refresh schema with new fetcher after a fetchError', async () => {
+      function firstFetcher() {
+        return Promise.reject('Schema Error');
+      }
+      function secondFetcher() {
+        return Promise.resolve(simpleIntrospection);
+      }
+
+      // Use a bad fetcher for our initial render
+      const { rerender, container, getByLabelText } = render(
+        <GraphiQL fetcher={firstFetcher} />,
       );
 
-      expect(
-        container.querySelector('.graphiql-container'),
-      ).toBeInTheDocument();
-      expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-      expect(getByRole('toolbar')).toBeInTheDocument();
+      const showDocExplorerButton = getByLabelText('Show Documentation Explorer');
+
+      await waitFor(() => {
+        expect(showDocExplorerButton).not.toBe(null);
+      });  
+
+      act(() => {
+        fireEvent.click(showDocExplorerButton);
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('.graphiql-doc-explorer-error')).not.toBe(null);
+      });  
+
+      // Re-render with valid fetcher
+      await act( async () => {
+        rerender(<GraphiQL fetcher={secondFetcher} />);
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector('.graphiql-doc-explorer-error')).toBe(null);
+      });  
     });
+  }); // fetcher
 
-    describe('GraphiQL.Logo', () => {
-      it('can be overridden using the exported type', () => {
-        const { container } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <GraphiQL.Logo>My Great Logo</GraphiQL.Logo>
-          </GraphiQL>,
-        );
+  describe('schema', () => {
+    it('should not throw error if schema missing and query provided', async () => {
+      await act( async () => {
+        expect(() => render(<GraphiQL fetcher={noOpFetcher} query="{}" />)).not.toThrow();
+      });
+    });
+  }); // schema
 
+  describe('default query', () => {
+    it('defaults to the built-in default query', async () => {
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+      
+      await waitFor(() => {
+        const mockEditor = container.querySelector('[data-testid="query-editor"] .mockCodeMirror') as HTMLTextAreaElement;
+        expect(mockEditor.value).toContain('# Welcome to GraphiQL');
+      });  
+
+    });
+  
+    it('accepts a custom default query', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} defaultQuery="GraphQL Party!!" />,
+      );
+
+      await waitFor(() => {
         expect(
-          container.querySelector('.graphiql-container'),
-        ).toBeInTheDocument();
+          container.querySelector('[data-testid="query-editor"] .mockCodeMirror'),
+        ).toHaveValue('GraphQL Party!!');
+      });  
+
+    });
+  }); // default query
+
+  // TODO: rewrite these plugin tests after plugin API has more structure
+  describe('plugins', () => {
+    it('displays correct plugin when visiblePlugin prop is used', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} visiblePlugin="Documentation Explorer" />,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('.graphiql-doc-explorer')).toBeInTheDocument();
+      });  
+    });
+    
+    it('defaults to not displaying plugin pane', async () => {
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('.graphiql-plugin')).not.toBeVisible();
+      });        
+    });
+  }); // plugins
+  
+  describe('editor tools', () => {
+    it('can control the default editor tools visibility', async () => {
+      
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+      
+      const editorToolTabPanelWrap = container.querySelector('.graphiql-editor-tool');
+
+      await waitFor(() => {
+        expect(editorToolTabPanelWrap).not.toBeVisible();
+      });         
+
+      const secondaryEditorTitle = container.querySelector(
+        '.graphiql-editor-tools',
+      ) as Element;
+      
+      // drag the editor tools handle up
+      act(() => {
+        fireEvent.mouseDown(secondaryEditorTitle);
+        fireEvent.mouseMove(secondaryEditorTitle, { buttons: 1, clientY: 50 });
       });
-
-      it('can be overridden using a named component', () => {
-        const WrappedLogo = wrap(<GraphiQL.Logo>My Great Logo</GraphiQL.Logo>);
-        WrappedLogo.displayName = 'GraphiQLLogo';
-
-        const { getByText } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <WrappedLogo />
-          </GraphiQL>,
-        );
-
-        expect(getByText('My Great Logo')).toBeInTheDocument();
-      });
+      
+      await waitFor(() => {
+        expect(editorToolTabPanelWrap).toBeVisible();
+      });   
     });
 
-    describe('GraphiQL.Toolbar', () => {
-      it('can be overridden using the exported type', () => {
-        const { container } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <GraphiQL.Toolbar>
-              <ToolbarButton />
-            </GraphiQL.Toolbar>
-          </GraphiQL>,
-        );
+    it('correctly displays variables editor when using defaultEditorToolsVisibility prop', async () => {
+      const { container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          defaultEditorToolsVisibility="variables"
+        />,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('[aria-label="Variables"]')).toBeVisible();
+      });  
+    });
 
+    it('correctly displays headers editor when using defaultEditorToolsVisibility prop', async () => {
+      const { container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          defaultEditorToolsVisibility="headers"
+        />,
+      );
+      await waitFor(() => {
+        expect(container.querySelector('[aria-label="Headers"]')).toBeVisible();
+      });  
+    });
+
+    it('correctly hides editor tools when using defaultEditorToolsVisibility prop is false but either of the editors has a value', async () => {
+      const { container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          variables="{test: 'value'}"
+          defaultEditorToolsVisibility={false}
+        />,
+      );
+
+      const editorToolTabPanelWrap = container.querySelector('.graphiql-editor-tool');
+
+      await waitFor(() => {
+        expect(editorToolTabPanelWrap).not.toBeVisible();
+      });  
+    });
+
+  }); // editor tools 
+
+
+  describe('panel resizing', () => {
+
+    it('readjusts the query wrapper flex style field when the result panel is resized', async () => {
+      // Mock the drag bar width
+      const clientWidthSpy = jest
+        .spyOn(Element.prototype, 'clientWidth', 'get')
+        .mockReturnValue(0);
+      // Mock the container width
+      const boundingClientRectSpy = jest
+        .spyOn(Element.prototype, 'getBoundingClientRect')
+        // @ts-expect-error missing properties from type 'DOMRect'
+        .mockReturnValue({ left: 0, right: 900 });
+
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+
+      const dragBar = container.querySelector('.graphiql-horizontal-drag-bar') as Element;
+      const editors = container.querySelector('.graphiql-editors') as Element;
+
+      act(() => {
+        fireEvent.mouseDown(dragBar, {
+          button: 0,
+          ctrlKey: false,
+        });
+        
+        fireEvent.mouseMove(dragBar, {
+          buttons: 1,
+          clientX: 700,
+        });
+        
+        fireEvent.mouseUp(dragBar);
+      });
+        
+      await waitFor(() => {
+        // 700 / (900 - 700) = 3.5
+        expect((editors.parentElement as HTMLElement).style.flex).toEqual('3.5');
+      });  
+
+      clientWidthSpy.mockRestore();
+      boundingClientRectSpy.mockRestore();
+    });
+
+    it('allows for resizing the doc explorer correctly', async () => {
+      // Mock the drag bar width
+      const clientWidthSpy = jest
+        .spyOn(Element.prototype, 'clientWidth', 'get')
+        .mockReturnValue(0);
+      // Mock the container width
+      const boundingClientRectSpy = jest
+        .spyOn(Element.prototype, 'getBoundingClientRect')
+        // @ts-expect-error missing properties from type 'DOMRect'
+        .mockReturnValue({ left: 0, right: 1200 });
+
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+
+      act(() => {
+        fireEvent.click(
+          container.querySelector('[aria-label="Show Documentation Explorer"]') as Element,
+        );
+      });
+      
+      const dragBar = container.querySelectorAll(
+        '.graphiql-horizontal-drag-bar',
+      )[0];
+
+      act(() => {
+        fireEvent.mouseDown(dragBar, {
+          clientX: 3,
+        });
+        
+        fireEvent.mouseMove(dragBar, {
+          buttons: 1,
+          clientX: 800,
+        });
+        fireEvent.mouseUp(dragBar);
+      });
+
+      await waitFor(() => {
+        // 797 / (1200 - 797) = 1.977667493796526
         expect(
-          container.querySelectorAll(
-            '[role="toolbar"] .graphiql-toolbar-button',
-          ),
-        ).toHaveLength(1);
-      });
+          (container.querySelector('.graphiql-plugin')?.parentElement as HTMLElement).style.flex,
+        ).toBe('1.977667493796526');
+      }); 
 
-      it('can be overridden using a named component', () => {
-        const WrappedToolbar = wrap(
-          <GraphiQL.Toolbar>
-            <ToolbarButton />
-          </GraphiQL.Toolbar>,
-        );
-        WrappedToolbar.displayName = 'GraphiQLToolbar';
-
-        const { container } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <WrappedToolbar />
-          </GraphiQL>,
-        );
-
-        expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
-        expect(
-          container.querySelectorAll(
-            '[role="toolbar"] .graphiql-toolbar-button',
-          ),
-        ).toHaveLength(1);
-      });
+      clientWidthSpy.mockRestore();
+      boundingClientRectSpy.mockRestore();
     });
-
-    describe('GraphiQL.Footer', () => {
-      it('can be overridden using the exported type', () => {
-        const { container } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <GraphiQL.Footer>
-              <ToolbarButton />
-            </GraphiQL.Footer>
-          </GraphiQL>,
-        );
-
-        expect(
-          container.querySelectorAll('.graphiql-footer button'),
-        ).toHaveLength(1);
-      });
-
-      it('can be overridden using a named component', () => {
-        const WrappedFooter = wrap(
-          <GraphiQL.Footer data-test-selector="override-footer">
-            <ToolbarButton />
-          </GraphiQL.Footer>,
-        );
-        WrappedFooter.displayName = 'GraphiQLFooter';
-
-        const { container } = render(
-          <GraphiQL fetcher={noOpFetcher}>
-            <WrappedFooter />
-          </GraphiQL>,
-        );
-
-        expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
-        expect(
-          container.querySelectorAll('.graphiql-footer button'),
-        ).toHaveLength(1);
-      });
-    });
-  });
-
-  it('readjusts the query wrapper flex style field when the result panel is resized', async () => {
-    // Mock the drag bar width
-    const clientWidthSpy = jest
-      .spyOn(Element.prototype, 'clientWidth', 'get')
-      .mockReturnValue(0);
-    // Mock the container width
-    const boundingClientRectSpy = jest
-      .spyOn(Element.prototype, 'getBoundingClientRect')
-      .mockReturnValue({ left: 0, right: 900 });
-
-    const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-
-    await wait();
-
-    const dragBar = container.querySelector('.graphiql-horizontal-drag-bar');
-    const editors = container.querySelector('.graphiql-editors');
-
-    fireEvent.mouseDown(dragBar, {
-      button: 0,
-      ctrlKey: false,
-    });
-
-    fireEvent.mouseMove(dragBar, {
-      buttons: 1,
-      clientX: 700,
-    });
-
-    fireEvent.mouseUp(dragBar);
-
-    // 700 / (900 - 700) = 3.5
-    expect(editors.parentElement.style.flex).toEqual('3.5');
-
-    clientWidthSpy.mockRestore();
-    boundingClientRectSpy.mockRestore();
-  });
-
-  it('allows for resizing the doc explorer correctly', () => {
-    // Mock the drag bar width
-    const clientWidthSpy = jest
-      .spyOn(Element.prototype, 'clientWidth', 'get')
-      .mockReturnValue(0);
-    // Mock the container width
-    const boundingClientRectSpy = jest
-      .spyOn(Element.prototype, 'getBoundingClientRect')
-      .mockReturnValue({ left: 0, right: 1200 });
-
-    const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
-
-    fireEvent.click(
-      container.querySelector('[aria-label="Show Documentation Explorer"]'),
-    );
-    const dragBar = container.querySelectorAll(
-      '.graphiql-horizontal-drag-bar',
-    )[0];
-
-    fireEvent.mouseDown(dragBar, {
-      clientX: 3,
-    });
-
-    fireEvent.mouseMove(dragBar, {
-      buttons: 1,
-      clientX: 800,
-    });
-
-    fireEvent.mouseUp(dragBar);
-
-    // 797 / (1200 - 797) = 1.977667493796526
-    expect(
-      container.querySelector('.graphiql-plugin').parentElement.style.flex,
-    ).toBe('1.977667493796526');
-
-    clientWidthSpy.mockRestore();
-    boundingClientRectSpy.mockRestore();
-  });
+  }); // panel resizing
 
   describe('Tabs', () => {
-    it('show tabs if there are more than one', () => {
+    it('show tabs if there are more than one', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
-      expect(
-        container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-      ).toHaveLength(0);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
+        ).toHaveLength(0);
+      }); 
 
-      fireEvent.click(container.querySelector('.graphiql-tab-add'));
-      expect(
-        container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-      ).toHaveLength(2);
+      act(() => {
+        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+      });
 
-      fireEvent.click(container.querySelector('.graphiql-tab-add'));
-      expect(
-        container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-      ).toHaveLength(3);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
+        ).toHaveLength(2);
+      }); 
+
+      act(() => {
+        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+      });
+      
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
+        ).toHaveLength(3);
+      });       
     });
 
-    it('each tab has a close button when multiple tabs are open', () => {
+    it('each tab has a close button when multiple tabs are open', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
-      expect(
-        container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
-      ).toHaveLength(0);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
+        ).toHaveLength(0);
+      }); 
 
-      fireEvent.click(container.querySelector('.graphiql-tab-add'));
-      expect(
-        container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
-      ).toHaveLength(2);
+      act(() => {
+        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+      });
 
-      fireEvent.click(container.querySelector('.graphiql-tab-add'));
-      expect(
-        container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
-      ).toHaveLength(3);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
+        ).toHaveLength(2);
+      });       
+
+      act(() => {
+        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+      });
+
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
+        ).toHaveLength(3);
+      });         
     });
 
-    it('close button removes a tab', () => {
+    it('close button removes a tab', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
-      fireEvent.click(container.querySelector('.graphiql-tab-add'));
+      act(() => {
+        fireEvent.click(container.querySelector('.graphiql-tab-add') as Element);
+      });
 
-      expect(
-        container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
-      ).toHaveLength(2);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
+        ).toHaveLength(2);
+      });  
 
-      fireEvent.click(
-        container.querySelector('.graphiql-tab .graphiql-tab-close'),
-      );
-      expect(
-        container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-      ).toHaveLength(0);
-      expect(
-        container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
-      ).toHaveLength(0);
+      act(() => {
+        fireEvent.click(
+          container.querySelector('.graphiql-tab .graphiql-tab-close') as Element,
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
+        ).toHaveLength(0);
+        expect(
+          container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
+        ).toHaveLength(0);
+      });        
     });
 
-    it('shows initial tabs', () => {
+    it('shows initial tabs', async () => {
       const { container } = render(
         <GraphiQL
           fetcher={noOpFetcher}
@@ -705,9 +460,473 @@ describe('GraphiQL', () => {
         />,
       );
 
-      expect(
-        container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-      ).toHaveLength(2);
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
+        ).toHaveLength(2);
+      });        
     });
   });
+
+  describe('children overrides', () => {
+    const MyFunctionalComponent = () => {
+      return null;
+    };
+  
+    it('properly ignores fragments', async () => {
+      const myFragment = (
+        <React.Fragment>
+          <MyFunctionalComponent />
+          <MyFunctionalComponent />
+        </React.Fragment>
+      );
+  
+      const { container, getByRole } = render(
+        <GraphiQL fetcher={noOpFetcher}>{myFragment}</GraphiQL>,
+      );
+  
+      await waitFor(() => {
+        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
+        expect(getByRole('toolbar')).toBeInTheDocument();
+      });  
+    });
+  
+    it('properly ignores non-override children components', async () => {
+      const { container, getByRole } = render(
+        <GraphiQL fetcher={noOpFetcher}>
+          <MyFunctionalComponent />
+        </GraphiQL>,
+      );
+  
+      await waitFor(() => {      
+        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
+        expect(getByRole('toolbar')).toBeInTheDocument();
+      });  
+    });
+  
+    it('properly ignores non-override class components',async () => {
+      // eslint-disable-next-line react/prefer-stateless-function
+      class MyClassComponent extends React.Component {
+        render() {
+          return null;
+        }
+      } 
+  
+      const { container, getByRole } = render(
+        <GraphiQL fetcher={noOpFetcher}>
+          <MyClassComponent />
+        </GraphiQL>,
+      );
+  
+      await waitFor(() => {      
+        expect(container.querySelector('.graphiql-container')).toBeInTheDocument();
+        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
+        expect(getByRole('toolbar')).toBeInTheDocument();
+      });  
+    });
+  
+    describe('GraphiQL.Logo', () => {
+      it('can be overridden using the exported type', async () => {
+        const { getByText } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <GraphiQL.Logo>My Exported Type Logo</GraphiQL.Logo>
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(getByText('My Exported Type Logo')).toBeInTheDocument();
+        });  
+      });
+  
+      it('can be overridden using a named component', async() => {
+        const WrappedLogo = () => {
+          return (
+            <div className="test-wrapper">
+              <GraphiQL.Logo>My Named Component Logo</GraphiQL.Logo>
+            </div>
+          )
+        };
+        WrappedLogo.displayName = 'GraphiQLLogo';
+  
+        const { container, getByText } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedLogo />
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
+          expect(getByText('My Named Component Logo')).toBeInTheDocument();
+        });  
+      });
+    });
+  
+    describe('GraphiQL.Toolbar', () => {
+      it('can be overridden using the exported type', async () => {
+        const { container } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <GraphiQL.Toolbar>
+              <ToolbarButton label="My Fun Label" />
+            </GraphiQL.Toolbar>
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(container.querySelectorAll('[role="toolbar"] .graphiql-toolbar-button')).toHaveLength(1);
+        });  
+      });
+  
+      it('can be overridden using a named component', async () => {
+        const WrappedToolbar = () => {
+          return (
+            <div className="test-wrapper">
+              <GraphiQL.Toolbar>
+                <ToolbarButton label="My Fun Label" />
+              </GraphiQL.Toolbar>,            
+            </div>
+          )
+        };
+        WrappedToolbar.displayName = 'GraphiQLToolbar';
+  
+  
+        const { container } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedToolbar />
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
+          expect(container.querySelectorAll('[role="toolbar"] .graphiql-toolbar-button')).toHaveLength(1);
+        });  
+      });
+    });
+  
+    describe('GraphiQL.Footer', () => {
+      it('can be overridden using the exported type', async () => {
+        const { container } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <GraphiQL.Footer>
+              <ToolbarButton label="My Fun Label" />
+            </GraphiQL.Footer>
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(
+            container.querySelectorAll('.graphiql-footer button'),
+            ).toHaveLength(1);
+        }); 
+      });
+  
+      it('can be overridden using a named component', async () => {
+        const WrappedFooter = () => {
+          return (
+            <div className="test-wrapper">
+              <GraphiQL.Footer data-test-selector="override-footer">
+                <ToolbarButton label="My Fun Label" />
+              </GraphiQL.Footer>,        
+            </div>
+          )
+        };
+        WrappedFooter.displayName = 'GraphiQLFooter';      
+  
+        const { container } = render(
+          <GraphiQL fetcher={noOpFetcher}>
+            <WrappedFooter />
+          </GraphiQL>,
+        );
+  
+        await waitFor(() => {      
+          expect(container.querySelector('.test-wrapper')).toBeInTheDocument();
+          expect(
+            container.querySelectorAll('.graphiql-footer button'),
+            ).toHaveLength(1);
+        });  
+      });
+    });
+  });  
+
+  describe('history', () => {
+    it('defaults to closed history panel', async () => {
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+  
+      await waitFor(() => {
+        expect(
+          container.querySelector('.graphiql-history'),
+        ).not.toBeInTheDocument();
+      });  
+    });
+  
+    it('will save history item even when history panel is closed', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+          operationName={mockOperationName1}
+          fetcher={noOpFetcher}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
+        fireEvent.click(getByLabelText('Show History'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(1);
+      });  
+  
+    });
+  
+    it('adds a history item when the execute query function button is clicked', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+          operationName={mockOperationName1}
+          fetcher={noOpFetcher}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+        fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(1);
+      });
+    });
+  
+    it('will not save invalid queries', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL query={mockBadQuery} fetcher={noOpFetcher} />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+        fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(0);
+      });
+    });
+  
+    it('will save if there was not a previously saved query', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          operationName={mockOperationName1}
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+        fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(1);
+      });
+    });
+  
+    it('will not save a query if the query is the same as previous query', async () => {
+      const { getByLabelText, findByLabelText, container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          operationName={mockOperationName1}
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+        fireEvent.click(getByLabelText('Execute query (Ctrl-Enter)'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(1);
+      });
+        
+      await act(async () => {
+        fireEvent.click(await findByLabelText('Execute query (Ctrl-Enter)'));
+      });
+  
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('.graphiql-history-items li'),
+        ).toHaveLength(1);
+      });
+  
+    });
+  
+    it('will save if new query is different than previous query', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          operationName={mockOperationName1}
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+      });
+  
+      const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
+  
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+  
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(1);
+      });
+  
+      act(() => {
+        fireEvent.change(
+          container.querySelector('[data-testid="query-editor"] .mockCodeMirror') as Element,
+          {
+            target: { value: mockQuery2 },
+          },
+        );
+      });
+  
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+  
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
+          2,
+        );
+      });
+  
+    });
+  
+    it('will save query if variables are different', async () => {
+      const { getByLabelText, container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          operationName={mockOperationName1}
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+      });
+  
+      const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
+      
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+  
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
+          1,
+        );
+      });
+  
+      act(() => {
+        fireEvent.change(
+          container.querySelector('[aria-label="Variables"] .mockCodeMirror') as Element,
+          {
+            target: { value: mockVariables2 },
+          },
+        );
+      });
+  
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+  
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
+          2,
+        );
+      });      
+    });
+  
+  
+    it('will save query if headers are different', async () => {
+      const { getByLabelText, getByText, container } = render(
+        <GraphiQL
+          fetcher={noOpFetcher}
+          operationName={mockOperationName1}
+          query={mockQuery1}
+          variables={mockVariables1}
+          headers={mockHeaders1}
+          isHeadersEditorEnabled
+        />,
+      );
+  
+      act(() => {
+        fireEvent.click(getByLabelText('Show History'));
+      });
+  
+      const executeQueryButton = getByLabelText('Execute query (Ctrl-Enter)');
+      
+        
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+      
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
+          1,
+        );
+      });   
+  
+      act(() => {
+        fireEvent.click(getByText('Headers'));
+      });
+  
+      act(() => {
+        fireEvent.change(
+          container.querySelector('[aria-label="Headers"] .mockCodeMirror') as Element,
+          {
+            target: { value: mockHeaders2 },
+          },
+        );
+      });
+  
+      act(() => {
+        fireEvent.click(executeQueryButton);
+      });
+  
+      await waitFor(() => {
+        expect(container.querySelectorAll('.graphiql-history-item')).toHaveLength(
+          2,
+        );
+      });   
+    });
+  
+  }); // history  
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.0.1.tgz#b38b444ad3aa5fedbb15f2f746dcd934226a12dd"
+  integrity sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==
+
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
@@ -2832,25 +2837,10 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@^7.10.2":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
-  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.8.3":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2860,6 +2850,13 @@
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
   dependencies:
     regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.5":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
+  integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
+  dependencies:
+    regenerator-runtime "^0.13.10"
 
 "@babel/runtime@^7.7.2":
   version "7.9.2"
@@ -4088,27 +4085,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
-    "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
-
-"@jest/types@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
-  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
 "@jest/types@^26.6.2":
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
@@ -5196,11 +5172,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sheerun/mutationobserver-shim@^0.3.2":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz#5405ee8e444ed212db44e79351f0c70a582aae25"
-  integrity sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==
-
 "@sideway/address@^4.1.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d"
@@ -5347,54 +5318,43 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@*":
-  version "7.24.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.24.1.tgz#0e8acd042070f2c1b183fbfe5c0d38b3194ad3c0"
-  integrity sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==
+"@testing-library/dom@^8.0.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
+  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.10.3"
+    "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.1"
-    pretty-format "^26.4.2"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
 
-"@testing-library/dom@^6.11.0":
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.16.0.tgz#04ada27ed74ad4c0f0d984a1245bb29b1fd90ba9"
-  integrity sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==
+"@testing-library/jest-dom@5.16.5":
+  version "5.16.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
+  integrity sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==
   dependencies:
-    "@babel/runtime" "^7.8.4"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    "@types/testing-library__dom" "^6.12.1"
-    aria-query "^4.0.2"
-    dom-accessibility-api "^0.3.0"
-    pretty-format "^25.1.0"
-    wait-for-expect "^3.0.2"
-
-"@testing-library/jest-dom@^5.4.0":
-  version "5.11.10"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz#1cd90715023e1627f5ed26ab3b38e6f22d77046c"
-  integrity sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==
-  dependencies:
+    "@adobe/css-tools" "^4.0.1"
     "@babel/runtime" "^7.9.2"
     "@types/testing-library__jest-dom" "^5.9.1"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^3.0.0"
-    css "^3.0.0"
     css.escape "^1.5.1"
+    dom-accessibility-api "^0.5.6"
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@9.4.1":
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.4.1.tgz#955771568aa3216107d307bfdf470bf2394308a0"
-  integrity sha512-sta3ui24HPgW92quHyQj6gpOkNgLNx8BX/QOU4k1bddo43ZdqlGwmzCYwL93bExfhergwiau+IzBGl7TCsSFeA==
+"@testing-library/react@12.1.5":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   dependencies:
-    "@babel/runtime" "^7.8.3"
-    "@testing-library/dom" "^6.11.0"
-    "@types/testing-library__react" "^9.1.2"
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -5769,12 +5729,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-dom@*":
-  version "16.9.8"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
-  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+"@types/react-dom@<18.0.0":
+  version "17.0.18"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.18.tgz#8f7af38f5d9b42f79162eea7492e5a1caff70dc2"
+  integrity sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^17"
 
 "@types/react-dom@^17.0.17":
   version "17.0.17"
@@ -5782,14 +5742,6 @@
   integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
   dependencies:
     "@types/react" "^17"
-
-"@types/react@*":
-  version "16.9.34"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
-  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
 
 "@types/react@^17":
   version "17.0.48"
@@ -5869,24 +5821,10 @@
   dependencies:
     "@types/estree" "*"
 
-"@types/testing-library__dom@*":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-7.5.0.tgz#e0a00dd766983b1d6e9d10d33e708005ce6ad13e"
-  integrity sha512-mj1aH4cj3XUpMEgVpognma5kHVtbm6U6cHZmEFzCRiXPvKkuHrFr3+yXdGLXvfFRBaQIVshPGHI+hGTOJlhS/g==
-  dependencies:
-    "@testing-library/dom" "*"
-
-"@types/testing-library__dom@^6.12.1":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz#1aede831cb4ed4a398448df5a2c54b54a365644e"
-  integrity sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==
-  dependencies:
-    pretty-format "^24.3.0"
-
-"@types/testing-library__jest-dom@^5.0.1":
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz#59e4771a1cf87d51e89a5cc8195cd3b647cba322"
-  integrity sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==
+"@types/testing-library__jest-dom@5.14.5":
+  version "5.14.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
+  integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
   dependencies:
     "@types/jest" "*"
 
@@ -5896,15 +5834,6 @@
   integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
   dependencies:
     "@types/jest" "*"
-
-"@types/testing-library__react@^9.1.2":
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.3.tgz#35eca61cc6ea923543796f16034882a1603d7302"
-  integrity sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==
-  dependencies:
-    "@types/react-dom" "*"
-    "@types/testing-library__dom" "*"
-    pretty-format "^25.1.0"
 
 "@types/ua-parser-js@^0.7.36":
   version "0.7.36"
@@ -6550,7 +6479,7 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
-ansi-regex@^4.0.0, ansi-regex@^4.1.0:
+ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
@@ -6676,13 +6605,12 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-query@^4.0.2, aria-query@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
-  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+aria-query@^5.0.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
   dependencies:
-    "@babel/runtime" "^7.10.2"
-    "@babel/runtime-corejs3" "^7.10.2"
+    deep-equal "^2.0.5"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -6898,6 +6826,11 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 aws-serverless-express@^3.4.0:
   version "3.4.0"
@@ -8433,11 +8366,6 @@ core-js-compat@^3.8.1, core-js-compat@^3.9.0:
     browserslist "^4.16.3"
     semver "7.0.0"
 
-core-js-pure@^3.0.0:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
-  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
-
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -8829,15 +8757,6 @@ css.escape@^1.5.1:
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
 
-css@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
-  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
-  dependencies:
-    inherits "^2.0.4"
-    source-map "^0.6.1"
-    source-map-resolve "^0.6.0"
-
 cssdb@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
@@ -8951,11 +8870,6 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
-
-csstype@^2.2.0:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
-  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
 
 csstype@^3.0.2:
   version "3.0.10"
@@ -9169,6 +9083,27 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
+
+deep-equal@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.1.0.tgz#5ba60402cf44ab92c2c07f3f3312c3d857a0e1dd"
+  integrity sha512-2pxgvWu3Alv1PoWEyVg7HS8YhGlUFUV7N5oOvfL6d+7xAmLSemMwv/c8Zv/i9KFzxV5Kt5CAvQc70fLwVuf4UA==
+  dependencies:
+    call-bind "^1.0.2"
+    es-get-iterator "^1.1.2"
+    get-intrinsic "^1.1.3"
+    is-arguments "^1.1.1"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.8"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -9403,15 +9338,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz#511e5993dd673b97c87ea47dba0e3892f7e0c983"
-  integrity sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==
-
-dom-accessibility-api@^0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz#ef3cdb5d3f0d599d8f9c8b18df2fb63c9793739d"
-  integrity sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -9829,6 +9759,20 @@ es-abstract@^1.19.1, es-abstract@^1.19.2:
     string.prototype.trimend "^1.0.4"
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
+
+es-get-iterator@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.2.tgz#9234c54aba713486d7ebde0220864af5e2b283f7"
+  integrity sha512-+DTO8GYwbMCwbywjimwZMHp8AuYXOS2JZFWoi2AlPOS3ebnII9w/NLpNZtA7A0YLaVDw+O7KFCeoIV7OPvM7hQ==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.0"
+    has-symbols "^1.0.1"
+    is-arguments "^1.1.0"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.5"
+    isarray "^2.0.5"
 
 es-module-lexer@^0.9.3:
   version "0.9.3"
@@ -11222,6 +11166,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.13.2, follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
   integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -11478,6 +11429,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-intrinsic@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
 
 get-nonce@^1.0.0:
   version "1.0.1"
@@ -11786,6 +11746,13 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
 
 got@^9.6.0:
   version "9.6.0"
@@ -12655,6 +12622,14 @@ is-arguments@^1.0.4:
   dependencies:
     call-bind "^1.0.0"
 
+is-arguments@^1.1.0, is-arguments@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.1.tgz#15b3f88fda01f2a97fec84ca761a560f123efa9b"
+  integrity sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -12695,6 +12670,11 @@ is-buffer@^1.1.0, is-buffer@^1.1.3, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-callable@^1.1.4, is-callable@^1.2.3:
   version "1.2.3"
@@ -12769,6 +12749,13 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-date-object@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -12889,6 +12876,11 @@ is-json@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
   integrity sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==
+
+is-map@^2.0.1, is-map@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
+  integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
 is-negative-zero@^2.0.1:
   version "2.0.1"
@@ -13052,6 +13044,11 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
+is-set@^2.0.1, is-set@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.2.tgz#90755fa4c2562dc1c5d4024760d6119b94ca18ec"
+  integrity sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==
+
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
@@ -13107,6 +13104,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   dependencies:
     has-symbols "^1.0.1"
 
+is-typed-array@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -13134,12 +13142,25 @@ is-valid-glob@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
   integrity sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=
 
+is-weakmap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.1.tgz#5008b59bdc43b698201d18f62b37b2ca243e8cf2"
+  integrity sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==
+
 is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-weakset@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.2.tgz#4569d67a747a1ce5a994dfd4ef6dcea76e7c0a1d"
+  integrity sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -13160,6 +13181,11 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isbot@3.4.5:
   version "3.4.5"
@@ -14319,6 +14345,11 @@ lunr@^2.3.9:
   resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
   integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -15286,7 +15317,7 @@ object-inspect@^1.7.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
   integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
 
-object-is@^1.0.1:
+object-is@^1.0.1, object-is@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
@@ -15319,6 +15350,16 @@ object.assign@^4.1.0, object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.5:
@@ -16760,26 +16801,6 @@ pretty-error@^2.1.1:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
-pretty-format@^24.3.0:
-  version "24.9.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
-  integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
-  dependencies:
-    "@jest/types" "^24.9.0"
-    ansi-regex "^4.0.0"
-    ansi-styles "^3.2.0"
-    react-is "^16.8.4"
-
-pretty-format@^25.1.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  dependencies:
-    "@jest/types" "^25.5.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
@@ -16790,17 +16811,7 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^26.4.2:
-  version "26.4.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
-  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
-  dependencies:
-    "@jest/types" "^26.3.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^27.5.1:
+pretty-format@^27.0.2, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
@@ -17120,7 +17131,7 @@ react-hot-loader@^4.12.20:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -17329,6 +17340,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.10:
+  version "0.13.10"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
+  integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
 regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
   version "0.13.9"
@@ -18332,14 +18348,6 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-resolve@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
-  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
-  dependencies:
-    atob "^2.1.2"
-    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.20:
   version "0.5.21"
@@ -20099,11 +20107,6 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
-wait-for-expect@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
-  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
-
 wait-on@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.3.0.tgz#584e17d4b3fe7b46ac2b9f8e5e102c005c2776c7"
@@ -20419,6 +20422,16 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-collection@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.1.tgz#70eab71ebbbd2aefaf32f917082fc62cdcb70906"
+  integrity sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==
+  dependencies:
+    is-map "^2.0.1"
+    is-set "^2.0.1"
+    is-weakmap "^2.0.1"
+    is-weakset "^2.0.1"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -20436,6 +20449,18 @@ which-pm@2.0.0:
   dependencies:
     load-yaml-file "^0.2.0"
     path-exists "^4.0.0"
+
+which-typed-array@^1.1.8:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
This PR removes the act() warnings we've been experiencing with tests. Apologies for the lack of more precise commits, turned out there were additional issues that I discovered while updating the tests that just need to be fixed in place. These included updating tests that tested _no longer used_ props and removing the ts-nocheck comment and fixing up the TS bits.

I've also updated the testing-library packages to the nearest allowed version with our React 17 requirement.

There are still two `no-op` errors in the output that, based on [this](https://github.com/facebook/react/pull/22114) Facebook PR, are likely false positives. These errors have been removed in React 18 but won't be back-ported to React 17.

Resolves #2892 