### PR TITLE
fix: prevent default event for graphiql-doc-explorer-back link

### DIFF
--- a/.changeset/loud-guests-drive.md
+++ b/.changeset/loud-guests-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix: prevent default event for graphiql-doc-explorer-back link

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
@@ -70,8 +70,8 @@ export function DocExplorer() {
               href="#"
               className="graphiql-doc-explorer-back"
               onClick={event => {
-                  event.preventDefault();
-                  pop();
+                event.preventDefault();
+                pop();
               }}
               aria-label={`Go back to ${prevName}`}
             >

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.tsx
@@ -69,7 +69,10 @@ export function DocExplorer() {
             <a
               href="#"
               className="graphiql-doc-explorer-back"
-              onClick={pop}
+              onClick={event => {
+                  event.preventDefault();
+                  pop();
+              }}
               aria-label={`Go back to ${prevName}`}
             >
               <ChevronLeftIcon />


### PR DESCRIPTION
This PR prevents the default event when clicking the doc explorer's back button. Without this change, clicking the back button will cause the page to navigate away in some use-cases.