### PR TITLE
fix: support cts/mts extensions

### DIFF
--- a/.changeset/heavy-dancers-deliver.md
+++ b/.changeset/heavy-dancers-deliver.md
@@ -1,0 +1,7 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+'vscode-graphql-syntax': patch
+---
+
+support cts and mts file extensions

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -133,7 +133,7 @@ export function findGraphQLTags(
       parsedASTs.push(...parseVueSFCResult.scriptSetupAst);
     }
   } else {
-    const isTypeScript = ext === '.ts' || ext === '.tsx';
+    const isTypeScript = ['.ts', '.tsx', '.cts', '.mts'].includes(ext);
     if (isTypeScript) {
       plugins?.push('typescript');
     } else {

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -17,6 +17,8 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.tsx',
   '.vue',
   '.svelte',
+  '.cts',
+  '.mts',
 ];
 
 /**

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -10,7 +10,9 @@
     "ts",
     "tsx",
     "vue",
-    "svelte"
+    "svelte",
+    "cts",
+    "mts"
   ],
   "injectionSelector": "L:source -string -comment",
   "patterns": [

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(context: ExtensionContext) {
         // TODO: load ignore
         // These ignore node_modules and .git by default
         workspace.createFileSystemWatcher(
-          '**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue,*.svelte}',
+          '**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue,*.svelte,*.cts,*.mts}',
         ),
       ],
     },


### PR DESCRIPTION
Resolves #2855 

Introduces support for the `.cts` and `.mts` in the VSCode extension(s) and the LSP server

note: no tests were created for this patch