### PR TITLE
enable `unicorn/throw-new-error` rule

### DIFF
--- a/.changeset/sweet-olives-flow.md
+++ b/.changeset/sweet-olives-flow.md
@@ -1,0 +1,9 @@
+---
+'graphiql': patch
+'@graphiql/toolkit': patch
+'graphql-language-service': patch
+'graphql-language-service-cli': patch
+'monaco-graphql': patch
+---
+
+enable `unicorn/throw-new-error` rule

--- a/examples/monaco-graphql-react-vite/src/App.tsx
+++ b/examples/monaco-graphql-react-vite/src/App.tsx
@@ -160,7 +160,7 @@ export default function App() {
       getSchema()
         .then(data => {
           if (!('data' in data)) {
-            throw Error(
+            throw new Error(
               'this demo does not support subscriptions or http multipart yet',
             );
           }

--- a/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
@@ -30,7 +30,7 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
     httpFetch = options.fetch;
   }
   if (!httpFetch) {
-    throw Error('No valid fetcher implementation available');
+    throw new Error('No valid fetcher implementation available');
   }
   // simpler fetcher for schema requests
   const simpleFetcher = createSimpleFetcher(options, httpFetch);
@@ -56,7 +56,7 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
       const wsFetcher = getWsFetcher(options, fetcherOpts);
 
       if (!wsFetcher) {
-        throw Error(
+        throw new Error(
           `Your GraphiQL createFetcher is not properly configured for websocket subscriptions yet. ${
             options.subscriptionUrl
               ? `Provided URL ${options.subscriptionUrl} failed`

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -89,7 +89,7 @@ export const createWebsocketsFetcherFromUrl = (
   } catch (err) {
     if (errorHasCode(err)) {
       if (err.code === 'MODULE_NOT_FOUND') {
-        throw Error(
+        throw new Error(
           "You need to install the 'graphql-ws' package to use websockets when passing a 'subscriptionUrl'",
         );
       }

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -58,7 +58,7 @@ import {
 const majorVersion = parseInt(React.version.slice(0, 2), 10);
 
 if (majorVersion < 16) {
-  throw Error(
+  throw new Error(
     [
       'GraphiQL 0.18.0 and after is not compatible with React 15 or below.',
       'If you are using a CDN source (jsdelivr, unpkg, etc), follow this example:',

--- a/packages/graphql-language-service-cli/src/client.ts
+++ b/packages/graphql-language-service-cli/src/client.ts
@@ -152,7 +152,7 @@ function _getOutline(queryText: string): EXIT_CODE {
     if (outline) {
       process.stdout.write(JSON.stringify(outline, null, 2));
     } else {
-      throw Error('Error parsing or no outline tree found');
+      throw new Error('Error parsing or no outline tree found');
     }
   } catch (error) {
     process.stderr.write(formatUnknownError(error) + '\n');

--- a/packages/graphql-language-service/src/interface/getDefinition.ts
+++ b/packages/graphql-language-service/src/interface/getDefinition.ts
@@ -59,7 +59,7 @@ export async function getDefinitionQueryResultForNamedType(
   );
 
   if (defNodes.length === 0) {
-    throw Error(`Definition not found for GraphQL type ${name}`);
+    throw new Error(`Definition not found for GraphQL type ${name}`);
   }
   const definitions: Array<Definition> = defNodes.map(
     ({ filePath, content, definition }) =>
@@ -82,7 +82,7 @@ export async function getDefinitionQueryResultForField(
   );
 
   if (defNodes.length === 0) {
-    throw Error(`Definition not found for GraphQL type ${typeName}`);
+    throw new Error(`Definition not found for GraphQL type ${typeName}`);
   }
 
   const definitions: Array<Definition> = [];
@@ -119,7 +119,7 @@ export async function getDefinitionQueryResultForFragmentSpread(
   );
 
   if (defNodes.length === 0) {
-    throw Error(`Definition not found for GraphQL fragment ${name}`);
+    throw new Error(`Definition not found for GraphQL fragment ${name}`);
   }
   const definitions: Array<Definition> = defNodes.map(
     ({ filePath, content, definition }) =>
@@ -150,7 +150,7 @@ function getDefinitionForFragmentDefinition(
 ): Definition {
   const name = definition.name;
   if (!name) {
-    throw Error('Expected ASTNode to have a Name.');
+    throw new Error('Expected ASTNode to have a Name.');
   }
 
   return {

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -140,7 +140,7 @@ export class LanguageService {
           },
         });
       } catch (err) {
-        throw Error(
+        throw new Error(
           `Failed parsing externalFragmentDefinitions string:\n${this._externalFragmentDefinitionsString}`,
         );
       }

--- a/packages/monaco-graphql/src/graphqlMode.ts
+++ b/packages/monaco-graphql/src/graphqlMode.ts
@@ -26,7 +26,7 @@ export function setupMode(defaults: MonacoGraphQLAPI): IDisposable {
     try {
       return client!.getLanguageServiceWorker(...uris);
     } catch (err) {
-      throw Error('Error fetching graphql language service worker');
+      throw new Error('Error fetching graphql language service worker');
     }
   };
 

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -132,7 +132,7 @@ export class DiagnosticsAdapter {
 
     if (variablesUris) {
       if (variablesUris.length < 1) {
-        throw Error('no variables URI strings provided to validate');
+        throw new Error('no variables URI strings provided to validate');
       }
       const jsonSchema = await worker.doGetVariablesJSONSchema(
         resource.toString(),

--- a/packages/monaco-graphql/src/schemaLoader.ts
+++ b/packages/monaco-graphql/src/schemaLoader.ts
@@ -28,5 +28,5 @@ export const defaultSchemaLoader: SchemaLoader = (schemaConfig, parser) => {
   if (documentAST) {
     return buildASTSchema(documentAST, buildSchemaOptions);
   }
-  throw Error('no schema supplied');
+  throw new Error('no schema supplied');
 };

--- a/packages/monaco-graphql/src/utils.ts
+++ b/packages/monaco-graphql/src/utils.ts
@@ -163,5 +163,5 @@ export const getStringSchema = (schemaConfig: SchemaConfig) => {
       documentString: printSchema(schema),
     };
   }
-  throw Error('no schema supplied');
+  throw new Error('no schema supplied');
 };

--- a/scripts/renameFileExtensions.js
+++ b/scripts/renameFileExtensions.js
@@ -51,5 +51,5 @@ if (tempPath) {
     rimraf.sync(tempRenamePath);
   });
 } else {
-  throw Error(`Could not generate temporary path\n${tempRenamePath}`);
+  throw new Error(`Could not generate temporary path\n${tempRenamePath}`);
 }

--- a/scripts/set-resolution.js
+++ b/scripts/set-resolution.js
@@ -4,12 +4,12 @@ const path = require('path');
 async function setResolution() {
   const [, , tag] = process.argv;
   if (!tag) {
-    throw Error('no tag provided');
+    throw new Error('no tag provided');
   }
 
   const [package, version] = tag.split('@');
   if (!package || !version) {
-    throw Error(`Invalid tag ${tag}`);
+    throw new Error(`Invalid tag ${tag}`);
   }
   const pkgPath = path.resolve(path.join(process.cwd(), 'package.json'));
   const pkg = JSON.parse((await readFile(pkgPath, 'utf-8')).toString());


### PR DESCRIPTION
`throw Error` is technically valid but `throw new Error` is like a pattern, it's better to be explicit