### PR TITLE
add missing effect dep for default headers

### DIFF
--- a/.changeset/red-ligers-scream.md
+++ b/.changeset/red-ligers-scream.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': patch
+---
+
+Add missing effect dependency to make sure updates to the `defaultHeaders` prop
+have the desired effect

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -329,7 +329,13 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       onTabChange?.(updated);
       return updated;
     });
-  }, [onTabChange, setEditorValues, storeTabs, synchronizeActiveTabValues]);
+  }, [
+    props.defaultHeaders,
+    onTabChange,
+    setEditorValues,
+    storeTabs,
+    synchronizeActiveTabValues,
+  ]);
 
   const changeTab = useCallback<EditorContextType['changeTab']>(
     index => {


### PR DESCRIPTION
Following up on https://github.com/graphql/graphiql/pull/2886, this adds a missing effect dependency so that updates to the `defaultHeaders` prop are reflected when subsequently adding new tabs.