### PR TITLE
fix: avoid infinity recursiveness in getVariablesJSONSchema

### DIFF
--- a/.changeset/fifty-points-share.md
+++ b/.changeset/fifty-points-share.md
@@ -2,4 +2,4 @@
 "graphql-language-service": patch
 ---
 
-Fix infinity recursiveness in getVariablesJSONSchema when the schema contains types that reference themselves
+Fix infinite recursiveness in getVariablesJSONSchema when the schema contains types that reference themselves

--- a/.changeset/fifty-points-share.md
+++ b/.changeset/fifty-points-share.md
@@ -1,0 +1,5 @@
+---
+"graphql-language-service": patch
+---
+
+Fix infinity recursiveness in getVariablesJSONSchema when the schema contains types that reference themselves

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/RecursiveSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/RecursiveSchema.graphql
@@ -1,0 +1,21 @@
+schema {
+  query: query_root
+}
+
+input string_options {
+  _eq: String
+  _ilike: String
+}
+
+type issues {
+  name: String
+}
+
+input issues_where_input {
+  _and: [issues_where_input!]
+  name: string_options
+}
+
+type query_root {
+  issues(where: issues_where_input): [issues!]!
+}

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -257,4 +257,23 @@ describe('getVariablesJSONSchema', () => {
       },
     });
   });
+
+  it('should handle recursive schema properly', () => {
+    const schemaPath = join(__dirname, '__schema__', 'RecursiveSchema.graphql');
+    schema = buildSchema(readFileSync(schemaPath, 'utf8'));
+
+    const variableToType = collectVariables(
+      schema,
+      parse(`query Example(
+      $where: issues_where_input! = {}
+    ) {
+      issues(where: $where) {
+        name
+      }
+    }`),
+    );
+
+    getVariablesJSONSchema(variableToType, { useMarkdownDescription: true });
+    expect(true).toEqual(true);
+  });
 });

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -44,6 +44,9 @@ export type JSONSchemaOptions = {
    */
   useMarkdownDescription?: boolean;
 };
+type JSONSchemaRunningOptions = JSONSchemaOptions & {
+  definitionMarker: Marker;
+};
 
 export const defaultJSONSchemaOptions = {
   useMarkdownDescription: false,
@@ -107,13 +110,13 @@ const scalarTypesMap: { [key: string]: JSONSchema6TypeName } = {
 };
 
 class Marker {
-  private set = new Set<string>()
+  private set = new Set<string>();
   mark(name: string): boolean {
     if (this.set.has(name)) {
-      return false
+      return false;
     } else {
-      this.set.add(name)
-      return true
+      this.set.add(name);
+      return true;
     }
   }
 }
@@ -127,7 +130,7 @@ class Marker {
  */
 function getJSONSchemaFromGraphQLType(
   type: GraphQLInputType | GraphQLInputField,
-  options?: JSONSchemaOptions,
+  options?: JSONSchemaRunningOptions,
   definitionMarker: Marker = new Marker(),
 ): DefinitionResult {
   let required = false;
@@ -179,72 +182,75 @@ function getJSONSchemaFromGraphQLType(
       });
     }
   }
-  if (isInputObjectType(type) && definitionMarker.mark(type.name)) {
+  if (isInputObjectType(type)) {
     definition.$ref = `#/definitions/${type.name}`;
-    const fields = type.getFields();
+    if (options?.definitionMarker.mark(type.name)) {
+      const fields = type.getFields();
 
-    const fieldDef: PropertiedJSON6 = {
-      type: 'object',
-      properties: {},
-      required: [],
-    };
-    if (type.description) {
-      fieldDef.description = type.description + `\n` + renderTypeToString(type);
-      if (options?.useMarkdownDescription) {
-        // @ts-expect-error
-        fieldDef.markdownDescription =
-          type.description + `\n` + renderTypeToString(type, true);
-      }
-    } else {
-      fieldDef.description = renderTypeToString(type);
-      if (options?.useMarkdownDescription) {
-        // @ts-expect-error
-        fieldDef.markdownDescription = renderTypeToString(type, true);
-      }
-    }
-
-    Object.keys(fields).forEach(fieldName => {
-      const field = fields[fieldName];
-      const {
-        required: fieldRequired,
-        definition: typeDefinition,
-        definitions: typeDefinitions,
-      } = getJSONSchemaFromGraphQLType(field.type, options, definitionMarker);
-
-      const {
-        definition: fieldDefinition,
-        // definitions: fieldDefinitions,
-      } = getJSONSchemaFromGraphQLType(field, options, definitionMarker);
-
-      fieldDef.properties[fieldName] = {
-        ...typeDefinition,
-        ...fieldDefinition,
-      } as JSONSchema6;
-
-      const renderedField = renderTypeToString(field.type);
-      fieldDef.properties[fieldName].description = field.description
-        ? field.description + '\n' + renderedField
-        : renderedField;
-      if (options?.useMarkdownDescription) {
-        const renderedFieldMarkdown = renderTypeToString(field.type, true);
-        fieldDef.properties[
-          fieldName
+      const fieldDef: PropertiedJSON6 = {
+        type: 'object',
+        properties: {},
+        required: [],
+      };
+      if (type.description) {
+        fieldDef.description =
+          type.description + `\n` + renderTypeToString(type);
+        if (options?.useMarkdownDescription) {
           // @ts-expect-error
-        ].markdownDescription = field.description
-          ? field.description + '\n' + renderedFieldMarkdown
-          : renderedFieldMarkdown;
+          fieldDef.markdownDescription =
+            type.description + `\n` + renderTypeToString(type, true);
+        }
+      } else {
+        fieldDef.description = renderTypeToString(type);
+        if (options?.useMarkdownDescription) {
+          // @ts-expect-error
+          fieldDef.markdownDescription = renderTypeToString(type, true);
+        }
       }
 
-      if (fieldRequired) {
-        fieldDef.required!.push(fieldName);
-      }
-      if (typeDefinitions) {
-        Object.keys(typeDefinitions).map(defName => {
-          definitions[defName] = typeDefinitions[defName];
-        });
-      }
-    });
-    definitions![type.name] = fieldDef;
+      Object.keys(fields).forEach(fieldName => {
+        const field = fields[fieldName];
+        const {
+          required: fieldRequired,
+          definition: typeDefinition,
+          definitions: typeDefinitions,
+        } = getJSONSchemaFromGraphQLType(field.type, options, definitionMarker);
+
+        const {
+          definition: fieldDefinition,
+          // definitions: fieldDefinitions,
+        } = getJSONSchemaFromGraphQLType(field, options, definitionMarker);
+
+        fieldDef.properties[fieldName] = {
+          ...typeDefinition,
+          ...fieldDefinition,
+        } as JSONSchema6;
+
+        const renderedField = renderTypeToString(field.type);
+        fieldDef.properties[fieldName].description = field.description
+          ? field.description + '\n' + renderedField
+          : renderedField;
+        if (options?.useMarkdownDescription) {
+          const renderedFieldMarkdown = renderTypeToString(field.type, true);
+          fieldDef.properties[
+            fieldName
+            // @ts-expect-error
+          ].markdownDescription = field.description
+            ? field.description + '\n' + renderedFieldMarkdown
+            : renderedFieldMarkdown;
+        }
+
+        if (fieldRequired) {
+          fieldDef.required!.push(fieldName);
+        }
+        if (typeDefinitions) {
+          Object.keys(typeDefinitions).map(defName => {
+            definitions[defName] = typeDefinitions[defName];
+          });
+        }
+      });
+      definitions![type.name] = fieldDef;
+    }
   }
   // append descriptions
   if (
@@ -317,11 +323,16 @@ export function getVariablesJSONSchema(
     required: [],
   };
 
+  const runtimeOptions: JSONSchemaRunningOptions = {
+    ...options,
+    definitionMarker: new Marker(),
+  };
+
   if (variableToType) {
     // I would use a reduce here, but I wanted it to be readable.
     Object.entries(variableToType).forEach(([variableName, type]) => {
       const { definition, required, definitions } =
-        getJSONSchemaFromGraphQLType(type, options);
+        getJSONSchemaFromGraphQLType(type, runtimeOptions);
       jsonSchema.properties[variableName] = definition;
       if (required) {
         jsonSchema.required?.push(variableName);

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -125,13 +125,11 @@ class Marker {
  *
  * @param type {GraphQLInputType}
  * @param options
- * @param definitionMarker
  * @returns {DefinitionResult}
  */
 function getJSONSchemaFromGraphQLType(
   type: GraphQLInputType | GraphQLInputField,
   options?: JSONSchemaRunningOptions,
-  definitionMarker: Marker = new Marker(),
 ): DefinitionResult {
   let required = false;
   let definition: CombinedSchema = Object.create(null);
@@ -155,7 +153,6 @@ function getJSONSchemaFromGraphQLType(
     const { definition: def, definitions: defs } = getJSONSchemaFromGraphQLType(
       type.ofType,
       options,
-      definitionMarker,
     );
     if (def.$ref) {
       definition.items = { $ref: def.$ref };
@@ -173,7 +170,6 @@ function getJSONSchemaFromGraphQLType(
     const { definition: def, definitions: defs } = getJSONSchemaFromGraphQLType(
       type.ofType,
       options,
-      definitionMarker,
     );
     definition = def;
     if (defs) {
@@ -214,12 +210,12 @@ function getJSONSchemaFromGraphQLType(
           required: fieldRequired,
           definition: typeDefinition,
           definitions: typeDefinitions,
-        } = getJSONSchemaFromGraphQLType(field.type, options, definitionMarker);
+        } = getJSONSchemaFromGraphQLType(field.type, options);
 
         const {
           definition: fieldDefinition,
           // definitions: fieldDefinitions,
-        } = getJSONSchemaFromGraphQLType(field, options, definitionMarker);
+        } = getJSONSchemaFromGraphQLType(field, options);
 
         fieldDef.properties[fieldName] = {
           ...typeDefinition,


### PR DESCRIPTION
add a marker to mark analyzed InputObject to avoid infinity recursiveness while generating JsonSchema.

see https://github.com/graphql/graphiql/issues/2685