### PR TITLE
rename the `initialTabs` prop to `defaultTabs`

### DIFF
--- a/.changeset/loud-beans-mate.md
+++ b/.changeset/loud-beans-mate.md
@@ -1,4 +1,5 @@
 ---
+'graphiql': minor
 '@graphiql/react': minor
 ---
 

--- a/.changeset/loud-beans-mate.md
+++ b/.changeset/loud-beans-mate.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+---
+
+Deprecate the `initialTabs` prop and add a `defaultTabs` props that supersedes
+it

--- a/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
+++ b/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
@@ -108,7 +108,7 @@ describe('getDefaultTabState', () => {
       getDefaultTabState({
         defaultQuery: '# Default',
         headers: null,
-        initialTabs: [
+        defaultTabs: [
           {
             headers: null,
             query: 'query Person { person { name } }',

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -174,8 +174,9 @@ export type EditorContextProviderProps = {
    */
   initialTabs?: TabDefinition[];
   /**
-   * This prop can be used to defined the initial set of tabs with their queries,
-   * variables and headers.
+   * This prop can be used to define the default set of tabs, with their
+   * queries, variables, and headers. It will be used as default only if
+   * there is no tab state persisted in storage.
    *
    * @example
    * ```tsx

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -170,20 +170,24 @@ export type EditorContextProviderProps = {
    */
   headers?: string;
   /**
+   * @deprecated Use `defaultTabs` instead.
+   */
+  initialTabs?: TabDefinition[];
+  /**
    * This prop can be used to defined the initial set of tabs with their queries,
    * variables and headers.
    *
    * @example
    * ```tsx
    * <GraphiQL
-   *   initialTabs={[
+   *   defaultTabs={[
    *     { query: 'query myExampleQuery {}' },
    *     { query: '{ id }' }
    *   ]}
    * />
    *```
    */
-  initialTabs?: TabDefinition[];
+  defaultTabs?: TabDefinition[];
   /**
    * Invoked when the operation name changes. Possible triggers are:
    * - Editing the contents of the query editor
@@ -278,7 +282,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       query,
       variables,
       headers,
-      initialTabs: props.initialTabs,
+      defaultTabs: props.defaultTabs || props.initialTabs,
       defaultQuery: props.defaultQuery || DEFAULT_QUERY,
       defaultHeaders: props.defaultHeaders,
       storage,

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -68,7 +68,7 @@ export function getDefaultTabState({
   defaultQuery,
   defaultHeaders,
   headers,
-  initialTabs,
+  defaultTabs,
   query,
   variables,
   storage,
@@ -76,7 +76,7 @@ export function getDefaultTabState({
   defaultQuery: string;
   defaultHeaders?: string;
   headers: string | null;
-  initialTabs?: TabDefinition[];
+  defaultTabs?: TabDefinition[];
   query: string | null;
   variables: string | null;
   storage: StorageAPI | null;
@@ -128,7 +128,7 @@ export function getDefaultTabState({
     return {
       activeTabIndex: 0,
       tabs: (
-        initialTabs || [
+        defaultTabs || [
           {
             query: query ?? defaultQuery,
             variables,

--- a/packages/graphiql-react/src/provider.tsx
+++ b/packages/graphiql-react/src/provider.tsx
@@ -25,6 +25,7 @@ export function GraphiQLProvider({
   dangerouslyAssumeSchemaIsValid,
   defaultQuery,
   defaultHeaders,
+  defaultTabs,
   externalFragments,
   fetcher,
   getDefaultFieldNames,
@@ -55,6 +56,7 @@ export function GraphiQLProvider({
         <EditorContextProvider
           defaultQuery={defaultQuery}
           defaultHeaders={defaultHeaders}
+          defaultTabs={defaultTabs}
           externalFragments={externalFragments}
           headers={headers}
           initialTabs={initialTabs}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -94,6 +94,7 @@ export type GraphiQLProps = Omit<GraphiQLProviderProps, 'children'> &
 export function GraphiQL({
   dangerouslyAssumeSchemaIsValid,
   defaultQuery,
+  defaultTabs,
   externalFragments,
   fetcher,
   getDefaultFieldNames,
@@ -133,6 +134,7 @@ export function GraphiQL({
       dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
       defaultQuery={defaultQuery}
       defaultHeaders={defaultHeaders}
+      defaultTabs={defaultTabs}
       externalFragments={externalFragments}
       fetcher={fetcher}
       headers={headers}

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -482,11 +482,11 @@ describe('GraphiQL', () => {
       });
     });
 
-    it('shows initial tabs', async () => {
+    it('shows default tabs', async () => {
       const { container } = render(
         <GraphiQL
           fetcher={noOpFetcher}
-          initialTabs={[
+          defaultTabs={[
             {
               query: 'query Person { person { name } }',
             },


### PR DESCRIPTION
Following up on https://github.com/graphql/graphiql/pull/2821 (I didn't manage to review even though it was open for a while, sorry for that 🙈 ).

This PR suggests a different naming for the `initialTabs` prop. The word "initial" suggests that GraphiQL will always spawn with a certain set of tabs if I pass them to this prop. But it's actually just the default set of tabs that will be shown if there is no tab state persisted in `localStorage`. Imho, `defaultTabs` would be a better wording here and also aligns with other props like `defaultQuery`.

As renaming would be a breaking change now (the new prop is already released), we deprecate the existing prop and add a new one. The deprecated prop can then be removed in a future major version.