### PR TITLE
avoid bundling code from `react/jsx-runtime`

### DIFF
--- a/.changeset/twenty-flies-unite.md
+++ b/.changeset/twenty-flies-unite.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-explorer': patch
+'@graphiql/react': patch
+---
+
+Avoid bundling code from `react/jsx-runtime` so that the package can be used with Preact

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,7 +132,11 @@ module.exports = {
 
     '@typescript-eslint/no-unused-vars': [
       'error',
-      { argsIgnorePattern: '^_', ignoreRestSiblings: true },
+      {
+        varsIgnorePattern: '^React$',
+        argsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
     ],
 
     'no-use-before-define': 0,

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -96,6 +96,7 @@ onegraph
 openvsx
 ovsx
 picomatch
+preact
 snyk
 stackblitz
 strictsoftware

--- a/packages/graphiql-plugin-code-exporter/src/index.tsx
+++ b/packages/graphiql-plugin-code-exporter/src/index.tsx
@@ -1,5 +1,5 @@
 import type { GraphiQLPlugin } from '@graphiql/react';
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 import GraphiQLCodeExporter, {
   GraphiQLCodeExporterProps,
 } from 'graphiql-code-exporter';

--- a/packages/graphiql-plugin-code-exporter/tsconfig.json
+++ b/packages/graphiql-plugin-code-exporter/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "declaration": true,
     "declarationDir": "types",
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/graphiql-plugin-code-exporter/vite.config.ts
+++ b/packages/graphiql-plugin-code-exporter/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react({ jsxRuntime: 'classic' })],
   build: {
     lib: {
       entry: 'src/index.tsx',

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -5,7 +5,7 @@ import {
   useSchemaContext,
 } from '@graphiql/react';
 import GraphiQLExplorer, { GraphiQLExplorerProps } from 'graphiql-explorer';
-import { useRef } from 'react';
+import React, { useRef } from 'react';
 
 import './graphiql-explorer.d.ts';
 import './index.css';

--- a/packages/graphiql-plugin-explorer/tsconfig.json
+++ b/packages/graphiql-plugin-explorer/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "declaration": true,
     "declarationDir": "types",
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/graphiql-plugin-explorer/vite.config.ts
+++ b/packages/graphiql-plugin-explorer/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react({ jsxRuntime: 'classic' })],
   build: {
     lib: {
       entry: 'src/index.tsx',

--- a/packages/graphiql-react/vite.config.ts
+++ b/packages/graphiql-react/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       formats: ['cjs', 'es'],
     },
     rollupOptions: {
-      external: ['graphql', 'react', 'react-dom'],
+      external: ['graphql', 'react', 'react-dom', 'react/jsx-runtime'],
       output: {
         chunkFileNames: '[name].[format].js',
       },


### PR DESCRIPTION
We currently include code from `react/jsx-runtime` in the bundled output files. That prevents anybody from using these packages with Preact, as using React-packages with Preact relies on import aliasing. We solve that for all affected packages in two different ways:
- For `@graphiql/react` we're simply marking `react/jsx-runtime` as external.
- For the plugin packages (`@graphiql/plugin-explorer` and `@graphiql/plugin-code-exporter`) the above doesn't work because these packages also provide a UMD build. There's currently no file provided by `react` that would allow to load the JSX runtime transform as UMD bundle. So instead we fall back to the "classic" JSX transform that requires us to `import React from 'react'` in all `tsx` files. However, these plugins are quite lean and only consist of one such file, so the overhead is minimal.