### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ the now-retired `graphql-language-service-interface`,
 
 Provides language services for LSP-based IDE extensions
 
-## [`graphql-language-service-server-cli`](packages/graphql-language-service-server-cli#readme)
+## [`graphql-language-service-cli`](packages/graphql-language-service-cli#readme)
 
-[![NPM](https://img.shields.io/npm/v/graphql-language-service-server-cli.svg)](https://npmjs.com/graphql-language-service-server-cli)
-![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-server-cli?label=npm%20downloads)
-![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/graphql-language-service-server-cli)
+[![NPM](https://img.shields.io/npm/v/graphql-language-service-cli.svg)](https://npmjs.com/graphql-language-service-cli)
+![npm downloads](https://img.shields.io/npm/dm/graphql-language-service-cli?label=npm%20downloads)
+![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/graphql-language-service-cli)
 
 Provides a CLI for the language service server
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@
 ![GitHub top language](https://img.shields.io/github/languages/top/graphql/graphiql)
 ![GitHub language count](https://img.shields.io/github/languages/count/graphql/graphiql)
 [![Snyk Vulnerabilities for GitHub Repo](https://img.shields.io/snyk/vulnerabilities/github/graphql/graphiql)](https://snyk.io/test/github/graphql/graphiql)
-![LGTM Grade](https://img.shields.io/lgtm/grade/javascript/github/graphql/graphiql)
-![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/graphql/graphiql)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3887/badge)](https://bestpractices.coreinfrastructure.org/projects/3887)
 
 ## Overview


### PR DESCRIPTION
- LGTM.com is down since last year
  (https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)
- `graphql-language-service-server-cli` -> `graphql-language-service-cli`