### PR TITLE
fix workspaces bug on merge

### DIFF
--- a/packages/cm6-graphql/tsconfig.json
+++ b/packages/cm6-graphql/tsconfig.json
@@ -9,5 +9,10 @@
     "moduleResolution": "node",
     "outDir": "dist"
   },
-  "include": ["src/*.ts"]
+  "include": ["src/*.ts"],
+  "references": [
+    {
+      "path": "../graphql-language-service"
+    }
+  ]
 }


### PR DESCRIPTION
when we added `cm6-graphql` we forgot to add the workspace `references`, to teach typescript project references about the dependency tree

This will fix a bug we are seeing in netlify (e.g. #2928)