### PR TITLE
Fix typo (`/* GraphiQL */` => `/* GraphQL */`)

### DIFF
--- a/packages/vscode-graphql/README.md
+++ b/packages/vscode-graphql/README.md
@@ -270,7 +270,7 @@ or
 
 ```ts
 const myQuery =
-  /* GraphiQL */
+  /* GraphQL */
 
   `
   query {

--- a/packages/vscode-graphql/README.md
+++ b/packages/vscode-graphql/README.md
@@ -273,10 +273,10 @@ const myQuery =
   /* GraphQL */
 
   `
-  query {
-    something
-  }
-`;
+    query {
+      something
+    }
+  `;
 ```
 
 ## Known Issues


### PR DESCRIPTION
ref: https://github.com/graphql/graphiql/issues/2843
related: https://github.com/graphql/graphiql/pull/2849

It seems that there was a part of the problem that we forgot to address in #2849.

I confirmed with `git grep` that there are no other omissions.

```console
$ git grep "\/\* GraphiQL \*\/"
packages/vscode-graphql-syntax/CHANGELOG.md:  (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` &
packages/vscode-graphql/CHANGELOG.md:  (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` &
```
