### PR TITLE
Reproduction of a bug in validation of undefined variables

### DIFF
--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
@@ -46,33 +46,37 @@ describe('getDiagnostics', () => {
     expect(error.source).toEqual('GraphQL: Validation');
   });
 
-  it('validates undefined variables', () => {
+  it('catches with multiple highlighted nodes', () => {
     const errors = validateQuery(
       parse('{ hero(episode: $ep) { name } }'),
       schema,
     );
-    expect(errors).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "message": "Variable \\"$ep\\" is not defined.",
-          "range": Range {
-            "containsPosition": [Function],
-            "end": Position {
-              "character": 20,
-              "lessThanOrEqualTo": [Function],
-              "line": 0,
-            },
-            "start": Position {
-              "character": 16,
-              "lessThanOrEqualTo": [Function],
-              "line": 0,
-            },
+    expect(errors).toMatchObject([
+      {
+        range: {
+          end: {
+            character: 20,
+            line: 0,
           },
-          "severity": 1,
-          "source": "GraphQL: Validation",
+          start: {
+            character: 16,
+            line: 0,
+          },
         },
-      ]
-    `);
+      },
+      {
+        range: {
+          end: {
+            character: 32,
+            line: 0,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+      },
+    ]);
   });
 
   it('catches multi root validation errors without breaking (with a custom validation function that always throws errors)', () => {

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics-test.ts
@@ -46,6 +46,35 @@ describe('getDiagnostics', () => {
     expect(error.source).toEqual('GraphQL: Validation');
   });
 
+  it('validates undefined variables', () => {
+    const errors = validateQuery(
+      parse('{ hero(episode: $ep) { name } }'),
+      schema,
+    );
+    expect(errors).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "Variable \\"$ep\\" is not defined.",
+          "range": Range {
+            "containsPosition": [Function],
+            "end": Position {
+              "character": 20,
+              "lessThanOrEqualTo": [Function],
+              "line": 0,
+            },
+            "start": Position {
+              "character": 16,
+              "lessThanOrEqualTo": [Function],
+              "line": 0,
+            },
+          },
+          "severity": 1,
+          "source": "GraphQL: Validation",
+        },
+      ]
+    `);
+  });
+
   it('catches multi root validation errors without breaking (with a custom validation function that always throws errors)', () => {
     const error = validateQuery(parse('{ hero { name } } { seq }'), schema, [
       validationContext => {

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -139,7 +139,7 @@ function annotations(
     return [];
   }
   const highlightedNodes: Diagnostic[] = [];
-  error.nodes.forEach(node => {
+  error.nodes.forEach((node, i) => {
     const highlightNode =
       node.kind !== 'Variable' && 'name' in node && node.name !== undefined
         ? node.name
@@ -154,7 +154,7 @@ function annotations(
 
       // @ts-ignore
       // https://github.com/microsoft/TypeScript/pull/32695
-      const loc = error.locations[0];
+      const loc = error.locations[i];
       const highlightLoc = getLocation(highlightNode);
       const end = loc.column + (highlightLoc.end - highlightLoc.start);
       highlightedNodes.push({


### PR DESCRIPTION
Hello! 

This PR adds a unit test with the reproduction of a bug in undefined variables validation: `getDiagnostics` function returns an "undefined variable" error twice and has the wrong end position for the second entry.

For instance for a following query on star wars schema:

`{ hero(episode: $ep) { name } }`

1. it returns two "Variable \\"$ep\\" is not defined." erros instead of one 
2. The second error has end position = 48 which is greater than the query itself 


