### PR TITLE
avoid literal asterisks, use underscores instead

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,8 +9,8 @@ prompted by the EasyCLA bot. For more details, please see the
 0. First, you will need the latest `git`, `yarn` 1.16, & `node` 12 or greater.
    macOS, Windows and Linux should all be supported as build environments.
 
-**\*Note:** None of the commands below will work with `npm`. Please use `yarn`
-in this repo.\*
+_**Note:** None of the commands below will work with `npm`. Please use `yarn` in
+this repo._
 
 1. Fork this repo by using the "Fork" button in the upper-right
 


### PR DESCRIPTION
Prettier auto-formats three asterisks to one being a literal character. To use italic and bold font simultaneously without prettier interfering, we use a single underscore to mark italic text.