### PR TITLE
enable `@typescript-eslint/no-unused-expressions` rule

### DIFF
--- a/.changeset/polite-crabs-double.md
+++ b/.changeset/polite-crabs-double.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': patch
+'graphql-language-service-server': patch
+---
+
+enable @typescript-eslint/no-unused-expressions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,7 @@ module.exports = {
       'error',
       { argsIgnorePattern: '^_', ignoreRestSiblings: true },
     ],
+    '@typescript-eslint/no-unused-expressions': 'error',
 
     'no-use-before-define': 0,
 

--- a/examples/monaco-graphql-react-vite/src/App.tsx
+++ b/examples/monaco-graphql-react-vite/src/App.tsx
@@ -108,7 +108,7 @@ export default function App() {
     const variablesModel = getOrCreateModel('variables.json', defaultVariables);
     const resultsModel = getOrCreateModel('results.json', '{}');
 
-    queryEditor ??
+    if (!queryEditor) {
       setQueryEditor(
         createEditor(opsRef, {
           theme: 'vs-dark',
@@ -116,14 +116,16 @@ export default function App() {
           language: 'graphql',
         }),
       );
-    variablesEditor ??
+    }
+    if (!variablesEditor) {
       setVariablesEditor(
         createEditor(varsRef, {
           theme: 'vs-dark',
           model: variablesModel,
         }),
       );
-    resultsViewer ??
+    }
+    if (!resultsViewer) {
       setResultsViewer(
         createEditor(resultsRef, {
           theme: 'vs-dark',
@@ -132,7 +134,7 @@ export default function App() {
           smoothScrolling: true,
         }),
       );
-
+    }
     queryModel.onDidChangeContent(
       debounce(300, () => {
         localStorage.setItem('operations', queryModel.getValue());

--- a/packages/graphiql-react/src/utility/resize.ts
+++ b/packages/graphiql-react/src/utility/resize.ts
@@ -155,7 +155,6 @@ export function useDragResize({
       if (!Number.isFinite(flex) || flex < 1) {
         firstRef.current.style.flex = '1';
       }
-      firstRef.current.style.flex;
     }
   }, []);
 

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -665,7 +665,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
     const schemaKey = this._getSchemaCacheKeyForProject(
       projectConfig,
     ) as string;
-    schemaKey && this._schemaMap.delete(schemaKey);
+    if (schemaKey) {
+      this._schemaMap.delete(schemaKey);
+    }
   }
 
   _getSchemaCacheKeyForProject(


### PR DESCRIPTION
found code that does nothing https://github.com/graphql/graphiql/blob/695100bd317940ff3ffd8f56b54248c1dba1ac04/packages/graphiql-react/src/utility/resize.ts#L158

a good case to enable this rule