### PR TITLE
fix: VariableJSONSchema for custom scalars

### DIFF
--- a/.changeset/eight-crews-clean.md
+++ b/.changeset/eight-crews-clean.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Fix JSON schema for custom scalars validation

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -128,9 +128,8 @@ function getJSONSchemaFromGraphQLType(
     definition.enum = type.getValues().map(val => val.name);
   }
 
-  if (isScalarType(type)) {
-    // I think this makes sense for custom scalars?
-    definition.type = scalarTypesMap[type.name] ?? 'any';
+  if (isScalarType(type) && scalarTypesMap[type.name]) {
+    definition.type = scalarTypesMap[type.name];
   }
   if (isListType(type)) {
     definition.type = 'array';


### PR DESCRIPTION
`any` is not an accepted value for [type](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-type), which gives an error in validation.

In order to accept any value, we should just not add the `type` property at all.

before:
![image](https://user-images.githubusercontent.com/7089997/210869353-fbb447d5-1d39-47fe-b0b5-7d06f6a51722.png)

after:
![image](https://user-images.githubusercontent.com/7089997/210869515-6b345a22-3abd-4aaf-bf28-d0704aabaf3d.png)
