### PR TITLE
fix styles of secondary editor buttons

### DIFF
--- a/.changeset/chilly-weeks-invent.md
+++ b/.changeset/chilly-weeks-invent.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix styles of secondary editor buttons

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -513,7 +513,8 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                         <UnStyledButton
                           type="button"
                           className={
-                            activeSecondaryEditor === 'variables'
+                            activeSecondaryEditor === 'variables' &&
+                            editorToolsResize.hiddenElement !== 'second'
                               ? 'active'
                               : ''
                           }
@@ -530,7 +531,8 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                           <UnStyledButton
                             type="button"
                             className={
-                              activeSecondaryEditor === 'headers'
+                              activeSecondaryEditor === 'headers' &&
+                              editorToolsResize.hiddenElement !== 'second'
                                 ? 'active'
                                 : ''
                             }

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -251,12 +251,11 @@ button.graphiql-tab-add > svg {
   width: 0;
 }
 
-/* Generic icon style */
 .graphiql-container .graphiql-chevron-icon {
   color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: var(--px-12);
-  padding: var(--px-12);
+  margin: var(--px-12);
   width: var(--px-12);
 }
 


### PR DESCRIPTION
Noticed that there were some broken styles:
- One of the variables was shown as active (bold color) even when no editor was visible
- The chevron in the toggle button was not visible

| Before | After |
| --- | --- |
| <img width="582" alt="CleanShot 2022-11-15 at 12 42 12@2x" src="https://user-images.githubusercontent.com/22288634/201911727-b2a44af4-ba48-4573-954a-8d3828780366.png"> | <img width="578" alt="CleanShot 2022-11-15 at 12 41 51@2x" src="https://user-images.githubusercontent.com/22288634/201911764-33d45c8b-403a-40c9-92a9-1939272cb24a.png"> |
| <img width="577" alt="CleanShot 2022-11-15 at 12 42 19@2x" src="https://user-images.githubusercontent.com/22288634/201911797-7bfde38c-9d8e-4146-8299-08989a03f16f.png"> | <img width="578" alt="CleanShot 2022-11-15 at 12 41 58@2x" src="https://user-images.githubusercontent.com/22288634/201911817-f7be8edf-330a-48d3-8c17-23595059a382.png"> |
