### PR TITLE
feat: maintain DocExplorer stack on schema update

### DIFF
--- a/.changeset/ninety-peaches-crash.md
+++ b/.changeset/ninety-peaches-crash.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+'graphiql': minor
+---
+
+GraphiQL now maintains the DocExplorer navigation stack as best it can when the schema is updated

--- a/packages/graphiql-react/src/explorer/context.tsx
+++ b/packages/graphiql-react/src/explorer/context.tsx
@@ -4,6 +4,15 @@ import type {
   GraphQLInputField,
   GraphQLNamedType,
 } from 'graphql';
+import {
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isNamedType,
+  isObjectType,
+  isScalarType,
+  isUnionType,
+} from 'graphql';
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useSchemaContext } from '../schema';
 import { createContextHook, createNullableContext } from '../utility/context';
@@ -63,7 +72,7 @@ export type ExplorerContextProviderProps = {
 };
 
 export function ExplorerContextProvider(props: ExplorerContextProviderProps) {
-  const { isFetching } = useSchemaContext({
+  const { schema, validationErrors } = useSchemaContext({
     nonNull: true,
     caller: ExplorerContextProvider,
   });
@@ -97,10 +106,89 @@ export function ExplorerContextProvider(props: ExplorerContextProviderProps) {
   }, []);
 
   useEffect(() => {
-    if (isFetching) {
+    // Whenever the schema changes, we must revalidate/replace the nav stack.
+    if (schema == null || validationErrors.length > 0) {
       reset();
+    } else {
+      // Replace the nav stack with an updated version using the new schema
+      setNavStack(oldNavStack => {
+        if (oldNavStack.length === 1) {
+          return oldNavStack;
+        }
+        const newNavStack: ExplorerNavStack = [initialNavStackItem];
+        let lastEntity: GraphQLNamedType | GraphQLField<any, any, any> | null =
+          null;
+        for (const item of oldNavStack) {
+          if (item === initialNavStackItem) {
+            // No need to copy the initial item
+            continue;
+          }
+          if (item.def) {
+            // If item.def isn't a named type, it must be a field, inputField, or argument
+            if (isNamedType(item.def)) {
+              // The type needs to be replaced with the new schema type of the same name
+              const newType = schema.getType(item.def.name);
+              if (newType) {
+                newNavStack.push({
+                  name: item.name,
+                  def: newType,
+                });
+                lastEntity = newType;
+              } else {
+                // This type no longer exists; the stack cannot be built beyond here
+                break;
+              }
+            } else if (lastEntity === null) {
+              // We can't have a sub-entity if we have no entity; stop rebuilding the nav stack
+              break;
+            } else if (
+              isObjectType(lastEntity) ||
+              isInputObjectType(lastEntity)
+            ) {
+              // item.def must be a Field / input field; replace with the new field of the same name
+              const field = lastEntity.getFields()[item.name];
+              if (field) {
+                newNavStack.push({
+                  name: item.name,
+                  def: field,
+                });
+              } else {
+                // This field no longer exists; the stack cannot be built beyond here
+                break;
+              }
+            } else if (
+              isScalarType(lastEntity) ||
+              isEnumType(lastEntity) ||
+              isInterfaceType(lastEntity) ||
+              isUnionType(lastEntity)
+            ) {
+              // These don't (currently) have non-type sub-entries; something has gone wrong.
+              // Handle gracefully by discontinuing rebuilding the stack.
+              break;
+            } else {
+              // lastEntity must be a field (because it's not a named type)
+              const field: GraphQLField<any, any, any> = lastEntity;
+              // Thus item.def must be an argument, so find the same named argument in the new schema
+              const arg = field.args.find(a => a.name === item.name);
+              if (arg) {
+                newNavStack.push({
+                  name: item.name,
+                  def: field,
+                });
+              } else {
+                // This argument no longer exists; the stack cannot be built beyond here
+                break;
+              }
+            }
+          } else {
+            lastEntity = null;
+            newNavStack.push(item);
+          }
+        }
+        return newNavStack;
+      });
     }
-  }, [isFetching, reset]);
+  }, [reset, schema, validationErrors]);
 
   const value = useMemo<ExplorerContextType>(
     () => ({ explorerNavStack: navStack, push, pop, reset }),

--- a/packages/graphiql-react/src/schema.tsx
+++ b/packages/graphiql-react/src/schema.tsx
@@ -193,8 +193,6 @@ export function SchemaContextProvider(props: SchemaContextProviderProps) {
 
     const counter = ++counterRef.current;
 
-    setSchema(undefined);
-
     const maybeIntrospectionData = props.schema;
     async function fetchIntrospectionData() {
       if (maybeIntrospectionData) {


### PR DESCRIPTION
Previously:

- when you click the schema reload button, the doc explorer stack was reset even if the schema is unchanged 😞 
- when you passed a new schema in, the doc explorer stack is _unaffected_, meaning it can render invalid content or even crash in some circumstances 🐞

I'm not sure what the need for resetting the explorer stack is, so I've raised this PR to begin discussions. I believe that the doc explorer should only be reset when an incompatible schema is loaded, and even then we should aim to keep the compatible parts of the stack where possible. I've attempted to achieve this (and included tests for the same) in this PR.