### PR TITLE
feature: add fragment arguments syntax highlights

### DIFF
--- a/.changeset/eighty-rabbits-ring.md
+++ b/.changeset/eighty-rabbits-ring.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': minor
+---
+
+Adds syntax highlighting for arguments on fragment spreads as well as variable definitions on fragments.

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -31,15 +31,21 @@
     },
     "graphql-fragment-definition": {
       "name": "meta.fragment.graphql",
-      "begin": "\\s*(?:(\\bfragment\\b)\\s*([_A-Za-z][_0-9A-Za-z]*)?\\s*(?:(\\bon\\b)\\s*([_A-Za-z][_0-9A-Za-z]*)))",
+      "begin": "\\s*(?:(\\bfragment\\b)\\s*([_A-Za-z][_0-9A-Za-z]*)?)",
       "end": "(?<=})",
       "captures": {
         "1": { "name": "keyword.fragment.graphql" },
-        "2": { "name": "entity.name.fragment.graphql" },
-        "3": { "name": "keyword.on.graphql" },
-        "4": { "name": "support.type.graphql" }
+        "2": { "name": "entity.name.fragment.graphql" }
       },
       "patterns": [
+        {
+          "match": "\\s*(?:(\\bon\\b)\\s*([_A-Za-z][_0-9A-Za-z]*))",
+          "captures": {
+            "1": { "name": "keyword.on.graphql" },
+            "2": { "name": "support.type.graphql" }
+          }
+        },
+        { "include": "#graphql-variable-definitions" },
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-description-singleline" },
@@ -487,6 +493,7 @@
         "2": { "name": "variable.fragment.graphql" }
       },
       "patterns": [
+        { "include": "#graphql-arguments" },
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-description-singleline" },


### PR DESCRIPTION
Adding fragment argument syntax highlighting to VSCode. This is needed as per discussion in https://github.com/graphql/graphql-wg/discussions/1239#discussioncomment-4908699

Before:
<img width="1136" alt="vscode-graphql-missing-fragment-args" src="https://user-images.githubusercontent.com/1741248/217733503-d4662749-0bd0-4663-b6b3-76383b2cf48e.png">

After:
<img width="1136" alt="vscode-graphql-with-fragment-args" src="https://user-images.githubusercontent.com/1741248/217733543-05eddddd-fe2a-4f0a-962d-9d6086a8d4d3.png">

To test this:
- Download VSCode from https://code.visualstudio.com/docs
- Download the *GraphQL Foundation* **GraphQL Syntax Highlighting** extension (in my case, v1.0.6)
- Write a `test.graphql` file and ensure syntax highlighting is working as expected.
- Copy `graphiql/packages/vscode-graphql-syntax/grammars/graphql.json` to `~/.vscode/extensions/graphql.vscode-graphql-syntax-1.0.6/grammars/graphql.json`
- Reload VSCode

*Probably* the fast-devex way to make changes here is to have some `ln -s` symlink from `~/.vscode/extensions/` to `graphiql/packages/vscode-graphql-syntax`, but this change was simple enough that I didn't need that quick an iteration cycle.