### PR TITLE
1620: added customize options for some panels

### DIFF
--- a/.changeset/rich-lamps-beg.md
+++ b/.changeset/rich-lamps-beg.md
@@ -1,0 +1,20 @@
+---
+'graphiql': minor
+---
+
+1) Added optional props which can be used to toggle the visibility of
+   - second panel — with the `hideSecondPanel` prop
+   - editor panel — with the `hideEditorPanel` prop
+   - results panel — with the `hideResultsPanel` prop
+
+These work independently of each other, so you can have the second panel visible, but the editor panel hidden.
+NOTE: If the second panel is hidden, the other two props will be ignored.
+
+2) Added optional props which can be used to add custom styles through class names:
+   - second panel — with the `secondPanelClassName` prop
+   - editor panel — with the `editorPanelClassName` prop
+   - results panel — with the `resultsPanelClassName` prop
+
+NOTE: These props are used only if the corresponding panel is not hidden.
+
+

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -198,10 +198,53 @@ export type GraphiQLInterfaceProps = WriteableEditorProps &
      * editor.
      */
     toolbar?: GraphiQLToolbarConfig;
+    /**
+     * Toggle if the second panel should be shown.
+     * @default false
+     */
+    hideSecondPanel?: boolean;
+    /**
+     * Toggle if the editor panel should be shown.
+     * @default false
+     */
+    hideEditorPanel?: boolean;
+    /**
+     * Toggle if the results panel should be shown.
+     * @default false
+     */
+    hideResultsPanel?: boolean;
+    /**
+     * Styles to be applied to the second panel.
+     * @default ''
+     */
+    secondPanelClassName?: String;
+    /**
+     * Styles to be applied to the editor panel.
+     * @default ''
+     */
+    editorPanelClassName?: String;
+    /**
+     * Styles to be applied to the results panel.
+     * @default ''
+     */
+    resultsPanelClassName?: String;
   };
 
 export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
   const isHeadersEditorEnabled = props.isHeadersEditorEnabled ?? true;
+  const hideSecondPanel = props.hideSecondPanel ?? false;
+  const hideEditorPanel = props.hideEditorPanel ?? false;
+  const hideResultsPanel = props.hideResultsPanel ?? false;
+
+  const secondPanelClassName = hideSecondPanel
+    ? 'graphiql-panel-hidden'
+    : `${props.secondPanelClassName} graphiql-panel-visible`;
+  const editorPanelClassName = hideEditorPanel
+    ? 'graphiql-panel-hidden'
+    : `${props.editorPanelClassName} graphiql-panel-visible`;
+  const resultsPanelClassName = hideResultsPanel
+    ? 'graphiql-panel-hidden'
+    : `${props.resultsPanelClassName} graphiql-panel-visible`;
 
   const editorContext = useEditorContext({ nonNull: true });
   const executionContext = useExecutionContext({ nonNull: true });
@@ -404,11 +447,19 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
           </div>
         </div>
         <div ref={pluginResize.dragBarRef}>
-          {pluginContext?.visiblePlugin ? (
-            <div className="graphiql-horizontal-drag-bar" />
+          {!hideSecondPanel && pluginContext?.visiblePlugin ? (
+            <div
+              className="graphiql-horizontal-drag-bar"
+              data-testid="panels-separator-drag-bar"
+            />
           ) : null}
         </div>
-        <div ref={pluginResize.secondRef} style={{ minWidth: 0 }}>
+        <div
+          ref={pluginResize.secondRef}
+          style={{ minWidth: 0 }}
+          data-testid="second-panel-container"
+          className={secondPanelClassName}
+        >
           <div className="graphiql-sessions">
             <div className="graphiql-session-header">
               <Tabs aria-label="Select active operation">
@@ -478,7 +529,11 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
               className="graphiql-session"
               aria-labelledby={`graphiql-session-tab-${editorContext.activeTabIndex}`}
             >
-              <div ref={editorResize.firstRef}>
+              <div
+                ref={editorResize.firstRef}
+                data-testid="editor-panel"
+                className={editorPanelClassName}
+              >
                 <div
                   className={`graphiql-editors${
                     editorContext.tabs.length === 1 ? ' full-height' : ''
@@ -619,9 +674,18 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                 </div>
               </div>
               <div ref={editorResize.dragBarRef}>
-                <div className="graphiql-horizontal-drag-bar" />
+                {hideEditorPanel && hideResultsPanel ? null : (
+                  <div
+                    className="graphiql-horizontal-drag-bar"
+                    data-testid="editor-results-drag-bar"
+                  />
+                )}
               </div>
-              <div ref={editorResize.secondRef}>
+              <div
+                ref={editorResize.secondRef}
+                data-testid="results-panel"
+                className={resultsPanelClassName}
+              >
                 <div className="graphiql-response">
                   {executionContext.isFetching ? <Spinner /> : null}
                   <ResponseEditor

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -983,4 +983,134 @@ describe('GraphiQL', () => {
       });
     });
   }); // history
+
+  describe('second panel (and children) visibility', () => {
+    it('hides the second panel', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} hideSecondPanel />,
+      );
+
+      const dragBar = container.querySelector(
+        '[data-testid="panels-separator-drag-bar"]',
+      ) as HTMLElement;
+
+      const secondPanel = container.querySelector(
+        '[data-testid="second-panel-container"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        expect(dragBar).toBeNull();
+
+        // get the react props of second panel
+        const hiddenSecondPanelObj = Object.values(secondPanel).find(
+          prop => prop?.className === 'graphiql-panel-hidden',
+        );
+        expect(hiddenSecondPanelObj.className).toBe('graphiql-panel-hidden');
+      });
+    });
+
+    it('hides the editor panel', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} hideEditorPanel />,
+      );
+
+      const dragBar = container.querySelector(
+        '[data-testid="editor-results-drag-bar"]',
+      ) as HTMLElement;
+
+      const editorPanel = container.querySelector(
+        '[data-testid="editor-panel"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        expect(dragBar).not.toBe(null);
+
+        // get the react props of the editor panel
+        const hiddenEditorPanelObj = Object.values(editorPanel).find(
+          prop => prop?.className === 'graphiql-panel-hidden',
+        );
+        expect(hiddenEditorPanelObj.className).toBe('graphiql-panel-hidden');
+      });
+    });
+
+    it('hides the results panel', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} hideResultsPanel />,
+      );
+
+      const dragBar = container.querySelector(
+        '[data-testid="editor-results-drag-bar"]',
+      ) as HTMLElement;
+
+      const resultsPanel = container.querySelector(
+        '[data-testid="results-panel"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        expect(dragBar).not.toBe(null);
+
+        // get the react props of the results panel
+        const hiddenResultsPanelObj = Object.values(resultsPanel).find(
+          prop => prop?.className === 'graphiql-panel-hidden',
+        );
+        expect(hiddenResultsPanelObj.className).toBe('graphiql-panel-hidden');
+      });
+    });
+  });
+
+  describe('second panel (and children) custom class names', () => {
+    it('second panel with test class', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} secondPanelClassName="test" />,
+      );
+
+      const secondPanel = container.querySelector(
+        '[data-testid="second-panel-container"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        // get the react props of second panel
+        const secondPanelObj = Object.values(secondPanel).find(
+          prop => prop?.className === 'test graphiql-panel-visible',
+        );
+        expect(secondPanelObj.className).toBe('test graphiql-panel-visible');
+      });
+    });
+
+    it('editor panel with test class', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} editorPanelClassName="test" />,
+      );
+
+      const editorPanel = container.querySelector(
+        '[data-testid="editor-panel"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        // get the react props of the editor panel
+        const editorPanelObj = Object.values(editorPanel).find(
+          prop => prop?.className === 'test graphiql-panel-visible',
+        );
+        expect(editorPanelObj.className).toBe('test graphiql-panel-visible');
+      });
+    });
+
+    it('results panel with test class', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} resultsPanelClassName="test" />,
+      );
+
+      const resultsPanel = container.querySelector(
+        '[data-testid="results-panel"]',
+      ) as HTMLElement;
+
+      await waitFor(() => {
+        // get the react props of the results panel
+        const resultsPanelObj = Object.values(resultsPanel).find(
+          prop => prop?.className === 'test graphiql-panel-visible',
+        );
+        expect(resultsPanelObj.className).toBe('test graphiql-panel-visible');
+      });
+    });
+  });
 });

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -332,3 +332,11 @@ reach-portal .graphiql-key {
 .graphiql-container svg {
   pointer-events: none;
 }
+
+.graphiql-panel-hidden {
+  display: none !important;
+}
+
+.graphiql-panel-visible {
+  display: flex;
+}


### PR DESCRIPTION
- closes https://github.com/graphql/graphiql/issues/1620

- added the ability to hide/show the 'second panel'
- added the ability to hide/show just the 'editor panel' (inside second panel)
- added the ability to hide/show just the 'results panel' (inside second panel)
- added the ability to apply custom styles to the 'second panel' container
- added the ability to apply custom styles to the 'editor panel' container
- added the ability to apply custom styles to the 'results panel' container

I checked how the hiding of these panels would work and I noticed that the best option to implement the feature is using the 'display' CSS property when would like to hide the specific panel. The reason behind this is that the panel 'ref' does some calculations when the page is loaded. These are lost if we are "react" removing the panel, ie using the
`{ !hideSecondPanel && <div> ... </div> `}
syntax. Toggling the "displayness (display: none to flex)" fixes this issue and if we conditionally toggle these panels visibility, everything would work as it should.

I added separate optional properties related to styling. In this way, the user won't be confused when trying to use them.

Backward compatibility is provided, hence these new props are optional.