### PR TITLE
[graphql-language-service-cli] use a valid command in the readme example

### DIFF
--- a/packages/graphql-language-service-cli/README.md
+++ b/packages/graphql-language-service-cli/README.md
@@ -95,7 +95,7 @@ useful on projects maintaining compatibility with the intellij plugin
 ### Using the command-line interface
 
 ```sh
-graphql-lsp server --schema=localhost:3000
+graphql-lsp server -m stream -c .
 ```
 
 The node executable contains several commands: `server` and the command-line


### PR DESCRIPTION
The command originally there did not work, because "schema" is not a valid option to the CLI.