### PR TITLE
fix for graphiql-plugin-explorer example

### DIFF
--- a/packages/graphiql-plugin-explorer/examples/index.html
+++ b/packages/graphiql-plugin-explorer/examples/index.html
@@ -45,12 +45,12 @@
 
     <script
       src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha512-FmqQBx9FVDKvUNDuimXswv4o1eqQUqzQYIuEoIkmkDaoXMUvmD9fKQXYSrSEMf5LQUEZr5EEMesxUzex2wS/hg=="
+      integrity="sha512-FVCV2//UVo1qJ3Kg6kkHLe0Hg+IJhjrGa+aYHh8xD4KmwbbjthIzvaAcCJsQgA43+k+6u7HqORKXMyMt82Srfw=="
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://unpkg.com/@graphiql/plugin-code-exporter/dist/graphiql-plugin-code-exporter.umd.js"
-      integrity="sha512-NwP+k36ExLYeIqp2lniZCblbz/FLJ/lQlBV55B6vafZWIYppwHUp1gCdvlaaUjV95RWPInQy4z/sIa56psJy/g=="
+      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.12/dist/graphiql-plugin-explorer.umd.js"
+      integrity="sha512-Fjas/uSkzvsFjbv4jqU9nt4ulU7LDjiMAXW2YFTYD96NgKS1fhhAsGR4b2k2VaVLsE29aia3vyobAq9TNzusvA=="
       crossorigin="anonymous"
     ></script>
 


### PR DESCRIPTION
The example `index.html` was overwritten in #2835 with an incorrect unpkg URL.