### PR TITLE
Fix graphiql react issue with setting tabs title

### DIFF
--- a/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
+++ b/packages/graphiql-react/src/editor/__tests__/tabs.spec.ts
@@ -75,10 +75,27 @@ describe('fuzzyExtractionOperationTitle', () => {
   it('should return null for anonymous queries', () => {
     expect(fuzzyExtractOperationName('{}')).toBeNull();
   });
-  it('should not extract query names with comments', () => {
-    expect(
-      fuzzyExtractOperationName('# query My_3ExampleQuery() {}'),
-    ).toBeNull();
+
+  describe('comment line handling', () => {
+    it('should not extract query names within commented out lines', () => {
+      expect(
+        fuzzyExtractOperationName('# query My_3ExampleQuery() {}'),
+      ).toBeNull();
+    });
+    it('should extract query names when there is a single leading comment line', () => {
+      expect(
+        fuzzyExtractOperationName(
+          '# comment line 1 \n query MyExampleQueryWithSingleCommentLine() {}',
+        ),
+      ).toEqual('MyExampleQueryWithSingleCommentLine');
+    });
+    it('should extract query names when there are more than one leading comment lines', () => {
+      expect(
+        fuzzyExtractOperationName(
+          '# comment line 1 \n # comment line 2 \n query MyExampleQueryWithMultipleCommentLines() {}',
+        ),
+      ).toEqual('MyExampleQueryWithMultipleCommentLines');
+    });
   });
 });
 

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -332,7 +332,8 @@ function hashFromTabContents(args: {
 }
 
 export function fuzzyExtractOperationName(str: string): string | null {
-  const regex = /^(?!.*#).*(query|subscription|mutation)\s+([a-zA-Z0-9_]+)/;
+  const regex = /^(?!#).*(query|subscription|mutation)\s+([a-zA-Z0-9_]+)/m;
+
   const match = regex.exec(str);
 
   return match?.[2] ?? null;


### PR DESCRIPTION
A small regex fix with additional tests to address #2949.

Additionally, I visually tested this out by modifying `renderExample.js` to pass in default tabs.

Asking for review from @thomasheyenbrock (touched this code most recently) and @n1ru4l (originator).