### PR TITLE
fix monaco peer deps and linting

### DIFF
--- a/.changeset/warm-hotels-compare.md
+++ b/.changeset/warm-hotels-compare.md
@@ -1,0 +1,5 @@
+---
+'monaco-graphql': minor
+---
+
+Upgrade peer resolutions for monaco-graphql

--- a/examples/monaco-graphql-nextjs/package-lock.json
+++ b/examples/monaco-graphql-nextjs/package-lock.json
@@ -9,19 +9,15 @@
       "version": "0.1.0",
       "dependencies": {
         "@graphiql/toolkit": "^0.8.0",
-        "@next/font": "13.1.6",
         "@types/node": "18.13.0",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
-        "@zeit/next-css": "^1.0.1",
-        "css-loader": "^6.7.3",
         "eslint": "8.34.0",
         "eslint-config-next": "13.1.6",
         "graphql": "^16.6.0",
         "graphql-ws": "^5.11.3",
         "jsonc-parser": "^3.2.0",
         "marked": "^4.2.12",
-        "mini-css-extract-plugin": "^2.7.2",
         "monaco-editor": "^0.35.0",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "monaco-graphql": "^1.1.7",
@@ -30,9 +26,7 @@
         "prettier": "^2.8.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "style-loader": "^3.3.1",
-        "typescript": "4.9.5",
-        "worker-loader": "^3.0.8"
+        "typescript": "4.9.5"
       }
     },
     "node_modules/@babel/runtime": {
@@ -116,6 +110,64 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
     "node_modules/@n1ru4l/push-pull-async-iterable-iterator": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@n1ru4l/push-pull-async-iterable-iterator/-/push-pull-async-iterable-iterator-3.2.0.tgz",
@@ -136,11 +188,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.1.6.tgz",
-      "integrity": "sha512-AITjmeb1RgX1HKMCiA39ztx2mxeAyxl4ljv2UoSBUGAbFFMg8MO7YAvjHCgFhD39hL7YTbFjol04e/BPBH5RzQ=="
     },
     "node_modules/@next/swc-android-arm-eabi": {
       "version": "13.1.6",
@@ -401,10 +448,37 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
+      "integrity": "sha512-rc9K8ZpVjNcLs8Fp0dkozd5Pt2Apk1glO4Vgz8ix1u6yFByxfqo5Yavpy65o+93TAe24jr7v+eSBtFLvOQtCRQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "peer": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -540,273 +614,163 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@zeit/next-css": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@zeit/next-css/-/next-css-1.0.1.tgz",
-      "integrity": "sha512-yfHPRy/ne/5SddVClsoy+fpU7e0Cs1gkWA67/wm2uIu+9rznF45yQLxHEt5dPGF3h6IiIh7ZtIgA8VV8YKq87A==",
-      "deprecated": "Next.js now has built-in support for CSS: https://nextjs.org/docs/basic-features/built-in-css-support. The built-in support solves many bugs and painpoints that the next-css plugin had.",
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
+      "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+      "peer": true,
       "dependencies": {
-        "css-loader": "1.0.0",
-        "extracted-loader": "1.0.4",
-        "find-up": "2.1.0",
-        "ignore-loader": "0.1.2",
-        "mini-css-extract-plugin": "0.4.3",
-        "postcss-loader": "3.0.0"
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
+      "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
+      "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
+      "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
+      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+      "peer": true,
       "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
+      "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
+      "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+      "peer": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
+      "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+      "peer": true,
       "dependencies": {
-        "color-name": "1.1.3"
+        "@xtuc/ieee754": "^1.2.0"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@zeit/next-css/node_modules/css-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.0.tgz",
-      "integrity": "sha512-tMXlTYf3mIMt3b0dDCOQFJiVvxbocJ5Ho577WiGPYPZcqVEO218L2iU22pDXzkTZCLDE+9AmGSUkWxeh/nZReA==",
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
+      "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+      "peer": true,
       "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "css-selector-tokenizer": "^0.7.0",
-        "icss-utils": "^2.1.0",
-        "loader-utils": "^1.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "postcss": "^6.0.23",
-        "postcss-modules-extract-imports": "^1.2.0",
-        "postcss-modules-local-by-default": "^1.2.0",
-        "postcss-modules-scope": "^1.1.0",
-        "postcss-modules-values": "^1.3.0",
-        "postcss-value-parser": "^3.3.0",
-        "source-list-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0"
+        "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
+      "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+      "peer": true
     },
-    "node_modules/@zeit/next-css/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
+      "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+      "peer": true,
       "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/icss-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-      "integrity": "sha512-bsVoyn/1V4R1kYYjLcWLedozAM4FClZUdjE9nIr8uWY7xs78y9DATgwz2wGU7M+7z55KenmmTkN2DVJ7bqzjAA==",
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
+      "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+      "peer": true,
       "dependencies": {
-        "postcss": "^6.0.1"
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
+      "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+      "peer": true,
       "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
+      "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+      "peer": true,
       "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/mini-css-extract-plugin": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.3.tgz",
-      "integrity": "sha512-Mxs0nxzF1kxPv4TRi2NimewgXlJqh0rGE30vviCU2WHrpbta6wklnUV9dr9FUtoAHmB3p3LeXEC+ZjgHvB0Dzg==",
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
+      "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+      "peer": true,
       "dependencies": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.4.0"
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@zeit/next-css/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-      "dependencies": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/postcss-modules-extract-imports": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
-      "dependencies": {
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/postcss-modules-local-by-default": {
+    "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-      "integrity": "sha512-X4cquUPIaAd86raVrBwO8fwRfkIdbwFu7CTfEOjiZQHVQwlHRSkTgH5NLDmMm5+1hQO8u6dZ+TOOJDbay1hYpA==",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      }
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "peer": true
     },
-    "node_modules/@zeit/next-css/node_modules/postcss-modules-scope": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-      "integrity": "sha512-LTYwnA4C1He1BKZXIx1CYiHixdSe9LWYVKadq9lK5aCCMkoOkFyZ7aigt+srfjlRplJY3gIol6KUNefdMQJdlw==",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/postcss-modules-values": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-      "integrity": "sha512-i7IFaR9hlQ6/0UgFuqM6YWaCfA1Ej8WMg8A5DggnH1UGKJvTV/ugqq/KaULixzzOi3T/tF6ClBXcHGCzdd5unA==",
-      "dependencies": {
-        "icss-replace-symbols": "^1.1.0",
-        "postcss": "^6.0.1"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
-    },
-    "node_modules/@zeit/next-css/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zeit/next-css/node_modules/webpack-sources": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-      "dependencies": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      }
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.8.2",
@@ -817,6 +781,15 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -842,54 +815,11 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ajv-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "peerDependencies": {
-        "ajv": ">=5.0.0"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "peer": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
@@ -1033,79 +963,6 @@
         "deep-equal": "^2.0.5"
       }
     },
-    "node_modules/babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg=="
-    },
-    "node_modules/babel-code-frame/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1139,6 +996,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "peer": true
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1149,36 +1040,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-callsite/node_modules/callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -1219,6 +1080,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1240,64 +1110,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "peer": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1310,74 +1132,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-loader": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
-      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.19",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/css-loader/node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.4",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
-      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -1483,6 +1237,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.320",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.320.tgz",
+      "integrity": "sha512-h70iRscrNluMZPVICXYl5SSB+rBKo22XfuIS1ER0OQxQZpKTnFpuS6coj7wY9M/3trv7OR88rRMOlKmRvDty7Q==",
+      "peer": true
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -1506,14 +1266,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -1581,6 +1333,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+      "peer": true
+    },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
@@ -1616,6 +1374,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2031,18 +1798,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
@@ -2081,10 +1836,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extracted-loader": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/extracted-loader/-/extracted-loader-1.0.4.tgz",
-      "integrity": "sha512-G8A0hT/WCWIjesZm7BwbWdST5dQ08GNnCpTrJT/k/FYzuiJwlV1gyWjnuoizOzAR4jpEYXG2J++JyEKN/EB26Q=="
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2126,11 +1885,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
-    },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2303,6 +2057,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "peer": true
+    },
     "node_modules/globals": {
       "version": "13.20.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -2426,25 +2186,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -2508,44 +2249,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg=="
-    },
-    "node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ignore-loader": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
-      "integrity": "sha512-yOJQEKrNwoYqrWLS4DcnzM7SEQhRKis5mB+LdKKh4cPmGYlLPR0ozRzHV5jmEk2IxptqJNQA5Cc0gw8Fj12bXA=="
-    },
-    "node_modules/import-cwd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
-      "integrity": "sha512-Ew5AZzJQFqrOV5BTW3EIoHAnoie1LojZLXKcCQ/yTRyVZosBhK1x1ViYjHGf5pAFOq8ZyChZp6m/fSN7pJyZtg==",
-      "dependencies": {
-        "import-from": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/import-fresh": {
@@ -2561,25 +2270,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-from": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
-      "integrity": "sha512-0vdnLL2wSGnhlRmzHJAg5JHjt1l2vYhzJ7tNLGbeVg0fse56tpGaH0uzH+r9Slej+BSXXEHvBKDEnVSLLE9/+w==",
-      "dependencies": {
-        "resolve-from": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/import-from/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/imurmurhash": {
@@ -2645,11 +2335,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -2710,14 +2395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-docker": {
@@ -2934,6 +2611,35 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -2959,10 +2665,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3027,6 +2734,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
     "node_modules/loader-utils": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
@@ -3064,11 +2780,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3108,6 +2819,12 @@
         "node": ">= 12"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "peer": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3144,71 +2861,25 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mini-css-extract-plugin": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.2.tgz",
-      "integrity": "sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==",
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
       "dependencies": {
-        "schema-utils": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3282,6 +2953,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "peer": true
+    },
     "node_modules/next": {
       "version": "13.1.6",
       "resolved": "https://registry.npmjs.org/next/-/next-13.1.6.tgz",
@@ -3337,6 +3014,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/next-global-css/-/next-global-css-1.3.1.tgz",
       "integrity": "sha512-+OnTwQKmv1lDP7r4R3T94oq6372R9UGVivchBQu49j7ZjzvSXHCnv93yAuhgMkvUgAbGifTs8sQ5YL9wjyAxfA=="
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "peer": true
     },
     "node_modules/nullthrows": {
       "version": "1.1.1",
@@ -3524,14 +3207,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3541,18 +3216,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-exists": {
@@ -3642,155 +3305,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-load-config": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
-      "integrity": "sha512-/rDeGV6vMUo3mwJZmeHfEDvwnTKKqQ0S7OHUi/kJvvtx3aWtyWG2/0ZWnzCt2keEclwN6Tf0DST2v9kITdOKYw==",
-      "dependencies": {
-        "cosmiconfig": "^5.0.0",
-        "import-cwd": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-3.0.0.tgz",
-      "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
-      "dependencies": {
-        "loader-utils": "^1.1.0",
-        "postcss": "^7.0.0",
-        "postcss-load-config": "^2.0.0",
-        "schema-utils": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA=="
-    },
-    "node_modules/postcss-loader/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-loader/node_modules/schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3850,6 +3364,15 @@
         }
       ]
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -3908,14 +3431,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -3987,6 +3502,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -4012,6 +3547,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
       "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -4037,6 +3573,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {
@@ -4079,15 +3624,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4100,10 +3641,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
@@ -4190,21 +3736,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/style-loader": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
@@ -4270,6 +3801,58 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+      "integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.14",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "terser": "^5.14.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-table": {
@@ -4393,6 +3976,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4401,15 +4010,101 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.3",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "peer": true,
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.75.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
+      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.7.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4479,25 +4174,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/worker-loader": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
-      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
-      "dependencies": {
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/examples/monaco-graphql-nextjs/src/pages/_app.tsx
+++ b/examples/monaco-graphql-nextjs/src/pages/_app.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 

--- a/examples/monaco-graphql-nextjs/src/pages/_document.tsx
+++ b/examples/monaco-graphql-nextjs/src/pages/_document.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {

--- a/examples/monaco-graphql-nextjs/src/pages/index.tsx
+++ b/examples/monaco-graphql-nextjs/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Head from 'next/head';
 import dynamic from 'next/dynamic';
 

--- a/examples/monaco-graphql-webpack/CHANGELOG.md
+++ b/examples/monaco-graphql-webpack/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
   - monaco-graphql@1.1.8
 
-All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [1.1.1-alpha.7](https://github.com/graphql/graphiql/compare/example-monaco-graphql-webpack@1.1.1-alpha.6...example-monaco-graphql-webpack@1.1.1-alpha.7) (2021-01-07)
 
@@ -34,7 +40,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- improve setSchema & schema loading, allow primitive schema ([#1648](https://github.com/graphql/graphiql/issues/1648)) ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
+- improve setSchema & schema loading, allow primitive schema
+  ([#1648](https://github.com/graphql/graphiql/issues/1648))
+  ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
 
 ## [1.1.1-alpha.1](https://github.com/graphql/graphiql/compare/example-monaco-graphql-webpack@1.1.1-alpha.0...example-monaco-graphql-webpack@1.1.1-alpha.1) (2020-08-12)
 
@@ -48,13 +56,17 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-- [RFC] GraphiQL rewrite for monaco editor, react context and redesign, i18n ([#1523](https://github.com/graphql/graphiql/issues/1523)) ([ad730cd](https://github.com/graphql/graphiql/commit/ad730cdc2e3cb7216d821a01725c60475989ee20))
+- [RFC] GraphiQL rewrite for monaco editor, react context and redesign, i18n
+  ([#1523](https://github.com/graphql/graphiql/issues/1523))
+  ([ad730cd](https://github.com/graphql/graphiql/commit/ad730cdc2e3cb7216d821a01725c60475989ee20))
 
 # [1.0.0](https://github.com/graphql/graphiql/compare/example-monaco-graphql-webpack@1.0.0-alpha.8...example-monaco-graphql-webpack@1.0.0) (2020-06-11)
 
 ### Features
 
-- standalone monaco API ([#1575](https://github.com/graphql/graphiql/issues/1575)) ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
+- standalone monaco API
+  ([#1575](https://github.com/graphql/graphiql/issues/1575))
+  ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
 
 # [1.0.0-alpha.8](https://github.com/graphql/graphiql/compare/example-monaco-graphql-webpack@1.0.0-alpha.7...example-monaco-graphql-webpack@1.0.0-alpha.8) (2020-06-04)
 
@@ -76,5 +88,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-- Monaco Mode - Phase 2 - Mode & Worker ([#1459](https://github.com/graphql/graphiql/issues/1459)) ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
-- monaco-graphql docs, api, improvements ([#1521](https://github.com/graphql/graphiql/issues/1521)) ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))
+- Monaco Mode - Phase 2 - Mode & Worker
+  ([#1459](https://github.com/graphql/graphiql/issues/1459))
+  ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
+- monaco-graphql docs, api, improvements
+  ([#1521](https://github.com/graphql/graphiql/issues/1521))
+  ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))

--- a/packages/cm6-graphql/CHANGELOG.md
+++ b/packages/cm6-graphql/CHANGELOG.md
@@ -4,30 +4,54 @@
 
 ### Patch Changes
 
-- [#2995](https://github.com/graphql/graphiql/pull/2995) [`5f276c41`](https://github.com/graphql/graphiql/commit/5f276c415ad93350382fec873025ffecc9a29d9d) Thanks [@imolorhe](https://github.com/imolorhe)! - fix(cm6-graphql): Fix query token used as field name
+- [#2995](https://github.com/graphql/graphiql/pull/2995)
+  [`5f276c41`](https://github.com/graphql/graphiql/commit/5f276c415ad93350382fec873025ffecc9a29d9d)
+  Thanks [@imolorhe](https://github.com/imolorhe)! - fix(cm6-graphql): Fix query
+  token used as field name
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
 ## 0.0.2
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2992](https://github.com/graphql/graphiql/pull/2992) [`cc245246`](https://github.com/graphql/graphiql/commit/cc2452467688f3cdcd7a196dddf47e3b81367d62) Thanks [@acao](https://github.com/acao)! - fix tsconfig reference, new netlify deploy
+- [#2992](https://github.com/graphql/graphiql/pull/2992)
+  [`cc245246`](https://github.com/graphql/graphiql/commit/cc2452467688f3cdcd7a196dddf47e3b81367d62)
+  Thanks [@acao](https://github.com/acao)! - fix tsconfig reference, new netlify
+  deploy
 
 ## 0.0.1
 
 ### Patch Changes
 
-- [#2867](https://github.com/graphql/graphiql/pull/2867) [`9fd12838`](https://github.com/graphql/graphiql/commit/9fd128381a86220a7c658f21d72baa8eea45a8af) Thanks [@imolorhe](https://github.com/imolorhe)! - fix: fixed "Mark decorations may not be empty" error
+- [#2867](https://github.com/graphql/graphiql/pull/2867)
+  [`9fd12838`](https://github.com/graphql/graphiql/commit/9fd128381a86220a7c658f21d72baa8eea45a8af)
+  Thanks [@imolorhe](https://github.com/imolorhe)! - fix: fixed "Mark
+  decorations may not be empty" error
 
 ## 0.0.0
 
 ### Patch Changes
 
-- [#2852](https://github.com/graphql/graphiql/pull/2852) [`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b) Thanks [@acao](https://github.com/acao)! - First release of a modern codemirror 6 mode for graphql by @imolorhe!
+- [#2852](https://github.com/graphql/graphiql/pull/2852)
+  [`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b)
+  Thanks [@acao](https://github.com/acao)! - First release of a modern
+  codemirror 6 mode for graphql by @imolorhe!

--- a/packages/codemirror-graphql/CHANGELOG.md
+++ b/packages/codemirror-graphql/CHANGELOG.md
@@ -4,128 +4,200 @@
 
 ### Patch Changes
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
 
 ## 2.0.3
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2941](https://github.com/graphql/graphiql/pull/2941) [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-logical-operator-over-ternary` rule
+- [#2941](https://github.com/graphql/graphiql/pull/2941)
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-logical-operator-over-ternary` rule
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2936](https://github.com/graphql/graphiql/pull/2936) [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `lonely-if`/`unicorn/lonely-if` rules
+- [#2936](https://github.com/graphql/graphiql/pull/2936)
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `lonely-if`/`unicorn/lonely-if` rules
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
   - graphql-language-service@5.1.1
 
 ## 2.0.2
 
 ### Patch Changes
 
-- [#2852](https://github.com/graphql/graphiql/pull/2852) [`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b) Thanks [@acao](https://github.com/acao)! - increment @codemirror/language peer dependency to 6.0.0
+- [#2852](https://github.com/graphql/graphiql/pull/2852)
+  [`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b)
+  Thanks [@acao](https://github.com/acao)! - increment @codemirror/language peer
+  dependency to 6.0.0
 
 ## 2.0.1
 
 ### Patch Changes
 
-- [#2847](https://github.com/graphql/graphiql/pull/2847) [`353f434e`](https://github.com/graphql/graphiql/commit/353f434e5f6bfd1bf6f8ee97d4ae8ce4f897085f) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Don't show error in variable editor linting for missing input objects that have a default value
+- [#2847](https://github.com/graphql/graphiql/pull/2847)
+  [`353f434e`](https://github.com/graphql/graphiql/commit/353f434e5f6bfd1bf6f8ee97d4ae8ce4f897085f)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Don't show
+  error in variable editor linting for missing input objects that have a default
+  value
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: Change the implementation of the info popup when hovering items in the code editor:
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: Change the implementation
+  of the info popup when hovering items in the code editor:
   - For fields the type prefix was removed, i.e. `MyType.myField` -> `myField`
-  - For args, the type and field was removed, i.e. `MyType.myField(myArg: MyArgType)` -> `myArg: MyArgType`
-  - The DOM structure of the info tooltip changed to enable more flexible styling:
-    - The first section (i.e. the clickable parts like type and field name) are wrapped in an additional div
-    - The markdown content for deprecation reasons is wrapped in an additional div
+  - For args, the type and field was removed, i.e.
+    `MyType.myField(myArg: MyArgType)` -> `myArg: MyArgType`
+  - The DOM structure of the info tooltip changed to enable more flexible
+    styling:
+    - The first section (i.e. the clickable parts like type and field name) are
+      wrapped in an additional div
+    - The markdown content for deprecation reasons is wrapped in an additional
+      div
 
 ## 1.3.3
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
 
 ## 1.3.2
 
 ### Patch Changes
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service@5.0.6
 
 ## 1.3.1
 
 ### Patch Changes
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service@5.0.5
 
 ## 1.3.0
 
 ### Minor Changes
 
-- [#2369](https://github.com/graphql/graphiql/pull/2369) [`2dec55f2`](https://github.com/graphql/graphiql/commit/2dec55f2c5e979cc7bb1adadff4fb063775b088c) Thanks [@sergeichestakov](https://github.com/sergeichestakov)! - Moved @codemirror/language to peer dependencies and upgraded to 0.20.0
+- [#2369](https://github.com/graphql/graphiql/pull/2369)
+  [`2dec55f2`](https://github.com/graphql/graphiql/commit/2dec55f2c5e979cc7bb1adadff4fb063775b088c)
+  Thanks [@sergeichestakov](https://github.com/sergeichestakov)! - Moved
+  @codemirror/language to peer dependencies and upgraded to 0.20.0
 
 ### Patch Changes
 
-- Updated dependencies [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - graphql-language-service@5.0.4
 
 ## 1.2.17
 
 ### Patch Changes
 
-- Updated dependencies [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
+- Updated dependencies
+  [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
   - graphql-language-service@5.0.3
 
 ## 1.2.16
 
 ### Patch Changes
 
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service@5.0.2
 
 ## 1.2.15
 
 ### Patch Changes
 
-- [#2261](https://github.com/graphql/graphiql/pull/2261) [`261f2044`](https://github.com/graphql/graphiql/commit/261f2044066412e40f9962bef55295f7c9c35aec) Thanks [@acao](https://github.com/acao)! - Fix typescript path resolution bug in codemirror-graphql
+- [#2261](https://github.com/graphql/graphiql/pull/2261)
+  [`261f2044`](https://github.com/graphql/graphiql/commit/261f2044066412e40f9962bef55295f7c9c35aec)
+  Thanks [@acao](https://github.com/acao)! - Fix typescript path resolution bug
+  in codemirror-graphql
 
 ## 1.2.14
 
 ### Patch Changes
 
-- Updated dependencies [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa), [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
+- Updated dependencies
+  [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa),
+  [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
   - graphql-language-service@5.0.1
 
 ## 1.2.13
 
 ### Patch Changes
 
-- Updated dependencies [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
+- Updated dependencies
+  [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
   - graphql-language-service@5.0.0
 
 ## 1.2.12
 
 ### Patch Changes
 
-- Updated dependencies [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f), [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c), [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
+- Updated dependencies
+  [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f),
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c),
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
   - graphql-language-service@4.1.5
 
 ## 1.2.11
@@ -139,21 +211,26 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
+- Updated dependencies
+  [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
   - graphql-language-service@4.1.3
 
 ## 1.2.9
 
 ### Patch Changes
 
-- Updated dependencies [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
+- Updated dependencies
+  [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
   - graphql-language-service@4.1.2
 
 ## 1.2.8
 
 ### Patch Changes
 
-- [#2091](https://github.com/graphql/graphiql/pull/2091) [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63) Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues. Should now build & test interchangeably.
+- [#2091](https://github.com/graphql/graphiql/pull/2091)
+  [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)
+  Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues.
+  Should now build & test interchangeably.
 
 - Updated dependencies []:
   - graphql-language-service@4.1.1
@@ -162,21 +239,24 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
+- Updated dependencies
+  [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
   - graphql-language-service@4.1.0
 
 ## 1.2.6
 
 ### Patch Changes
 
-- Updated dependencies [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
+- Updated dependencies
+  [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
   - graphql-language-service@4.0.0
 
 ## 1.2.5
 
 ### Patch Changes
 
-- Updated dependencies [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+- Updated dependencies
+  [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service@3.2.5
 
 ## 1.2.4
@@ -190,47 +270,74 @@
 
 ### Patch Changes
 
-- [`c42b145f`](https://github.com/graphql/graphiql/commit/c42b145fffeaefbd1103bc7addee1873e939bc83) [#2052](https://github.com/graphql/graphiql/pull/2052) Thanks [@imolorhe](https://github.com/imolorhe)! - Added cm6-legacy to published files list
+- [`c42b145f`](https://github.com/graphql/graphiql/commit/c42b145fffeaefbd1103bc7addee1873e939bc83)
+  [#2052](https://github.com/graphql/graphiql/pull/2052) Thanks
+  [@imolorhe](https://github.com/imolorhe)! - Added cm6-legacy to published
+  files list
 
 ## 1.2.2
 
 ### Patch Changes
 
-- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf) [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks [@willstott101](https://github.com/willstott101)! - Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.
+- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)
+  [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks
+  [@willstott101](https://github.com/willstott101)! - Source code included in
+  all packages to fix source maps. codemirror-graphql includes esm build in
+  package.
 
-* [`8b486555`](https://github.com/graphql/graphiql/commit/8b486555e2aa4d90891070a1bbc52b59d9c670c4) [#2046](https://github.com/graphql/graphiql/pull/2046) Thanks [@willstott101](https://github.com/willstott101)! - Further resolves #1944, replaces graphql-language-service-parser with graphql-language-service in codemirror-graphql
+* [`8b486555`](https://github.com/graphql/graphiql/commit/8b486555e2aa4d90891070a1bbc52b59d9c670c4)
+  [#2046](https://github.com/graphql/graphiql/pull/2046) Thanks
+  [@willstott101](https://github.com/willstott101)! - Further resolves #1944,
+  replaces graphql-language-service-parser with graphql-language-service in
+  codemirror-graphql
 
-* Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
+* Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
   - graphql-language-service@3.2.3
 
 ## 1.2.1
 
 ### Patch Changes
 
-- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
-- Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+- Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - graphql-language-service@3.2.2
 
 ## 1.2.0
 
 ### Minor Changes
 
-- [`d0c22c4f`](https://github.com/graphql/graphiql/commit/d0c22c4fce5ea39611c7ecee553943fdf27fd03e) [#2035](https://github.com/graphql/graphiql/pull/2035) Thanks [@imolorhe](https://github.com/imolorhe)! - Added Codemirror 6 legacy support
+- [`d0c22c4f`](https://github.com/graphql/graphiql/commit/d0c22c4fce5ea39611c7ecee553943fdf27fd03e)
+  [#2035](https://github.com/graphql/graphiql/pull/2035) Thanks
+  [@imolorhe](https://github.com/imolorhe)! - Added Codemirror 6 legacy support
 
 ### Patch Changes
 
-- [`b79bf304`](https://github.com/graphql/graphiql/commit/b79bf304045add4b5c3b2539dd6b551a64e6ed87) [#2037](https://github.com/graphql/graphiql/pull/2037) Thanks [@acao](https://github.com/acao)! - Resolves #1944, replaces graphql-language-service-utils with graphql-language-service in codemirror-graphql
+- [`b79bf304`](https://github.com/graphql/graphiql/commit/b79bf304045add4b5c3b2539dd6b551a64e6ed87)
+  [#2037](https://github.com/graphql/graphiql/pull/2037) Thanks
+  [@acao](https://github.com/acao)! - Resolves #1944, replaces
+  graphql-language-service-utils with graphql-language-service in
+  codemirror-graphql
 
 ## 1.1.0
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`8869c4b1`](https://github.com/graphql/graphiql/commit/8869c4b18c900b9b35556255587ef5130a96a4d5), [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`8869c4b1`](https://github.com/graphql/graphiql/commit/8869c4b18c900b9b35556255587ef5130a96a4d5),
+  [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - graphql-language-service-interface@2.9.0
   - graphql-language-service-parser@1.10.0
 
@@ -238,30 +345,43 @@
 
 ### Patch Changes
 
-- [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+- [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-- Updated dependencies [[`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+- Updated dependencies
+  [[`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service-parser@1.9.3
 
 ## 1.0.2
 
 ### Patch Changes
 
-- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92) [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
+- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92)
+  [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks
+  [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
 
 ## 1.0.1
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## 1.0.0
 
 ### Major Changes
 
-- [`b4fc16c0`](https://github.com/graphql/graphiql/commit/b4fc16c025da6f466727dc17cab6026d14c6e7fe) Thanks [@imolorhe](https://github.com/imolorhe)! - BREAKING CHANGE Migrate to Typescript - [@imolorhe](https://github.com/imolorhe)
+- [`b4fc16c0`](https://github.com/graphql/graphiql/commit/b4fc16c025da6f466727dc17cab6026d14c6e7fe)
+  Thanks [@imolorhe](https://github.com/imolorhe)! - BREAKING CHANGE Migrate to
+  Typescript - [@imolorhe](https://github.com/imolorhe)
 
-All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [0.15.2](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.15.1...codemirror-graphql@0.15.2) (2021-01-07)
 
@@ -271,19 +391,26 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- bug with externalFragments in codemirror ([#1751](https://github.com/graphql/graphiql/issues/1751)) ([f423e61](https://github.com/graphql/graphiql/commit/f423e615330bf8529f4068889d6760501b732527))
+- bug with externalFragments in codemirror
+  ([#1751](https://github.com/graphql/graphiql/issues/1751))
+  ([f423e61](https://github.com/graphql/graphiql/commit/f423e615330bf8529f4068889d6760501b732527))
 
 ## [0.15.0](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.14.0...codemirror-graphql@0.15.0) (2021-01-07)
 
 ### Features
 
-- implied or external fragments, for [#612](https://github.com/graphql/graphiql/issues/612) ([#1750](https://github.com/graphql/graphiql/issues/1750)) ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
+- implied or external fragments, for
+  [#612](https://github.com/graphql/graphiql/issues/612)
+  ([#1750](https://github.com/graphql/graphiql/issues/1750))
+  ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
 
 ## [0.14.0](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.13.1...codemirror-graphql@0.14.0) (2021-01-03)
 
 ### Features
 
-- merge completion logic (for implements &, variables) ([#1747](https://github.com/graphql/graphiql/issues/1747)) ([0ac0a85](https://github.com/graphql/graphiql/commit/0ac0a856cfc715d7885a9965a9a9114ef2ca4b1a))
+- merge completion logic (for implements &, variables)
+  ([#1747](https://github.com/graphql/graphiql/issues/1747))
+  ([0ac0a85](https://github.com/graphql/graphiql/commit/0ac0a856cfc715d7885a9965a9a9114ef2ca4b1a))
 
 ## [0.13.1](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.13.0...codemirror-graphql@0.13.1) (2020-12-28)
 
@@ -293,7 +420,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-- provide validation rules via props ([#1716](https://github.com/graphql/graphiql/issues/1716)) ([0c5785c](https://github.com/graphql/graphiql/commit/0c5785c82adbd4affb25300ae2d128b42c9b81fe))
+- provide validation rules via props
+  ([#1716](https://github.com/graphql/graphiql/issues/1716))
+  ([0c5785c](https://github.com/graphql/graphiql/commit/0c5785c82adbd4affb25300ae2d128b42c9b81fe))
 
 ## [0.12.4](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.12.3...codemirror-graphql@0.12.4) (2020-11-28)
 
@@ -303,7 +432,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- **codemirror-graphql:** give interface field name suggestions ([#1695](https://github.com/graphql/graphiql/issues/1695)) ([669b301](https://github.com/graphql/graphiql/commit/669b3013fc679eca7c4e5c8ed6b0cd2fb2dbf2dc))
+- **codemirror-graphql:** give interface field name suggestions
+  ([#1695](https://github.com/graphql/graphiql/issues/1695))
+  ([669b301](https://github.com/graphql/graphiql/commit/669b3013fc679eca7c4e5c8ed6b0cd2fb2dbf2dc))
 
 ## [0.12.2](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.12.2-alpha.2...codemirror-graphql@0.12.2) (2020-09-18)
 
@@ -329,7 +460,9 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- value of documentation in completion list ([#1567](https://github.com/graphql/graphiql/issues/1567)) ([39c00a5](https://github.com/graphql/graphiql/commit/39c00a55d7af43ce4e57ad9b1d5cd55393beb0d0))
+- value of documentation in completion list
+  ([#1567](https://github.com/graphql/graphiql/issues/1567))
+  ([39c00a5](https://github.com/graphql/graphiql/commit/39c00a55d7af43ce4e57ad9b1d5cd55393beb0d0))
 
 ## [0.12.0-alpha.11](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.12.0-alpha.10...codemirror-graphql@0.12.0-alpha.11) (2020-06-04)
 
@@ -339,8 +472,11 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
-- make list type and non-nullable type available ([#902](https://github.com/graphql/graphiql/issues/902)) ([cea837f](https://github.com/graphql/graphiql/commit/cea837ff77c36dadb01b4302282821b00d7f5f2f))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- make list type and non-nullable type available
+  ([#902](https://github.com/graphql/graphiql/issues/902))
+  ([cea837f](https://github.com/graphql/graphiql/commit/cea837ff77c36dadb01b4302282821b00d7f5f2f))
 
 ## [0.12.0-alpha.9](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.12.0-alpha.8...codemirror-graphql@0.12.0-alpha.9) (2020-05-28)
 
@@ -362,7 +498,10 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-- upgrade to graphql@15.0.0 for [#1191](https://github.com/graphql/graphiql/issues/1191) ([#1204](https://github.com/graphql/graphiql/issues/1204)) ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
+- upgrade to graphql@15.0.0 for
+  [#1191](https://github.com/graphql/graphiql/issues/1191)
+  ([#1204](https://github.com/graphql/graphiql/issues/1204))
+  ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
 
 ## [0.12.0-alpha.4](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.12.0-alpha.3...codemirror-graphql@0.12.0-alpha.4) (2020-04-03)
 
@@ -380,31 +519,44 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Bug Fixes
 
-- linting issues, trailingCommas: all ([#1099](https://github.com/graphql/graphiql/issues/1099)) ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
-- screenshot/gif urls ([e3ea2fc](https://github.com/graphql/graphiql/commit/e3ea2fc))
+- linting issues, trailingCommas: all
+  ([#1099](https://github.com/graphql/graphiql/issues/1099))
+  ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
+- screenshot/gif urls
+  ([e3ea2fc](https://github.com/graphql/graphiql/commit/e3ea2fc))
 
 ### Features
 
-- convert LSP Server to Typescript, remove watchman ([#1138](https://github.com/graphql/graphiql/issues/1138)) ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
+- convert LSP Server to Typescript, remove watchman
+  ([#1138](https://github.com/graphql/graphiql/issues/1138))
+  ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
 
 ## [0.11.6](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.5...codemirror-graphql@0.11.6) (2019-12-09)
 
 ### Bug Fixes
 
-- codemirror results bundle ([dd06eb5](https://github.com/graphql/graphiql/commit/dd06eb5))
+- codemirror results bundle
+  ([dd06eb5](https://github.com/graphql/graphiql/commit/dd06eb5))
 
 ## [0.11.5](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.4...codemirror-graphql@0.11.5) (2019-12-09)
 
 ### Bug Fixes
 
-- a few more tweaks to babel ignore ([e0ad2c6](https://github.com/graphql/graphiql/commit/e0ad2c6))
+- a few more tweaks to babel ignore
+  ([e0ad2c6](https://github.com/graphql/graphiql/commit/e0ad2c6))
 
 ## [0.11.4](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.3...codemirror-graphql@0.11.4) (2019-12-03)
 
 ### Bug Fixes
 
-- convert browserify build to webpack, fixes [#976](https://github.com/graphql/graphiql/issues/976) ([#1001](https://github.com/graphql/graphiql/issues/1001)) ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
-- csp headers violation [@gracenoah](https://github.com/gracenoah) graphql/codemirror-graphql[#246](https://github.com/graphql/graphiql/issues/246) ([#1044](https://github.com/graphql/graphiql/issues/1044)) ([3c9dfa5](https://github.com/graphql/graphiql/commit/3c9dfa5))
+- convert browserify build to webpack, fixes
+  [#976](https://github.com/graphql/graphiql/issues/976)
+  ([#1001](https://github.com/graphql/graphiql/issues/1001))
+  ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
+- csp headers violation [@gracenoah](https://github.com/gracenoah)
+  graphql/codemirror-graphql[#246](https://github.com/graphql/graphiql/issues/246)
+  ([#1044](https://github.com/graphql/graphiql/issues/1044))
+  ([3c9dfa5](https://github.com/graphql/graphiql/commit/3c9dfa5))
 
 ## [0.11.3](https://github.com/graphql/graphiql/compare/codemirror-graphql@0.11.2...codemirror-graphql@0.11.3) (2019-11-26)
 
@@ -424,13 +576,19 @@ All notable changes to this project will be documented in this file. See [Conven
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 # 0.10.0 (2019-10-04)
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 0.9.1-alpha.1 (2019-09-01)
 

--- a/packages/graphiql-plugin-explorer/CHANGELOG.md
+++ b/packages/graphiql-plugin-explorer/CHANGELOG.md
@@ -4,28 +4,48 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b)]:
+- Updated dependencies
+  [[`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b)]:
   - @graphiql/react@0.17.0
 
 ## 0.1.13
 
 ### Patch Changes
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786), [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42), [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786),
+  [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42),
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
   - @graphiql/react@0.16.0
 
 ## 0.1.12
 
 ### Patch Changes
 
-- Updated dependencies [[`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911), [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4), [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a), [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665), [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d), [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816)]:
+- Updated dependencies
+  [[`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911),
+  [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4),
+  [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a),
+  [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665),
+  [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d),
+  [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816)]:
   - @graphiql/react@0.15.0
 
 ## 0.1.11
 
 ### Patch Changes
 
-- Updated dependencies [[`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8), [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef), [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)]:
+- Updated dependencies
+  [[`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8),
+  [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef),
+  [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)]:
   - @graphiql/react@0.14.0
 
 ## 0.1.10
@@ -46,28 +66,34 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2)]:
+- Updated dependencies
+  [[`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2)]:
   - @graphiql/react@0.13.5
 
 ## 0.1.7
 
 ### Patch Changes
 
-- Updated dependencies [[`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3)]:
+- Updated dependencies
+  [[`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3)]:
   - @graphiql/react@0.13.4
 
 ## 0.1.6
 
 ### Patch Changes
 
-- Updated dependencies [[`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657), [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14), [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)]:
+- Updated dependencies
+  [[`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657),
+  [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14),
+  [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)]:
   - @graphiql/react@0.13.3
 
 ## 0.1.5
 
 ### Patch Changes
 
-- Updated dependencies [[`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)]:
+- Updated dependencies
+  [[`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)]:
   - @graphiql/react@0.13.2
 
 ## 0.1.4
@@ -81,18 +107,30 @@
 
 ### Patch Changes
 
-- [#2735](https://github.com/graphql/graphiql/pull/2735) [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the new CSS variables for color alpha values defined in `@graphiql/react` in style definitions
+- [#2735](https://github.com/graphql/graphiql/pull/2735)
+  [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the new
+  CSS variables for color alpha values defined in `@graphiql/react` in style
+  definitions
 
-* [#2757](https://github.com/graphql/graphiql/pull/2757) [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use different colors for field names and argument names
+* [#2757](https://github.com/graphql/graphiql/pull/2757)
+  [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use
+  different colors for field names and argument names
 
-* Updated dependencies [[`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1), [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)]:
+* Updated dependencies
+  [[`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1),
+  [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)]:
   - @graphiql/react@0.13.0
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [#2750](https://github.com/graphql/graphiql/pull/2750) [`cdc44aab`](https://github.com/graphql/graphiql/commit/cdc44aabdc549f5a0359b8f69506cc0c31661d16) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Remove `type` field from `package.json` to support both ES Modules and CommonJS
+- [#2750](https://github.com/graphql/graphiql/pull/2750)
+  [`cdc44aab`](https://github.com/graphql/graphiql/commit/cdc44aabdc549f5a0359b8f69506cc0c31661d16)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Remove
+  `type` field from `package.json` to support both ES Modules and CommonJS
 
 - Updated dependencies []:
   - @graphiql/react@0.12.1
@@ -101,19 +139,38 @@
 
 ### Patch Changes
 
-- [#2745](https://github.com/graphql/graphiql/pull/2745) [`92a17490`](https://github.com/graphql/graphiql/commit/92a17490c3842b4f83ed1065b73a803f73d02a17) Thanks [@acao](https://github.com/acao)! - Specify MIT license for `@graphiql/plugin-explorer` `package.json`
+- [#2745](https://github.com/graphql/graphiql/pull/2745)
+  [`92a17490`](https://github.com/graphql/graphiql/commit/92a17490c3842b4f83ed1065b73a803f73d02a17)
+  Thanks [@acao](https://github.com/acao)! - Specify MIT license for
+  `@graphiql/plugin-explorer` `package.json`
 
-* [#2731](https://github.com/graphql/graphiql/pull/2731) [`3e8f0d1f`](https://github.com/graphql/graphiql/commit/3e8f0d1fe4da5cdea94240119bbad587720ca324) Thanks [@hasparus](https://github.com/hasparus)! - Expose typings for graphiql-explorer
+* [#2731](https://github.com/graphql/graphiql/pull/2731)
+  [`3e8f0d1f`](https://github.com/graphql/graphiql/commit/3e8f0d1fe4da5cdea94240119bbad587720ca324)
+  Thanks [@hasparus](https://github.com/hasparus)! - Expose typings for
+  graphiql-explorer
 
-- [#2738](https://github.com/graphql/graphiql/pull/2738) [`33bef178`](https://github.com/graphql/graphiql/commit/33bef17832edb29f5b26f4ed1cf33fd0d7fbbed1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix peer dependency versions
+- [#2738](https://github.com/graphql/graphiql/pull/2738)
+  [`33bef178`](https://github.com/graphql/graphiql/commit/33bef17832edb29f5b26f4ed1cf33fd0d7fbbed1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix peer
+  dependency versions
 
-* [#2747](https://github.com/graphql/graphiql/pull/2747) [`52d0003f`](https://github.com/graphql/graphiql/commit/52d0003fd0c405da65b7b23dcfed9f3aacbad067) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make `@graphiql/react` a real dependency instead of a peer dependency
+* [#2747](https://github.com/graphql/graphiql/pull/2747)
+  [`52d0003f`](https://github.com/graphql/graphiql/commit/52d0003fd0c405da65b7b23dcfed9f3aacbad067)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make
+  `@graphiql/react` a real dependency instead of a peer dependency
 
-* Updated dependencies [[`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9), [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7), [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058), [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)]:
+* Updated dependencies
+  [[`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9),
+  [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7),
+  [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058),
+  [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)]:
   - @graphiql/react@0.12.0
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [#2724](https://github.com/graphql/graphiql/pull/2724) [`dd5db3b2`](https://github.com/graphql/graphiql/commit/dd5db3b2ee08b240ba7b77a9b7ff621115bd25f3) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a package that exports a plugin to use the GraphiQL Explorer from OneGraph
+- [#2724](https://github.com/graphql/graphiql/pull/2724)
+  [`dd5db3b2`](https://github.com/graphql/graphiql/commit/dd5db3b2ee08b240ba7b77a9b7ff621115bd25f3)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  package that exports a plugin to use the GraphiQL Explorer from OneGraph

--- a/packages/graphiql-react/CHANGELOG.md
+++ b/packages/graphiql-react/CHANGELOG.md
@@ -4,13 +4,24 @@
 
 ### Minor Changes
 
-- [#3012](https://github.com/graphql/graphiql/pull/3012) [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b) Thanks [@benjie](https://github.com/benjie)! - GraphiQL now maintains the DocExplorer navigation stack as best it can when the schema is updated
+- [#3012](https://github.com/graphql/graphiql/pull/3012)
+  [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b)
+  Thanks [@benjie](https://github.com/benjie)! - GraphiQL now maintains the
+  DocExplorer navigation stack as best it can when the schema is updated
 
 ### Patch Changes
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
   - codemirror-graphql@2.0.4
   - @graphiql/toolkit@0.8.2
@@ -19,27 +30,63 @@
 
 ### Minor Changes
 
-- [#2895](https://github.com/graphql/graphiql/pull/2895) [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42) Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Add user facing setting for persisting headers
+- [#2895](https://github.com/graphql/graphiql/pull/2895)
+  [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42)
+  Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Add user
+  facing setting for persisting headers
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2964](https://github.com/graphql/graphiql/pull/2964) [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-export-from` rule
+- [#2964](https://github.com/graphql/graphiql/pull/2964)
+  [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-export-from` rule
 
-- [#2932](https://github.com/graphql/graphiql/pull/2932) [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7) Thanks [@B2o5T](https://github.com/B2o5T)! - replace `compose.ts` with `clsx` for class concatenation
+- [#2932](https://github.com/graphql/graphiql/pull/2932)
+  [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - replace `compose.ts` with `clsx`
+  for class concatenation
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2933](https://github.com/graphql/graphiql/pull/2933) [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d) Thanks [@B2o5T](https://github.com/B2o5T)! - enable @typescript-eslint/no-unused-expressions
+- [#2933](https://github.com/graphql/graphiql/pull/2933)
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  @typescript-eslint/no-unused-expressions
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
-- [#2942](https://github.com/graphql/graphiql/pull/2942) [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-redundant-jump` rule
+- [#2942](https://github.com/graphql/graphiql/pull/2942)
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `sonarjs/no-redundant-jump` rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
   - codemirror-graphql@2.0.3
   - @graphiql/toolkit@0.8.1
   - graphql-language-service@5.1.1
@@ -48,155 +95,275 @@
 
 ### Minor Changes
 
-- [#2908](https://github.com/graphql/graphiql/pull/2908) [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate the `initialTabs` prop and add a `defaultTabs` props that supersedes it
+- [#2908](https://github.com/graphql/graphiql/pull/2908)
+  [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate
+  the `initialTabs` prop and add a `defaultTabs` props that supersedes it
 
-- [#2907](https://github.com/graphql/graphiql/pull/2907) [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Clearly separate the fetching and subscription states for multipart requests (like subscriptions) and show the stop-button as long as the subscription is running
+- [#2907](https://github.com/graphql/graphiql/pull/2907)
+  [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Clearly
+  separate the fetching and subscription states for multipart requests (like
+  subscriptions) and show the stop-button as long as the subscription is running
 
 ### Patch Changes
 
-- [#2910](https://github.com/graphql/graphiql/pull/2910) [`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix autocomplete styles for field type and description on the right
+- [#2910](https://github.com/graphql/graphiql/pull/2910)
+  [`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  autocomplete styles for field type and description on the right
 
-- [#2919](https://github.com/graphql/graphiql/pull/2919) [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix overflow when there are lots of tabs that don't fit into the tab bar at once
+- [#2919](https://github.com/graphql/graphiql/pull/2919)
+  [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  overflow when there are lots of tabs that don't fit into the tab bar at once
 
-- [#2905](https://github.com/graphql/graphiql/pull/2905) [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665) Thanks [@ccbrown](https://github.com/ccbrown)! - Fix: prevent default event for graphiql-doc-explorer-back link
+- [#2905](https://github.com/graphql/graphiql/pull/2905)
+  [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665)
+  Thanks [@ccbrown](https://github.com/ccbrown)! - Fix: prevent default event
+  for graphiql-doc-explorer-back link
 
-- [#2912](https://github.com/graphql/graphiql/pull/2912) [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing effect dependency to make sure updates to the `defaultHeaders` prop have the desired effect
+- [#2912](https://github.com/graphql/graphiql/pull/2912)
+  [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing
+  effect dependency to make sure updates to the `defaultHeaders` prop have the
+  desired effect
 
 ## 0.14.0
 
 ### Minor Changes
 
-- [#2821](https://github.com/graphql/graphiql/pull/2821) [`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8) Thanks [@avaly](https://github.com/avaly)! - Initial tabs support
+- [#2821](https://github.com/graphql/graphiql/pull/2821)
+  [`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8)
+  Thanks [@avaly](https://github.com/avaly)! - Initial tabs support
 
 ### Patch Changes
 
-- [#2885](https://github.com/graphql/graphiql/pull/2885) [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef) Thanks [@simhnna](https://github.com/simhnna)! - Fix stop execution button showing a dropdown
+- [#2885](https://github.com/graphql/graphiql/pull/2885)
+  [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef)
+  Thanks [@simhnna](https://github.com/simhnna)! - Fix stop execution button
+  showing a dropdown
 
-- [#2886](https://github.com/graphql/graphiql/pull/2886) [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08) Thanks [@B2o5T](https://github.com/B2o5T)! - feat: add `defaultHeaders` prop
+- [#2886](https://github.com/graphql/graphiql/pull/2886)
+  [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - feat: add `defaultHeaders` prop
 
 ## 0.13.7
 
 ### Patch Changes
 
-- Updated dependencies [[`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b)]:
+- Updated dependencies
+  [[`20869583`](https://github.com/graphql/graphiql/commit/20869583eff563f5d6494e93302a835f0e034f4b)]:
   - codemirror-graphql@2.0.2
 
 ## 0.13.6
 
 ### Patch Changes
 
-- Updated dependencies [[`353f434e`](https://github.com/graphql/graphiql/commit/353f434e5f6bfd1bf6f8ee97d4ae8ce4f897085f)]:
+- Updated dependencies
+  [[`353f434e`](https://github.com/graphql/graphiql/commit/353f434e5f6bfd1bf6f8ee97d4ae8ce4f897085f)]:
   - codemirror-graphql@2.0.1
 
 ## 0.13.5
 
 ### Patch Changes
 
-- [#2839](https://github.com/graphql/graphiql/pull/2839) [`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2) Thanks [@ClemensSahs](https://github.com/ClemensSahs)! - Export the `PluginContextProvider` component
+- [#2839](https://github.com/graphql/graphiql/pull/2839)
+  [`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2)
+  Thanks [@ClemensSahs](https://github.com/ClemensSahs)! - Export the
+  `PluginContextProvider` component
 
 ## 0.13.4
 
 ### Patch Changes
 
-- [#2824](https://github.com/graphql/graphiql/pull/2824) [`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3) Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - fix: prevent key down events when pressing escape to close autocomplete dialogs
+- [#2824](https://github.com/graphql/graphiql/pull/2824)
+  [`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3)
+  Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - fix:
+  prevent key down events when pressing escape to close autocomplete dialogs
 
 ## 0.13.3
 
 ### Patch Changes
 
-- [#2791](https://github.com/graphql/graphiql/pull/2791) [`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure that the info overlay in editors is shown above the vertical scrollbar
+- [#2791](https://github.com/graphql/graphiql/pull/2791)
+  [`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure
+  that the info overlay in editors is shown above the vertical scrollbar
 
-* [#2792](https://github.com/graphql/graphiql/pull/2792) [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Avoid resetting visible plugin state when explorer or history context changes
+* [#2792](https://github.com/graphql/graphiql/pull/2792)
+  [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Avoid
+  resetting visible plugin state when explorer or history context changes
 
-- [#2778](https://github.com/graphql/graphiql/pull/2778) [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e) Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - Adds a box-model reset for all children of the `.graphiql-container` class. This change facilitated another change to the `--sidebar-width` variable.
+- [#2778](https://github.com/graphql/graphiql/pull/2778)
+  [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)
+  Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - Adds a
+  box-model reset for all children of the `.graphiql-container` class. This
+  change facilitated another change to the `--sidebar-width` variable.
 
 ## 0.13.2
 
 ### Patch Changes
 
-- [#2653](https://github.com/graphql/graphiql/pull/2653) [`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80) Thanks [@dylanowen](https://github.com/dylanowen)! - Fix `fetchError` not being cleared when a new `fetcher` is used
+- [#2653](https://github.com/graphql/graphiql/pull/2653)
+  [`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)
+  Thanks [@dylanowen](https://github.com/dylanowen)! - Fix `fetchError` not
+  being cleared when a new `fetcher` is used
 
 ## 0.13.1
 
 ### Patch Changes
 
-- Updated dependencies [[`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4)]:
+- Updated dependencies
+  [[`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4)]:
   - @graphiql/toolkit@0.8.0
 
 ## 0.13.0
 
 ### Minor Changes
 
-- [#2735](https://github.com/graphql/graphiql/pull/2735) [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add CSS variables for color alpha values:
-  - `--alpha-secondary`: A color for supplementary text that should be read but not be the main focus
-  - `--alpha-tertiary`: A color for supplementary text which is optional to read, i.e. the UI would function without the user reading this text
-  - `--alpha-background-light`, `--alpha-background-medium` and `--alpha-background-heavy`: Three alpha values used for backgrounds and borders that have different intensity
+- [#2735](https://github.com/graphql/graphiql/pull/2735)
+  [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add CSS
+  variables for color alpha values:
+  - `--alpha-secondary`: A color for supplementary text that should be read but
+    not be the main focus
+  - `--alpha-tertiary`: A color for supplementary text which is optional to
+    read, i.e. the UI would function without the user reading this text
+  - `--alpha-background-light`, `--alpha-background-medium` and
+    `--alpha-background-heavy`: Three alpha values used for backgrounds and
+    borders that have different intensity
 
 ### Patch Changes
 
-- [#2757](https://github.com/graphql/graphiql/pull/2757) [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use different colors for field names and argument names
+- [#2757](https://github.com/graphql/graphiql/pull/2757)
+  [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use
+  different colors for field names and argument names
 
-- Updated dependencies [[`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af)]:
+- Updated dependencies
+  [[`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af)]:
   - @graphiql/toolkit@0.7.3
 
 ## 0.12.1
 
 ### Patch Changes
 
-- Updated dependencies [[`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f), [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679)]:
+- Updated dependencies
+  [[`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f),
+  [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679)]:
   - @graphiql/toolkit@0.7.2
 
 ## 0.12.0
 
 ### Minor Changes
 
-- [#2739](https://github.com/graphql/graphiql/pull/2739) [`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add `DocsFilledIcon` component and use show that icon in the sidebar when the docs plugin is visible
+- [#2739](https://github.com/graphql/graphiql/pull/2739)
+  [`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add
+  `DocsFilledIcon` component and use show that icon in the sidebar when the docs
+  plugin is visible
 
 ### Patch Changes
 
-- [#2740](https://github.com/graphql/graphiql/pull/2740) [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make SVG icon `stroke-width` consistent
+- [#2740](https://github.com/graphql/graphiql/pull/2740)
+  [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make SVG
+  icon `stroke-width` consistent
 
-* [#2734](https://github.com/graphql/graphiql/pull/2734) [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Stop propagating keyboard events too far upwards in the search component for the docs
+* [#2734](https://github.com/graphql/graphiql/pull/2734)
+  [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Stop
+  propagating keyboard events too far upwards in the search component for the
+  docs
 
-- [#2741](https://github.com/graphql/graphiql/pull/2741) [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add hover styles for buttons
+- [#2741](https://github.com/graphql/graphiql/pull/2741)
+  [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add hover
+  styles for buttons
 
-- Updated dependencies [[`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13)]:
+- Updated dependencies
+  [[`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13)]:
   - @graphiql/toolkit@0.7.1
 
 ## 0.11.1
 
 ### Patch Changes
 
-- [#2712](https://github.com/graphql/graphiql/pull/2712) [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure the back link and title are hidden when focussing the input field for searching the docs
+- [#2712](https://github.com/graphql/graphiql/pull/2712)
+  [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure
+  the back link and title are hidden when focussing the input field for
+  searching the docs
 
-* [#2708](https://github.com/graphql/graphiql/pull/2708) [`f15ee38d`](https://github.com/graphql/graphiql/commit/f15ee38d56e4f749c145e0a17f0ed8e9a6096ac2) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix computing the initial state for editor values and tabs to avoid duplicating tabs on page reload
+* [#2708](https://github.com/graphql/graphiql/pull/2708)
+  [`f15ee38d`](https://github.com/graphql/graphiql/commit/f15ee38d56e4f749c145e0a17f0ed8e9a6096ac2)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  computing the initial state for editor values and tabs to avoid duplicating
+  tabs on page reload
 
-- [#2712](https://github.com/graphql/graphiql/pull/2712) [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure hidden editors don't overflow
+- [#2712](https://github.com/graphql/graphiql/pull/2712)
+  [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Make sure
+  hidden editors don't overflow
 
 ## 0.11.0
 
 ### Minor Changes
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The `onHasCompletion` export has been removed as it is only meant to be used internally.
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The `onHasCompletion`
+  export has been removed as it is only meant to be used internally.
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - Add new components:
-  - UI components (`Button`, `ButtonGroup`, `Dialog`, `Menu`, `Spinner`, `Tab`, `Tabs`, `Tooltip`, `UnStyledButton` and lots of icon components)
-  - Editor components (`QueryEditor`, `VariableEditor`, `HeaderEditor` and `ResponseEditor`)
-  - Toolbar components (`ExecuteButton`, `ToolbarButton`, `ToolbarMenu` and `ToolbarSelect`)
-  - Docs components (`Argument`, `DefaultValue`, `DeprecationReason`, `Directive`, `DocExplorer`, `ExplorerSection`, `FieldDocumentation`, `FieldLink`, `SchemaDocumentation`, `Search`, `TypeDocumentation` and `TypeLink`)
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - Add new components:
+  - UI components (`Button`, `ButtonGroup`, `Dialog`, `Menu`, `Spinner`, `Tab`,
+    `Tabs`, `Tooltip`, `UnStyledButton` and lots of icon components)
+  - Editor components (`QueryEditor`, `VariableEditor`, `HeaderEditor` and
+    `ResponseEditor`)
+  - Toolbar components (`ExecuteButton`, `ToolbarButton`, `ToolbarMenu` and
+    `ToolbarSelect`)
+  - Docs components (`Argument`, `DefaultValue`, `DeprecationReason`,
+    `Directive`, `DocExplorer`, `ExplorerSection`, `FieldDocumentation`,
+    `FieldLink`, `SchemaDocumentation`, `Search`, `TypeDocumentation` and
+    `TypeLink`)
   - `History` component
-  - A `GraphiQLProvider` component that renders all other existing provider components from `@graphiql/react` for ease of use
+  - A `GraphiQLProvider` component that renders all other existing provider
+    components from `@graphiql/react` for ease of use
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: Add a new context provider for plugins. This induces changes to the following other contexts and their provider components:
-  - The property `isVisible` and the methods `hide` and `show` of the `ExplorerContext` have been removed. Also, the property `isVisible` and the methods `hide`, `show` and `toggle` of the `HistoryContext` have been removed. Visibility state of plugins is now part of the `PluginContext` using the `visiblePlugin` property. The visibility state can be altered using the `setVisiblePlugin` method of the `PluginContext`.
-  - The `isVisible` prop of the `ExplorerContextProvider` has been removed. For controlling the visibility state of plugins you can now use the `visiblePlugin` prop of the `PluginContextProvider`.
-  - The `onToggle` prop of the `HistoryContextProvider` and the `onToggleVisibility` prop of the `ExplorerContextProvider` have been removed. For listening on visibility changes for any plugin you can now use the `onTogglePluginVisibility` prop of the `PluginContextProvider`.
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: Add a new context
+  provider for plugins. This induces changes to the following other contexts and
+  their provider components:
+  - The property `isVisible` and the methods `hide` and `show` of the
+    `ExplorerContext` have been removed. Also, the property `isVisible` and the
+    methods `hide`, `show` and `toggle` of the `HistoryContext` have been
+    removed. Visibility state of plugins is now part of the `PluginContext`
+    using the `visiblePlugin` property. The visibility state can be altered
+    using the `setVisiblePlugin` method of the `PluginContext`.
+  - The `isVisible` prop of the `ExplorerContextProvider` has been removed. For
+    controlling the visibility state of plugins you can now use the
+    `visiblePlugin` prop of the `PluginContextProvider`.
+  - The `onToggle` prop of the `HistoryContextProvider` and the
+    `onToggleVisibility` prop of the `ExplorerContextProvider` have been
+    removed. For listening on visibility changes for any plugin you can now use
+    the `onTogglePluginVisibility` prop of the `PluginContextProvider`.
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The `ResponseTooltip` prop of the `ResponseEditor` has been renamed to `responseTooltip`
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The `ResponseTooltip`
+  prop of the `ResponseEditor` has been renamed to `responseTooltip`
 
 ### Patch Changes
 
-- Updated dependencies [[`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)]:
+- Updated dependencies
+  [[`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)]:
   - codemirror-graphql@2.0.0
   - @graphiql/toolkit@0.7.0
 
@@ -204,7 +371,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
   - codemirror-graphql@1.3.3
 
@@ -212,90 +380,162 @@
 
 ### Minor Changes
 
-- [#2651](https://github.com/graphql/graphiql/pull/2651) [`85d5af25`](https://github.com/graphql/graphiql/commit/85d5af25d77c29b7d02da90a431c8c15f610c22a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING: The following context properties have been removed as they are only meant for internal use:
+- [#2651](https://github.com/graphql/graphiql/pull/2651)
+  [`85d5af25`](https://github.com/graphql/graphiql/commit/85d5af25d77c29b7d02da90a431c8c15f610c22a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
+  The following context properties have been removed as they are only meant for
+  internal use:
   - The `subscription` property of the `ExecutionContext`
   - The `setSchema` method of the `SchemaContext`
   - The `setFetchError` method of the `SchemaContext`
 
-* [#2652](https://github.com/graphql/graphiql/pull/2652) [`6ff0bab9`](https://github.com/graphql/graphiql/commit/6ff0bab978d63778b8ab4ba6e79fceb36c2db87f) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING: The `validationErrors` property of the `SchemaContext` is now always non-null. If the schema is valid then it will contain an empty list.
+* [#2652](https://github.com/graphql/graphiql/pull/2652)
+  [`6ff0bab9`](https://github.com/graphql/graphiql/commit/6ff0bab978d63778b8ab4ba6e79fceb36c2db87f)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
+  The `validationErrors` property of the `SchemaContext` is now always non-null.
+  If the schema is valid then it will contain an empty list.
 
-- [#2644](https://github.com/graphql/graphiql/pull/2644) [`0aff68a6`](https://github.com/graphql/graphiql/commit/0aff68a645cceb6b9689e0f394e8bece01710efc) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING: The `ResponseEditor` component no longer accepts the prop `value`. Instead you can now pass the prop `response` to the `EditorContextProvider`. This aligns it with the API design of the other editor components.
+- [#2644](https://github.com/graphql/graphiql/pull/2644)
+  [`0aff68a6`](https://github.com/graphql/graphiql/commit/0aff68a645cceb6b9689e0f394e8bece01710efc)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
+  The `ResponseEditor` component no longer accepts the prop `value`. Instead you
+  can now pass the prop `response` to the `EditorContextProvider`. This aligns
+  it with the API design of the other editor components.
 
 ## 0.9.0
 
 ### Minor Changes
 
-- [#2642](https://github.com/graphql/graphiql/pull/2642) [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a new prop `operationName` to the `ExecutionContextProvider` component that controls the operation sent with the request
+- [#2642](https://github.com/graphql/graphiql/pull/2642)
+  [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a new
+  prop `operationName` to the `ExecutionContextProvider` component that controls
+  the operation sent with the request
 
-* [#2642](https://github.com/graphql/graphiql/pull/2642) [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING: The `ExecutionContextProvider` and `QueryEditor` components no longer accepts the `onEditOperationName` prop. Instead you can now pass this prop to the `EditorContextProvider` component.
+* [#2642](https://github.com/graphql/graphiql/pull/2642)
+  [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
+  The `ExecutionContextProvider` and `QueryEditor` components no longer accepts
+  the `onEditOperationName` prop. Instead you can now pass this prop to the
+  `EditorContextProvider` component.
 
 ## 0.8.0
 
 ### Minor Changes
 
-- [#2636](https://github.com/graphql/graphiql/pull/2636) [`62317e0b`](https://github.com/graphql/graphiql/commit/62317e0bae6d4ccf89d9e1e6607fd8feeb100078) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
-  - The `ExecutionContextProvider` and `QueryEditor` components no longer accept the `externalFragments` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will normalize the prop value and provide a map of type `Map<string, FragmentDefinitionNode>` (using the fragment names as keys) as part of the value of the `EditorContext`.
-  - The `QueryEditor` component no longer accept the `validationRules` prop. Instead the prop can now be passed to the `EditorContextProvider` component. The provider component will provide the list of validation rules (empty if there are none) as part of the value of the `EditorContext`.
-  - The `ExecutionContextProvider` and `HeaderEditor` components no longer accept the `shouldPersistHeaders` prop. Instead the `EditorContextProvider` component now provides the value of its equally named prop as part of the value of the `EditorContext`.
+- [#2636](https://github.com/graphql/graphiql/pull/2636)
+  [`62317e0b`](https://github.com/graphql/graphiql/commit/62317e0bae6d4ccf89d9e1e6607fd8feeb100078)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - BREAKING:
+  - The `ExecutionContextProvider` and `QueryEditor` components no longer accept
+    the `externalFragments` prop. Instead the prop can now be passed to the
+    `EditorContextProvider` component. The provider component will normalize the
+    prop value and provide a map of type `Map<string, FragmentDefinitionNode>`
+    (using the fragment names as keys) as part of the value of the
+    `EditorContext`.
+  - The `QueryEditor` component no longer accept the `validationRules` prop.
+    Instead the prop can now be passed to the `EditorContextProvider` component.
+    The provider component will provide the list of validation rules (empty if
+    there are none) as part of the value of the `EditorContext`.
+  - The `ExecutionContextProvider` and `HeaderEditor` components no longer
+    accept the `shouldPersistHeaders` prop. Instead the `EditorContextProvider`
+    component now provides the value of its equally named prop as part of the
+    value of the `EditorContext`.
 
 ## 0.7.1
 
 ### Patch Changes
 
-- Updated dependencies [[`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12)]:
+- Updated dependencies
+  [[`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12)]:
   - @graphiql/toolkit@0.6.1
 
 ## 0.7.0
 
 ### Minor Changes
 
-- [#2618](https://github.com/graphql/graphiql/pull/2618) [`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a method `introspect` to the schema context and provide a short key (`Shift-Ctrl-R`) for triggering introspection
+- [#2618](https://github.com/graphql/graphiql/pull/2618)
+  [`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  method `introspect` to the schema context and provide a short key
+  (`Shift-Ctrl-R`) for triggering introspection
 
 ## 0.6.0
 
 ### Minor Changes
 
-- [#2574](https://github.com/graphql/graphiql/pull/2574) [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow passing introspection data to the `schema` prop of the `SchemaContextProvider` component
+- [#2574](https://github.com/graphql/graphiql/pull/2574)
+  [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow
+  passing introspection data to the `schema` prop of the `SchemaContextProvider`
+  component
 
 ### Patch Changes
 
-- [#2574](https://github.com/graphql/graphiql/pull/2574) [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Set the schema correctly after refetching introspection (e.g. when the `fetcher` prop changes)
+- [#2574](https://github.com/graphql/graphiql/pull/2574)
+  [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Set the
+  schema correctly after refetching introspection (e.g. when the `fetcher` prop
+  changes)
 
 ## 0.5.2
 
 ### Patch Changes
 
-- [#2565](https://github.com/graphql/graphiql/pull/2565) [`f581b437`](https://github.com/graphql/graphiql/commit/f581b437e5bdab6f3ad817d230ee6d1b410bb591) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Don't invoke editor change callbacks when manually signaling "empty" changes.
+- [#2565](https://github.com/graphql/graphiql/pull/2565)
+  [`f581b437`](https://github.com/graphql/graphiql/commit/f581b437e5bdab6f3ad817d230ee6d1b410bb591)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Don't
+  invoke editor change callbacks when manually signaling "empty" changes.
 
 ## 0.5.1
 
 ### Patch Changes
 
-- [#2561](https://github.com/graphql/graphiql/pull/2561) [`08346cba`](https://github.com/graphql/graphiql/commit/08346cba136825341881f9dfefc62a60d748e0ee) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing effect dependencies to make sure editors are recreated when changing the `keyMap` prop
+- [#2561](https://github.com/graphql/graphiql/pull/2561)
+  [`08346cba`](https://github.com/graphql/graphiql/commit/08346cba136825341881f9dfefc62a60d748e0ee)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing
+  effect dependencies to make sure editors are recreated when changing the
+  `keyMap` prop
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [#2541](https://github.com/graphql/graphiql/pull/2541) [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add `onSchemaChange` callback prop to the `SchemaContextProvider` component
+- [#2541](https://github.com/graphql/graphiql/pull/2541)
+  [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add
+  `onSchemaChange` callback prop to the `SchemaContextProvider` component
 
 ### Patch Changes
 
-- [#2545](https://github.com/graphql/graphiql/pull/2545) [`8ce5b483`](https://github.com/graphql/graphiql/commit/8ce5b483ee190b5f5dd84eaf42e5d1359ce185e6) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Avoid top-level dynamic imports from `codemirror` that break importing the package in non-browser environments
+- [#2545](https://github.com/graphql/graphiql/pull/2545)
+  [`8ce5b483`](https://github.com/graphql/graphiql/commit/8ce5b483ee190b5f5dd84eaf42e5d1359ce185e6)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Avoid
+  top-level dynamic imports from `codemirror` that break importing the package
+  in non-browser environments
 
 ## 0.4.3
 
 ### Patch Changes
 
-- [#2526](https://github.com/graphql/graphiql/pull/2526) [`26e44120`](https://github.com/graphql/graphiql/commit/26e44120a18d49af451c97619fe3386a65579e05) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing `caller` arguments to hook calls so that the error message printed when a context provider is missing is more accurate about the component or hook that caused the error
+- [#2526](https://github.com/graphql/graphiql/pull/2526)
+  [`26e44120`](https://github.com/graphql/graphiql/commit/26e44120a18d49af451c97619fe3386a65579e05)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add missing
+  `caller` arguments to hook calls so that the error message printed when a
+  context provider is missing is more accurate about the component or hook that
+  caused the error
 
 ## 0.4.2
 
 ### Patch Changes
 
-- [#2501](https://github.com/graphql/graphiql/pull/2501) [`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4) Thanks [@acao](https://github.com/acao)! - Allow Codemirror 5 `keyMap` to be defined, default `vim` or `emacs` allowed in addition to the original default of `sublime`.
+- [#2501](https://github.com/graphql/graphiql/pull/2501)
+  [`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4)
+  Thanks [@acao](https://github.com/acao)! - Allow Codemirror 5 `keyMap` to be
+  defined, default `vim` or `emacs` allowed in addition to the original default
+  of `sublime`.
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service@5.0.6
   - codemirror-graphql@1.3.2
 
@@ -303,7 +543,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service@5.0.5
   - codemirror-graphql@1.3.1
 
@@ -311,83 +552,171 @@
 
 ### Minor Changes
 
-- [#2461](https://github.com/graphql/graphiql/pull/2461) [`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add `useDragResize` utility hook
+- [#2461](https://github.com/graphql/graphiql/pull/2461)
+  [`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add
+  `useDragResize` utility hook
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#2453](https://github.com/graphql/graphiql/pull/2453) [`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add execution context to `@graphiql/react` and move over the logic from `graphiql`
+- [#2453](https://github.com/graphql/graphiql/pull/2453)
+  [`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add
+  execution context to `@graphiql/react` and move over the logic from `graphiql`
 
-* [#2452](https://github.com/graphql/graphiql/pull/2452) [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move tab state from `graphiql` into editor context from `@graphiql/react`
+* [#2452](https://github.com/graphql/graphiql/pull/2452)
+  [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move tab
+  state from `graphiql` into editor context from `@graphiql/react`
 
-- [#2449](https://github.com/graphql/graphiql/pull/2449) [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Assume all context values are nullable and create hooks to consume individual contexts
+- [#2449](https://github.com/graphql/graphiql/pull/2449)
+  [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Assume all
+  context values are nullable and create hooks to consume individual contexts
 
-* [#2450](https://github.com/graphql/graphiql/pull/2450) [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Extract the `copy`, `merge`, `prettify`, and `autoCompleteLeafs` functions into hooks and remove these functions from the editor context value
+* [#2450](https://github.com/graphql/graphiql/pull/2450)
+  [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Extract the
+  `copy`, `merge`, `prettify`, and `autoCompleteLeafs` functions into hooks and
+  remove these functions from the editor context value
 
 ### Patch Changes
 
-- [#2451](https://github.com/graphql/graphiql/pull/2451) [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Always use the current value of the headers for the introspection request
+- [#2451](https://github.com/graphql/graphiql/pull/2451)
+  [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Always use
+  the current value of the headers for the introspection request
 
 ## 0.2.1
 
 ### Patch Changes
 
-- [#2435](https://github.com/graphql/graphiql/pull/2435) [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix deriving default values for editors from storage
+- [#2435](https://github.com/graphql/graphiql/pull/2435)
+  [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  deriving default values for editors from storage
 
-* [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move prettify query functionality to editor context in `@graphiql/react`
+* [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  prettify query functionality to editor context in `@graphiql/react`
 
-- [#2435](https://github.com/graphql/graphiql/pull/2435) [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic for deriving operation facts from the current query to `@graphiql/react` and store these facts as properties on the query editor instance
+- [#2435](https://github.com/graphql/graphiql/pull/2435)
+  [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic for deriving operation facts from the current query to `@graphiql/react`
+  and store these facts as properties on the query editor instance
 
-* [#2448](https://github.com/graphql/graphiql/pull/2448) [`3dae62fc`](https://github.com/graphql/graphiql/commit/3dae62fc871385e148a799cde55a52a5e6b41d19) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - don't introspect the schema if it's provided via props
+* [#2448](https://github.com/graphql/graphiql/pull/2448)
+  [`3dae62fc`](https://github.com/graphql/graphiql/commit/3dae62fc871385e148a799cde55a52a5e6b41d19)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - don't
+  introspect the schema if it's provided via props
 
-- [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move copy query functionality to editor context in `@graphiql/react`
+- [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move copy
+  query functionality to editor context in `@graphiql/react`
 
-* [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move merge query functionality to editor context in `@graphiql/react`
+* [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move merge
+  query functionality to editor context in `@graphiql/react`
 
-- [#2436](https://github.com/graphql/graphiql/pull/2436) [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Inline logic for clicking a reference to open the docs and remove the `onClickReference` and `onHintInformationRender` props of the editor components and hooks
+- [#2436](https://github.com/graphql/graphiql/pull/2436)
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Inline
+  logic for clicking a reference to open the docs and remove the
+  `onClickReference` and `onHintInformationRender` props of the editor
+  components and hooks
 
-* [#2436](https://github.com/graphql/graphiql/pull/2436) [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move visibility state for doc explorer from `graphiql` to the explorer context in `@graphiql/react`
+* [#2436](https://github.com/graphql/graphiql/pull/2436)
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  visibility state for doc explorer from `graphiql` to the explorer context in
+  `@graphiql/react`
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [#2413](https://github.com/graphql/graphiql/pull/2413) [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a `StorageContext` and a `HistoryContext` to `@graphiql/react` that replaces the logic in the `graphiql` package
+- [#2413](https://github.com/graphql/graphiql/pull/2413)
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  `StorageContext` and a `HistoryContext` to `@graphiql/react` that replaces the
+  logic in the `graphiql` package
 
-* [#2420](https://github.com/graphql/graphiql/pull/2420) [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a `SchemaContext` to `@graphiql/react` that replaces the logic for fetching and validating the schema in the `graphiql` package
+* [#2420](https://github.com/graphql/graphiql/pull/2420)
+  [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  `SchemaContext` to `@graphiql/react` that replaces the logic for fetching and
+  validating the schema in the `graphiql` package
 
 ### Patch Changes
 
-- Updated dependencies [[`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e), [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9), [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e), [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)]:
+- Updated dependencies
+  [[`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e),
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9),
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e),
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)]:
   - @graphiql/toolkit@0.6.0
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [#2427](https://github.com/graphql/graphiql/pull/2427) [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Mark `graphql` as external dependency to avoid importing multiple instances
+- [#2427](https://github.com/graphql/graphiql/pull/2427)
+  [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Mark
+  `graphql` as external dependency to avoid importing multiple instances
 
-* [#2427](https://github.com/graphql/graphiql/pull/2427) [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix linting by also updating the options object in the internal codemirror state
+* [#2427](https://github.com/graphql/graphiql/pull/2427)
+  [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix linting
+  by also updating the options object in the internal codemirror state
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [#2423](https://github.com/graphql/graphiql/pull/2423) [`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f) Thanks [@chentsulin](https://github.com/chentsulin)! - Fix peer dependency declaration by using `||` instead of `|` to link multiple major versions
+- [#2423](https://github.com/graphql/graphiql/pull/2423)
+  [`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f)
+  Thanks [@chentsulin](https://github.com/chentsulin)! - Fix peer dependency
+  declaration by using `||` instead of `|` to link multiple major versions
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [#2409](https://github.com/graphql/graphiql/pull/2409) [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the variable editor from the `graphiql` package into a hook `useVariableEditor` provided by `@graphiql/react`
+- [#2409](https://github.com/graphql/graphiql/pull/2409)
+  [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the variable editor from the `graphiql` package into a hook
+  `useVariableEditor` provided by `@graphiql/react`
 
-* [#2408](https://github.com/graphql/graphiql/pull/2408) [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the query editor from the `graphiql` package into a hook `useQueryEditor` provided by `@graphiql/react`
+* [#2408](https://github.com/graphql/graphiql/pull/2408)
+  [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the query editor from the `graphiql` package into a hook
+  `useQueryEditor` provided by `@graphiql/react`
 
-- [#2411](https://github.com/graphql/graphiql/pull/2411) [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the result viewer from the `graphiql` package into a hook `useResponseEditor` provided by `@graphiql/react`
+- [#2411](https://github.com/graphql/graphiql/pull/2411)
+  [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the result viewer from the `graphiql` package into a hook
+  `useResponseEditor` provided by `@graphiql/react`
 
-* [#2404](https://github.com/graphql/graphiql/pull/2404) [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a context provider for editors and move the logic of the headers editor from the `graphiql` package into a hook `useHeaderEditor` provided by `@graphiql/react`
+* [#2404](https://github.com/graphql/graphiql/pull/2404)
+  [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  context provider for editors and move the logic of the headers editor from the
+  `graphiql` package into a hook `useHeaderEditor` provided by `@graphiql/react`
 
 ### Patch Changes
 
-- [#2370](https://github.com/graphql/graphiql/pull/2370) [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a context with provider component and hooks that manages the state related to the docs/explorer.
+- [#2370](https://github.com/graphql/graphiql/pull/2370)
+  [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  context with provider component and hooks that manages the state related to
+  the docs/explorer.

--- a/packages/graphiql-react/tsconfig.cjs.json
+++ b/packages/graphiql-react/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "cjs"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**"]
+}

--- a/packages/graphiql-react/vite.config.d.ts
+++ b/packages/graphiql-react/vite.config.d.ts
@@ -1,0 +1,2 @@
+declare const _default: import('vite').UserConfigExport;
+export default _default;

--- a/packages/graphiql-react/vite.config.js
+++ b/packages/graphiql-react/vite.config.js
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import reactSvgPlugin from 'vite-plugin-react-svg';
+import postCssNestingPlugin from 'postcss-nesting';
+// import noBundlePlugin from 'vite-plugin-no-bundle';
+export default defineConfig({
+  plugins: [
+    // TODO:  disable bundling dependencies
+    // noBundlePlugin(),
+    react(),
+    reactSvgPlugin({
+      defaultExport: 'component',
+      expandProps: 'end',
+      titleProp: true,
+    }),
+  ],
+  css: {
+    postcss: {
+      // @ts-expect-error
+      plugins: [postCssNestingPlugin()],
+    },
+  },
+  esbuild: {
+    // We use function names for generating readable error messages, so we want
+    // them to be preserved when building and minifying.
+    keepNames: true,
+  },
+  build: {
+    sourcemap: true,
+    lib: {
+      entry: 'src/index.ts',
+      fileName: 'graphiql-react',
+      formats: ['cjs', 'es'],
+    },
+    rollupOptions: {
+      external: ['graphql', 'react', 'react-dom'],
+      output: {
+        chunkFileNames: '[name].[format].js',
+      },
+    },
+  },
+});

--- a/packages/graphiql-toolkit/CHANGELOG.md
+++ b/packages/graphiql-toolkit/CHANGELOG.md
@@ -4,55 +4,96 @@
 
 ### Patch Changes
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
 ## 0.8.1
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2923](https://github.com/graphql/graphiql/pull/2923) [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04) Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Remove side-effect in StorageAPI that overrides localStorage.clear
+- [#2923](https://github.com/graphql/graphiql/pull/2923)
+  [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04)
+  Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Remove
+  side-effect in StorageAPI that overrides localStorage.clear
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2936](https://github.com/graphql/graphiql/pull/2936) [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `lonely-if`/`unicorn/lonely-if` rules
+- [#2936](https://github.com/graphql/graphiql/pull/2936)
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `lonely-if`/`unicorn/lonely-if` rules
 
-- [#2938](https://github.com/graphql/graphiql/pull/2938) [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error` rule
+- [#2938](https://github.com/graphql/graphiql/pull/2938)
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error`
+  rule
 
 ## 0.8.0
 
 ### Minor Changes
 
-- [#2719](https://github.com/graphql/graphiql/pull/2719) [`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4) Thanks [@andreialecu](https://github.com/andreialecu)! - Allow passing Headers for subscriptions into connection_init payload
+- [#2719](https://github.com/graphql/graphiql/pull/2719)
+  [`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4)
+  Thanks [@andreialecu](https://github.com/andreialecu)! - Allow passing Headers
+  for subscriptions into connection_init payload
 
 ## 0.7.3
 
 ### Patch Changes
 
-- [#2755](https://github.com/graphql/graphiql/pull/2755) [`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Only remove namespaced items when clearing `localStorage`
+- [#2755](https://github.com/graphql/graphiql/pull/2755)
+  [`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Only remove
+  namespaced items when clearing `localStorage`
 
 ## 0.7.2
 
 ### Patch Changes
 
-- [#2753](https://github.com/graphql/graphiql/pull/2753) [`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Mark the `graphql-ws` peer dependency as optional (as it's only needed when the fetcher needs to support subscriptions)
+- [#2753](https://github.com/graphql/graphiql/pull/2753)
+  [`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Mark the
+  `graphql-ws` peer dependency as optional (as it's only needed when the fetcher
+  needs to support subscriptions)
 
-* [#2751](https://github.com/graphql/graphiql/pull/2751) [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Correctly handle `null` in type-guard functions for `Promise` and `Observable`
+* [#2751](https://github.com/graphql/graphiql/pull/2751)
+  [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Correctly
+  handle `null` in type-guard functions for `Promise` and `Observable`
 
 ## 0.7.1
 
 ### Patch Changes
 
-- [#2737](https://github.com/graphql/graphiql/pull/2737) [`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Handle execution when there is no document AST (because the query editor is empty or the query string contains syntax errors)
+- [#2737](https://github.com/graphql/graphiql/pull/2737)
+  [`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Handle
+  execution when there is no document AST (because the query editor is empty or
+  the query string contains syntax errors)
 
 ## 0.7.0
 
 ### Minor Changes
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: Don't pass `shouldPersistHeaders` anymore when invoking the fetcher function. This value can be looked up by consuming the `EditorContext`:
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: Don't pass
+  `shouldPersistHeaders` anymore when invoking the fetcher function. This value
+  can be looked up by consuming the `EditorContext`:
 
   ```js
   import { useEditorContext } from '@graphiql/react';
@@ -63,139 +104,237 @@
   }
   ```
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - Add a `clear` method to `Storage` classes
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - Add a `clear` method to `Storage`
+  classes
 
 ## 0.6.1
 
 ### Patch Changes
 
-- [#2535](https://github.com/graphql/graphiql/pull/2535) [`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix error formatting for websocket requests and make error formatting more generic in general
+- [#2535](https://github.com/graphql/graphiql/pull/2535)
+  [`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix error
+  formatting for websocket requests and make error formatting more generic in
+  general
 
 ## 0.6.0
 
 ### Minor Changes
 
-- [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `fillLeafs` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+- [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `fillLeafs` utility function from `graphiql` into `@graphiql/toolkit` and
+  deprecate the export from `graphiql`
 
-* [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `mergeAst` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+* [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `mergeAst` utility function from `graphiql` into `@graphiql/toolkit` and
+  deprecate the export from `graphiql`
 
-- [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `getSelectedOperationName` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+- [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `getSelectedOperationName` utility function from `graphiql` into
+  `@graphiql/toolkit` and deprecate the export from `graphiql`
 
 ### Patch Changes
 
-- [#2413](https://github.com/graphql/graphiql/pull/2413) [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow creating noop StorageAPI instances by passing `null` to the constructor
+- [#2413](https://github.com/graphql/graphiql/pull/2413)
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow
+  creating noop StorageAPI instances by passing `null` to the constructor
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move QueryStore from `graphiql` package to `@graphiql/toolkit`
+- [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  QueryStore from `graphiql` package to `@graphiql/toolkit`
 
-* [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move HistoryStore from `graphiql` package to `@graphiql/toolkit`
+* [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  HistoryStore from `graphiql` package to `@graphiql/toolkit`
 
-- [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move StorageAPI from `graphiql` package to `@graphiql/toolkit`
+- [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  StorageAPI from `graphiql` package to `@graphiql/toolkit`
 
 ### Patch Changes
 
-- [#2407](https://github.com/graphql/graphiql/pull/2407) [`bc3dc64c`](https://github.com/graphql/graphiql/commit/bc3dc64c37478ba6170c49c25fb755b4f2e020b2) Thanks [@benjdlambert](https://github.com/benjdlambert)! - Move `graphql-ws` dependency to a dynamic import, and add a nice error message when it's not installed
+- [#2407](https://github.com/graphql/graphiql/pull/2407)
+  [`bc3dc64c`](https://github.com/graphql/graphiql/commit/bc3dc64c37478ba6170c49c25fb755b4f2e020b2)
+  Thanks [@benjdlambert](https://github.com/benjdlambert)! - Move `graphql-ws`
+  dependency to a dynamic import, and add a nice error message when it's not
+  installed
 
 ## 0.4.5
 
 ### Patch Changes
 
-- [#2401](https://github.com/graphql/graphiql/pull/2401) [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - move async helper functions and formatting functions over into the @graphiql/toolkit package
+- [#2401](https://github.com/graphql/graphiql/pull/2401)
+  [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - move async
+  helper functions and formatting functions over into the @graphiql/toolkit
+  package
 
-* [#2401](https://github.com/graphql/graphiql/pull/2401) [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - deprecate the unused `shouldPersistHeaders` property from fetcher options to be removed in the next major version
+* [#2401](https://github.com/graphql/graphiql/pull/2401)
+  [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - deprecate
+  the unused `shouldPersistHeaders` property from fetcher options to be removed
+  in the next major version
 
 ## 0.4.4
 
 ### Patch Changes
 
-- [#2373](https://github.com/graphql/graphiql/pull/2373) [`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597) Thanks [@benjie](https://github.com/benjie)! - Fix TypeScript definition of FetcherParams to reflect that operationName is optional
+- [#2373](https://github.com/graphql/graphiql/pull/2373)
+  [`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597)
+  Thanks [@benjie](https://github.com/benjie)! - Fix TypeScript definition of
+  FetcherParams to reflect that operationName is optional
 
 ## 0.4.3
 
 ### Patch Changes
 
-- [#2274](https://github.com/graphql/graphiql/pull/2274) [`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216) Thanks [@B2o5T](https://github.com/B2o5T)! - turn `valid-typeof` as `error`, SSR fix
+- [#2274](https://github.com/graphql/graphiql/pull/2274)
+  [`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - turn `valid-typeof` as `error`,
+  SSR fix
 
 ## 0.4.2
 
 ### Patch Changes
 
-- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
 ## 0.4.1
 
 ### Patch Changes
 
-- [`dec207e7`](https://github.com/graphql/graphiql/commit/dec207e74f0506db069482cc30f8cd1f045d8107) [#2017](https://github.com/graphql/graphiql/pull/2017) Thanks [@acao](https://github.com/acao)! - graphql-ws is now a peerDependency. It supports ~4.5.0 to the latest graphql-ws@5.5.5 and beyond. we suggest using the latest version!
+- [`dec207e7`](https://github.com/graphql/graphiql/commit/dec207e74f0506db069482cc30f8cd1f045d8107)
+  [#2017](https://github.com/graphql/graphiql/pull/2017) Thanks
+  [@acao](https://github.com/acao)! - graphql-ws is now a peerDependency. It
+  supports ~4.5.0 to the latest graphql-ws@5.5.5 and beyond. we suggest using
+  the latest version!
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ## 0.3.2
 
 ### Patch Changes
 
-- [`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46) Thanks [@acao](https://github.com/acao)! - Remove bad type definition from `subscriptions-transport-ws` #1992 closes #1989
+- [`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46)
+  Thanks [@acao](https://github.com/acao)! - Remove bad type definition from
+  `subscriptions-transport-ws` #1992 closes #1989
 
 ## 0.3.1
 
 ### Patch Changes
 
-- [`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748) [#1990](https://github.com/graphql/graphiql/pull/1990) Thanks [@acao](https://github.com/acao)! - Remove type definition from `subscriptions-transport-ws`
+- [`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748)
+  [#1990](https://github.com/graphql/graphiql/pull/1990) Thanks
+  [@acao](https://github.com/acao)! - Remove type definition from
+  `subscriptions-transport-ws`
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca) [#1968](https://github.com/graphql/graphiql/pull/1968) Thanks [@acao](https://github.com/acao)! - Remove `optionalDependencies` entirely, remove `subscriptions-transport-ws` which introduces vulnerabilities, upgrade `@n1ru4l/push-pull-async-iterable-iterator` to 3.0.0, upgrade `graphql-ws` several minor versions - the `graphql-ws@5.x` upgrade will come in a later minor release.
+- [`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca)
+  [#1968](https://github.com/graphql/graphiql/pull/1968) Thanks
+  [@acao](https://github.com/acao)! - Remove `optionalDependencies` entirely,
+  remove `subscriptions-transport-ws` which introduces vulnerabilities, upgrade
+  `@n1ru4l/push-pull-async-iterable-iterator` to 3.0.0, upgrade `graphql-ws`
+  several minor versions - the `graphql-ws@5.x` upgrade will come in a later
+  minor release.
 
 ## 0.2.2
 
 ### Patch Changes
 
-- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92) [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
+- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92)
+  [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks
+  [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
 
 ## 0.2.1
 
 ### Patch Changes
 
-- [`3f002710`](https://github.com/graphql/graphiql/commit/3f00271089cbc519e221976c9308f60b317cae80) [#1840](https://github.com/graphql/graphiql/pull/1840) Thanks [@enisdenjo](https://github.com/enisdenjo)! - Use provided `wsConnectionParams`
+- [`3f002710`](https://github.com/graphql/graphiql/commit/3f00271089cbc519e221976c9308f60b317cae80)
+  [#1840](https://github.com/graphql/graphiql/pull/1840) Thanks
+  [@enisdenjo](https://github.com/enisdenjo)! - Use provided
+  `wsConnectionParams`
 
-* [`94f16957`](https://github.com/graphql/graphiql/commit/94f169572f643374ead829af690b6dcc2eb0b6a1) [#1841](https://github.com/graphql/graphiql/pull/1841) Thanks [@enisdenjo](https://github.com/enisdenjo)! - Subscriptions async iterator completes and better error handling
+* [`94f16957`](https://github.com/graphql/graphiql/commit/94f169572f643374ead829af690b6dcc2eb0b6a1)
+  [#1841](https://github.com/graphql/graphiql/pull/1841) Thanks
+  [@enisdenjo](https://github.com/enisdenjo)! - Subscriptions async iterator
+  completes and better error handling
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3) [#1819](https://github.com/graphql/graphiql/pull/1819) Thanks [@acao](https://github.com/acao)! - `GraphiQL.createClient()` accepts custom `legacyClient`, exports typescript types, fixes #1800.
+- [`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3)
+  [#1819](https://github.com/graphql/graphiql/pull/1819) Thanks
+  [@acao](https://github.com/acao)! - `GraphiQL.createClient()` accepts custom
+  `legacyClient`, exports typescript types, fixes #1800.
 
-  `createGraphiQLFetcher` now only attempts an `graphql-ws` connection when only `subscriptionUrl` is provided. In order to use `graphql-transport-ws`, you'll need to provide the `legacyClient` option only, and no `subscriptionUrl` or `wsClient` option.
+  `createGraphiQLFetcher` now only attempts an `graphql-ws` connection when only
+  `subscriptionUrl` is provided. In order to use `graphql-transport-ws`, you'll
+  need to provide the `legacyClient` option only, and no `subscriptionUrl` or
+  `wsClient` option.
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [`d3278556`](https://github.com/graphql/graphiql/commit/d3278556d050d948930c4b35a73039255f9a92b7) Thanks [@harshithpabbati](https://github.com/harshithpabbati)! - Move `@graphiql/create-fetcher` to `@graphiql/toolkit` because it doesn't need to be it's own package as @imolorhe pointed out
+- [`d3278556`](https://github.com/graphql/graphiql/commit/d3278556d050d948930c4b35a73039255f9a92b7)
+  Thanks [@harshithpabbati](https://github.com/harshithpabbati)! - Move
+  `@graphiql/create-fetcher` to `@graphiql/toolkit` because it doesn't need to
+  be it's own package as @imolorhe pointed out
 
 ## 0.1.0
 
 ### Minor Changes
 
-- 1c119386: `@defer`, `@stream`, and `graphql-ws` support in a `createGraphiQLFetcher` utility (#1770)
+- 1c119386: `@defer`, `@stream`, and `graphql-ws` support in a
+  `createGraphiQLFetcher` utility (#1770)
 
-  - support for `@defer` and `@stream` in `GraphiQL` itself on fetcher execution and when handling stream payloads
-  - introduce `@graphiql/toolkit` for types and utilities used to compose `GraphiQL` and other related libraries
-  - introduce `@graphiql/create-fetcher` to accept simplified parameters to generate a `fetcher` that covers the most commonly used `graphql-over-http` transport spec proposals. using `meros` for multipart http, and `graphql-ws` for websockets subscriptions.
-  - use `graphql` and `graphql-express` `experimental-defer-stream` branch in development until it's merged
+  - support for `@defer` and `@stream` in `GraphiQL` itself on fetcher execution
+    and when handling stream payloads
+  - introduce `@graphiql/toolkit` for types and utilities used to compose
+    `GraphiQL` and other related libraries
+  - introduce `@graphiql/create-fetcher` to accept simplified parameters to
+    generate a `fetcher` that covers the most commonly used `graphql-over-http`
+    transport spec proposals. using `meros` for multipart http, and `graphql-ws`
+    for websockets subscriptions.
+  - use `graphql` and `graphql-express` `experimental-defer-stream` branch in
+    development until it's merged
   - add cypress e2e tests for `@stream` in different scenarios
   - add some unit tests for `createGraphiQLFetcher`

--- a/packages/graphiql/CHANGELOG.md
+++ b/packages/graphiql/CHANGELOG.md
@@ -4,17 +4,35 @@
 
 ### Minor Changes
 
-- [#3012](https://github.com/graphql/graphiql/pull/3012) [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b) Thanks [@benjie](https://github.com/benjie)! - GraphiQL now maintains the DocExplorer navigation stack as best it can when the schema is updated
+- [#3012](https://github.com/graphql/graphiql/pull/3012)
+  [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b)
+  Thanks [@benjie](https://github.com/benjie)! - GraphiQL now maintains the
+  DocExplorer navigation stack as best it can when the schema is updated
 
 ### Patch Changes
 
-- [#2995](https://github.com/graphql/graphiql/pull/2995) [`5f276c41`](https://github.com/graphql/graphiql/commit/5f276c415ad93350382fec873025ffecc9a29d9d) Thanks [@imolorhe](https://github.com/imolorhe)! - fix(cm6-graphql): Fix query token used as field name
+- [#2995](https://github.com/graphql/graphiql/pull/2995)
+  [`5f276c41`](https://github.com/graphql/graphiql/commit/5f276c415ad93350382fec873025ffecc9a29d9d)
+  Thanks [@imolorhe](https://github.com/imolorhe)! - fix(cm6-graphql): Fix query
+  token used as field name
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`65f5176a`](https://github.com/graphql/graphiql/commit/65f5176a408cfbbc514ca60e2e4bd2ea133a8b0b),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
   - @graphiql/react@0.17.0
   - @graphiql/toolkit@0.8.2
@@ -23,23 +41,59 @@
 
 ### Minor Changes
 
-- [#2895](https://github.com/graphql/graphiql/pull/2895) [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42) Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Add user facing setting for persisting headers
+- [#2895](https://github.com/graphql/graphiql/pull/2895)
+  [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42)
+  Thanks [@TheMightyPenguin](https://github.com/TheMightyPenguin)! - Add user
+  facing setting for persisting headers
 
 ### Patch Changes
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2941](https://github.com/graphql/graphiql/pull/2941) [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-logical-operator-over-ternary` rule
+- [#2941](https://github.com/graphql/graphiql/pull/2941)
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-logical-operator-over-ternary` rule
 
-- [#2964](https://github.com/graphql/graphiql/pull/2964) [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-export-from` rule
+- [#2964](https://github.com/graphql/graphiql/pull/2964)
+  [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-export-from` rule
 
-- [#2939](https://github.com/graphql/graphiql/pull/2939) [`bca318ce`](https://github.com/graphql/graphiql/commit/bca318ceb7821f0c4b3973c5b05131c9a23bf2cf) Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - removes regenerator-runtime from cdn.ts, resolves #2868
+- [#2939](https://github.com/graphql/graphiql/pull/2939)
+  [`bca318ce`](https://github.com/graphql/graphiql/commit/bca318ceb7821f0c4b3973c5b05131c9a23bf2cf)
+  Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - removes
+  regenerator-runtime from cdn.ts, resolves #2868
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
-- [#2938](https://github.com/graphql/graphiql/pull/2938) [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error` rule
+- [#2938](https://github.com/graphql/graphiql/pull/2938)
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error`
+  rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786), [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04), [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171), [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`cec3fb2a`](https://github.com/graphql/graphiql/commit/cec3fb2a493c4a0c40df7dfad04e1a95ed35e786),
+  [`695100bd`](https://github.com/graphql/graphiql/commit/695100bd317940ff3ffd8f56b54248c1dba1ac04),
+  [`11e6ad11`](https://github.com/graphql/graphiql/commit/11e6ad11e745c671eb320731697887bb8d7177b7),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`ccba2f33`](https://github.com/graphql/graphiql/commit/ccba2f33b67a03f492222f7afde1354cfd033b42),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171),
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
   - @graphiql/react@0.16.0
   - @graphiql/toolkit@0.8.1
   - graphql-language-service@5.1.1
@@ -48,30 +102,55 @@
 
 ### Minor Changes
 
-- [#2908](https://github.com/graphql/graphiql/pull/2908) [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate the `initialTabs` prop and add a `defaultTabs` props that supersedes it
+- [#2908](https://github.com/graphql/graphiql/pull/2908)
+  [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate
+  the `initialTabs` prop and add a `defaultTabs` props that supersedes it
 
 ### Patch Changes
 
-- [#2911](https://github.com/graphql/graphiql/pull/2911) [`118db402`](https://github.com/graphql/graphiql/commit/118db402eb1f5569e29f8f9bffef86d941dd2634) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix styles of secondary editor buttons
+- [#2911](https://github.com/graphql/graphiql/pull/2911)
+  [`118db402`](https://github.com/graphql/graphiql/commit/118db402eb1f5569e29f8f9bffef86d941dd2634)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix styles
+  of secondary editor buttons
 
-- [#2919](https://github.com/graphql/graphiql/pull/2919) [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix overflow when there are lots of tabs that don't fit into the tab bar at once
+- [#2919](https://github.com/graphql/graphiql/pull/2919)
+  [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  overflow when there are lots of tabs that don't fit into the tab bar at once
 
-- Updated dependencies [[`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911), [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4), [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a), [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665), [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d), [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816)]:
+- Updated dependencies
+  [[`16174a05`](https://github.com/graphql/graphiql/commit/16174a053ed89fb9554d096395ab7bf69c8f6911),
+  [`f6cae4ea`](https://github.com/graphql/graphiql/commit/f6cae4eaa0258ea7fcde97ba6368830955f0abf4),
+  [`3340fd74`](https://github.com/graphql/graphiql/commit/3340fd745e181ba8f1f5a6ed002a04d253a78d4a),
+  [`0851d5f9`](https://github.com/graphql/graphiql/commit/0851d5f9ecf709597d0a698609d88f99c4395665),
+  [`83364b28`](https://github.com/graphql/graphiql/commit/83364b28020b5946ed58908d6d977f1de766e75d),
+  [`3a7d0007`](https://github.com/graphql/graphiql/commit/3a7d00071922e2005777c92daf6ad0c1ce3e2816)]:
   - @graphiql/react@0.15.0
 
 ## 2.1.0
 
 ### Minor Changes
 
-- [#2821](https://github.com/graphql/graphiql/pull/2821) [`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8) Thanks [@avaly](https://github.com/avaly)! - Initial tabs support
+- [#2821](https://github.com/graphql/graphiql/pull/2821)
+  [`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8)
+  Thanks [@avaly](https://github.com/avaly)! - Initial tabs support
 
 ### Patch Changes
 
-- [#2885](https://github.com/graphql/graphiql/pull/2885) [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef) Thanks [@simhnna](https://github.com/simhnna)! - Fix stop execution button showing a dropdown
+- [#2885](https://github.com/graphql/graphiql/pull/2885)
+  [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef)
+  Thanks [@simhnna](https://github.com/simhnna)! - Fix stop execution button
+  showing a dropdown
 
-- [#2886](https://github.com/graphql/graphiql/pull/2886) [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08) Thanks [@B2o5T](https://github.com/B2o5T)! - feat: add `defaultHeaders` prop
+- [#2886](https://github.com/graphql/graphiql/pull/2886)
+  [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - feat: add `defaultHeaders` prop
 
-- Updated dependencies [[`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8), [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef), [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)]:
+- Updated dependencies
+  [[`29630c22`](https://github.com/graphql/graphiql/commit/29630c2219bca8b825ab0897840864364a9de2e8),
+  [`8f926489`](https://github.com/graphql/graphiql/commit/8f9264896e9971951853463a283a90ba3d1310ef),
+  [`2ba2f620`](https://github.com/graphql/graphiql/commit/2ba2f620b6e7de3ae6b5ea641f33e600f7f44e08)]:
   - @graphiql/react@0.14.0
 
 ## 2.0.13
@@ -85,7 +164,10 @@
 
 ### Patch Changes
 
-- [#2758](https://github.com/graphql/graphiql/pull/2758) [`d63801fa`](https://github.com/graphql/graphiql/commit/d63801fad08e840eff7ff26f55694c6d18769466) Thanks [@LekoArts](https://github.com/LekoArts)! - Fix the width of the plugin pane
+- [#2758](https://github.com/graphql/graphiql/pull/2758)
+  [`d63801fa`](https://github.com/graphql/graphiql/commit/d63801fad08e840eff7ff26f55694c6d18769466)
+  Thanks [@LekoArts](https://github.com/LekoArts)! - Fix the width of the plugin
+  pane
 
 - Updated dependencies []:
   - @graphiql/react@0.13.6
@@ -94,39 +176,53 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2)]:
+- Updated dependencies
+  [[`682ad06e`](https://github.com/graphql/graphiql/commit/682ad06e58ded2f82fa973e8e6613dd654417fe2)]:
   - @graphiql/react@0.13.5
 
 ## 2.0.10
 
 ### Patch Changes
 
-- Updated dependencies [[`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3)]:
+- Updated dependencies
+  [[`4e2f7ff9`](https://github.com/graphql/graphiql/commit/4e2f7ff99c578ceae54a1ae17c02088bd91b89c3)]:
   - @graphiql/react@0.13.4
 
 ## 2.0.9
 
 ### Patch Changes
 
-- [#2778](https://github.com/graphql/graphiql/pull/2778) [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e) Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - Adds a box-model reset for all children of the `.graphiql-container` class. This change facilitated another change to the `--sidebar-width` variable.
+- [#2778](https://github.com/graphql/graphiql/pull/2778)
+  [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)
+  Thanks [@jonathanawesome](https://github.com/jonathanawesome)! - Adds a
+  box-model reset for all children of the `.graphiql-container` class. This
+  change facilitated another change to the `--sidebar-width` variable.
 
-- Updated dependencies [[`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657), [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14), [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)]:
+- Updated dependencies
+  [[`42700076`](https://github.com/graphql/graphiql/commit/4270007671ce52f6c2250739916083611748b657),
+  [`36839800`](https://github.com/graphql/graphiql/commit/36839800de128b05d11c262036c8240390c72a14),
+  [`905f2e5e`](https://github.com/graphql/graphiql/commit/905f2e5ea3f0b304d27ea583e250ed4baff5016e)]:
   - @graphiql/react@0.13.3
 
 ## 2.0.8
 
 ### Patch Changes
 
-- [#2653](https://github.com/graphql/graphiql/pull/2653) [`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80) Thanks [@dylanowen](https://github.com/dylanowen)! - Fix `fetchError` not being cleared when a new `fetcher` is used
+- [#2653](https://github.com/graphql/graphiql/pull/2653)
+  [`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)
+  Thanks [@dylanowen](https://github.com/dylanowen)! - Fix `fetchError` not
+  being cleared when a new `fetcher` is used
 
-- Updated dependencies [[`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)]:
+- Updated dependencies
+  [[`39b4668d`](https://github.com/graphql/graphiql/commit/39b4668d43176526d37ecf07d8c86901d53e0d80)]:
   - @graphiql/react@0.13.2
 
 ## 2.0.7
 
 ### Patch Changes
 
-- Updated dependencies [[`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4)]:
+- Updated dependencies
+  [[`e244b782`](https://github.com/graphql/graphiql/commit/e244b78291c2e2bb02d5753db82437926ebb4df4)]:
   - @graphiql/toolkit@0.8.0
   - @graphiql/react@0.13.1
 
@@ -134,9 +230,16 @@
 
 ### Patch Changes
 
-- [#2735](https://github.com/graphql/graphiql/pull/2735) [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the new CSS variables for color alpha values defined in `@graphiql/react` in style definitions
+- [#2735](https://github.com/graphql/graphiql/pull/2735)
+  [`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the new
+  CSS variables for color alpha values defined in `@graphiql/react` in style
+  definitions
 
-- Updated dependencies [[`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1), [`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af), [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)]:
+- Updated dependencies
+  [[`ca067d88`](https://github.com/graphql/graphiql/commit/ca067d88148c5d221d196790a997ad599038fad1),
+  [`674bf3f8`](https://github.com/graphql/graphiql/commit/674bf3f8ff321dfb8471b0f6e5419bb77ddc94af),
+  [`32a70065`](https://github.com/graphql/graphiql/commit/32a70065434eaa7733e28cda0ea0e7d51952e62a)]:
   - @graphiql/react@0.13.0
   - @graphiql/toolkit@0.7.3
 
@@ -144,7 +247,9 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f), [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679)]:
+- Updated dependencies
+  [[`bfa90f24`](https://github.com/graphql/graphiql/commit/bfa90f249be4f68049c1bb81abfb524ae623313f),
+  [`8ab5fcd0`](https://github.com/graphql/graphiql/commit/8ab5fcd0a8399a0f8eb1b569751dd0e8390b9679)]:
   - @graphiql/toolkit@0.7.2
   - @graphiql/react@0.12.1
 
@@ -152,13 +257,28 @@
 
 ### Patch Changes
 
-- [#2745](https://github.com/graphql/graphiql/pull/2745) [`92a17490`](https://github.com/graphql/graphiql/commit/92a17490c3842b4f83ed1065b73a803f73d02a17) Thanks [@acao](https://github.com/acao)! - Specify MIT license for `@graphiql/plugin-explorer` `package.json`
+- [#2745](https://github.com/graphql/graphiql/pull/2745)
+  [`92a17490`](https://github.com/graphql/graphiql/commit/92a17490c3842b4f83ed1065b73a803f73d02a17)
+  Thanks [@acao](https://github.com/acao)! - Specify MIT license for
+  `@graphiql/plugin-explorer` `package.json`
 
-* [#2741](https://github.com/graphql/graphiql/pull/2741) [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Improved sizing of button for adding tabs
+* [#2741](https://github.com/graphql/graphiql/pull/2741)
+  [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Improved
+  sizing of button for adding tabs
 
-- [#2746](https://github.com/graphql/graphiql/pull/2746) [`6f0fa98e`](https://github.com/graphql/graphiql/commit/6f0fa98eadf897c7eaf8eb89e49c46880d381033) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix CodeMirror editors overlapping other parts of the UI on certain browser-OS-combinations (e.g. Chrome on Windows)
+- [#2746](https://github.com/graphql/graphiql/pull/2746)
+  [`6f0fa98e`](https://github.com/graphql/graphiql/commit/6f0fa98eadf897c7eaf8eb89e49c46880d381033)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  CodeMirror editors overlapping other parts of the UI on certain
+  browser-OS-combinations (e.g. Chrome on Windows)
 
-- Updated dependencies [[`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9), [`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13), [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7), [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058), [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)]:
+- Updated dependencies
+  [[`98e14155`](https://github.com/graphql/graphiql/commit/98e14155c650ee7c5ac639e594eb47f0052b7fa9),
+  [`48872a87`](https://github.com/graphql/graphiql/commit/48872a87e6edec0c301102baaf669ffcce043a13),
+  [`7dfea94a`](https://github.com/graphql/graphiql/commit/7dfea94afc0cfe79b5080f10d840bfdce53f02d7),
+  [`3aa1f39f`](https://github.com/graphql/graphiql/commit/3aa1f39f6df559b54f703937ed510c8ba1f21058),
+  [`0219eef3`](https://github.com/graphql/graphiql/commit/0219eef39146495749aca2487112db52fa3bb8fd)]:
   - @graphiql/react@0.12.0
   - @graphiql/toolkit@0.7.1
 
@@ -166,45 +286,87 @@
 
 ### Patch Changes
 
-- [#2706](https://github.com/graphql/graphiql/pull/2706) [`ff20a381`](https://github.com/graphql/graphiql/commit/ff20a3818f10f648d7b8c18229138b0424b8b25c) Thanks [@mxstbr](https://github.com/mxstbr)! - Wrap the GraphiQL logo with a link to the repository
+- [#2706](https://github.com/graphql/graphiql/pull/2706)
+  [`ff20a381`](https://github.com/graphql/graphiql/commit/ff20a3818f10f648d7b8c18229138b0424b8b25c)
+  Thanks [@mxstbr](https://github.com/mxstbr)! - Wrap the GraphiQL logo with a
+  link to the repository
 
-* [#2715](https://github.com/graphql/graphiql/pull/2715) [`c922719e`](https://github.com/graphql/graphiql/commit/c922719e6b960776cd0a71f14d2b86c6bb69373c) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add the contents of `graphql` and `@graphiql/react` as static properties to the `GraphiQL` component in CDN bundles so that these modules can be reused from plugin CDN bundles.
+* [#2715](https://github.com/graphql/graphiql/pull/2715)
+  [`c922719e`](https://github.com/graphql/graphiql/commit/c922719e6b960776cd0a71f14d2b86c6bb69373c)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add the
+  contents of `graphql` and `@graphiql/react` as static properties to the
+  `GraphiQL` component in CDN bundles so that these modules can be reused from
+  plugin CDN bundles.
 
 ## 2.0.2
 
 ### Patch Changes
 
-- Updated dependencies [[`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410), [`f15ee38d`](https://github.com/graphql/graphiql/commit/f15ee38d56e4f749c145e0a17f0ed8e9a6096ac2), [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410)]:
+- Updated dependencies
+  [[`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410),
+  [`f15ee38d`](https://github.com/graphql/graphiql/commit/f15ee38d56e4f749c145e0a17f0ed8e9a6096ac2),
+  [`d65f00ea`](https://github.com/graphql/graphiql/commit/d65f00ea2d158cf532d1c71844630c5d9ec13410)]:
   - @graphiql/react@0.11.1
 
 ## 2.0.1
 
 ### Patch Changes
 
-- [#2699](https://github.com/graphql/graphiql/pull/2699) [`3b642aa3`](https://github.com/graphql/graphiql/commit/3b642aa31b306994e3052bb2454933307aa51426) Thanks [@patrick91](https://github.com/patrick91)! - Export hooks in CDN bundle
+- [#2699](https://github.com/graphql/graphiql/pull/2699)
+  [`3b642aa3`](https://github.com/graphql/graphiql/commit/3b642aa31b306994e3052bb2454933307aa51426)
+  Thanks [@patrick91](https://github.com/patrick91)! - Export hooks in CDN
+  bundle
 
-* [#2700](https://github.com/graphql/graphiql/pull/2700) [`3acacf5b`](https://github.com/graphql/graphiql/commit/3acacf5b90040bbede30ad1a778e06bc969a5900) Thanks [@patrick91](https://github.com/patrick91)! - Fix cannot access `initialHeaders` before initialization
+* [#2700](https://github.com/graphql/graphiql/pull/2700)
+  [`3acacf5b`](https://github.com/graphql/graphiql/commit/3acacf5b90040bbede30ad1a778e06bc969a5900)
+  Thanks [@patrick91](https://github.com/patrick91)! - Fix cannot access
+  `initialHeaders` before initialization
 
 ## 2.0.0
 
 ### Major Changes
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The `GraphiQL` component does no longer set a property `g` on the `window` object.
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The `GraphiQL` component
+  does no longer set a property `g` on the `window` object.
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: Implement a new design for the GraphiQL UI. This changes both DOM structure and class names. We consider this a breaking change as custom GraphQL IDEs built on top of GraphiQL relied on these internals, e.g. overriding styles using certain class names.
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: Implement a new design
+  for the GraphiQL UI. This changes both DOM structure and class names. We
+  consider this a breaking change as custom GraphQL IDEs built on top of
+  GraphiQL relied on these internals, e.g. overriding styles using certain class
+  names.
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The following static properties of the `GraphiQL` component have been removed:
-  - `GraphiQL.formatResult`: You can use the function `formatResult` from `@graphiql/toolkit` instead.
-  - `GraphiQL.formatError`: You can use the function `formatError` from `@graphiql/toolkit` instead.
-  - `GraphiQL.QueryEditor`: You can use the `QueryEditor` component from `@graphiql/react` instead.
-  - `GraphiQL.VariableEditor`: You can use the `VariableEditor` component from `@graphiql/react` instead.
-  - `GraphiQL.HeaderEditor`: You can use the `HeaderEditor` component from `@graphiql/react` instead.
-  - `GraphiQL.ResultViewer`: You can use the `ResponseEditor` component from `@graphiql/react` instead.
-  - `GraphiQL.Button`: You can use the `ToolbarButton` component from `@graphiql/react` instead.
-  - `GraphiQL.ToolbarButton`: This exposed the same component as `GraphiQL.Button`.
-  - `GraphiQL.Menu`: You can use the `ToolbarMenu` component from `@graphiql/react` instead.
-  - `GraphiQL.MenuItem`: You can use the `ToolbarMenu.Item` component from `@graphiql/react` instead.
-  - `GraphiQL.Group`: Grouping multiple buttons side-by-side is not provided out-of-the box anymore in the new GraphiQL UI. If you want to implement a similar feature in the new vertical toolbar you can do so by adding your own styles for your custom toolbar elements. Example:
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The following static
+  properties of the `GraphiQL` component have been removed:
+  - `GraphiQL.formatResult`: You can use the function `formatResult` from
+    `@graphiql/toolkit` instead.
+  - `GraphiQL.formatError`: You can use the function `formatError` from
+    `@graphiql/toolkit` instead.
+  - `GraphiQL.QueryEditor`: You can use the `QueryEditor` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.VariableEditor`: You can use the `VariableEditor` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.HeaderEditor`: You can use the `HeaderEditor` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.ResultViewer`: You can use the `ResponseEditor` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.Button`: You can use the `ToolbarButton` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.ToolbarButton`: This exposed the same component as
+    `GraphiQL.Button`.
+  - `GraphiQL.Menu`: You can use the `ToolbarMenu` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.MenuItem`: You can use the `ToolbarMenu.Item` component from
+    `@graphiql/react` instead.
+  - `GraphiQL.Group`: Grouping multiple buttons side-by-side is not provided
+    out-of-the box anymore in the new GraphiQL UI. If you want to implement a
+    similar feature in the new vertical toolbar you can do so by adding your own
+    styles for your custom toolbar elements. Example:
     ```jsx
     import { GraphiQL } from 'graphiql';
     function CustomGraphiQL() {
@@ -223,18 +385,24 @@
     }
     ```
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The following exports of the `graphiql` package have been removed:
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The following exports of
+  the `graphiql` package have been removed:
   - `DocExplorer`: Now exported from `@graphiql/react` as `DocExplorer`
-    - The `schema` prop has been removed, the component now uses the schema provided by the `ExplorerContext`
+    - The `schema` prop has been removed, the component now uses the schema
+      provided by the `ExplorerContext`
   - `fillLeafs`: Now exported from `@graphiql/toolkit` as `fillLeafs`
-  - `getSelectedOperationName`: Now exported from `@graphiql/toolkit` as `getSelectedOperationName`
+  - `getSelectedOperationName`: Now exported from `@graphiql/toolkit` as
+    `getSelectedOperationName`
   - `mergeAst`: Now exported from `@graphiql/toolkit` as `mergeAst`
   - `onHasCompletion`: Now exported from `@graphiql/react` as `onHasCompletion`
   - `QueryEditor`: Now exported from `@graphiql/react` as `QueryEditor`
   - `ToolbarMenu`: Now exported from `@graphiql/react` as `ToolbarMenu`
   - `ToolbarMenuItem`: Now exported from `@graphiql/react` as `ToolbarMenu.Item`
   - `ToolbarSelect`: Now exported from `@graphiql/react` as `ToolbarListbox`
-  - `ToolbarSelectOption`: Now exported from `@graphiql/react` as `ToolbarListbox.Option`
+  - `ToolbarSelectOption`: Now exported from `@graphiql/react` as
+    `ToolbarListbox.Option`
   - `VariableEditor`: Now exported from `@graphiql/react` as `VariableEditor`
   - type `Fetcher`: Now exported from `@graphiql/toolkit`
   - type `FetcherOpts`: Now exported from `@graphiql/toolkit`
@@ -245,18 +413,37 @@
   - type `Storage`: Now exported from `@graphiql/toolkit`
   - type `SyncFetcherResult`: Now exported from `@graphiql/toolkit`
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The `GraphiQL` component has been refactored to be a function component. Attaching a ref to this component will no longer provide access to props, state or class methods. In order to interact with or change `GraphiQL` state you need to use the contexts and hooks provided by the `@graphiql/react` package. More details and examples can be found in the migration guide.
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The `GraphiQL` component
+  has been refactored to be a function component. Attaching a ref to this
+  component will no longer provide access to props, state or class methods. In
+  order to interact with or change `GraphiQL` state you need to use the contexts
+  and hooks provided by the `@graphiql/react` package. More details and examples
+  can be found in the migration guide.
 
-* [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - BREAKING: The following props of the `GraphiQL` component have been changed:
-  - The props `defaultVariableEditorOpen` and `defaultSecondaryEditorOpen` have been merged into one prop `defaultEditorToolsVisibility`. The default behavior if this prop is not passed is that the editor tools are shown if at least one of the secondary editors has contents. You can pass the following values to the prop:
+* [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - BREAKING: The following props of
+  the `GraphiQL` component have been changed:
+  - The props `defaultVariableEditorOpen` and `defaultSecondaryEditorOpen` have
+    been merged into one prop `defaultEditorToolsVisibility`. The default
+    behavior if this prop is not passed is that the editor tools are shown if at
+    least one of the secondary editors has contents. You can pass the following
+    values to the prop:
     - Passing `false` hides the editor tools.
     - Passing `true` shows the editor tools.
     - Passing `"variables"` explicitly shows the variables editor.
     - Passing `"headers"` explicitly shows the headers editor.
-  - The props `docExplorerOpen`, `onToggleDocs` and `onToggleHistory` have been removed. They are replaced by the more generic props `visiblePlugin` (for controlling which plugin is visible) and `onTogglePluginVisibility` (which is called each time the visibility of any plugin changes).
+  - The props `docExplorerOpen`, `onToggleDocs` and `onToggleHistory` have been
+    removed. They are replaced by the more generic props `visiblePlugin` (for
+    controlling which plugin is visible) and `onTogglePluginVisibility` (which
+    is called each time the visibility of any plugin changes).
   - The `headerEditorEnabled` prop has been renamed to `isHeadersEditorEnabled`.
   - The `ResultsTooltip` prop has been renamed to `responseTooltip`.
-  - Tabs are now always enabled. The `tabs` prop has therefore been replaced with a prop `onTabChange`. If you used the `tabs` prop before to pass this function you can change your implementation like so:
+  - Tabs are now always enabled. The `tabs` prop has therefore been replaced
+    with a prop `onTabChange`. If you used the `tabs` prop before to pass this
+    function you can change your implementation like so:
     ```diff
     <GraphiQL
     -  tabs={{ onTabChange: (tabState) => {/* do something */} }}
@@ -266,11 +453,21 @@
 
 ### Minor Changes
 
-- [#2694](https://github.com/graphql/graphiql/pull/2694) [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279) Thanks [@acao](https://github.com/acao)! - GraphiQL now ships with a dark theme. By default the interface respects the system settings, the theme can also be explicitly chosen via the new settings dialog.
+- [#2694](https://github.com/graphql/graphiql/pull/2694)
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)
+  Thanks [@acao](https://github.com/acao)! - GraphiQL now ships with a dark
+  theme. By default the interface respects the system settings, the theme can
+  also be explicitly chosen via the new settings dialog.
 
 ### Patch Changes
 
-- Updated dependencies [[`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279), [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)]:
+- Updated dependencies
+  [[`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279),
+  [`e59ec32e`](https://github.com/graphql/graphiql/commit/e59ec32e7ccdf3f7f68656533555c63620826279)]:
   - @graphiql/react@0.11.0
   - @graphiql/toolkit@0.7.0
 
@@ -278,7 +475,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
   - @graphiql/react@0.10.1
 
@@ -286,36 +484,50 @@
 
 ### Patch Changes
 
-- [#2678](https://github.com/graphql/graphiql/pull/2678) [`b3470b99`](https://github.com/graphql/graphiql/commit/b3470b993bd4c1b90ab7831581de2021af1bb6b0) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add the attribute `type="button"` to all buttons
+- [#2678](https://github.com/graphql/graphiql/pull/2678)
+  [`b3470b99`](https://github.com/graphql/graphiql/commit/b3470b993bd4c1b90ab7831581de2021af1bb6b0)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add the
+  attribute `type="button"` to all buttons
 
 ## 1.11.4
 
 ### Patch Changes
 
-- Updated dependencies [[`85d5af25`](https://github.com/graphql/graphiql/commit/85d5af25d77c29b7d02da90a431c8c15f610c22a), [`6ff0bab9`](https://github.com/graphql/graphiql/commit/6ff0bab978d63778b8ab4ba6e79fceb36c2db87f), [`0aff68a6`](https://github.com/graphql/graphiql/commit/0aff68a645cceb6b9689e0f394e8bece01710efc)]:
+- Updated dependencies
+  [[`85d5af25`](https://github.com/graphql/graphiql/commit/85d5af25d77c29b7d02da90a431c8c15f610c22a),
+  [`6ff0bab9`](https://github.com/graphql/graphiql/commit/6ff0bab978d63778b8ab4ba6e79fceb36c2db87f),
+  [`0aff68a6`](https://github.com/graphql/graphiql/commit/0aff68a645cceb6b9689e0f394e8bece01710efc)]:
   - @graphiql/react@0.10.0
 
 ## 1.11.3
 
 ### Patch Changes
 
-- [#2642](https://github.com/graphql/graphiql/pull/2642) [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix controlling the operation name sent with the request using the `operationName` prop
+- [#2642](https://github.com/graphql/graphiql/pull/2642)
+  [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  controlling the operation name sent with the request using the `operationName`
+  prop
 
-- Updated dependencies [[`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b), [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b)]:
+- Updated dependencies
+  [[`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b),
+  [`100af928`](https://github.com/graphql/graphiql/commit/100af9284de18ca89524c646e86854313c5d067b)]:
   - @graphiql/react@0.9.0
 
 ## 1.11.2
 
 ### Patch Changes
 
-- Updated dependencies [[`62317e0b`](https://github.com/graphql/graphiql/commit/62317e0bae6d4ccf89d9e1e6607fd8feeb100078)]:
+- Updated dependencies
+  [[`62317e0b`](https://github.com/graphql/graphiql/commit/62317e0bae6d4ccf89d9e1e6607fd8feeb100078)]:
   - @graphiql/react@0.8.0
 
 ## 1.11.1
 
 ### Patch Changes
 
-- Updated dependencies [[`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12)]:
+- Updated dependencies
+  [[`ea732ea8`](https://github.com/graphql/graphiql/commit/ea732ea8e12272c998f1467af8b3b88b6b508e12)]:
   - @graphiql/toolkit@0.6.1
   - @graphiql/react@0.7.1
 
@@ -323,61 +535,85 @@
 
 ### Minor Changes
 
-- [#2618](https://github.com/graphql/graphiql/pull/2618) [`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a toolbar button for manually triggering introspection
+- [#2618](https://github.com/graphql/graphiql/pull/2618)
+  [`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  toolbar button for manually triggering introspection
 
 ### Patch Changes
 
-- Updated dependencies [[`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a)]:
+- Updated dependencies
+  [[`4c814506`](https://github.com/graphql/graphiql/commit/4c814506183579b78731659d871cd4b0ba93305a)]:
   - @graphiql/react@0.7.0
 
 ## 1.10.0
 
 ### Minor Changes
 
-- [#2574](https://github.com/graphql/graphiql/pull/2574) [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow passing introspection data to the `schema` prop of the `GraphiQL` component
+- [#2574](https://github.com/graphql/graphiql/pull/2574)
+  [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Allow
+  passing introspection data to the `schema` prop of the `GraphiQL` component
 
 ### Patch Changes
 
-- Updated dependencies [[`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1), [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1)]:
+- Updated dependencies
+  [[`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1),
+  [`0c98fa59`](https://github.com/graphql/graphiql/commit/0c98fa5924eadaee33713ccd8a9be6419d50cab1)]:
   - @graphiql/react@0.6.0
 
 ## 1.9.13
 
 ### Patch Changes
 
-- Updated dependencies [[`f581b437`](https://github.com/graphql/graphiql/commit/f581b437e5bdab6f3ad817d230ee6d1b410bb591)]:
+- Updated dependencies
+  [[`f581b437`](https://github.com/graphql/graphiql/commit/f581b437e5bdab6f3ad817d230ee6d1b410bb591)]:
   - @graphiql/react@0.5.2
 
 ## 1.9.12
 
 ### Patch Changes
 
-- Updated dependencies [[`08346cba`](https://github.com/graphql/graphiql/commit/08346cba136825341881f9dfefc62a60d748e0ee)]:
+- Updated dependencies
+  [[`08346cba`](https://github.com/graphql/graphiql/commit/08346cba136825341881f9dfefc62a60d748e0ee)]:
   - @graphiql/react@0.5.1
 
 ## 1.9.11
 
 ### Patch Changes
 
-- [#2541](https://github.com/graphql/graphiql/pull/2541) [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix the `onSchemaChange` prop, it is now again called after the schema is fetched (this was broken since v1.9.3)
+- [#2541](https://github.com/graphql/graphiql/pull/2541)
+  [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix the
+  `onSchemaChange` prop, it is now again called after the schema is fetched
+  (this was broken since v1.9.3)
 
-- Updated dependencies [[`8ce5b483`](https://github.com/graphql/graphiql/commit/8ce5b483ee190b5f5dd84eaf42e5d1359ce185e6), [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb)]:
+- Updated dependencies
+  [[`8ce5b483`](https://github.com/graphql/graphiql/commit/8ce5b483ee190b5f5dd84eaf42e5d1359ce185e6),
+  [`788d84ef`](https://github.com/graphql/graphiql/commit/788d84ef2784188981f1b4cfb78fba24153bf0cb)]:
   - @graphiql/react@0.5.0
 
 ## 1.9.10
 
 ### Patch Changes
 
-- Updated dependencies [[`26e44120`](https://github.com/graphql/graphiql/commit/26e44120a18d49af451c97619fe3386a65579e05)]:
+- Updated dependencies
+  [[`26e44120`](https://github.com/graphql/graphiql/commit/26e44120a18d49af451c97619fe3386a65579e05)]:
   - @graphiql/react@0.4.3
 
 ## 1.9.9
 
 ### Patch Changes
 
-- [#2501](https://github.com/graphql/graphiql/pull/2501) [`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4) Thanks [@acao](https://github.com/acao)! - Allow Codemirror 5 `keyMap` to be defined, default `vim` or `emacs` allowed in addition to the original default of `sublime`.
+- [#2501](https://github.com/graphql/graphiql/pull/2501)
+  [`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4)
+  Thanks [@acao](https://github.com/acao)! - Allow Codemirror 5 `keyMap` to be
+  defined, default `vim` or `emacs` allowed in addition to the original default
+  of `sublime`.
 
-- Updated dependencies [[`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4), [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`5437ee61`](https://github.com/graphql/graphiql/commit/5437ee61e1ba6cd28ccc1cb3543df1ea788278f4),
+  [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - @graphiql/react@0.4.2
   - graphql-language-service@5.0.6
 
@@ -385,13 +621,17 @@
 
 ### Patch Changes
 
-- [#2499](https://github.com/graphql/graphiql/pull/2499) [`731b3b72`](https://github.com/graphql/graphiql/commit/731b3b72e9f087a3b429ef5e8143219a0dcf7f00) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - fix the default value for the `headerEditorEnabled` prop to be `true`
+- [#2499](https://github.com/graphql/graphiql/pull/2499)
+  [`731b3b72`](https://github.com/graphql/graphiql/commit/731b3b72e9f087a3b429ef5e8143219a0dcf7f00)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - fix the
+  default value for the `headerEditorEnabled` prop to be `true`
 
 ## 1.9.7
 
 ### Patch Changes
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service@5.0.5
   - @graphiql/react@0.4.1
 
@@ -399,72 +639,171 @@
 
 ### Patch Changes
 
-- [#2475](https://github.com/graphql/graphiql/pull/2475) [`d6558e43`](https://github.com/graphql/graphiql/commit/d6558e43bd24a3af7c5f78dbae572bd8ca7b3995) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix using the `GraphiQL` export as type by exporting a class again
+- [#2475](https://github.com/graphql/graphiql/pull/2475)
+  [`d6558e43`](https://github.com/graphql/graphiql/commit/d6558e43bd24a3af7c5f78dbae572bd8ca7b3995)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix using
+  the `GraphiQL` export as type by exporting a class again
 
-* [#2461](https://github.com/graphql/graphiql/pull/2461) [`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the `useDragResize` hook from `@graphiql/react` for the sizing of the editors and the docs explorer
+* [#2461](https://github.com/graphql/graphiql/pull/2461)
+  [`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Use the
+  `useDragResize` hook from `@graphiql/react` for the sizing of the editors and
+  the docs explorer
 
-* Updated dependencies [[`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d)]:
+* Updated dependencies
+  [[`7dfe3ece`](https://github.com/graphql/graphiql/commit/7dfe3ece4e8ab6b3400888f7f357e394db63439d)]:
   - @graphiql/react@0.4.0
 
 ## 1.9.5
 
 ### Patch Changes
 
-- [#2453](https://github.com/graphql/graphiql/pull/2453) [`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add execution context to `@graphiql/react` and move over the logic from `graphiql`
+- [#2453](https://github.com/graphql/graphiql/pull/2453)
+  [`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add
+  execution context to `@graphiql/react` and move over the logic from `graphiql`
 
-* [#2454](https://github.com/graphql/graphiql/pull/2454) [`a53bec64`](https://github.com/graphql/graphiql/commit/a53bec64b511fca2da828d7c0ff100e3a110aec1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate the public methods `getQueryEditor`, `getVariableEditor`, `getHeaderEditor`, and `refresh` on the `GraphiQL` class.
+* [#2454](https://github.com/graphql/graphiql/pull/2454)
+  [`a53bec64`](https://github.com/graphql/graphiql/commit/a53bec64b511fca2da828d7c0ff100e3a110aec1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate
+  the public methods `getQueryEditor`, `getVariableEditor`, `getHeaderEditor`,
+  and `refresh` on the `GraphiQL` class.
 
-- [#2451](https://github.com/graphql/graphiql/pull/2451) [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Always use the current value of the headers for the introspection request
+- [#2451](https://github.com/graphql/graphiql/pull/2451)
+  [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Always use
+  the current value of the headers for the introspection request
 
-* [#2452](https://github.com/graphql/graphiql/pull/2452) [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move tab state from `graphiql` into editor context from `@graphiql/react`
+* [#2452](https://github.com/graphql/graphiql/pull/2452)
+  [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move tab
+  state from `graphiql` into editor context from `@graphiql/react`
 
-- [#2454](https://github.com/graphql/graphiql/pull/2454) [`a53bec64`](https://github.com/graphql/graphiql/commit/a53bec64b511fca2da828d7c0ff100e3a110aec1) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Continue forwarding the ref to the class component to not break public methods
+- [#2454](https://github.com/graphql/graphiql/pull/2454)
+  [`a53bec64`](https://github.com/graphql/graphiql/commit/a53bec64b511fca2da828d7c0ff100e3a110aec1)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Continue
+  forwarding the ref to the class component to not break public methods
 
-* [#2449](https://github.com/graphql/graphiql/pull/2449) [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Assume all context values are nullable and create hooks to consume individual contexts
+* [#2449](https://github.com/graphql/graphiql/pull/2449)
+  [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Assume all
+  context values are nullable and create hooks to consume individual contexts
 
-- [#2450](https://github.com/graphql/graphiql/pull/2450) [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Extract the `copy`, `merge`, `prettify`, and `autoCompleteLeafs` functions into hooks and remove these functions from the editor context value
+- [#2450](https://github.com/graphql/graphiql/pull/2450)
+  [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Extract the
+  `copy`, `merge`, `prettify`, and `autoCompleteLeafs` functions into hooks and
+  remove these functions from the editor context value
 
-- Updated dependencies [[`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8), [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327), [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239), [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921), [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14)]:
+- Updated dependencies
+  [[`1b41e33c`](https://github.com/graphql/graphiql/commit/1b41e33c4a871a345836de58f415b7c461ced1f8),
+  [`0659e96e`](https://github.com/graphql/graphiql/commit/0659e96e07f98d532619f29f52cba59e2d528327),
+  [`ee0fd8bf`](https://github.com/graphql/graphiql/commit/ee0fd8bf4042053ec647080b83656dc5e54a7239),
+  [`a0b02eda`](https://github.com/graphql/graphiql/commit/a0b02edaa629c6113c1c5518fd3aa05b355a1921),
+  [`1e6fc68b`](https://github.com/graphql/graphiql/commit/1e6fc68b73941544ee64e0499e459f9c7d39aa14)]:
   - @graphiql/react@0.3.0
 
 ## 1.9.4
 
 ### Patch Changes
 
-- [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move prettify query functionality to editor context in `@graphiql/react`
+- [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  prettify query functionality to editor context in `@graphiql/react`
 
-* [#2435](https://github.com/graphql/graphiql/pull/2435) [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic for deriving operation facts from the current query to `@graphiql/react` and store these facts as properties on the query editor instance
+* [#2435](https://github.com/graphql/graphiql/pull/2435)
+  [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic for deriving operation facts from the current query to `@graphiql/react`
+  and store these facts as properties on the query editor instance
 
-- [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move copy query functionality to editor context in `@graphiql/react`
+- [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move copy
+  query functionality to editor context in `@graphiql/react`
 
-* [#2437](https://github.com/graphql/graphiql/pull/2437) [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move merge query functionality to editor context in `@graphiql/react`
+* [#2437](https://github.com/graphql/graphiql/pull/2437)
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move merge
+  query functionality to editor context in `@graphiql/react`
 
-- [#2436](https://github.com/graphql/graphiql/pull/2436) [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Inline logic for clicking a reference to open the docs and remove the `onClickReference` and `onHintInformationRender` props of the editor components and hooks
+- [#2436](https://github.com/graphql/graphiql/pull/2436)
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Inline
+  logic for clicking a reference to open the docs and remove the
+  `onClickReference` and `onHintInformationRender` props of the editor
+  components and hooks
 
-* [#2436](https://github.com/graphql/graphiql/pull/2436) [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move visibility state for doc explorer from `graphiql` to the explorer context in `@graphiql/react`
+* [#2436](https://github.com/graphql/graphiql/pull/2436)
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  visibility state for doc explorer from `graphiql` to the explorer context in
+  `@graphiql/react`
 
-* Updated dependencies [[`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995), [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789), [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995), [`3dae62fc`](https://github.com/graphql/graphiql/commit/3dae62fc871385e148a799cde55a52a5e6b41d19), [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789), [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789), [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50), [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)]:
+* Updated dependencies
+  [[`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995),
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789),
+  [`89f0244f`](https://github.com/graphql/graphiql/commit/89f0244f7b7cdf01c168638a09f5137788401995),
+  [`3dae62fc`](https://github.com/graphql/graphiql/commit/3dae62fc871385e148a799cde55a52a5e6b41d19),
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789),
+  [`1f933505`](https://github.com/graphql/graphiql/commit/1f9335051fffc9e6a6f950b6f8060ed521b56789),
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50),
+  [`3e5295f0`](https://github.com/graphql/graphiql/commit/3e5295f0fd3b5f999643ea97e6cee706554f0b50)]:
   - @graphiql/react@0.2.1
 
 ## 1.9.3
 
 ### Patch Changes
 
-- [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `fillLeafs` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+- [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `fillLeafs` utility function from `graphiql` into `@graphiql/toolkit` and
+  deprecate the export from `graphiql`
 
-* [#2413](https://github.com/graphql/graphiql/pull/2413) [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a `StorageContext` and a `HistoryContext` to `@graphiql/react` that replaces the logic in the `graphiql` package
+* [#2413](https://github.com/graphql/graphiql/pull/2413)
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  `StorageContext` and a `HistoryContext` to `@graphiql/react` that replaces the
+  logic in the `graphiql` package
 
-- [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `mergeAst` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+- [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `mergeAst` utility function from `graphiql` into `@graphiql/toolkit` and
+  deprecate the export from `graphiql`
 
-* [#2420](https://github.com/graphql/graphiql/pull/2420) [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix sending multiple introspection requests when loading the page
+* [#2420](https://github.com/graphql/graphiql/pull/2420)
+  [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix sending
+  multiple introspection requests when loading the page
 
-- [#2420](https://github.com/graphql/graphiql/pull/2420) [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate the `autoCompleteLeafs` method of the `GraphiQL` component in favor of the function provided by the `EditorContext` from `@graphiql/react`
+- [#2420](https://github.com/graphql/graphiql/pull/2420)
+  [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Deprecate
+  the `autoCompleteLeafs` method of the `GraphiQL` component in favor of the
+  function provided by the `EditorContext` from `@graphiql/react`
 
-* [#2420](https://github.com/graphql/graphiql/pull/2420) [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a `SchemaContext` to `@graphiql/react` that replaces the logic for fetching and validating the schema in the `graphiql` package
+* [#2420](https://github.com/graphql/graphiql/pull/2420)
+  [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  `SchemaContext` to `@graphiql/react` that replaces the logic for fetching and
+  validating the schema in the `graphiql` package
 
-- [#2419](https://github.com/graphql/graphiql/pull/2419) [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the `getSelectedOperationName` utility function from `graphiql` into `@graphiql/toolkit` and deprecate the export from `graphiql`
+- [#2419](https://github.com/graphql/graphiql/pull/2419)
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  `getSelectedOperationName` utility function from `graphiql` into
+  `@graphiql/toolkit` and deprecate the export from `graphiql`
 
-- Updated dependencies [[`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e), [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9), [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9), [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e), [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962), [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)]:
+- Updated dependencies
+  [[`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e),
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9),
+  [`8be164b1`](https://github.com/graphql/graphiql/commit/8be164b1e158d00752d6d3f30630a797d07d08c9),
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e),
+  [`3467cd33`](https://github.com/graphql/graphiql/commit/3467cd33264e0766a0a43cf53e52ec371df26962),
+  [`84d8985b`](https://github.com/graphql/graphiql/commit/84d8985b87701133cc41fd424a24bb61c9b7272e)]:
   - @graphiql/toolkit@0.6.0
   - @graphiql/react@0.2.0
 
@@ -472,43 +811,92 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec), [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec)]:
+- Updated dependencies
+  [[`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec),
+  [`ebc864f0`](https://github.com/graphql/graphiql/commit/ebc864f0ab05000758cb2898daaa73a2f15255ec)]:
   - @graphiql/react@0.1.2
 
 ## 1.9.1
 
 ### Patch Changes
 
-- [#2423](https://github.com/graphql/graphiql/pull/2423) [`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f) Thanks [@chentsulin](https://github.com/chentsulin)! - Fix peer dependency declaration by using `||` instead of `|` to link multiple major versions
+- [#2423](https://github.com/graphql/graphiql/pull/2423)
+  [`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f)
+  Thanks [@chentsulin](https://github.com/chentsulin)! - Fix peer dependency
+  declaration by using `||` instead of `|` to link multiple major versions
 
-- Updated dependencies [[`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f)]:
+- Updated dependencies
+  [[`838e58da`](https://github.com/graphql/graphiql/commit/838e58dad652d8f5559af7b88d049b1c62348f2f)]:
   - @graphiql/react@0.1.1
 
 ## 1.9.0
 
 ### Minor Changes
 
-- [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move QueryStore from `graphiql` package to `@graphiql/toolkit`
+- [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  QueryStore from `graphiql` package to `@graphiql/toolkit`
 
-* [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move HistoryStore from `graphiql` package to `@graphiql/toolkit`
+* [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  HistoryStore from `graphiql` package to `@graphiql/toolkit`
 
-- [#2409](https://github.com/graphql/graphiql/pull/2409) [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the variable editor from the `graphiql` package into a hook `useVariableEditor` provided by `@graphiql/react`
+- [#2409](https://github.com/graphql/graphiql/pull/2409)
+  [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the variable editor from the `graphiql` package into a hook
+  `useVariableEditor` provided by `@graphiql/react`
 
-* [#2408](https://github.com/graphql/graphiql/pull/2408) [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the query editor from the `graphiql` package into a hook `useQueryEditor` provided by `@graphiql/react`
+* [#2408](https://github.com/graphql/graphiql/pull/2408)
+  [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the query editor from the `graphiql` package into a hook
+  `useQueryEditor` provided by `@graphiql/react`
 
-- [#2411](https://github.com/graphql/graphiql/pull/2411) [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the logic of the result viewer from the `graphiql` package into a hook `useResponseEditor` provided by `@graphiql/react`
+- [#2411](https://github.com/graphql/graphiql/pull/2411)
+  [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move the
+  logic of the result viewer from the `graphiql` package into a hook
+  `useResponseEditor` provided by `@graphiql/react`
 
-* [#2370](https://github.com/graphql/graphiql/pull/2370) [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Include the context provider for the explorer from `@graphiql/react` and replace the local state for the nav stack of the docs with methods provided by hooks from `@graphiql/react`.
+* [#2370](https://github.com/graphql/graphiql/pull/2370)
+  [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Include the
+  context provider for the explorer from `@graphiql/react` and replace the local
+  state for the nav stack of the docs with methods provided by hooks from
+  `@graphiql/react`.
 
-- [#2412](https://github.com/graphql/graphiql/pull/2412) [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move StorageAPI from `graphiql` package to `@graphiql/toolkit`
+- [#2412](https://github.com/graphql/graphiql/pull/2412)
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Move
+  StorageAPI from `graphiql` package to `@graphiql/toolkit`
 
-* [#2404](https://github.com/graphql/graphiql/pull/2404) [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a context provider for editors and move the logic of the headers editor from the `graphiql` package into a hook `useHeaderEditor` provided by `@graphiql/react`
+* [#2404](https://github.com/graphql/graphiql/pull/2404)
+  [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Add a
+  context provider for editors and move the logic of the headers editor from the
+  `graphiql` package into a hook `useHeaderEditor` provided by `@graphiql/react`
 
 ### Patch Changes
 
-- [#2418](https://github.com/graphql/graphiql/pull/2418) [`6d7fb6e6`](https://github.com/graphql/graphiql/commit/6d7fb6e6fa4734e2274d8875971613a8254674e3) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix persisting headers in tab state and avoid opening duplicate tabs when reloading
+- [#2418](https://github.com/graphql/graphiql/pull/2418)
+  [`6d7fb6e6`](https://github.com/graphql/graphiql/commit/6d7fb6e6fa4734e2274d8875971613a8254674e3)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - Fix
+  persisting headers in tab state and avoid opening duplicate tabs when
+  reloading
 
-- Updated dependencies [[`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29), [`bc3dc64c`](https://github.com/graphql/graphiql/commit/bc3dc64c37478ba6170c49c25fb755b4f2e020b2), [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29), [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46), [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003), [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079), [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482), [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29), [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247)]:
+- Updated dependencies
+  [[`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29),
+  [`bc3dc64c`](https://github.com/graphql/graphiql/commit/bc3dc64c37478ba6170c49c25fb755b4f2e020b2),
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29),
+  [`f2025ba0`](https://github.com/graphql/graphiql/commit/f2025ba06c5aa8e8ac68d29538ff135f3efc8e46),
+  [`d825bb75`](https://github.com/graphql/graphiql/commit/d825bb7569ca6b1ebbe534b893354645c790e003),
+  [`ad448693`](https://github.com/graphql/graphiql/commit/ad4486934ba69247efd33ee500e30f8236ecd079),
+  [`7f695b10`](https://github.com/graphql/graphiql/commit/7f695b104f9b25ba8c6d36f7827c475b297b7482),
+  [`c2e2f53d`](https://github.com/graphql/graphiql/commit/c2e2f53d3b2ae369feb68537f92c73bcfd962f29),
+  [`029ddf82`](https://github.com/graphql/graphiql/commit/029ddf82c29754ab8518ae7df66f9b25361a8247)]:
   - @graphiql/toolkit@0.5.0
   - @graphiql/react@0.1.0
 
@@ -516,31 +904,52 @@
 
 ### Patch Changes
 
-- [#2397](https://github.com/graphql/graphiql/pull/2397) [`a63ff958`](https://github.com/graphql/graphiql/commit/a63ff958838cf4fcf31f7eaa3e3b022d02838f65) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - upgrade to React v17
+- [#2397](https://github.com/graphql/graphiql/pull/2397)
+  [`a63ff958`](https://github.com/graphql/graphiql/commit/a63ff958838cf4fcf31f7eaa3e3b022d02838f65)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - upgrade to
+  React v17
 
-* [#2401](https://github.com/graphql/graphiql/pull/2401) [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5) Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - move async helper functions and formatting functions over into the @graphiql/toolkit package
+* [#2401](https://github.com/graphql/graphiql/pull/2401)
+  [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5)
+  Thanks [@thomasheyenbrock](https://github.com/thomasheyenbrock)! - move async
+  helper functions and formatting functions over into the @graphiql/toolkit
+  package
 
-* Updated dependencies [[`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5), [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5)]:
+* Updated dependencies
+  [[`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5),
+  [`60a744b1`](https://github.com/graphql/graphiql/commit/60a744b1d73d1021afb7abeea1573f26178102b5)]:
   - @graphiql/toolkit@0.4.5
 
 ## 1.8.9
 
 ### Patch Changes
 
-- [#2387](https://github.com/graphql/graphiql/pull/2387) [`e823697b`](https://github.com/graphql/graphiql/commit/e823697b5d47565671d5919be84f69919e70977f) Thanks [@benjie](https://github.com/benjie)! - Add 'children' type definition to various component props
+- [#2387](https://github.com/graphql/graphiql/pull/2387)
+  [`e823697b`](https://github.com/graphql/graphiql/commit/e823697b5d47565671d5919be84f69919e70977f)
+  Thanks [@benjie](https://github.com/benjie)! - Add 'children' type definition
+  to various component props
 
-* [#2388](https://github.com/graphql/graphiql/pull/2388) [`d3ae074c`](https://github.com/graphql/graphiql/commit/d3ae074c9b9dae6ed4f69b0a79efaa0353dcea2d) Thanks [@benjie](https://github.com/benjie)! - Add 'pointer-events: none' to SVG style for dropdown arrow in GraphiQL.Menu component
+* [#2388](https://github.com/graphql/graphiql/pull/2388)
+  [`d3ae074c`](https://github.com/graphql/graphiql/commit/d3ae074c9b9dae6ed4f69b0a79efaa0353dcea2d)
+  Thanks [@benjie](https://github.com/benjie)! - Add 'pointer-events: none' to
+  SVG style for dropdown arrow in GraphiQL.Menu component
 
-- [#2373](https://github.com/graphql/graphiql/pull/2373) [`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597) Thanks [@benjie](https://github.com/benjie)! - Fix TypeScript definition of FetcherParams to reflect that operationName is optional
+- [#2373](https://github.com/graphql/graphiql/pull/2373)
+  [`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597)
+  Thanks [@benjie](https://github.com/benjie)! - Fix TypeScript definition of
+  FetcherParams to reflect that operationName is optional
 
-- Updated dependencies [[`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597)]:
+- Updated dependencies
+  [[`5b2c1b20`](https://github.com/graphql/graphiql/commit/5b2c1b2054a70e8dca173f380f44766438cb5597)]:
   - @graphiql/toolkit@0.4.4
 
 ## 1.8.8
 
 ### Patch Changes
 
-- Updated dependencies [[`2dec55f2`](https://github.com/graphql/graphiql/commit/2dec55f2c5e979cc7bb1adadff4fb063775b088c), [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`2dec55f2`](https://github.com/graphql/graphiql/commit/2dec55f2c5e979cc7bb1adadff4fb063775b088c),
+  [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - codemirror-graphql@1.3.0
   - graphql-language-service@5.0.4
 
@@ -548,15 +957,23 @@
 
 ### Patch Changes
 
-- [#2316](https://github.com/graphql/graphiql/pull/2316) [`3d8510c8`](https://github.com/graphql/graphiql/commit/3d8510c87b9f0cc73f747ed4cd88e112f9fe65f7) Thanks [@AlirezaHaghshenas](https://github.com/AlirezaHaghshenas)! - Fix: With tabs enabled, if a subscription is restored from storage, a query request is sent instead
+- [#2316](https://github.com/graphql/graphiql/pull/2316)
+  [`3d8510c8`](https://github.com/graphql/graphiql/commit/3d8510c87b9f0cc73f747ed4cd88e112f9fe65f7)
+  Thanks [@AlirezaHaghshenas](https://github.com/AlirezaHaghshenas)! - Fix: With
+  tabs enabled, if a subscription is restored from storage, a query request is
+  sent instead
 
 ## 1.8.6
 
 ### Patch Changes
 
-- [#2312](https://github.com/graphql/graphiql/pull/2312) [`3c97cf63`](https://github.com/graphql/graphiql/commit/3c97cf63f0d6a8c27265905af1a2da243925ff01) Thanks [@AlirezaHaghshenas](https://github.com/AlirezaHaghshenas)! - Fix: After changing to a tab with a subscription, graphiql sends a query request
+- [#2312](https://github.com/graphql/graphiql/pull/2312)
+  [`3c97cf63`](https://github.com/graphql/graphiql/commit/3c97cf63f0d6a8c27265905af1a2da243925ff01)
+  Thanks [@AlirezaHaghshenas](https://github.com/AlirezaHaghshenas)! - Fix:
+  After changing to a tab with a subscription, graphiql sends a query request
 
-- Updated dependencies [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
+- Updated dependencies
+  [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
   - graphql-language-service@5.0.3
   - codemirror-graphql@1.2.17
 
@@ -564,7 +981,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service@5.0.2
   - codemirror-graphql@1.2.16
 
@@ -572,57 +990,90 @@
 
 ### Patch Changes
 
-- [#2274](https://github.com/graphql/graphiql/pull/2274) [`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216) Thanks [@B2o5T](https://github.com/B2o5T)! - turn `valid-typeof` as `error`, SSR fix
+- [#2274](https://github.com/graphql/graphiql/pull/2274)
+  [`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - turn `valid-typeof` as `error`,
+  SSR fix
 
-- Updated dependencies [[`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216)]:
+- Updated dependencies
+  [[`12950380`](https://github.com/graphql/graphiql/commit/12950380e92c38f6eec23499e7fca5dc9dcd8216)]:
   - @graphiql/toolkit@0.4.3
 
 ## 1.8.3
 
 ### Patch Changes
 
-- [#2268](https://github.com/graphql/graphiql/pull/2268) [`b1886822`](https://github.com/graphql/graphiql/commit/b188682296ee04a87fbf09dc51385f127bffcec0) Thanks [@acao](https://github.com/acao)! - remove dependency on `global` for esbuild/etc users!
+- [#2268](https://github.com/graphql/graphiql/pull/2268)
+  [`b1886822`](https://github.com/graphql/graphiql/commit/b188682296ee04a87fbf09dc51385f127bffcec0)
+  Thanks [@acao](https://github.com/acao)! - remove dependency on `global` for
+  esbuild/etc users!
 
-* [#2265](https://github.com/graphql/graphiql/pull/2265) [`9458e10b`](https://github.com/graphql/graphiql/commit/9458e10ba24a6c919142ea1cebb409c7d055baf9) Thanks [@acao](https://github.com/acao)! - fix `codemirror` import bug for `onHasCompletion` for #2263. for esm/cjs users on autocomplete (umd bundle users not impacted)
+* [#2265](https://github.com/graphql/graphiql/pull/2265)
+  [`9458e10b`](https://github.com/graphql/graphiql/commit/9458e10ba24a6c919142ea1cebb409c7d055baf9)
+  Thanks [@acao](https://github.com/acao)! - fix `codemirror` import bug for
+  `onHasCompletion` for #2263. for esm/cjs users on autocomplete (umd bundle
+  users not impacted)
 
 ## 1.8.2
 
 ### Patch Changes
 
-- Updated dependencies [[`261f2044`](https://github.com/graphql/graphiql/commit/261f2044066412e40f9962bef55295f7c9c35aec)]:
+- Updated dependencies
+  [[`261f2044`](https://github.com/graphql/graphiql/commit/261f2044066412e40f9962bef55295f7c9c35aec)]:
   - codemirror-graphql@1.2.15
 
 ## 1.8.1
 
 ### Patch Changes
 
-- [#2257](https://github.com/graphql/graphiql/pull/2257) [`6cc95851`](https://github.com/graphql/graphiql/commit/6cc9585119f33ba80f960da310f7ef2747b7bc38) Thanks [@acao](https://github.com/acao)! - _security fix:_ replace the vulnerable `dset` dependency with `set-value`
+- [#2257](https://github.com/graphql/graphiql/pull/2257)
+  [`6cc95851`](https://github.com/graphql/graphiql/commit/6cc9585119f33ba80f960da310f7ef2747b7bc38)
+  Thanks [@acao](https://github.com/acao)! - _security fix:_ replace the
+  vulnerable `dset` dependency with `set-value`
 
-  `dset` is vulnerable to prototype pollution attacks. this is only possible if you are doing all of the following:
+  `dset` is vulnerable to prototype pollution attacks. this is only possible if
+  you are doing all of the following:
 
-  1. running graphiql with an experimental graphql-js release tag that supports @stream and @defer
-  2. executing a properly @streamed or @deferred query ala IncrementalDelivery spec, with multipart chunks
-  3. consuming a malicious schema that contains field names like proto, prototype, or constructor that return malicious data designed to exploit a prototype pollution attack
+  1. running graphiql with an experimental graphql-js release tag that supports
+     @stream and @defer
+  2. executing a properly @streamed or @deferred query ala IncrementalDelivery
+     spec, with multipart chunks
+  3. consuming a malicious schema that contains field names like proto,
+     prototype, or constructor that return malicious data designed to exploit a
+     prototype pollution attack
 
 ## 1.8.0
 
 ### Minor Changes
 
-- [#2197](https://github.com/graphql/graphiql/pull/2197) [`3137a6c4`](https://github.com/graphql/graphiql/commit/3137a6c4333dad8db8a0eb980d6c6464c7292946) Thanks [@n1ru4l](https://github.com/n1ru4l)! - Now featuring: tabs! 🥳 🍾 just opt-in with new prop `<GraphiQL tabs />`. You can also both opt-in and provide a handler via `<GraphiQL tabs={{ onTabsChange }} />`!
+- [#2197](https://github.com/graphql/graphiql/pull/2197)
+  [`3137a6c4`](https://github.com/graphql/graphiql/commit/3137a6c4333dad8db8a0eb980d6c6464c7292946)
+  Thanks [@n1ru4l](https://github.com/n1ru4l)! - Now featuring: tabs! 🥳 🍾 just
+  opt-in with new prop `<GraphiQL tabs />`. You can also both opt-in and provide
+  a handler via `<GraphiQL tabs={{ onTabsChange }} />`!
 
 ### Patch Changes
 
-- [#2249](https://github.com/graphql/graphiql/pull/2249) [`1540fd3d`](https://github.com/graphql/graphiql/commit/1540fd3d0df553798e41a153c5f0386d9d52be01) Thanks [@acao](https://github.com/acao)! - Finally remove inline `require()` for codemirror addon imports, replace with modern dynamic `import()` (which enables `esbuild`, `vite`, etc).
+- [#2249](https://github.com/graphql/graphiql/pull/2249)
+  [`1540fd3d`](https://github.com/graphql/graphiql/commit/1540fd3d0df553798e41a153c5f0386d9d52be01)
+  Thanks [@acao](https://github.com/acao)! - Finally remove inline `require()`
+  for codemirror addon imports, replace with modern dynamic `import()` (which
+  enables `esbuild`, `vite`, etc).
 
-  This change should allow your bundler to code split codemirror-graphql and the codemirror addons based on which you import. For SSR support, GraphiQL must load these modules dynamically.
+  This change should allow your bundler to code split codemirror-graphql and the
+  codemirror addons based on which you import. For SSR support, GraphiQL must
+  load these modules dynamically.
 
-  If you want to use other codemirror addons (vim, etc) for non-ssr you can just import them top level, or for SSR, you can just dynamically import them.
+  If you want to use other codemirror addons (vim, etc) for non-ssr you can just
+  import them top level, or for SSR, you can just dynamically import them.
 
 ## 1.7.2
 
 ### Patch Changes
 
-- Updated dependencies [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa), [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
+- Updated dependencies
+  [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa),
+  [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
   - graphql-language-service@5.0.1
   - codemirror-graphql@1.2.14
 
@@ -630,7 +1081,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
+- Updated dependencies
+  [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
   - graphql-language-service@5.0.0
   - codemirror-graphql@1.2.13
 
@@ -638,27 +1090,51 @@
 
 ### Minor Changes
 
-- [#2221](https://github.com/graphql/graphiql/pull/2221) [`64826c87`](https://github.com/graphql/graphiql/commit/64826c8776dfc8394a65c98663d47cc3c9d397b9) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - Fix to trigger codemirror update when externalFragments prop changes [#2220](https://github.com/graphql/graphiql/pull/2220)
+- [#2221](https://github.com/graphql/graphiql/pull/2221)
+  [`64826c87`](https://github.com/graphql/graphiql/commit/64826c8776dfc8394a65c98663d47cc3c9d397b9)
+  Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - Fix to trigger codemirror
+  update when externalFragments prop changes
+  [#2220](https://github.com/graphql/graphiql/pull/2220)
 
-* [#2213](https://github.com/graphql/graphiql/pull/2213) [`ba85bc24`](https://github.com/graphql/graphiql/commit/ba85bc242b8271cbd09ade9d69a93d86e4e1a49f) Thanks [@hatappi](https://github.com/hatappi)! - remove IE7 CSS star property hack
+* [#2213](https://github.com/graphql/graphiql/pull/2213)
+  [`ba85bc24`](https://github.com/graphql/graphiql/commit/ba85bc242b8271cbd09ade9d69a93d86e4e1a49f)
+  Thanks [@hatappi](https://github.com/hatappi)! - remove IE7 CSS star property
+  hack
 
 ### Patch Changes
 
-- [#2205](https://github.com/graphql/graphiql/pull/2205) [`91500d4e`](https://github.com/graphql/graphiql/commit/91500d4eba8b99bf779ff6ac899c814070c6dff3) Thanks [@francisu](https://github.com/francisu)! - Fixed problem where 'global' variable is referenced when it might not be present (#2155)
+- [#2205](https://github.com/graphql/graphiql/pull/2205)
+  [`91500d4e`](https://github.com/graphql/graphiql/commit/91500d4eba8b99bf779ff6ac899c814070c6dff3)
+  Thanks [@francisu](https://github.com/francisu)! - Fixed problem where
+  'global' variable is referenced when it might not be present (#2155)
 
 ## 1.6.0
 
 ### Minor Changes
 
-- [#2191](https://github.com/graphql/graphiql/pull/2191) [`eb8af7b5`](https://github.com/graphql/graphiql/commit/eb8af7b5666e7ed01497a862127011524fc400f5) Thanks [@n1ru4l](https://github.com/n1ru4l)! - Allow inserting content before the topBar element via the `beforeTopBarContent` property.
+- [#2191](https://github.com/graphql/graphiql/pull/2191)
+  [`eb8af7b5`](https://github.com/graphql/graphiql/commit/eb8af7b5666e7ed01497a862127011524fc400f5)
+  Thanks [@n1ru4l](https://github.com/n1ru4l)! - Allow inserting content before
+  the topBar element via the `beforeTopBarContent` property.
 
   ```ts
   <GraphiQL beforeTopBarContent={<SomeComponent />} />
   ```
 
-* [#2189](https://github.com/graphql/graphiql/pull/2189) [`96d47267`](https://github.com/graphql/graphiql/commit/96d4726716b782fcafa9d6c1671f3a3050ebe0b7) Thanks [@n1ru4l](https://github.com/n1ru4l)! - Apply variable editor title text styles via class `variable-editor-title-text` instead of using inline-styles. This allows better customization of styles. An active element also has the class `active`. This allows overriding the inactive state color using the selector `.graphiql-container .variable-editor-title-text` and overriding the active state color using the selector `.graphiql-container .variable-editor-title-text.active`.
+* [#2189](https://github.com/graphql/graphiql/pull/2189)
+  [`96d47267`](https://github.com/graphql/graphiql/commit/96d4726716b782fcafa9d6c1671f3a3050ebe0b7)
+  Thanks [@n1ru4l](https://github.com/n1ru4l)! - Apply variable editor title
+  text styles via class `variable-editor-title-text` instead of using
+  inline-styles. This allows better customization of styles. An active element
+  also has the class `active`. This allows overriding the inactive state color
+  using the selector `.graphiql-container .variable-editor-title-text` and
+  overriding the active state color using the selector
+  `.graphiql-container .variable-editor-title-text.active`.
 
-- [#2190](https://github.com/graphql/graphiql/pull/2190) [`d5179899`](https://github.com/graphql/graphiql/commit/d517989996cf6f33ef7e08d18a870e2bed565cca) Thanks [@n1ru4l](https://github.com/n1ru4l)! - New callback property `onSchemaChange` for `GraphiQL`.
+- [#2190](https://github.com/graphql/graphiql/pull/2190)
+  [`d5179899`](https://github.com/graphql/graphiql/commit/d517989996cf6f33ef7e08d18a870e2bed565cca)
+  Thanks [@n1ru4l](https://github.com/n1ru4l)! - New callback property
+  `onSchemaChange` for `GraphiQL`.
 
   The callback is invoked with the successfully fetched schema from the remote.
 
@@ -672,7 +1148,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f), [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c), [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
+- Updated dependencies
+  [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f),
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c),
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
   - graphql-language-service@4.1.5
   - codemirror-graphql@1.2.12
 
@@ -680,19 +1159,28 @@
 
 ### Patch Changes
 
-- [#2167](https://github.com/graphql/graphiql/pull/2167) [`bc81f0ee`](https://github.com/graphql/graphiql/commit/bc81f0ee6d382fe996d92e55f90cdc3be10910a7) Thanks [@acao](https://github.com/acao)! - Fix legacy bug where global is expected
+- [#2167](https://github.com/graphql/graphiql/pull/2167)
+  [`bc81f0ee`](https://github.com/graphql/graphiql/commit/bc81f0ee6d382fe996d92e55f90cdc3be10910a7)
+  Thanks [@acao](https://github.com/acao)! - Fix legacy bug where global is
+  expected
 
 ## 1.5.18
 
 ### Patch Changes
 
-- [#2156](https://github.com/graphql/graphiql/pull/2156) [`ae5ea77b`](https://github.com/graphql/graphiql/commit/ae5ea77b4c2ec2a25e25c542ae72b2c3dabbe256) Thanks [@francisu](https://github.com/francisu)! - Fixed problem where 'global' variable is referenced when it might not be present (#2155)
+- [#2156](https://github.com/graphql/graphiql/pull/2156)
+  [`ae5ea77b`](https://github.com/graphql/graphiql/commit/ae5ea77b4c2ec2a25e25c542ae72b2c3dabbe256)
+  Thanks [@francisu](https://github.com/francisu)! - Fixed problem where
+  'global' variable is referenced when it might not be present (#2155)
 
 ## 1.5.17
 
 ### Patch Changes
 
-- [#2138](https://github.com/graphql/graphiql/pull/2138) [`8700b4bb`](https://github.com/graphql/graphiql/commit/8700b4bbaadb17136f649f504c9575a8c853cd0b) Thanks [@danielleletarte](https://github.com/danielleletarte)! - Correctly render line breaks for Descriptions in Doc Explorer - #2137 - @danielleletarte
+- [#2138](https://github.com/graphql/graphiql/pull/2138)
+  [`8700b4bb`](https://github.com/graphql/graphiql/commit/8700b4bbaadb17136f649f504c9575a8c853cd0b)
+  Thanks [@danielleletarte](https://github.com/danielleletarte)! - Correctly
+  render line breaks for Descriptions in Doc Explorer - #2137 - @danielleletarte
 
 ## 1.5.16
 
@@ -706,7 +1194,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
+- Updated dependencies
+  [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
   - graphql-language-service@4.1.3
   - codemirror-graphql@1.2.10
 
@@ -714,7 +1203,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
+- Updated dependencies
+  [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
   - graphql-language-service@4.1.2
   - codemirror-graphql@1.2.9
 
@@ -722,15 +1212,22 @@
 
 ### Patch Changes
 
-- [#2097](https://github.com/graphql/graphiql/pull/2097) [`4d3eeaa4`](https://github.com/graphql/graphiql/commit/4d3eeaa4446c84e92cd77f213e454059602a72e5) Thanks [@acao](https://github.com/acao)! - Disable introspection of schema.description by default
+- [#2097](https://github.com/graphql/graphiql/pull/2097)
+  [`4d3eeaa4`](https://github.com/graphql/graphiql/commit/4d3eeaa4446c84e92cd77f213e454059602a72e5)
+  Thanks [@acao](https://github.com/acao)! - Disable introspection of
+  schema.description by default
 
 ## 1.5.12
 
 ### Patch Changes
 
-- [#2091](https://github.com/graphql/graphiql/pull/2091) [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63) Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues. Should now build & test interchangeably.
+- [#2091](https://github.com/graphql/graphiql/pull/2091)
+  [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)
+  Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues.
+  Should now build & test interchangeably.
 
-- Updated dependencies [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
+- Updated dependencies
+  [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
   - codemirror-graphql@1.2.8
   - graphql-language-service@4.1.1
 
@@ -738,7 +1235,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
+- Updated dependencies
+  [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
   - graphql-language-service@4.1.0
   - codemirror-graphql@1.2.7
 
@@ -746,14 +1244,25 @@
 
 ### Patch Changes
 
-- [#2087](https://github.com/graphql/graphiql/pull/2087) [`45a9075d`](https://github.com/graphql/graphiql/commit/45a9075d718046e0f17c930162fa9752dfe052ec) Thanks [@acao](https://github.com/acao)! - Fix issue with introspection in servers which don't support `inputValueDeprecation`. make `inputValueDeprecation` an opt-in prop for DocExplorer features
+- [#2087](https://github.com/graphql/graphiql/pull/2087)
+  [`45a9075d`](https://github.com/graphql/graphiql/commit/45a9075d718046e0f17c930162fa9752dfe052ec)
+  Thanks [@acao](https://github.com/acao)! - Fix issue with introspection in
+  servers which don't support `inputValueDeprecation`. make
+  `inputValueDeprecation` an opt-in prop for DocExplorer features
 
 ## 1.5.9
 
 ### Patch Changes
 
-- [#2077](https://github.com/graphql/graphiql/pull/2077) [`701ca13f`](https://github.com/graphql/graphiql/commit/701ca13f625735564d71931e6d917e5bf69c8aa5) Thanks [@acao](https://github.com/acao)! - Include schema description in DocExplorer for schema introspection requests. Enables the `schemaDescription` option for `getIntrospectionQuery()`. Also includes `deprecationReason` support in DocExplorer for arguments! Enables `inputValueDeprecation` in `getIntrospectionQuery()` and displays deprecation section on field doc view.
-- Updated dependencies [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
+- [#2077](https://github.com/graphql/graphiql/pull/2077)
+  [`701ca13f`](https://github.com/graphql/graphiql/commit/701ca13f625735564d71931e6d917e5bf69c8aa5)
+  Thanks [@acao](https://github.com/acao)! - Include schema description in
+  DocExplorer for schema introspection requests. Enables the `schemaDescription`
+  option for `getIntrospectionQuery()`. Also includes `deprecationReason`
+  support in DocExplorer for arguments! Enables `inputValueDeprecation` in
+  `getIntrospectionQuery()` and displays deprecation section on field doc view.
+- Updated dependencies
+  [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
   - graphql-language-service@4.0.0
   - codemirror-graphql@1.2.6
 
@@ -761,7 +1270,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+- Updated dependencies
+  [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service@3.2.5
   - codemirror-graphql@1.2.5
 
@@ -769,7 +1279,10 @@
 
 ### Patch Changes
 
-- [`49bce429`](https://github.com/graphql/graphiql/commit/49bce429f0780a5e2856cfb7ccda50d10d38f724) [#2051](https://github.com/graphql/graphiql/pull/2051) Thanks [@willstott101](https://github.com/willstott101)! - Include source maps for minified JS and CSS in the graphiql package.
+- [`49bce429`](https://github.com/graphql/graphiql/commit/49bce429f0780a5e2856cfb7ccda50d10d38f724)
+  [#2051](https://github.com/graphql/graphiql/pull/2051) Thanks
+  [@willstott101](https://github.com/willstott101)! - Include source maps for
+  minified JS and CSS in the graphiql package.
 
 ## 1.5.6
 
@@ -783,16 +1296,23 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c42b145f`](https://github.com/graphql/graphiql/commit/c42b145fffeaefbd1103bc7addee1873e939bc83)]:
+- Updated dependencies
+  [[`c42b145f`](https://github.com/graphql/graphiql/commit/c42b145fffeaefbd1103bc7addee1873e939bc83)]:
   - codemirror-graphql@1.2.3
 
 ## 1.5.4
 
 ### Patch Changes
 
-- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf) [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks [@willstott101](https://github.com/willstott101)! - Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.
+- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)
+  [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks
+  [@willstott101](https://github.com/willstott101)! - Source code included in
+  all packages to fix source maps. codemirror-graphql includes esm build in
+  package.
 
-- Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf), [`8b486555`](https://github.com/graphql/graphiql/commit/8b486555e2aa4d90891070a1bbc52b59d9c670c4)]:
+- Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf),
+  [`8b486555`](https://github.com/graphql/graphiql/commit/8b486555e2aa4d90891070a1bbc52b59d9c670c4)]:
   - codemirror-graphql@1.2.2
   - graphql-language-service@3.2.3
 
@@ -800,11 +1320,17 @@
 
 ### Patch Changes
 
-- [`c83d1d4c`](https://github.com/graphql/graphiql/commit/c83d1d4c518ad1b0862aae5f46359dfaee00dda1) Thanks [@kikkupico](https://github.com/kikkupico)! - fix `schema` type nullability for #2028
+- [`c83d1d4c`](https://github.com/graphql/graphiql/commit/c83d1d4c518ad1b0862aae5f46359dfaee00dda1)
+  Thanks [@kikkupico](https://github.com/kikkupico)! - fix `schema` type
+  nullability for #2028
 
-* [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+* [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
-* Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+* Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - codemirror-graphql@1.2.1
   - @graphiql/toolkit@0.4.2
   - graphql-language-service@3.2.2
@@ -813,7 +1339,10 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`dec207e7`](https://github.com/graphql/graphiql/commit/dec207e74f0506db069482cc30f8cd1f045d8107), [`b79bf304`](https://github.com/graphql/graphiql/commit/b79bf304045add4b5c3b2539dd6b551a64e6ed87), [`d0c22c4f`](https://github.com/graphql/graphiql/commit/d0c22c4fce5ea39611c7ecee553943fdf27fd03e)]:
+- Updated dependencies
+  [[`dec207e7`](https://github.com/graphql/graphiql/commit/dec207e74f0506db069482cc30f8cd1f045d8107),
+  [`b79bf304`](https://github.com/graphql/graphiql/commit/b79bf304045add4b5c3b2539dd6b551a64e6ed87),
+  [`d0c22c4f`](https://github.com/graphql/graphiql/commit/d0c22c4fce5ea39611c7ecee553943fdf27fd03e)]:
   - @graphiql/toolkit@0.4.1
   - codemirror-graphql@1.2.0
 
@@ -821,20 +1350,27 @@
 
 ### Patch Changes
 
-- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce) [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks [@PabloSzx](https://github.com/PabloSzx)! - Update utils
+- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)
+  [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks
+  [@PabloSzx](https://github.com/PabloSzx)! - Update utils
 
-- Updated dependencies [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
+- Updated dependencies
+  [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
   - graphql-language-service@3.2.1
 
 ## 1.5.0
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - codemirror-graphql@1.1.0
   - @graphiql/toolkit@0.4.0
   - graphql-language-service@3.2.0
@@ -843,25 +1379,44 @@
 
 ### Patch Changes
 
-- [`e63696de`](https://github.com/graphql/graphiql/commit/e63696de57a85c34d937bfb53345e2e0d0b874a4) [#2005](https://github.com/graphql/graphiql/pull/2005) Thanks [@acao](https://github.com/acao)! - Correct the npm readme security fix version number and links, thanks [@glasser](https://github.com/glasser) & [@dotansimha](https://github.com/dotansimha)!
+- [`e63696de`](https://github.com/graphql/graphiql/commit/e63696de57a85c34d937bfb53345e2e0d0b874a4)
+  [#2005](https://github.com/graphql/graphiql/pull/2005) Thanks
+  [@acao](https://github.com/acao)! - Correct the npm readme security fix
+  version number and links, thanks [@glasser](https://github.com/glasser) &
+  [@dotansimha](https://github.com/dotansimha)!
 
 ## 1.4.7
 
 ### Patch Changes
 
-- [`130ddad6`](https://github.com/graphql/graphiql/commit/130ddad6d0394356ec32070a6fee1840450a4660) Thanks [@acao](https://github.com/acao)! - **CRITICAL SECURITY PATCH** for the [GraphiQL introspection schema template injection attack](https://github.com/graphql/graphiql/security/advisories/GHSA-x4r7-m2q9-69c8)
+- [`130ddad6`](https://github.com/graphql/graphiql/commit/130ddad6d0394356ec32070a6fee1840450a4660)
+  Thanks [@acao](https://github.com/acao)! - **CRITICAL SECURITY PATCH** for the
+  [GraphiQL introspection schema template injection attack](https://github.com/graphql/graphiql/security/advisories/GHSA-x4r7-m2q9-69c8)
 
 ## 1.4.6
 
 ### Patch Changes
 
-- [`d3a88283`](https://github.com/graphql/graphiql/commit/d3a88283c7b618376ad4a06c7db20e60b066d1a0) [#1934](https://github.com/graphql/graphiql/pull/1934) Thanks [@tonyfromundefined](https://github.com/tonyfromundefined)! - add react 17, 18 in peerDependencies
+- [`d3a88283`](https://github.com/graphql/graphiql/commit/d3a88283c7b618376ad4a06c7db20e60b066d1a0)
+  [#1934](https://github.com/graphql/graphiql/pull/1934) Thanks
+  [@tonyfromundefined](https://github.com/tonyfromundefined)! - add react 17, 18
+  in peerDependencies
 
-* [`afaa36c1`](https://github.com/graphql/graphiql/commit/afaa36c198648e84f305986a0b1dfefa97e70221) [#1883](https://github.com/graphql/graphiql/pull/1883) Thanks [@Sweetabix1](https://github.com/Sweetabix1)! - Updating font colors for line numbers, comments & brackets from #999 to #666 for accessibility purposes. #666 passes AA accessibility standards for small text, with a contrast ratio of over 5:1.
+* [`afaa36c1`](https://github.com/graphql/graphiql/commit/afaa36c198648e84f305986a0b1dfefa97e70221)
+  [#1883](https://github.com/graphql/graphiql/pull/1883) Thanks
+  [@Sweetabix1](https://github.com/Sweetabix1)! - Updating font colors for line
+  numbers, comments & brackets from #999 to #666 for accessibility purposes.
+  #666 passes AA accessibility standards for small text, with a contrast ratio
+  of over 5:1.
 
-- [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+- [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-- Updated dependencies [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb), [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+- Updated dependencies
+  [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb),
+  [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service@3.1.6
   - codemirror-graphql@1.0.3
 
@@ -869,33 +1424,57 @@
 
 ### Patch Changes
 
-- [`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46) Thanks [@acao](https://github.com/acao)! - Remove bad type definition from `subscriptions-transport-ws` #1992 closes #1989
+- [`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46)
+  Thanks [@acao](https://github.com/acao)! - Remove bad type definition from
+  `subscriptions-transport-ws` #1992 closes #1989
 
-- Updated dependencies [[`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46)]:
+- Updated dependencies
+  [[`86795d5f`](https://github.com/graphql/graphiql/commit/86795d5ffa2d3e6c8aee74f761d02f054b428d46)]:
   - @graphiql/toolkit@0.3.2
 
 ## 1.4.4
 
 ### Patch Changes
 
-- [`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748) [#1990](https://github.com/graphql/graphiql/pull/1990) Thanks [@acao](https://github.com/acao)! - Remove type definition from `subscriptions-transport-ws`
+- [`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748)
+  [#1990](https://github.com/graphql/graphiql/pull/1990) Thanks
+  [@acao](https://github.com/acao)! - Remove type definition from
+  `subscriptions-transport-ws`
 
-- Updated dependencies [[`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748)]:
+- Updated dependencies
+  [[`62e786b5`](https://github.com/graphql/graphiql/commit/62e786b57cc5748eccac59814dfc8ecd0104c748)]:
   - @graphiql/toolkit@0.3.1
 
 ## 1.4.3
 
 ### Patch Changes
 
-- [`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca) [#1968](https://github.com/graphql/graphiql/pull/1968) Thanks [@acao](https://github.com/acao)! - Remove `optionalDependencies` entirely, remove `subscriptions-transport-ws` which introduces vulnerabilities, upgrade `@n1ru4l/push-pull-async-iterable-iterator` to 3.0.0, upgrade `graphql-ws` several minor versions - the `graphql-ws@5.x` upgrade will come in a later minor release.
+- [`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca)
+  [#1968](https://github.com/graphql/graphiql/pull/1968) Thanks
+  [@acao](https://github.com/acao)! - Remove `optionalDependencies` entirely,
+  remove `subscriptions-transport-ws` which introduces vulnerabilities, upgrade
+  `@n1ru4l/push-pull-async-iterable-iterator` to 3.0.0, upgrade `graphql-ws`
+  several minor versions - the `graphql-ws@5.x` upgrade will come in a later
+  minor release.
 
-* [`eb2d91fa`](https://github.com/graphql/graphiql/commit/eb2d91fa8e4a03cb5663f27f724db2c95989a40f) [#1914](https://github.com/graphql/graphiql/pull/1914) Thanks [@harshithpabbati](https://github.com/harshithpabbati)! - fix: history can now be saved even when query history panel is not opened feat: create a new maxHistoryLength prop to allow more than 20 queries in history panel
+* [`eb2d91fa`](https://github.com/graphql/graphiql/commit/eb2d91fa8e4a03cb5663f27f724db2c95989a40f)
+  [#1914](https://github.com/graphql/graphiql/pull/1914) Thanks
+  [@harshithpabbati](https://github.com/harshithpabbati)! - fix: history can now
+  be saved even when query history panel is not opened feat: create a new
+  maxHistoryLength prop to allow more than 20 queries in history panel
 
-- [`04fad79c`](https://github.com/graphql/graphiql/commit/04fad79c094318d4b4c9e0250c5cff55d9fc5116) [#1889](https://github.com/graphql/graphiql/pull/1889) Thanks [@henryqdineen](https://github.com/henryqdineen)! - feat: export ToolbarSelectOption and ToolbarMenuItem
+- [`04fad79c`](https://github.com/graphql/graphiql/commit/04fad79c094318d4b4c9e0250c5cff55d9fc5116)
+  [#1889](https://github.com/graphql/graphiql/pull/1889) Thanks
+  [@henryqdineen](https://github.com/henryqdineen)! - feat: export
+  ToolbarSelectOption and ToolbarMenuItem
 
-* [`cd685435`](https://github.com/graphql/graphiql/commit/cd6854352ac6beff57af76db7de38e8157ff13aa) [#1923](https://github.com/graphql/graphiql/pull/1923) Thanks [@cgarnier](https://github.com/cgarnier)! - Fix result window theme
+* [`cd685435`](https://github.com/graphql/graphiql/commit/cd6854352ac6beff57af76db7de38e8157ff13aa)
+  [#1923](https://github.com/graphql/graphiql/pull/1923) Thanks
+  [@cgarnier](https://github.com/cgarnier)! - Fix result window theme
 
-* Updated dependencies [[`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca), [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
+* Updated dependencies
+  [[`6a459f4c`](https://github.com/graphql/graphiql/commit/6a459f4c235bb0d70725ae6ad7fc1cfa34f49dca),
+  [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
   - @graphiql/toolkit@0.3.0
   - graphql-language-service@3.1.5
 
@@ -903,47 +1482,77 @@
 
 ### Patch Changes
 
-- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92) [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
+- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92)
+  [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks
+  [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
 
 ## 1.4.1
 
 ### Patch Changes
 
-- [`9f8c78ce`](https://github.com/graphql/graphiql/commit/9f8c78ce8c72a9dcf35b3e82bd3129ac17d845e6) [#1821](https://github.com/graphql/graphiql/pull/1821) Thanks [@harshithpabbati](https://github.com/harshithpabbati)! - fix: render query history panel only when it's toggled, instead of hiding with CSS
+- [`9f8c78ce`](https://github.com/graphql/graphiql/commit/9f8c78ce8c72a9dcf35b3e82bd3129ac17d845e6)
+  [#1821](https://github.com/graphql/graphiql/pull/1821) Thanks
+  [@harshithpabbati](https://github.com/harshithpabbati)! - fix: render query
+  history panel only when it's toggled, instead of hiding with CSS
 
-* [`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3) [#1819](https://github.com/graphql/graphiql/pull/1819) Thanks [@acao](https://github.com/acao)! - `GraphiQL.createClient()` accepts custom `legacyClient`, exports typescript types, fixes #1800.
+* [`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3)
+  [#1819](https://github.com/graphql/graphiql/pull/1819) Thanks
+  [@acao](https://github.com/acao)! - `GraphiQL.createClient()` accepts custom
+  `legacyClient`, exports typescript types, fixes #1800.
 
-  `createGraphiQLFetcher` now only attempts an `graphql-ws` connection when only `subscriptionUrl` is provided. In order to use `graphql-transport-ws`, you'll need to provide the `legacyClient` option only, and no `subscriptionUrl` or `wsClient` option.
+  `createGraphiQLFetcher` now only attempts an `graphql-ws` connection when only
+  `subscriptionUrl` is provided. In order to use `graphql-transport-ws`, you'll
+  need to provide the `legacyClient` option only, and no `subscriptionUrl` or
+  `wsClient` option.
 
-- [`1f92d1dc`](https://github.com/graphql/graphiql/commit/1f92d1dcc0102bdec078263b87ca20cd670a1c86) [#1804](https://github.com/graphql/graphiql/pull/1804) Thanks [@maraisr](https://github.com/maraisr)! - Fixes issue where with IncrementalDelivery directives objects wouldn't deep-merge.
+- [`1f92d1dc`](https://github.com/graphql/graphiql/commit/1f92d1dcc0102bdec078263b87ca20cd670a1c86)
+  [#1804](https://github.com/graphql/graphiql/pull/1804) Thanks
+  [@maraisr](https://github.com/maraisr)! - Fixes issue where with
+  IncrementalDelivery directives objects wouldn't deep-merge.
 
-* [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+* [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
-* Updated dependencies [[`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3), [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)]:
+* Updated dependencies
+  [[`dd9397e4`](https://github.com/graphql/graphiql/commit/dd9397e4c693b5ceadbd26d6fa92aa6246aac9c3),
+  [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)]:
   - @graphiql/toolkit@0.2.0
 
 ## 1.4.0
 
 ### Patch Changes
 
-- Updated dependencies [[`b4fc16c0`](https://github.com/graphql/graphiql/commit/b4fc16c025da6f466727dc17cab6026d14c6e7fe)]:
+- Updated dependencies
+  [[`b4fc16c0`](https://github.com/graphql/graphiql/commit/b4fc16c025da6f466727dc17cab6026d14c6e7fe)]:
   - codemirror-graphql@1.0.0
 
 ## 1.4.0
 
 ### Bugfixes
 
-- Fixes the search icon misalignment. (#1776) by [@iifawzi](https://github.com/iifawzi)
-- run `onToggleDocs` when setting `docExplorerOpen` to false (#1768) by [@ChiragKasat](https://github.com/ChiragKasat)
+- Fixes the search icon misalignment. (#1776) by
+  [@iifawzi](https://github.com/iifawzi)
+- run `onToggleDocs` when setting `docExplorerOpen` to false (#1768) by
+  [@ChiragKasat](https://github.com/ChiragKasat)
 
 ### Minor Changes
 
-- 1c119386: `@defer`, `@stream`, and `graphql-ws` support in a `createGraphiQLFetcher` utility (#1770)
+- 1c119386: `@defer`, `@stream`, and `graphql-ws` support in a
+  `createGraphiQLFetcher` utility (#1770)
 
-  - support for `@defer` and `@stream` in `GraphiQL` itself on fetcher execution and when handling stream payloads
-  - introduce `@graphiql/toolkit` for types and utilities used to compose `GraphiQL` and other related libraries
-  - introduce `@graphiql/create-fetcher` to accept simplified parameters to generate a `fetcher` that covers the most commonly used `graphql-over-http` transport spec proposals. using `meros` for multipart http, and `graphql-ws` for websockets subscriptions.
-  - use `graphql` and `graphql-express` `experimental-defer-stream` branch in development until it's merged
+  - support for `@defer` and `@stream` in `GraphiQL` itself on fetcher execution
+    and when handling stream payloads
+  - introduce `@graphiql/toolkit` for types and utilities used to compose
+    `GraphiQL` and other related libraries
+  - introduce `@graphiql/create-fetcher` to accept simplified parameters to
+    generate a `fetcher` that covers the most commonly used `graphql-over-http`
+    transport spec proposals. using `meros` for multipart http, and `graphql-ws`
+    for websockets subscriptions.
+  - use `graphql` and `graphql-express` `experimental-defer-stream` branch in
+    development until it's merged
   - add cypress e2e tests for `@stream` in different scenarios
   - add some unit tests for `createGraphiQLFetcher`
 
@@ -965,8 +1574,13 @@
 
 ### Features
 
-- also support fetcher functions that return Promise<Observable> or Promise ([#1739](https://github.com/graphql/graphiql/issues/1739)) ([a804f3c](https://github.com/graphql/graphiql/commit/a804f3c011e7cafb4f8a48a1ba101b875be3540d))
-- implied or external fragments, for [#612](https://github.com/graphql/graphiql/issues/612) ([#1750](https://github.com/graphql/graphiql/issues/1750)) ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
+- also support fetcher functions that return Promise<Observable> or Promise
+  ([#1739](https://github.com/graphql/graphiql/issues/1739))
+  ([a804f3c](https://github.com/graphql/graphiql/commit/a804f3c011e7cafb4f8a48a1ba101b875be3540d))
+- implied or external fragments, for
+  [#612](https://github.com/graphql/graphiql/issues/612)
+  ([#1750](https://github.com/graphql/graphiql/issues/1750))
+  ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
 
 ## [1.2.2](https://github.com/graphql/graphiql/compare/graphiql@1.2.1...graphiql@1.2.2) (2021-01-03)
 
@@ -976,32 +1590,44 @@
 
 ### Bug Fixes
 
-- display schema description if available ([050c506](https://github.com/graphql/graphiql/commit/050c506ed4ed2852bf9a5b099f967928d9856156))
-- fix linting issue ([7117b7c](https://github.com/graphql/graphiql/commit/7117b7ccd2a2872e0051c8751252040d4042e190))
+- display schema description if available
+  ([050c506](https://github.com/graphql/graphiql/commit/050c506ed4ed2852bf9a5b099f967928d9856156))
+- fix linting issue
+  ([7117b7c](https://github.com/graphql/graphiql/commit/7117b7ccd2a2872e0051c8751252040d4042e190))
 
 ## [1.2.0](https://github.com/graphql/graphiql/compare/graphiql@1.1.0...graphiql@1.2.0) (2020-12-08)
 
 ### Features
 
-- add AsyncIterable support to fetcher function ([#1724](https://github.com/graphql/graphiql/issues/1724)) ([a568af3](https://github.com/graphql/graphiql/commit/a568af3674404b8a15055792c2c35128b2bd711c))
-- provide validation rules via props ([#1716](https://github.com/graphql/graphiql/issues/1716)) ([0c5785c](https://github.com/graphql/graphiql/commit/0c5785c82adbd4affb25300ae2d128b42c9b81fe))
+- add AsyncIterable support to fetcher function
+  ([#1724](https://github.com/graphql/graphiql/issues/1724))
+  ([a568af3](https://github.com/graphql/graphiql/commit/a568af3674404b8a15055792c2c35128b2bd711c))
+- provide validation rules via props
+  ([#1716](https://github.com/graphql/graphiql/issues/1716))
+  ([0c5785c](https://github.com/graphql/graphiql/commit/0c5785c82adbd4affb25300ae2d128b42c9b81fe))
 
 ## [1.1.0](https://github.com/graphql/graphiql/compare/graphiql@1.0.6...graphiql@1.1.0) (2020-11-28)
 
 ### Bug Fixes
 
-- improve props in GraphiQL readme ([b9b2c8d](https://github.com/graphql/graphiql/commit/b9b2c8d8bde6064a4cdcb01911b024602fcdbe9f))
+- improve props in GraphiQL readme
+  ([b9b2c8d](https://github.com/graphql/graphiql/commit/b9b2c8d8bde6064a4cdcb01911b024602fcdbe9f))
 
 ### Features
 
-- **graphiql:** add prop for adding toolbar content while preserving the default buttons ([ea81056](https://github.com/graphql/graphiql/commit/ea81056e09b0a95e1536c79fab27e027739808c4))
-- deeper fragment merging ([238d0b5](https://github.com/graphql/graphiql/commit/238d0b5e52cfa9354757c9d52050692d152aae21))
+- **graphiql:** add prop for adding toolbar content while preserving the default
+  buttons
+  ([ea81056](https://github.com/graphql/graphiql/commit/ea81056e09b0a95e1536c79fab27e027739808c4))
+- deeper fragment merging
+  ([238d0b5](https://github.com/graphql/graphiql/commit/238d0b5e52cfa9354757c9d52050692d152aae21))
 
 ## [1.0.6](https://github.com/graphql/graphiql/compare/graphiql@1.0.5...graphiql@1.0.6) (2020-10-20)
 
 ### Bug Fixes
 
-- enable variable editor when header editor is not enabled ([#1682](https://github.com/graphql/graphiql/issues/1682)) ([205fbad](https://github.com/graphql/graphiql/commit/205fbad84806d175d66a6f5598e0a0f521129a16))
+- enable variable editor when header editor is not enabled
+  ([#1682](https://github.com/graphql/graphiql/issues/1682))
+  ([205fbad](https://github.com/graphql/graphiql/commit/205fbad84806d175d66a6f5598e0a0f521129a16))
 
 ## [1.0.5](https://github.com/graphql/graphiql/compare/graphiql@1.0.4...graphiql@1.0.5) (2020-09-18)
 
@@ -1011,13 +1637,17 @@
 
 ### Bug Fixes
 
-- don't use initial query on every re-render ([#1663](https://github.com/graphql/graphiql/issues/1663)) ([5aa890f](https://github.com/graphql/graphiql/commit/5aa890f6e145a7ad49f82cc122e209a291060709))
+- don't use initial query on every re-render
+  ([#1663](https://github.com/graphql/graphiql/issues/1663))
+  ([5aa890f](https://github.com/graphql/graphiql/commit/5aa890f6e145a7ad49f82cc122e209a291060709))
 
 ## [1.0.3](https://github.com/graphql/graphiql/compare/graphiql@1.0.2...graphiql@1.0.3) (2020-06-24)
 
 ### Bug Fixes
 
-- headers tab - highlighting and schema fetch ([#1593](https://github.com/graphql/graphiql/issues/1593)) ([0d050ca](https://github.com/graphql/graphiql/commit/0d050caeb5278799f2b1c206d0c61f3ac768e7cd))
+- headers tab - highlighting and schema fetch
+  ([#1593](https://github.com/graphql/graphiql/issues/1593))
+  ([0d050ca](https://github.com/graphql/graphiql/commit/0d050caeb5278799f2b1c206d0c61f3ac768e7cd))
 
 ## [1.0.2](https://github.com/graphql/graphiql/compare/graphiql@1.0.1...graphiql@1.0.2) (2020-06-19)
 
@@ -1027,17 +1657,31 @@
 
 ### Bug Fixes
 
-- more server side rendering fixes ([#1581](https://github.com/graphql/graphiql/issues/1581)) ([881a19f](https://github.com/graphql/graphiql/commit/881a19fbd5fbe5f65678de8074e593be7deb2ede)), closes [#1573](https://github.com/graphql/graphiql/issues/1573)
-- network cancellation for 1.0 ([#1582](https://github.com/graphql/graphiql/issues/1582)) ([ad3cc0d](https://github.com/graphql/graphiql/commit/ad3cc0d1567ea49ff5677d4cd8524e5e072b605e))
-- Set headers to localStorage ([#1578](https://github.com/graphql/graphiql/issues/1578)) ([cc7a7e2](https://github.com/graphql/graphiql/commit/cc7a7e2f6d25d7e8150dc89c6984e6a04b01566b))
+- more server side rendering fixes
+  ([#1581](https://github.com/graphql/graphiql/issues/1581))
+  ([881a19f](https://github.com/graphql/graphiql/commit/881a19fbd5fbe5f65678de8074e593be7deb2ede)),
+  closes [#1573](https://github.com/graphql/graphiql/issues/1573)
+- network cancellation for 1.0
+  ([#1582](https://github.com/graphql/graphiql/issues/1582))
+  ([ad3cc0d](https://github.com/graphql/graphiql/commit/ad3cc0d1567ea49ff5677d4cd8524e5e072b605e))
+- Set headers to localStorage
+  ([#1578](https://github.com/graphql/graphiql/issues/1578))
+  ([cc7a7e2](https://github.com/graphql/graphiql/commit/cc7a7e2f6d25d7e8150dc89c6984e6a04b01566b))
 
 ## [1.0.0](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.13...graphiql@1.0.0) (2020-06-11)
 
 ### Bug Fixes
 
-- call debounce statements as they are functions ([#1571](https://github.com/graphql/graphiql/issues/1571)) ([8541250](https://github.com/graphql/graphiql/commit/85412501307ccfffe258b7fbca74bb9309726a73))
-- fix server side rendering by using type only codemirror import ([#1573](https://github.com/graphql/graphiql/issues/1573)) ([1ee60a6](https://github.com/graphql/graphiql/commit/1ee60a6db87d54c7a1e8f1089e52a65f335351b6)), closes [#118](https://github.com/graphql/graphiql/issues/118)
-- Move all componentWillUnMount functionality to respective events ([#1544](https://github.com/graphql/graphiql/issues/1544)) ([046b09f](https://github.com/graphql/graphiql/commit/046b09f541e6a9f2ce4b46de590d49c04c916716))
+- call debounce statements as they are functions
+  ([#1571](https://github.com/graphql/graphiql/issues/1571))
+  ([8541250](https://github.com/graphql/graphiql/commit/85412501307ccfffe258b7fbca74bb9309726a73))
+- fix server side rendering by using type only codemirror import
+  ([#1573](https://github.com/graphql/graphiql/issues/1573))
+  ([1ee60a6](https://github.com/graphql/graphiql/commit/1ee60a6db87d54c7a1e8f1089e52a65f335351b6)),
+  closes [#118](https://github.com/graphql/graphiql/issues/118)
+- Move all componentWillUnMount functionality to respective events
+  ([#1544](https://github.com/graphql/graphiql/issues/1544))
+  ([046b09f](https://github.com/graphql/graphiql/commit/046b09f541e6a9f2ce4b46de590d49c04c916716))
 
 ## [1.0.0-alpha.13](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.12...graphiql@1.0.0-alpha.13) (2020-06-04)
 
@@ -1047,36 +1691,52 @@
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
-- display variable editor when headers are not enabled ([ce7b2e2](https://github.com/graphql/graphiql/commit/ce7b2e2b45d530b61e916112e864074cf3a6ddc7))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- display variable editor when headers are not enabled
+  ([ce7b2e2](https://github.com/graphql/graphiql/commit/ce7b2e2b45d530b61e916112e864074cf3a6ddc7))
 
 ## [1.0.0-alpha.11](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.10...graphiql@1.0.0-alpha.11) (2020-05-28)
 
 ### Bug Fixes
 
-- Safe setState ([#1547](https://github.com/graphql/graphiql/issues/1547)) ([f85969c](https://github.com/graphql/graphiql/commit/f85969c7e77e8fd269e026be36cc5065d6d33237))
-- trigger edit variables on first render ([#1545](https://github.com/graphql/graphiql/issues/1545)) ([e54e1a8](https://github.com/graphql/graphiql/commit/e54e1a8691483f1d336231314130d9822481b3be))
+- Safe setState ([#1547](https://github.com/graphql/graphiql/issues/1547))
+  ([f85969c](https://github.com/graphql/graphiql/commit/f85969c7e77e8fd269e026be36cc5065d6d33237))
+- trigger edit variables on first render
+  ([#1545](https://github.com/graphql/graphiql/issues/1545))
+  ([e54e1a8](https://github.com/graphql/graphiql/commit/e54e1a8691483f1d336231314130d9822481b3be))
 
 ### Features
 
-- Add Headers Editor to GraphiQL ([#1543](https://github.com/graphql/graphiql/issues/1543)) ([3faa1ac](https://github.com/graphql/graphiql/commit/3faa1ac46514252e90abf2b2bda0841edf6115ea))
+- Add Headers Editor to GraphiQL
+  ([#1543](https://github.com/graphql/graphiql/issues/1543))
+  ([3faa1ac](https://github.com/graphql/graphiql/commit/3faa1ac46514252e90abf2b2bda0841edf6115ea))
 
 ## [1.0.0-alpha.10](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.9...graphiql@1.0.0-alpha.10) (2020-05-19)
 
 ### Bug Fixes
 
-- graphiql non-relative import issues ([#1534](https://github.com/graphql/graphiql/issues/1534)) fixes [#1530](https://github.com/graphql/graphiql/issues/1530) ([0ac9fa0](https://github.com/graphql/graphiql/commit/0ac9fa0a8dcdf8464c8ce31c487ebcfd6b9536a8))
+- graphiql non-relative import issues
+  ([#1534](https://github.com/graphql/graphiql/issues/1534)) fixes
+  [#1530](https://github.com/graphql/graphiql/issues/1530)
+  ([0ac9fa0](https://github.com/graphql/graphiql/commit/0ac9fa0a8dcdf8464c8ce31c487ebcfd6b9536a8))
 
 ## [1.0.0-alpha.9](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.8...graphiql@1.0.0-alpha.9) (2020-05-17)
 
 ### Bug Fixes
 
-- remove problematic file resolution module from webpack sco… ([#1489](https://github.com/graphql/graphiql/issues/1489)) ([8dab038](https://github.com/graphql/graphiql/commit/8dab0385772f443f73b559e2c668080733168236))
+- remove problematic file resolution module from webpack sco…
+  ([#1489](https://github.com/graphql/graphiql/issues/1489))
+  ([8dab038](https://github.com/graphql/graphiql/commit/8dab0385772f443f73b559e2c668080733168236))
 
 ### Features
 
-- introduce proper vscode completion kinds ([#1488](https://github.com/graphql/graphiql/issues/1488)) ([f19aa0d](https://github.com/graphql/graphiql/commit/f19aa0ddde6109526c101c8a487f43bbb8238394))
-- Monaco Mode - Phase 2 - Mode & Worker ([#1459](https://github.com/graphql/graphiql/issues/1459)) ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
+- introduce proper vscode completion kinds
+  ([#1488](https://github.com/graphql/graphiql/issues/1488))
+  ([f19aa0d](https://github.com/graphql/graphiql/commit/f19aa0ddde6109526c101c8a487f43bbb8238394))
+- Monaco Mode - Phase 2 - Mode & Worker
+  ([#1459](https://github.com/graphql/graphiql/issues/1459))
+  ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
 
 ## [1.0.0-alpha.8](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.7...graphiql@1.0.0-alpha.8) (2020-04-10)
 
@@ -1094,13 +1754,18 @@
 
 ### Features
 
-- upgrade to graphql@15.0.0 for [#1191](https://github.com/graphql/graphiql/issues/1191) ([#1204](https://github.com/graphql/graphiql/issues/1204)) ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
+- upgrade to graphql@15.0.0 for
+  [#1191](https://github.com/graphql/graphiql/issues/1191)
+  ([#1204](https://github.com/graphql/graphiql/issues/1204))
+  ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
 
 ## [1.0.0-alpha.4](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.3...graphiql@1.0.0-alpha.4) (2020-04-03)
 
 ### Bug Fixes
 
-- fix query argument missing from onEditQuery call ([#1440](https://github.com/graphql/graphiql/issues/1440)) ([6c335a8](https://github.com/graphql/graphiql/commit/6c335a813f6101afded00c0e869c337a7ca44020))
+- fix query argument missing from onEditQuery call
+  ([#1440](https://github.com/graphql/graphiql/issues/1440))
+  ([6c335a8](https://github.com/graphql/graphiql/commit/6c335a813f6101afded00c0e869c337a7ca44020))
 
 ## [1.0.0-alpha.3](https://github.com/graphql/graphiql/compare/graphiql@1.0.0-alpha.2...graphiql@1.0.0-alpha.3) (2020-03-20)
 
@@ -1110,28 +1775,51 @@
 
 ### Bug Fixes
 
-- Fix typo in documentation (comments) ([#1431](https://github.com/graphql/graphiql/issues/1431)) ([fdda8f0](https://github.com/graphql/graphiql/commit/fdda8f04479412d22e9a3e9215c7caa5369e7d83))
-- initial request cache set, import tsc bugs ([#1266](https://github.com/graphql/graphiql/issues/1266)) ([6b98f8a](https://github.com/graphql/graphiql/commit/6b98f8a442d4a8ea160fb90a29acf33f5382db2e))
+- Fix typo in documentation (comments)
+  ([#1431](https://github.com/graphql/graphiql/issues/1431))
+  ([fdda8f0](https://github.com/graphql/graphiql/commit/fdda8f04479412d22e9a3e9215c7caa5369e7d83))
+- initial request cache set, import tsc bugs
+  ([#1266](https://github.com/graphql/graphiql/issues/1266))
+  ([6b98f8a](https://github.com/graphql/graphiql/commit/6b98f8a442d4a8ea160fb90a29acf33f5382db2e))
 
 ## [1.0.0-alpha.1](https://github.com/graphql/graphiql/compare/graphiql@0.17.5...graphiql@1.0.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 
-- hmr, file resolution warnings ([69bf701](https://github.com/graphql/graphiql/commit/69bf701))
-- prefer displayName over type equality for children overrides ([e4cec0a](https://github.com/graphql/graphiql/commit/e4cec0a))
-  - remove use of `findDOMNode` ([0b12323](https://github.com/graphql/graphiql/commit/0b12323)) by [@ryan-m-walker](https://github.com/ryan-m-walker)
+- hmr, file resolution warnings
+  ([69bf701](https://github.com/graphql/graphiql/commit/69bf701))
+- prefer displayName over type equality for children overrides
+  ([e4cec0a](https://github.com/graphql/graphiql/commit/e4cec0a))
+  - remove use of `findDOMNode`
+    ([0b12323](https://github.com/graphql/graphiql/commit/0b12323)) by
+    [@ryan-m-walker](https://github.com/ryan-m-walker)
 
 ### Features
 
-- deprecate support for 15, support react 16 features ([#1107](https://github.com/graphql/graphiql/issues/1107)) ([bc4b6fc](https://github.com/graphql/graphiql/commit/bc4b6fc))
-- **graphiql-theming:** Toolbar component ([#1203](https://github.com/graphql/graphiql/issues/1203)) by [@walaura](https://github.com/walaura) ([adb73f5](https://github.com/graphql/graphiql/commit/adb73f5))
-- [new-ui] Tabs & Tab-bars ([#1198](https://github.com/graphql/graphiql/issues/1198)) ([033f971](https://github.com/graphql/graphiql/commit/033f971)) by [@walaura](https://github.com/walaura)
-- replace use of enzyme with react-testing-library ([#1144](https://github.com/graphql/graphiql/issues/1144)) by [@ryan-m-walker](https://github.com/ryan-m-walker) ([de73d6c](https://github.com/graphql/graphiql/commit/de73d6c))
-- storybook+theme-ui for the new design ([#1145](https://github.com/graphql/graphiql/issues/1145)) ([7f97c0c](https://github.com/graphql/graphiql/commit/7f97c0c)) by [@walaura](https://github.com/walaura)
+- deprecate support for 15, support react 16 features
+  ([#1107](https://github.com/graphql/graphiql/issues/1107))
+  ([bc4b6fc](https://github.com/graphql/graphiql/commit/bc4b6fc))
+- **graphiql-theming:** Toolbar component
+  ([#1203](https://github.com/graphql/graphiql/issues/1203)) by
+  [@walaura](https://github.com/walaura)
+  ([adb73f5](https://github.com/graphql/graphiql/commit/adb73f5))
+- [new-ui] Tabs & Tab-bars
+  ([#1198](https://github.com/graphql/graphiql/issues/1198))
+  ([033f971](https://github.com/graphql/graphiql/commit/033f971)) by
+  [@walaura](https://github.com/walaura)
+- replace use of enzyme with react-testing-library
+  ([#1144](https://github.com/graphql/graphiql/issues/1144)) by
+  [@ryan-m-walker](https://github.com/ryan-m-walker)
+  ([de73d6c](https://github.com/graphql/graphiql/commit/de73d6c))
+- storybook+theme-ui for the new design
+  ([#1145](https://github.com/graphql/graphiql/issues/1145))
+  ([7f97c0c](https://github.com/graphql/graphiql/commit/7f97c0c)) by
+  [@walaura](https://github.com/walaura)
 
 ### BREAKING CHANGES
 
-- Deprecate support for React 15. Please use React 16.8 or greater for hooks support. Co-authored-by: @ryan-m-walker, @acao Reviewed-by: @benjie
+- Deprecate support for React 15. Please use React 16.8 or greater for hooks
+  support. Co-authored-by: @ryan-m-walker, @acao Reviewed-by: @benjie
 
 ## [0.17.5](https://github.com/graphql/graphiql/compare/graphiql@0.17.4...graphiql@0.17.5) (2019-12-09)
 
@@ -1141,52 +1829,79 @@
 
 ### Bug Fixes
 
-- graphiql babel test ignore paths ([e1588d9](https://github.com/graphql/graphiql/commit/e1588d9))
+- graphiql babel test ignore paths
+  ([e1588d9](https://github.com/graphql/graphiql/commit/e1588d9))
 
 ## [0.17.3](https://github.com/graphql/graphiql/compare/graphiql@0.17.2...graphiql@0.17.3) (2019-12-09)
 
 ### Bug Fixes
 
-- express-graphql version ([e9848b0](https://github.com/graphql/graphiql/commit/e9848b0))
-- test output, webpack resolution, clean build ([3b1c2c1](https://github.com/graphql/graphiql/commit/3b1c2c1))
+- express-graphql version
+  ([e9848b0](https://github.com/graphql/graphiql/commit/e9848b0))
+- test output, webpack resolution, clean build
+  ([3b1c2c1](https://github.com/graphql/graphiql/commit/3b1c2c1))
 
 ## [0.17.2](https://github.com/graphql/graphiql/compare/graphiql@0.17.1...graphiql@0.17.2) (2019-12-03)
 
 ### Bug Fixes
 
-- ensure css files move with babel dist ([ca95547](https://github.com/graphql/graphiql/commit/ca95547))
-- remove css from downstream components. soon to be replaced w styled ([e765543](https://github.com/graphql/graphiql/commit/e765543))
+- ensure css files move with babel dist
+  ([ca95547](https://github.com/graphql/graphiql/commit/ca95547))
+- remove css from downstream components. soon to be replaced w styled
+  ([e765543](https://github.com/graphql/graphiql/commit/e765543))
 
 ## [0.17.1](https://github.com/graphql/graphiql/compare/graphiql@0.17.0...graphiql@0.17.1) (2019-12-03)
 
 ### Bug Fixes
 
-- **graphiql:** duplicate query history key issue, fixes [#988](https://github.com/graphql/graphiql/issues/988) ([#1035](https://github.com/graphql/graphiql/issues/1035)) ([69c6826](https://github.com/graphql/graphiql/commit/69c6826))
-- convert browserify build to webpack, fixes [#976](https://github.com/graphql/graphiql/issues/976) ([#1001](https://github.com/graphql/graphiql/issues/1001)) ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
-- hints vertical scroll ([216eaeb](https://github.com/graphql/graphiql/commit/216eaeb))
+- **graphiql:** duplicate query history key issue, fixes
+  [#988](https://github.com/graphql/graphiql/issues/988)
+  ([#1035](https://github.com/graphql/graphiql/issues/1035))
+  ([69c6826](https://github.com/graphql/graphiql/commit/69c6826))
+- convert browserify build to webpack, fixes
+  [#976](https://github.com/graphql/graphiql/issues/976)
+  ([#1001](https://github.com/graphql/graphiql/issues/1001))
+  ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
+- hints vertical scroll
+  ([216eaeb](https://github.com/graphql/graphiql/commit/216eaeb))
 
 ## [0.17.0](https://github.com/graphql/graphiql/compare/graphiql@0.16.0...graphiql@0.17.0) (2019-11-26)
 
 ### Bug Fixes
 
-- security bump, resolves [#1004](https://github.com/graphql/graphiql/issues/1004), SNYK-JS-MARKDOWNIT-459438 ([89c83db](https://github.com/graphql/graphiql/commit/89c83db))
-- webpack resolutions for [#882](https://github.com/graphql/graphiql/issues/882), add webpack example ([ea9df3e](https://github.com/graphql/graphiql/commit/ea9df3e))
+- security bump, resolves
+  [#1004](https://github.com/graphql/graphiql/issues/1004),
+  SNYK-JS-MARKDOWNIT-459438
+  ([89c83db](https://github.com/graphql/graphiql/commit/89c83db))
+- webpack resolutions for
+  [#882](https://github.com/graphql/graphiql/issues/882), add webpack example
+  ([ea9df3e](https://github.com/graphql/graphiql/commit/ea9df3e))
 
 ### Features
 
-- **graphiql:** Prettify also formats query variables ([b7d0bfd](https://github.com/graphql/graphiql/commit/b7d0bfd))
+- **graphiql:** Prettify also formats query variables
+  ([b7d0bfd](https://github.com/graphql/graphiql/commit/b7d0bfd))
 
 ## [0.16.0](https://github.com/graphql/graphiql/compare/graphiql@0.15.1...graphiql@0.16.0) (2019-10-19)
 
 ### Bug Fixes
 
-- **accessibility:** improve accessibility of all components ([#967](https://github.com/graphql/graphiql/issues/967)) ([73a3f90](https://github.com/graphql/graphiql/commit/73a3f90))
-- **css:** added minimum width for result panel in GraphiQL ([#980](https://github.com/graphql/graphiql/issues/980)) ([0c8b7ad](https://github.com/graphql/graphiql/commit/0c8b7ad))
-- **graphiql:** better quota management ([#764](https://github.com/graphql/graphiql/issues/764)) ([7efed6c](https://github.com/graphql/graphiql/commit/7efed6c))
+- **accessibility:** improve accessibility of all components
+  ([#967](https://github.com/graphql/graphiql/issues/967))
+  ([73a3f90](https://github.com/graphql/graphiql/commit/73a3f90))
+- **css:** added minimum width for result panel in GraphiQL
+  ([#980](https://github.com/graphql/graphiql/issues/980))
+  ([0c8b7ad](https://github.com/graphql/graphiql/commit/0c8b7ad))
+- **graphiql:** better quota management
+  ([#764](https://github.com/graphql/graphiql/issues/764))
+  ([7efed6c](https://github.com/graphql/graphiql/commit/7efed6c))
 
 ### Features
 
-- **css:** beautify code tag in doc explorer ([#959](https://github.com/graphql/graphiql/issues/959)) resolves [#949](https://github.com/graphql/graphiql/issues/949) ([30810a2](https://github.com/graphql/graphiql/commit/30810a2))
+- **css:** beautify code tag in doc explorer
+  ([#959](https://github.com/graphql/graphiql/issues/959)) resolves
+  [#949](https://github.com/graphql/graphiql/issues/949)
+  ([30810a2](https://github.com/graphql/graphiql/commit/30810a2))
 
 ### [0.15.1](https://github.com/graphql/graphiql/compare/graphiql@0.15.0...graphiql@0.15.1) (2019-10-04)
 
@@ -1198,15 +1913,27 @@
 
 ### Bug Fixes
 
-- check `window` is defined before using it ([#962](https://github.com/graphql/graphiql/issues/962)) ([e4866ad](https://github.com/graphql/graphiql/commit/e4866ad))
-- **graphiql:** prettify keybinding bug for Firefox. Fixes [#905](https://github.com/graphql/graphiql/issues/905) ([fdf98ba](https://github.com/graphql/graphiql/commit/fdf98ba))
-- check `this.editor` exist before `this.editor.off` in QueryEditor ([#669](https://github.com/graphql/graphiql/issues/669)) ([ca226ee](https://github.com/graphql/graphiql/commit/ca226ee)), closes [#665](https://github.com/graphql/graphiql/issues/665)
-- extraKeys bugfix window regression ([f3d0427](https://github.com/graphql/graphiql/commit/f3d0427))
-- preserve ctrl-f key for macOS ([7c381f9](https://github.com/graphql/graphiql/commit/7c381f9))
+- check `window` is defined before using it
+  ([#962](https://github.com/graphql/graphiql/issues/962))
+  ([e4866ad](https://github.com/graphql/graphiql/commit/e4866ad))
+- **graphiql:** prettify keybinding bug for Firefox. Fixes
+  [#905](https://github.com/graphql/graphiql/issues/905)
+  ([fdf98ba](https://github.com/graphql/graphiql/commit/fdf98ba))
+- check `this.editor` exist before `this.editor.off` in QueryEditor
+  ([#669](https://github.com/graphql/graphiql/issues/669))
+  ([ca226ee](https://github.com/graphql/graphiql/commit/ca226ee)), closes
+  [#665](https://github.com/graphql/graphiql/issues/665)
+- extraKeys bugfix window regression
+  ([f3d0427](https://github.com/graphql/graphiql/commit/f3d0427))
+- preserve ctrl-f key for macOS
+  ([7c381f9](https://github.com/graphql/graphiql/commit/7c381f9))
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 0.13.2 (2019-06-21)
 
@@ -1214,9 +1941,14 @@
 
 ### Bug Fixes
 
-- check `this.editor` exist before `this.editor.off` in QueryEditor ([#669](https://github.com/graphql/graphiql/issues/669)) ([ca226ee](https://github.com/graphql/graphiql/commit/ca226ee)), closes [#665](https://github.com/graphql/graphiql/issues/665)
-- extraKeys bugfix window regression ([f3d0427](https://github.com/graphql/graphiql/commit/f3d0427))
-- preserve ctrl-f key for macOS ([7c381f9](https://github.com/graphql/graphiql/commit/7c381f9))
+- check `this.editor` exist before `this.editor.off` in QueryEditor
+  ([#669](https://github.com/graphql/graphiql/issues/669))
+  ([ca226ee](https://github.com/graphql/graphiql/commit/ca226ee)), closes
+  [#665](https://github.com/graphql/graphiql/issues/665)
+- extraKeys bugfix window regression
+  ([f3d0427](https://github.com/graphql/graphiql/commit/f3d0427))
+- preserve ctrl-f key for macOS
+  ([7c381f9](https://github.com/graphql/graphiql/commit/7c381f9))
 - remove newline ([19f5d1d](https://github.com/graphql/graphiql/commit/19f5d1d))
 
 ## 0.13.2 (2019-06-21)

--- a/packages/graphql-language-service-cli/CHANGELOG.md
+++ b/packages/graphql-language-service-cli/CHANGELOG.md
@@ -4,9 +4,18 @@
 
 ### Patch Changes
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
   - graphql-language-service-server@2.9.6
 
@@ -14,13 +23,35 @@
 
 ### Patch Changes
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2966](https://github.com/graphql/graphiql/pull/2966) [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch` and `sonarjs/no-duplicated-branches` rules
+- [#2966](https://github.com/graphql/graphiql/pull/2966)
+  [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch`
+  and `sonarjs/no-duplicated-branches` rules
 
-- [#2938](https://github.com/graphql/graphiql/pull/2938) [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error` rule
+- [#2938](https://github.com/graphql/graphiql/pull/2938)
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error`
+  rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde), [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171), [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde),
+  [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171),
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
   - graphql-language-service@5.1.1
   - graphql-language-service-server@2.9.5
 
@@ -28,88 +59,118 @@
 
 ### Patch Changes
 
-- [#2901](https://github.com/graphql/graphiql/pull/2901) [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f) Thanks [@acao](https://github.com/acao)! - Reload the language service when a legacy format .graphqlconfig file has changed
+- [#2901](https://github.com/graphql/graphiql/pull/2901)
+  [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)
+  Thanks [@acao](https://github.com/acao)! - Reload the language service when a
+  legacy format .graphqlconfig file has changed
 
-- Updated dependencies [[`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)]:
+- Updated dependencies
+  [[`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)]:
   - graphql-language-service-server@2.9.4
 
 ## 3.3.13
 
 ### Patch Changes
 
-- [#2900](https://github.com/graphql/graphiql/pull/2900) [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a) Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser plugin so that all styles of decorator usage are supported
-- Updated dependencies [[`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)]:
+- [#2900](https://github.com/graphql/graphiql/pull/2900)
+  [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)
+  Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser
+  plugin so that all styles of decorator usage are supported
+- Updated dependencies
+  [[`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)]:
   - graphql-language-service-server@2.9.3
 
 ## 3.3.12
 
 ### Patch Changes
 
-- Updated dependencies [[`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274), [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)]:
+- Updated dependencies
+  [[`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274),
+  [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)]:
   - graphql-language-service-server@2.9.2
 
 ## 3.3.11
 
 ### Patch Changes
 
-- [#2829](https://github.com/graphql/graphiql/pull/2829) [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10) Thanks [@acao](https://github.com/acao)! - svelte language support, using the vue sfc parser introduced for vue support
+- [#2829](https://github.com/graphql/graphiql/pull/2829)
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)
+  Thanks [@acao](https://github.com/acao)! - svelte language support, using the
+  vue sfc parser introduced for vue support
 
-- Updated dependencies [[`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10), [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)]:
+- Updated dependencies
+  [[`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10),
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)]:
   - graphql-language-service-server@2.9.1
 
 ## 3.3.10
 
 ### Patch Changes
 
-- Updated dependencies [[`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)]:
+- Updated dependencies
+  [[`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)]:
   - graphql-language-service-server@2.9.0
 
 ## 3.3.9
 
 ### Patch Changes
 
-- Updated dependencies [[`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)]:
+- Updated dependencies
+  [[`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)]:
   - graphql-language-service-server@2.8.9
 
 ## 3.3.8
 
 ### Patch Changes
 
-- [#2812](https://github.com/graphql/graphiql/pull/2812) [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd) Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode, rolling back graphql-config upgrade
+- [#2812](https://github.com/graphql/graphiql/pull/2812)
+  [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)
+  Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode,
+  rolling back graphql-config upgrade
 
-- Updated dependencies [[`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)]:
+- Updated dependencies
+  [[`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)]:
   - graphql-language-service-server@2.8.8
 
 ## 3.3.7
 
 ### Patch Changes
 
-- Updated dependencies [[`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)]:
+- Updated dependencies
+  [[`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)]:
   - graphql-language-service-server@2.8.7
 
 ## 3.3.6
 
 ### Patch Changes
 
-- Updated dependencies [[`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)]:
+- Updated dependencies
+  [[`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)]:
   - graphql-language-service-server@2.8.6
 
 ## 3.3.5
 
 ### Patch Changes
 
-- [#2616](https://github.com/graphql/graphiql/pull/2616) [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5) Thanks [@acao](https://github.com/acao)! - support vscode multi-root workspaces! creates an LSP server instance for each workspace.
+- [#2616](https://github.com/graphql/graphiql/pull/2616)
+  [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)
+  Thanks [@acao](https://github.com/acao)! - support vscode multi-root
+  workspaces! creates an LSP server instance for each workspace.
 
-  WARNING: large-scale vscode workspaces usage, and this in tandem with `graphql.config.*` multi-project configs could lead to excessive system resource usage. Optimizations coming soon.
+  WARNING: large-scale vscode workspaces usage, and this in tandem with
+  `graphql.config.*` multi-project configs could lead to excessive system
+  resource usage. Optimizations coming soon.
 
-- Updated dependencies [[`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)]:
+- Updated dependencies
+  [[`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)]:
   - graphql-language-service-server@2.8.5
 
 ## 3.3.4
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
   - graphql-language-service-server@2.8.4
 
@@ -117,63 +178,97 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)]:
+- Updated dependencies
+  [[`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)]:
   - graphql-language-service-server@2.8.3
 
 ## 3.3.2
 
 ### Patch Changes
 
-- [#2660](https://github.com/graphql/graphiql/pull/2660) [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf) Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also bumps to the latest patch releases of `graphql-config` fixed several issues with TypeScript loading ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2), [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)). We tested manually, but please open a bug if you encounter any with schema-as-url configs & schema introspection.
+- [#2660](https://github.com/graphql/graphiql/pull/2660)
+  [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)
+  Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that
+  TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also
+  bumps to the latest patch releases of `graphql-config` fixed several issues
+  with TypeScript loading
+  ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2),
+  [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)).
+  We tested manually, but please open a bug if you encounter any with
+  schema-as-url configs & schema introspection.
 
-- Updated dependencies [[`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)]:
+- Updated dependencies
+  [[`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)]:
   - graphql-language-service-server@2.8.2
 
 ## 3.3.1
 
 ### Patch Changes
 
-- Updated dependencies [[`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)]:
+- Updated dependencies
+  [[`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)]:
   - graphql-language-service-server@2.8.1
 
 ## 3.3.0
 
 ### Minor Changes
 
-- [#2557](https://github.com/graphql/graphiql/pull/2557) [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9) Thanks [@acao](https://github.com/acao)! - upgrades the `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the lsp server to the latest. also upgrades `vscode-languageclient` in `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in `vscode-graphql` at least!
+- [#2557](https://github.com/graphql/graphiql/pull/2557)
+  [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)
+  Thanks [@acao](https://github.com/acao)! - upgrades the
+  `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the
+  lsp server to the latest. also upgrades `vscode-languageclient` in
+  `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in
+  `vscode-graphql` at least!
 
   hopefully this solves #2230 once and for all!
 
 ### Patch Changes
 
-- Updated dependencies [[`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)]:
+- Updated dependencies
+  [[`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)]:
   - graphql-language-service-server@2.8.0
 
 ## 3.2.30
 
 ### Patch Changes
 
-- [#2553](https://github.com/graphql/graphiql/pull/2553) [`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4) Thanks [@acao](https://github.com/acao)! - Fix error with LSP crash for CLI users #2230. `vscode-graphql` not impacted - rather, `nvim.coc`, maybe other clients who use CLI directly). recreation of #2546 by [@xuanduc987](https://github.com/xuanduc987, thank you!)
+- [#2553](https://github.com/graphql/graphiql/pull/2553)
+  [`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)
+  Thanks [@acao](https://github.com/acao)! - Fix error with LSP crash for CLI
+  users #2230. `vscode-graphql` not impacted - rather, `nvim.coc`, maybe other
+  clients who use CLI directly). recreation of #2546 by
+  [@xuanduc987](https://github.com/xuanduc987, thank you!)
 
-- Updated dependencies [[`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)]:
+- Updated dependencies
+  [[`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)]:
   - graphql-language-service-server@2.7.29
 
 ## 3.2.29
 
 ### Patch Changes
 
-- [#2519](https://github.com/graphql/graphiql/pull/2519) [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8) Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode by default in the LSP server
+- [#2519](https://github.com/graphql/graphiql/pull/2519)
+  [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8)
+  Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode
+  by default in the LSP server
 
-* [#2509](https://github.com/graphql/graphiql/pull/2509) [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea) Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `, ` graphql(``) ` call expressions support for highlighting & language
+* [#2509](https://github.com/graphql/graphiql/pull/2509)
+  [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)
+  Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `,
+  ` graphql(``) ` call expressions support for highlighting & language
 
-* Updated dependencies [[`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8), [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)]:
+* Updated dependencies
+  [[`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8),
+  [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)]:
   - graphql-language-service-server@2.7.28
 
 ## 3.2.28
 
 ### Patch Changes
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service-server@2.7.27
   - graphql-language-service@5.0.6
 
@@ -181,11 +276,16 @@
 
 ### Patch Changes
 
-- [#2486](https://github.com/graphql/graphiql/pull/2486) [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa) Thanks [@stonexer](https://github.com/stonexer)! - definition support for operation fields ✨
+- [#2486](https://github.com/graphql/graphiql/pull/2486)
+  [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)
+  Thanks [@stonexer](https://github.com/stonexer)! - definition support for
+  operation fields ✨
 
-  you can now jump to the applicable object type definition for query/mutation/subscription fields!
+  you can now jump to the applicable object type definition for
+  query/mutation/subscription fields!
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service-server@2.7.26
   - graphql-language-service@5.0.5
 
@@ -193,35 +293,41 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99)]:
+- Updated dependencies
+  [[`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99)]:
   - graphql-language-service-server@2.7.25
 
 ## 3.2.25
 
 ### Patch Changes
 
-- Updated dependencies [[`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)]:
+- Updated dependencies
+  [[`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)]:
   - graphql-language-service-server@2.7.24
 
 ## 3.2.24
 
 ### Patch Changes
 
-- Updated dependencies [[`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)]:
+- Updated dependencies
+  [[`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)]:
   - graphql-language-service-server@2.7.23
 
 ## 3.2.23
 
 ### Patch Changes
 
-- Updated dependencies [[`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8), [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)]:
+- Updated dependencies
+  [[`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8),
+  [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)]:
   - graphql-language-service-server@2.7.22
 
 ## 3.2.22
 
 ### Patch Changes
 
-- Updated dependencies [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - graphql-language-service@5.0.4
   - graphql-language-service-server@2.7.21
 
@@ -229,9 +335,13 @@
 
 ### Patch Changes
 
-- [#2291](https://github.com/graphql/graphiql/pull/2291) [`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902) Thanks [@retrodaredevil](https://github.com/retrodaredevil)! - Target es6 for the languages services
+- [#2291](https://github.com/graphql/graphiql/pull/2291)
+  [`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)
+  Thanks [@retrodaredevil](https://github.com/retrodaredevil)! - Target es6 for
+  the languages services
 
-- Updated dependencies [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
+- Updated dependencies
+  [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
   - graphql-language-service@5.0.3
   - graphql-language-service-server@2.7.20
 
@@ -239,7 +349,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service@5.0.2
   - graphql-language-service-server@2.7.19
 
@@ -247,29 +358,38 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae)]:
+- Updated dependencies
+  [[`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae)]:
   - graphql-language-service-server@2.7.18
 
 ## 3.2.18
 
 ### Patch Changes
 
-- [#2267](https://github.com/graphql/graphiql/pull/2267) [`fe441272`](https://github.com/graphql/graphiql/commit/fe44127296f808e58407855c7f8806e04c8ddf03) Thanks [@elken](https://github.com/elken)! - Re-add `graphql-language-service-server` as a dep to `graphql-language-service-cli`
+- [#2267](https://github.com/graphql/graphiql/pull/2267)
+  [`fe441272`](https://github.com/graphql/graphiql/commit/fe44127296f808e58407855c7f8806e04c8ddf03)
+  Thanks [@elken](https://github.com/elken)! - Re-add
+  `graphql-language-service-server` as a dep to `graphql-language-service-cli`
 
 ## 3.2.17
 
 ### Patch Changes
 
-- [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa) Thanks [@acao](https://github.com/acao)! - fix lockfile and imports from LSP merge
+- [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)
+  Thanks [@acao](https://github.com/acao)! - fix lockfile and imports from LSP
+  merge
 
-- Updated dependencies [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa), [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
+- Updated dependencies
+  [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa),
+  [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
   - graphql-language-service@5.0.1
 
 ## 3.2.16
 
 ### Patch Changes
 
-- Updated dependencies [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
+- Updated dependencies
+  [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
   - graphql-language-service@5.0.0
   - graphql-language-service-server@2.7.16
 
@@ -277,14 +397,18 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`ab83198f`](https://github.com/graphql/graphiql/commit/ab83198fa8b3c5453d3733982ee9ca8a2d6bca7a)]:
+- Updated dependencies
+  [[`ab83198f`](https://github.com/graphql/graphiql/commit/ab83198fa8b3c5453d3733982ee9ca8a2d6bca7a)]:
   - graphql-language-service-server@2.7.15
 
 ## 3.2.14
 
 ### Patch Changes
 
-- Updated dependencies [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f), [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c), [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
+- Updated dependencies
+  [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f),
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c),
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
   - graphql-language-service-server@2.7.14
   - graphql-language-service@4.1.5
 
@@ -292,7 +416,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`08ff6dce`](https://github.com/graphql/graphiql/commit/08ff6dce0625f7ab58a45364aed9ca04c7862fa7)]:
+- Updated dependencies
+  [[`08ff6dce`](https://github.com/graphql/graphiql/commit/08ff6dce0625f7ab58a45364aed9ca04c7862fa7)]:
   - graphql-language-service-server@2.7.13
   - graphql-language-service@4.1.4
 
@@ -300,7 +425,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
+- Updated dependencies
+  [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
   - graphql-language-service@4.1.3
   - graphql-language-service-server@2.7.12
 
@@ -308,7 +434,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
+- Updated dependencies
+  [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
   - graphql-language-service@4.1.2
   - graphql-language-service-server@2.7.11
 
@@ -316,7 +443,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
+- Updated dependencies
+  [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
   - graphql-language-service-server@2.7.10
   - graphql-language-service-utils@2.7.1
   - graphql-language-service@4.1.1
@@ -325,7 +453,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
+- Updated dependencies
+  [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
   - graphql-language-service@4.1.0
   - graphql-language-service-server@2.7.9
 
@@ -333,7 +462,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
+- Updated dependencies
+  [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
   - graphql-language-service-utils@2.7.0
   - graphql-language-service@4.0.0
   - graphql-language-service-server@2.7.8
@@ -342,7 +472,9 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`c4236190`](https://github.com/graphql/graphiql/commit/c4236190f91adedaf4f4a54cd0400a6b42c3c407), [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+- Updated dependencies
+  [[`c4236190`](https://github.com/graphql/graphiql/commit/c4236190f91adedaf4f4a54cd0400a6b42c3c407),
+  [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service-server@2.7.7
   - graphql-language-service@3.2.5
 
@@ -350,20 +482,27 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`4286185c`](https://github.com/graphql/graphiql/commit/4286185cdc6119175e23d66b8e177ba32693a63a)]:
+- Updated dependencies
+  [[`4286185c`](https://github.com/graphql/graphiql/commit/4286185cdc6119175e23d66b8e177ba32693a63a)]:
   - graphql-language-service-server@2.7.6
 
 ## 3.2.5
 
 ### Patch Changes
 
-- [`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063) [#2055](https://github.com/graphql/graphiql/pull/2055) Thanks [@acao](https://github.com/acao)! - this fixes the URI scheme related bugs and make sure schema as sdl config works again.
+- [`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063)
+  [#2055](https://github.com/graphql/graphiql/pull/2055) Thanks
+  [@acao](https://github.com/acao)! - this fixes the URI scheme related bugs and
+  make sure schema as sdl config works again.
 
-  `fileURLToPath` had been introduced by a contributor and I didn't test properly, it broke sdl file loading!
+  `fileURLToPath` had been introduced by a contributor and I didn't test
+  properly, it broke sdl file loading!
 
-  definitions, autocomplete, diagnostics, etc should work again also hides the more verbose logging output for now
+  definitions, autocomplete, diagnostics, etc should work again also hides the
+  more verbose logging output for now
 
-- Updated dependencies [[`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063)]:
+- Updated dependencies
+  [[`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063)]:
   - graphql-language-service-server@2.7.5
   - graphql-language-service@3.2.4
   - graphql-language-service-utils@2.6.3
@@ -372,9 +511,14 @@
 
 ### Patch Changes
 
-- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf) [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks [@willstott101](https://github.com/willstott101)! - Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.
+- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)
+  [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks
+  [@willstott101](https://github.com/willstott101)! - Source code included in
+  all packages to fix source maps. codemirror-graphql includes esm build in
+  package.
 
-- Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
+- Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
   - graphql-language-service@3.2.3
   - graphql-language-service-server@2.7.4
   - graphql-language-service-utils@2.6.2
@@ -383,7 +527,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+- Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - graphql-language-service@3.2.2
   - graphql-language-service-server@2.7.3
   - graphql-language-service-utils@2.6.1
@@ -392,16 +537,21 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`7e98c6ff`](https://github.com/graphql/graphiql/commit/7e98c6fff3b1c62954c9c8d902ac64ddbf23fc5d)]:
+- Updated dependencies
+  [[`7e98c6ff`](https://github.com/graphql/graphiql/commit/7e98c6fff3b1c62954c9c8d902ac64ddbf23fc5d)]:
   - graphql-language-service-server@2.7.2
 
 ## 3.2.1
 
 ### Patch Changes
 
-- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce) [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks [@PabloSzx](https://github.com/PabloSzx)! - Update utils
+- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)
+  [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks
+  [@PabloSzx](https://github.com/PabloSzx)! - Update utils
 
-- Updated dependencies [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce), [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
+- Updated dependencies
+  [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce),
+  [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
   - graphql-language-service-utils@2.6.0
   - graphql-language-service@3.2.1
   - graphql-language-service-server@2.7.1
@@ -410,11 +560,15 @@
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - graphql-language-service-server@2.7.0
   - graphql-language-service@3.2.0
 
@@ -422,11 +576,20 @@
 
 ### Patch Changes
 
-- [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8) [#1964](https://github.com/graphql/graphiql/pull/1964) Thanks [@patrickszmucer](https://github.com/patrickszmucer)! - Fix unknown fragment errors on save
+- [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8)
+  [#1964](https://github.com/graphql/graphiql/pull/1964) Thanks
+  [@patrickszmucer](https://github.com/patrickszmucer)! - Fix unknown fragment
+  errors on save
 
-* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-* Updated dependencies [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb), [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8), [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+* Updated dependencies
+  [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb),
+  [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8),
+  [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service@3.1.6
   - graphql-language-service-server@2.6.5
 
@@ -434,7 +597,11 @@
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## [3.1.12](https://github.com/graphql/graphiql/compare/graphql-language-service-cli@3.1.11...graphql-language-service-cli@3.1.12) (2021-01-07)
 
@@ -512,11 +679,15 @@
 
 ### Bug Fixes
 
-- pre-caching schema bugs, new server config options ([#1636](https://github.com/graphql/graphiql/issues/1636)) ([d989456](https://github.com/graphql/graphiql/commit/d9894564c056134e15093956e0951dcefe061d76))
+- pre-caching schema bugs, new server config options
+  ([#1636](https://github.com/graphql/graphiql/issues/1636))
+  ([d989456](https://github.com/graphql/graphiql/commit/d9894564c056134e15093956e0951dcefe061d76))
 
 ### Features
 
-- graphql-config@3 support in lsp server ([#1616](https://github.com/graphql/graphiql/issues/1616)) ([27cd185](https://github.com/graphql/graphiql/commit/27cd18562b64dfe18e6343b6a49f3f606af89d86))
+- graphql-config@3 support in lsp server
+  ([#1616](https://github.com/graphql/graphiql/issues/1616))
+  ([27cd185](https://github.com/graphql/graphiql/commit/27cd18562b64dfe18e6343b6a49f3f606af89d86))
 
 ## [3.0.1](https://github.com/graphql/graphiql/compare/graphql-language-service-cli@3.0.0...graphql-language-service-cli@3.0.1) (2020-08-06)
 
@@ -534,7 +705,8 @@
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
 
 ## [3.0.0-alpha.3](https://github.com/graphql/graphiql/compare/graphql-language-service-cli@3.0.0-alpha.2...graphql-language-service-cli@3.0.0-alpha.3) (2020-05-28)
 
@@ -548,7 +720,9 @@
 
 ### Bug Fixes
 
-- repair CLI, handle all schema and LSP errors ([#1482](https://github.com/graphql/graphiql/issues/1482)) ([992f384](https://github.com/graphql/graphiql/commit/992f38494f20f5877bfd6ff54893854ac7a0eaa2))
+- repair CLI, handle all schema and LSP errors
+  ([#1482](https://github.com/graphql/graphiql/issues/1482))
+  ([992f384](https://github.com/graphql/graphiql/commit/992f38494f20f5877bfd6ff54893854ac7a0eaa2))
 
 ## [2.4.0-alpha.7](https://github.com/graphql/graphiql/compare/graphql-language-service@2.4.0-alpha.6...graphql-language-service@2.4.0-alpha.7) (2020-04-10)
 
@@ -562,7 +736,10 @@
 
 ### Features
 
-- upgrade to graphql@15.0.0 for [#1191](https://github.com/graphql/graphiql/issues/1191) ([#1204](https://github.com/graphql/graphiql/issues/1204)) ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
+- upgrade to graphql@15.0.0 for
+  [#1191](https://github.com/graphql/graphiql/issues/1191)
+  ([#1204](https://github.com/graphql/graphiql/issues/1204))
+  ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
 
 ## [2.4.0-alpha.4](https://github.com/graphql/graphiql/compare/graphql-language-service@2.4.0-alpha.3...graphql-language-service@2.4.0-alpha.4) (2020-04-03)
 
@@ -576,20 +753,32 @@
 
 ### Bug Fixes
 
-- error formatting, [#1319](https://github.com/graphql/graphiql/issues/1319) ([#1381](https://github.com/graphql/graphiql/issues/1381)) ([16509a4](https://github.com/graphql/graphiql/commit/16509a4278d523a7f0a96c846cc0f370d29a0700))
+- error formatting, [#1319](https://github.com/graphql/graphiql/issues/1319)
+  ([#1381](https://github.com/graphql/graphiql/issues/1381))
+  ([16509a4](https://github.com/graphql/graphiql/commit/16509a4278d523a7f0a96c846cc0f370d29a0700))
 
 ### Features
 
-- **cli:** recommend matching commands ([#1420](https://github.com/graphql/graphiql/issues/1420)) ([0fbae82](https://github.com/graphql/graphiql/commit/0fbae828ced2e8b95016268805654cde8322b076))
-- **graphql-config:** add graphql config extensions ([#1118](https://github.com/graphql/graphiql/issues/1118)) ([2a77e47](https://github.com/graphql/graphiql/commit/2a77e47719ec9181a00183a08ffa11287b8fd2f5))
-- capture unknown commands making use of the in-house s… ([#1417](https://github.com/graphql/graphiql/issues/1417)) ([dd12a6b](https://github.com/graphql/graphiql/commit/dd12a6b903976ce8d35cf91d3c9606450f1c0990))
-- use new GraphQL Config ([#1342](https://github.com/graphql/graphiql/issues/1342)) ([e45838f](https://github.com/graphql/graphiql/commit/e45838f5ba579e05b20f1a147ce431478ffad9aa))
+- **cli:** recommend matching commands
+  ([#1420](https://github.com/graphql/graphiql/issues/1420))
+  ([0fbae82](https://github.com/graphql/graphiql/commit/0fbae828ced2e8b95016268805654cde8322b076))
+- **graphql-config:** add graphql config extensions
+  ([#1118](https://github.com/graphql/graphiql/issues/1118))
+  ([2a77e47](https://github.com/graphql/graphiql/commit/2a77e47719ec9181a00183a08ffa11287b8fd2f5))
+- capture unknown commands making use of the in-house s…
+  ([#1417](https://github.com/graphql/graphiql/issues/1417))
+  ([dd12a6b](https://github.com/graphql/graphiql/commit/dd12a6b903976ce8d35cf91d3c9606450f1c0990))
+- use new GraphQL Config
+  ([#1342](https://github.com/graphql/graphiql/issues/1342))
+  ([e45838f](https://github.com/graphql/graphiql/commit/e45838f5ba579e05b20f1a147ce431478ffad9aa))
 
 ## [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service@2.3.4...graphql-language-service@2.4.0-alpha.1) (2020-01-18)
 
 ### Features
 
-- convert LSP Server to Typescript, remove watchman ([#1138](https://github.com/graphql/graphiql/issues/1138)) ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
+- convert LSP Server to Typescript, remove watchman
+  ([#1138](https://github.com/graphql/graphiql/issues/1138))
+  ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
 
 ## [2.3.4](https://github.com/graphql/graphiql/compare/graphql-language-service@2.3.3...graphql-language-service@2.3.4) (2019-12-09)
 
@@ -611,7 +800,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 2.0.1 (2019-05-14)
 
@@ -667,7 +859,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 2.0.1 (2019-05-14)
 
@@ -723,7 +918,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 2.0.1 (2019-05-14)
 

--- a/packages/graphql-language-service-server/CHANGELOG.md
+++ b/packages/graphql-language-service-server/CHANGELOG.md
@@ -4,150 +4,268 @@
 
 ### Patch Changes
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
-- [#3051](https://github.com/graphql/graphiql/pull/3051) [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9) Thanks [@B2o5T](https://github.com/B2o5T)! - update babel, support `satisfies` operator
+- [#3051](https://github.com/graphql/graphiql/pull/3051)
+  [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - update babel, support `satisfies`
+  operator
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
 
 ## 2.9.5
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2966](https://github.com/graphql/graphiql/pull/2966) [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch` and `sonarjs/no-duplicated-branches` rules
+- [#2966](https://github.com/graphql/graphiql/pull/2966)
+  [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch`
+  and `sonarjs/no-duplicated-branches` rules
 
-- [#2926](https://github.com/graphql/graphiql/pull/2926) [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772) Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts file extensions
+- [#2926](https://github.com/graphql/graphiql/pull/2926)
+  [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772)
+  Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts
+  file extensions
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2933](https://github.com/graphql/graphiql/pull/2933) [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d) Thanks [@B2o5T](https://github.com/B2o5T)! - enable @typescript-eslint/no-unused-expressions
+- [#2933](https://github.com/graphql/graphiql/pull/2933)
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  @typescript-eslint/no-unused-expressions
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
-- [#2942](https://github.com/graphql/graphiql/pull/2942) [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-redundant-jump` rule
+- [#2942](https://github.com/graphql/graphiql/pull/2942)
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `sonarjs/no-redundant-jump` rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
   - graphql-language-service@5.1.1
 
 ## 2.9.4
 
 ### Patch Changes
 
-- [#2901](https://github.com/graphql/graphiql/pull/2901) [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f) Thanks [@acao](https://github.com/acao)! - Reload the language service when a legacy format .graphqlconfig file has changed
+- [#2901](https://github.com/graphql/graphiql/pull/2901)
+  [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)
+  Thanks [@acao](https://github.com/acao)! - Reload the language service when a
+  legacy format .graphqlconfig file has changed
 
 ## 2.9.3
 
 ### Patch Changes
 
-- [#2900](https://github.com/graphql/graphiql/pull/2900) [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a) Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser plugin so that all styles of decorator usage are supported
+- [#2900](https://github.com/graphql/graphiql/pull/2900)
+  [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)
+  Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser
+  plugin so that all styles of decorator usage are supported
 
 ## 2.9.2
 
 ### Patch Changes
 
-- [#2861](https://github.com/graphql/graphiql/pull/2861) [`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274) Thanks [@aloker](https://github.com/aloker)! - add missing pieces for svelte language support
+- [#2861](https://github.com/graphql/graphiql/pull/2861)
+  [`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274)
+  Thanks [@aloker](https://github.com/aloker)! - add missing pieces for svelte
+  language support
 
-* [#2488](https://github.com/graphql/graphiql/pull/2488) [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf) Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by default
+* [#2488](https://github.com/graphql/graphiql/pull/2488)
+  [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)
+  Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by
+  default
 
-  Users found this generally annoying by default, especially when there are required arguments
+  Users found this generally annoying by default, especially when there are
+  required arguments
 
-  Without automatically prompting autocompletion of required arguments as well as lead expansion, it makes the extension harder to use
+  Without automatically prompting autocompletion of required arguments as well
+  as lead expansion, it makes the extension harder to use
 
   You can now supply this in your graphql config:
 
   `config.extensions.languageService.fillLeafsOnComplete`
 
-  Setting it to to `true` will enable this feature. Will soon add the ability to manually enable this in `monaco-graphql` as well.
+  Setting it to to `true` will enable this feature. Will soon add the ability to
+  manually enable this in `monaco-graphql` as well.
 
-  For both, this kind of behavior would be better as a keyboard command, context menu item &/or codelens prompt
+  For both, this kind of behavior would be better as a keyboard command, context
+  menu item &/or codelens prompt
 
 ## 2.9.1
 
 ### Patch Changes
 
-- [#2829](https://github.com/graphql/graphiql/pull/2829) [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10) Thanks [@acao](https://github.com/acao)! - major bugfixes with `onDidChange` and `onDidChangeWatchedFiles` events
+- [#2829](https://github.com/graphql/graphiql/pull/2829)
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)
+  Thanks [@acao](https://github.com/acao)! - major bugfixes with `onDidChange`
+  and `onDidChangeWatchedFiles` events
 
-* [#2829](https://github.com/graphql/graphiql/pull/2829) [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10) Thanks [@acao](https://github.com/acao)! - svelte language support, using the vue sfc parser introduced for vue support
+* [#2829](https://github.com/graphql/graphiql/pull/2829)
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)
+  Thanks [@acao](https://github.com/acao)! - svelte language support, using the
+  vue sfc parser introduced for vue support
 
 ## 2.9.0
 
 ### Minor Changes
 
-- [#2827](https://github.com/graphql/graphiql/pull/2827) [`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708) Thanks [@acao](https://github.com/acao)! - Introducing vue.js support for intellisense! Thanks @AumyF
+- [#2827](https://github.com/graphql/graphiql/pull/2827)
+  [`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)
+  Thanks [@acao](https://github.com/acao)! - Introducing vue.js support for
+  intellisense! Thanks @AumyF
 
 ## 2.8.9
 
 ### Patch Changes
 
-- [#2818](https://github.com/graphql/graphiql/pull/2818) [`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67) Thanks [@acao](https://github.com/acao)! - Workspaces support introduced a regression for no-config scenario. Reverting to fix bugs with no graphql config crashing the server.
+- [#2818](https://github.com/graphql/graphiql/pull/2818)
+  [`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)
+  Thanks [@acao](https://github.com/acao)! - Workspaces support introduced a
+  regression for no-config scenario. Reverting to fix bugs with no graphql
+  config crashing the server.
 
 ## 2.8.8
 
 ### Patch Changes
 
-- [#2812](https://github.com/graphql/graphiql/pull/2812) [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd) Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode, rolling back graphql-config upgrade
+- [#2812](https://github.com/graphql/graphiql/pull/2812)
+  [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)
+  Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode,
+  rolling back graphql-config upgrade
 
 ## 2.8.7
 
 ### Patch Changes
 
-- [#2810](https://github.com/graphql/graphiql/pull/2810) [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662) Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade `graphql-config`, fix issue with graphql-config cosmiconfig typescript config loader.
+- [#2810](https://github.com/graphql/graphiql/pull/2810)
+  [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)
+  Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade
+  `graphql-config`, fix issue with graphql-config cosmiconfig typescript config
+  loader.
 
 ## 2.8.6
 
 ### Patch Changes
 
-- [#2808](https://github.com/graphql/graphiql/pull/2808) [`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6) Thanks [@acao](https://github.com/acao)! - fix graphql config init bug
+- [#2808](https://github.com/graphql/graphiql/pull/2808)
+  [`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)
+  Thanks [@acao](https://github.com/acao)! - fix graphql config init bug
 
 ## 2.8.5
 
 ### Patch Changes
 
-- [#2616](https://github.com/graphql/graphiql/pull/2616) [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5) Thanks [@acao](https://github.com/acao)! - support vscode multi-root workspaces! creates an LSP server instance for each workspace.
+- [#2616](https://github.com/graphql/graphiql/pull/2616)
+  [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)
+  Thanks [@acao](https://github.com/acao)! - support vscode multi-root
+  workspaces! creates an LSP server instance for each workspace.
 
-  WARNING: large-scale vscode workspaces usage, and this in tandem with `graphql.config.*` multi-project configs could lead to excessive system resource usage. Optimizations coming soon.
+  WARNING: large-scale vscode workspaces usage, and this in tandem with
+  `graphql.config.*` multi-project configs could lead to excessive system
+  resource usage. Optimizations coming soon.
 
 ## 2.8.4
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
 
 ## 2.8.3
 
 ### Patch Changes
 
-- [#2664](https://github.com/graphql/graphiql/pull/2664) [`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee) Thanks [@acao](https://github.com/acao)! - This reverts the bugfix for .graphqlrc.ts users, which broke the extension for schema url users
+- [#2664](https://github.com/graphql/graphiql/pull/2664)
+  [`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)
+  Thanks [@acao](https://github.com/acao)! - This reverts the bugfix for
+  .graphqlrc.ts users, which broke the extension for schema url users
 
 ## 2.8.2
 
 ### Patch Changes
 
-- [#2660](https://github.com/graphql/graphiql/pull/2660) [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf) Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also bumps to the latest patch releases of `graphql-config` fixed several issues with TypeScript loading ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2), [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)). We tested manually, but please open a bug if you encounter any with schema-as-url configs & schema introspection.
+- [#2660](https://github.com/graphql/graphiql/pull/2660)
+  [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)
+  Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that
+  TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also
+  bumps to the latest patch releases of `graphql-config` fixed several issues
+  with TypeScript loading
+  ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2),
+  [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)).
+  We tested manually, but please open a bug if you encounter any with
+  schema-as-url configs & schema introspection.
 
 ## 2.8.1
 
 ### Patch Changes
 
-- [#2623](https://github.com/graphql/graphiql/pull/2623) [`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb) Thanks [@acao](https://github.com/acao)! - In #2624, fix introspection schema fetching regression in lsp server, and fix for users writing new .gql/.graphql files
+- [#2623](https://github.com/graphql/graphiql/pull/2623)
+  [`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)
+  Thanks [@acao](https://github.com/acao)! - In #2624, fix introspection schema
+  fetching regression in lsp server, and fix for users writing new .gql/.graphql
+  files
 
 ## 2.8.0
 
 ### Minor Changes
 
-- [#2557](https://github.com/graphql/graphiql/pull/2557) [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9) Thanks [@acao](https://github.com/acao)! - upgrades the `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the lsp server to the latest. also upgrades `vscode-languageclient` in `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in `vscode-graphql` at least!
+- [#2557](https://github.com/graphql/graphiql/pull/2557)
+  [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)
+  Thanks [@acao](https://github.com/acao)! - upgrades the
+  `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the
+  lsp server to the latest. also upgrades `vscode-languageclient` in
+  `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in
+  `vscode-graphql` at least!
 
   hopefully this solves #2230 once and for all!
 
@@ -155,141 +273,216 @@
 
 ### Patch Changes
 
-- [#2553](https://github.com/graphql/graphiql/pull/2553) [`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4) Thanks [@acao](https://github.com/acao)! - Fix error with LSP crash for CLI users #2230. `vscode-graphql` not impacted - rather, `nvim.coc`, maybe other clients who use CLI directly). recreation of #2546 by [@xuanduc987](https://github.com/xuanduc987, thank you!)
+- [#2553](https://github.com/graphql/graphiql/pull/2553)
+  [`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)
+  Thanks [@acao](https://github.com/acao)! - Fix error with LSP crash for CLI
+  users #2230. `vscode-graphql` not impacted - rather, `nvim.coc`, maybe other
+  clients who use CLI directly). recreation of #2546 by
+  [@xuanduc987](https://github.com/xuanduc987, thank you!)
 
 ## 2.7.28
 
 ### Patch Changes
 
-- [#2519](https://github.com/graphql/graphiql/pull/2519) [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8) Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode by default in the LSP server
+- [#2519](https://github.com/graphql/graphiql/pull/2519)
+  [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8)
+  Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode
+  by default in the LSP server
 
-* [#2509](https://github.com/graphql/graphiql/pull/2509) [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea) Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `, ` graphql(``) ` call expressions support for highlighting & language
+* [#2509](https://github.com/graphql/graphiql/pull/2509)
+  [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)
+  Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `,
+  ` graphql(``) ` call expressions support for highlighting & language
 
 ## 2.7.27
 
 ### Patch Changes
 
-- [#2506](https://github.com/graphql/graphiql/pull/2506) [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c) Thanks [@acao](https://github.com/acao)! - Remove redundant check, trigger LSP release
+- [#2506](https://github.com/graphql/graphiql/pull/2506)
+  [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)
+  Thanks [@acao](https://github.com/acao)! - Remove redundant check, trigger LSP
+  release
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service@5.0.6
 
 ## 2.7.26
 
 ### Patch Changes
 
-- [#2486](https://github.com/graphql/graphiql/pull/2486) [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa) Thanks [@stonexer](https://github.com/stonexer)! - definition support for operation fields ✨
+- [#2486](https://github.com/graphql/graphiql/pull/2486)
+  [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)
+  Thanks [@stonexer](https://github.com/stonexer)! - definition support for
+  operation fields ✨
 
-  you can now jump to the applicable object type definition for query/mutation/subscription fields!
+  you can now jump to the applicable object type definition for
+  query/mutation/subscription fields!
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service@5.0.5
 
 ## 2.7.25
 
 ### Patch Changes
 
-- [#2481](https://github.com/graphql/graphiql/pull/2481) [`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99) Thanks [@acao](https://github.com/acao)! - No longer load dotenv in the LSP server
+- [#2481](https://github.com/graphql/graphiql/pull/2481)
+  [`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99)
+  Thanks [@acao](https://github.com/acao)! - No longer load dotenv in the LSP
+  server
 
 ## 2.7.24
 
 ### Patch Changes
 
-- [#2470](https://github.com/graphql/graphiql/pull/2470) [`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b) Thanks [@acao](https://github.com/acao)! - Aims to resolve #2421
+- [#2470](https://github.com/graphql/graphiql/pull/2470)
+  [`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)
+  Thanks [@acao](https://github.com/acao)! - Aims to resolve #2421
 
   - graphql config errors only log to output channel, no longer crash the LSP
   - more performant LSP request no-ops for failing/missing config
 
-  this used to fail silently in the output channel, but vscode introduced a new retry and notification for this
+  this used to fail silently in the output channel, but vscode introduced a new
+  retry and notification for this
 
-  would like to provide more helpful graphql config DX in the future but this should be better for now
+  would like to provide more helpful graphql config DX in the future but this
+  should be better for now
 
 ## 2.7.23
 
 ### Patch Changes
 
-- [#2417](https://github.com/graphql/graphiql/pull/2417) [`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2) Thanks [@acao](https://github.com/acao)! - fix annoying trigger character on newline issue #2182
+- [#2417](https://github.com/graphql/graphiql/pull/2417)
+  [`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)
+  Thanks [@acao](https://github.com/acao)! - fix annoying trigger character on
+  newline issue #2182
 
 ## 2.7.22
 
 ### Patch Changes
 
-- [#2385](https://github.com/graphql/graphiql/pull/2385) [`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8) Thanks [@acao](https://github.com/acao)! - Stop reporting unnecessary EOF errors when authoring new queries
+- [#2385](https://github.com/graphql/graphiql/pull/2385)
+  [`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8)
+  Thanks [@acao](https://github.com/acao)! - Stop reporting unnecessary EOF
+  errors when authoring new queries
 
-* [#2382](https://github.com/graphql/graphiql/pull/2382) [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a) Thanks [@acao](https://github.com/acao)! - allow disabling query/SDL validation with `graphql-config` setting `{ extensions: { languageService: { enableValidation: false } } }`.
+* [#2382](https://github.com/graphql/graphiql/pull/2382)
+  [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)
+  Thanks [@acao](https://github.com/acao)! - allow disabling query/SDL
+  validation with `graphql-config` setting
+  `{ extensions: { languageService: { enableValidation: false } } }`.
 
-  Currently, users receive duplicate validation messages when using our LSP alongside existing validation tools like `graphql-eslint`, and this allows them to disable the LSP feature in that case.
+  Currently, users receive duplicate validation messages when using our LSP
+  alongside existing validation tools like `graphql-eslint`, and this allows
+  them to disable the LSP feature in that case.
 
 ## 2.7.21
 
 ### Patch Changes
 
-- [#2378](https://github.com/graphql/graphiql/pull/2378) [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2) Thanks [@acao](https://github.com/acao)! - Trap all graphql parsing exceptions from (relatively) newly added logic. This should clear up bugs that have been plaguing users for two years now, sorry!
+- [#2378](https://github.com/graphql/graphiql/pull/2378)
+  [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)
+  Thanks [@acao](https://github.com/acao)! - Trap all graphql parsing exceptions
+  from (relatively) newly added logic. This should clear up bugs that have been
+  plaguing users for two years now, sorry!
 
-- Updated dependencies [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - graphql-language-service@5.0.4
 
 ## 2.7.20
 
 ### Patch Changes
 
-- Updated dependencies [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
+- Updated dependencies
+  [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
   - graphql-language-service@5.0.3
 
 ## 2.7.19
 
 ### Patch Changes
 
-- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f) Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to latest in server
-  - remove `graphql-config` dependency from `vscode-graphql` and `graphql-language-service`
-  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql` [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild` version
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)
+  Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to
+  latest in server
+  - remove `graphql-config` dependency from `vscode-graphql` and
+    `graphql-language-service`
+  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql`
+    [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild`
+    version
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service@5.0.2
 
 ## 2.7.18
 
 ### Patch Changes
 
-- [#2271](https://github.com/graphql/graphiql/pull/2271) [`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae) Thanks [@acao](https://github.com/acao)! - a few bugfixes related to config handling impacting vim and potentially other LSP server users
+- [#2271](https://github.com/graphql/graphiql/pull/2271)
+  [`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae)
+  Thanks [@acao](https://github.com/acao)! - a few bugfixes related to config
+  handling impacting vim and potentially other LSP server users
 
 ## 2.7.17
 
 ### Patch Changes
 
-- Updated dependencies [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa), [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
+- Updated dependencies
+  [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa),
+  [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
   - graphql-language-service@5.0.1
 
 ## 2.7.16
 
 ### Patch Changes
 
-- Updated dependencies [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
+- Updated dependencies
+  [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
   - graphql-language-service@5.0.0
 
 ## 2.7.15
 
 ### Patch Changes
 
-- [#2214](https://github.com/graphql/graphiql/pull/2214) [`ab83198f`](https://github.com/graphql/graphiql/commit/ab83198fa8b3c5453d3733982ee9ca8a2d6bca7a) Thanks [@Cellule](https://github.com/Cellule)! - Fixed Windows fileUri when resolving type definition location
+- [#2214](https://github.com/graphql/graphiql/pull/2214)
+  [`ab83198f`](https://github.com/graphql/graphiql/commit/ab83198fa8b3c5453d3733982ee9ca8a2d6bca7a)
+  Thanks [@Cellule](https://github.com/Cellule)! - Fixed Windows fileUri when
+  resolving type definition location
 
 ## 2.7.14
 
 ### Patch Changes
 
-- [#2161](https://github.com/graphql/graphiql/pull/2161) [`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f) Thanks [@orta](https://github.com/orta)! - Do not log errors when a JS/TS file has no embedded graphql tags
+- [#2161](https://github.com/graphql/graphiql/pull/2161)
+  [`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f)
+  Thanks [@orta](https://github.com/orta)! - Do not log errors when a JS/TS file
+  has no embedded graphql tags
 
-* [#2176](https://github.com/graphql/graphiql/pull/2176) [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c) Thanks [@orta](https://github.com/orta)! - Update babel parser in the graphql language server
+* [#2176](https://github.com/graphql/graphiql/pull/2176)
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c)
+  Thanks [@orta](https://github.com/orta)! - Update babel parser in the graphql
+  language server
 
-- [#2175](https://github.com/graphql/graphiql/pull/2175) [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5) Thanks [@orta](https://github.com/orta)! - Better handling of unparsable babel JS/TS files
+- [#2175](https://github.com/graphql/graphiql/pull/2175)
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)
+  Thanks [@orta](https://github.com/orta)! - Better handling of unparsable babel
+  JS/TS files
 
-- Updated dependencies [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f), [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c), [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
+- Updated dependencies
+  [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f),
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c),
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
   - graphql-language-service@4.1.5
 
 ## 2.7.13
 
 ### Patch Changes
 
-- [#2111](https://github.com/graphql/graphiql/pull/2111) [`08ff6dce`](https://github.com/graphql/graphiql/commit/08ff6dce0625f7ab58a45364aed9ca04c7862fa7) Thanks [@acao](https://github.com/acao)! - Support template literals and tagged template literals with replacement expressions
+- [#2111](https://github.com/graphql/graphiql/pull/2111)
+  [`08ff6dce`](https://github.com/graphql/graphiql/commit/08ff6dce0625f7ab58a45364aed9ca04c7862fa7)
+  Thanks [@acao](https://github.com/acao)! - Support template literals and
+  tagged template literals with replacement expressions
 
 - Updated dependencies []:
   - graphql-language-service@4.1.4
@@ -298,23 +491,29 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
+- Updated dependencies
+  [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
   - graphql-language-service@4.1.3
 
 ## 2.7.11
 
 ### Patch Changes
 
-- Updated dependencies [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
+- Updated dependencies
+  [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
   - graphql-language-service@4.1.2
 
 ## 2.7.10
 
 ### Patch Changes
 
-- [#2091](https://github.com/graphql/graphiql/pull/2091) [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63) Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues. Should now build & test interchangeably.
+- [#2091](https://github.com/graphql/graphiql/pull/2091)
+  [`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)
+  Thanks [@acao](https://github.com/acao)! - Fix graphql 15 related issues.
+  Should now build & test interchangeably.
 
-- Updated dependencies [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
+- Updated dependencies
+  [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
   - graphql-language-service-utils@2.7.1
   - graphql-language-service@4.1.1
 
@@ -322,14 +521,16 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
+- Updated dependencies
+  [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
   - graphql-language-service@4.1.0
 
 ## 2.7.8
 
 ### Patch Changes
 
-- Updated dependencies [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
+- Updated dependencies
+  [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
   - graphql-language-service-utils@2.7.0
   - graphql-language-service@4.0.0
 
@@ -337,40 +538,62 @@
 
 ### Patch Changes
 
-- [`c4236190`](https://github.com/graphql/graphiql/commit/c4236190f91adedaf4f4a54cd0400a6b42c3c407) [#2072](https://github.com/graphql/graphiql/pull/2072) Thanks [@acao](https://github.com/acao)! - this fixes the parsing of file URIs by `graphql-language-service-server` in cases such as:
+- [`c4236190`](https://github.com/graphql/graphiql/commit/c4236190f91adedaf4f4a54cd0400a6b42c3c407)
+  [#2072](https://github.com/graphql/graphiql/pull/2072) Thanks
+  [@acao](https://github.com/acao)! - this fixes the parsing of file URIs by
+  `graphql-language-service-server` in cases such as:
 
   - windows without WSL
   - special characters in filenames
   - likely other cases
 
-  previously we were using the old approach of `URL(uri).pathname` which was not working! now using the standard `vscode-uri` approach of `URI.parse(uri).fsName`.
+  previously we were using the old approach of `URL(uri).pathname` which was not
+  working! now using the standard `vscode-uri` approach of
+  `URI.parse(uri).fsName`.
 
-  this should fix issues with object and fragment type completion as well I think
+  this should fix issues with object and fragment type completion as well I
+  think
 
-  also for #2066 made it so that graphql config is not loaded into the file cache unnecessarily, and that it's only loaded on editor save events rather than on file changed events
+  also for #2066 made it so that graphql config is not loaded into the file
+  cache unnecessarily, and that it's only loaded on editor save events rather
+  than on file changed events
 
   fixes #1644 and #2066
 
-* [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1) [#2065](https://github.com/graphql/graphiql/pull/2065) Thanks [@acao](https://github.com/acao)! - Add an opt-in feature to generate markdown in hover elements, starting with highlighting type information. Enabled for the language server and also the language service and thus `monaco-graphql` as well.
+* [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)
+  [#2065](https://github.com/graphql/graphiql/pull/2065) Thanks
+  [@acao](https://github.com/acao)! - Add an opt-in feature to generate markdown
+  in hover elements, starting with highlighting type information. Enabled for
+  the language server and also the language service and thus `monaco-graphql` as
+  well.
 
-* Updated dependencies [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+* Updated dependencies
+  [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service@3.2.5
 
 ## 2.7.6
 
 ### Patch Changes
 
-- [`4286185c`](https://github.com/graphql/graphiql/commit/4286185cdc6119175e23d66b8e177ba32693a63a) [#2060](https://github.com/graphql/graphiql/pull/2060) Thanks [@acao](https://github.com/acao)! - Parse more JS extensions in the language server
+- [`4286185c`](https://github.com/graphql/graphiql/commit/4286185cdc6119175e23d66b8e177ba32693a63a)
+  [#2060](https://github.com/graphql/graphiql/pull/2060) Thanks
+  [@acao](https://github.com/acao)! - Parse more JS extensions in the language
+  server
 
 ## 2.7.5
 
 ### Patch Changes
 
-- [`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063) [#2055](https://github.com/graphql/graphiql/pull/2055) Thanks [@acao](https://github.com/acao)! - this fixes the URI scheme related bugs and make sure schema as sdl config works again.
+- [`f82bd7a9`](https://github.com/graphql/graphiql/commit/f82bd7a931eb5fa9a33e59d417303706844c9063)
+  [#2055](https://github.com/graphql/graphiql/pull/2055) Thanks
+  [@acao](https://github.com/acao)! - this fixes the URI scheme related bugs and
+  make sure schema as sdl config works again.
 
-  `fileURLToPath` had been introduced by a contributor and I didn't test properly, it broke sdl file loading!
+  `fileURLToPath` had been introduced by a contributor and I didn't test
+  properly, it broke sdl file loading!
 
-  definitions, autocomplete, diagnostics, etc should work again also hides the more verbose logging output for now
+  definitions, autocomplete, diagnostics, etc should work again also hides the
+  more verbose logging output for now
 
 - Updated dependencies []:
   - graphql-language-service@3.2.4
@@ -380,9 +603,14 @@
 
 ### Patch Changes
 
-- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf) [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks [@willstott101](https://github.com/willstott101)! - Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.
+- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)
+  [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks
+  [@willstott101](https://github.com/willstott101)! - Source code included in
+  all packages to fix source maps. codemirror-graphql includes esm build in
+  package.
 
-- Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
+- Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
   - graphql-language-service@3.2.3
   - graphql-language-service-utils@2.6.2
 
@@ -390,9 +618,13 @@
 
 ### Patch Changes
 
-- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
-- Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+- Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - graphql-language-service@3.2.2
   - graphql-language-service-utils@2.6.1
 
@@ -400,15 +632,23 @@
 
 ### Patch Changes
 
-- [`7e98c6ff`](https://github.com/graphql/graphiql/commit/7e98c6fff3b1c62954c9c8d902ac64ddbf23fc5d) Thanks [@acao](https://github.com/acao)! - upgrade graphql-language-service-server to use graphql-config 4.1.0! adds support for .ts and .toml config files in the language server, amongst many other improvements!
+- [`7e98c6ff`](https://github.com/graphql/graphiql/commit/7e98c6fff3b1c62954c9c8d902ac64ddbf23fc5d)
+  Thanks [@acao](https://github.com/acao)! - upgrade
+  graphql-language-service-server to use graphql-config 4.1.0! adds support for
+  .ts and .toml config files in the language server, amongst many other
+  improvements!
 
 ## 2.7.1
 
 ### Patch Changes
 
-- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce) [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks [@PabloSzx](https://github.com/PabloSzx)! - Update utils
+- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)
+  [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks
+  [@PabloSzx](https://github.com/PabloSzx)! - Update utils
 
-- Updated dependencies [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce), [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
+- Updated dependencies
+  [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce),
+  [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
   - graphql-language-service-utils@2.6.0
   - graphql-language-service@3.2.1
 
@@ -416,40 +656,63 @@
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - graphql-language-service@3.2.0
 
 ## 2.6.5
 
 ### Patch Changes
 
-- [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8) [#1964](https://github.com/graphql/graphiql/pull/1964) Thanks [@patrickszmucer](https://github.com/patrickszmucer)! - Fix unknown fragment errors on save
+- [`83c4a007`](https://github.com/graphql/graphiql/commit/83c4a0070a4df704ce874ec977d65ca6c7e43ee8)
+  [#1964](https://github.com/graphql/graphiql/pull/1964) Thanks
+  [@patrickszmucer](https://github.com/patrickszmucer)! - Fix unknown fragment
+  errors on save
 
-* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-* Updated dependencies [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb), [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+* Updated dependencies
+  [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb),
+  [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service@3.1.6
 
 ## 2.6.4
 
 ### Patch Changes
 
-- [`72bff0e7`](https://github.com/graphql/graphiql/commit/72bff0e7db46fb53293efc990dc64d2c06401459) [#1951](https://github.com/graphql/graphiql/pull/1951) Thanks [@GoodForOneFare](https://github.com/GoodForOneFare)! - fix: skip config updates when no custom filename is defined
+- [`72bff0e7`](https://github.com/graphql/graphiql/commit/72bff0e7db46fb53293efc990dc64d2c06401459)
+  [#1951](https://github.com/graphql/graphiql/pull/1951) Thanks
+  [@GoodForOneFare](https://github.com/GoodForOneFare)! - fix: skip config
+  updates when no custom filename is defined
 
-* [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb) [#1941](https://github.com/graphql/graphiql/pull/1941) Thanks [@arcanis](https://github.com/arcanis)! - Adds support for `#graphql` and `/* GraphQL */` in the language server
+* [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)
+  [#1941](https://github.com/graphql/graphiql/pull/1941) Thanks
+  [@arcanis](https://github.com/arcanis)! - Adds support for `#graphql` and
+  `/* GraphQL */` in the language server
 
-* Updated dependencies [[`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
+* Updated dependencies
+  [[`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
   - graphql-language-service@3.1.5
 
 ## 2.6.3
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## [2.6.2](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.6.1...graphql-language-service-server@2.6.2) (2021-01-07)
 
@@ -463,7 +726,10 @@
 
 ### Features
 
-- implied or external fragments, for [#612](https://github.com/graphql/graphiql/issues/612) ([#1750](https://github.com/graphql/graphiql/issues/1750)) ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
+- implied or external fragments, for
+  [#612](https://github.com/graphql/graphiql/issues/612)
+  ([#1750](https://github.com/graphql/graphiql/issues/1750))
+  ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
 
 ## [2.5.9](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.8...graphql-language-service-server@2.5.9) (2021-01-03)
 
@@ -481,8 +747,12 @@
 
 ### Bug Fixes
 
-- crash on receiving an LSP message in "stream" mode ([1238075](https://github.com/graphql/graphiql/commit/1238075c5bbd18b09f493c0018da5e4b24e8e615)), closes [#1708](https://github.com/graphql/graphiql/issues/1708)
-- languageserver filepath on Windows ([#1715](https://github.com/graphql/graphiql/issues/1715)) ([d2feff9](https://github.com/graphql/graphiql/commit/d2feff92aba979fb52fd0e5846776be223fbf11e))
+- crash on receiving an LSP message in "stream" mode
+  ([1238075](https://github.com/graphql/graphiql/commit/1238075c5bbd18b09f493c0018da5e4b24e8e615)),
+  closes [#1708](https://github.com/graphql/graphiql/issues/1708)
+- languageserver filepath on Windows
+  ([#1715](https://github.com/graphql/graphiql/issues/1715))
+  ([d2feff9](https://github.com/graphql/graphiql/commit/d2feff92aba979fb52fd0e5846776be223fbf11e))
 
 ## [2.5.5](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.4...graphql-language-service-server@2.5.5) (2020-10-20)
 
@@ -492,7 +762,9 @@
 
 ### Bug Fixes
 
-- useSchemaFileDefinitions, cleanup ([#1674](https://github.com/graphql/graphiql/issues/1674)) ([3673455](https://github.com/graphql/graphiql/commit/36734557e2874384adbfe86b64aeaa93e06df53f))
+- useSchemaFileDefinitions, cleanup
+  ([#1674](https://github.com/graphql/graphiql/issues/1674))
+  ([3673455](https://github.com/graphql/graphiql/commit/36734557e2874384adbfe86b64aeaa93e06df53f))
 
 ## [2.5.3](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.2...graphql-language-service-server@2.5.3) (2020-09-23)
 
@@ -502,13 +774,17 @@
 
 ### Bug Fixes
 
-- re-introduce allowed extensions ([#1668](https://github.com/graphql/graphiql/issues/1668)) ([eedd575](https://github.com/graphql/graphiql/commit/eedd5753751857bd5837dd8be8602bf7fadb5517))
+- re-introduce allowed extensions
+  ([#1668](https://github.com/graphql/graphiql/issues/1668))
+  ([eedd575](https://github.com/graphql/graphiql/commit/eedd5753751857bd5837dd8be8602bf7fadb5517))
 
 ## [2.5.1](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.0...graphql-language-service-server@2.5.1) (2020-09-20)
 
 ### Bug Fixes
 
-- better error handling when the config isn't present ([#1667](https://github.com/graphql/graphiql/issues/1667)) ([f414300](https://github.com/graphql/graphiql/commit/f4143008f93a8849dfa4caae948d2eceb299a141))
+- better error handling when the config isn't present
+  ([#1667](https://github.com/graphql/graphiql/issues/1667))
+  ([f414300](https://github.com/graphql/graphiql/commit/f4143008f93a8849dfa4caae948d2eceb299a141))
 
 ## [2.5.0](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.0-alpha.5...graphql-language-service-server@2.5.0) (2020-09-18)
 
@@ -522,7 +798,9 @@
 
 ### Features
 
-- custom config baseDir, embedded fragment def offsets ([#1651](https://github.com/graphql/graphiql/issues/1651)) ([e8dc958](https://github.com/graphql/graphiql/commit/e8dc958b46544022fe58b498ca5eef572f54afe0))
+- custom config baseDir, embedded fragment def offsets
+  ([#1651](https://github.com/graphql/graphiql/issues/1651))
+  ([e8dc958](https://github.com/graphql/graphiql/commit/e8dc958b46544022fe58b498ca5eef572f54afe0))
 
 ## [2.5.0-alpha.3](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.5.0-alpha.2...graphql-language-service-server@2.5.0-alpha.3) (2020-08-22)
 
@@ -536,17 +814,23 @@
 
 ### Bug Fixes
 
-- recursively write tmp directories, write schema async ([#1641](https://github.com/graphql/graphiql/issues/1641)) ([cd0061e](https://github.com/graphql/graphiql/commit/cd0061e1abe47f5f4075d52a6c1e4157cbd0a95a))
+- recursively write tmp directories, write schema async
+  ([#1641](https://github.com/graphql/graphiql/issues/1641))
+  ([cd0061e](https://github.com/graphql/graphiql/commit/cd0061e1abe47f5f4075d52a6c1e4157cbd0a95a))
 
 ## [2.5.0-alpha.0](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.1...graphql-language-service-server@2.5.0-alpha.0) (2020-08-10)
 
 ### Bug Fixes
 
-- pre-caching schema bugs, new server config options ([#1636](https://github.com/graphql/graphiql/issues/1636)) ([d989456](https://github.com/graphql/graphiql/commit/d9894564c056134e15093956e0951dcefe061d76))
+- pre-caching schema bugs, new server config options
+  ([#1636](https://github.com/graphql/graphiql/issues/1636))
+  ([d989456](https://github.com/graphql/graphiql/commit/d9894564c056134e15093956e0951dcefe061d76))
 
 ### Features
 
-- graphql-config@3 support in lsp server ([#1616](https://github.com/graphql/graphiql/issues/1616)) ([27cd185](https://github.com/graphql/graphiql/commit/27cd18562b64dfe18e6343b6a49f3f606af89d86))
+- graphql-config@3 support in lsp server
+  ([#1616](https://github.com/graphql/graphiql/issues/1616))
+  ([27cd185](https://github.com/graphql/graphiql/commit/27cd18562b64dfe18e6343b6a49f3f606af89d86))
 
 ## [2.4.1](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.0...graphql-language-service-server@2.4.1) (2020-08-06)
 
@@ -564,7 +848,8 @@
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
 
 ## [2.4.0-alpha.10](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.0-alpha.9...graphql-language-service-server@2.4.0-alpha.10) (2020-05-28)
 
@@ -578,12 +863,18 @@
 
 ### Bug Fixes
 
-- remove problematic file resolution module from webpack sco… ([#1489](https://github.com/graphql/graphiql/issues/1489)) ([8dab038](https://github.com/graphql/graphiql/commit/8dab0385772f443f73b559e2c668080733168236))
-- repair CLI, handle all schema and LSP errors ([#1482](https://github.com/graphql/graphiql/issues/1482)) ([992f384](https://github.com/graphql/graphiql/commit/992f38494f20f5877bfd6ff54893854ac7a0eaa2))
+- remove problematic file resolution module from webpack sco…
+  ([#1489](https://github.com/graphql/graphiql/issues/1489))
+  ([8dab038](https://github.com/graphql/graphiql/commit/8dab0385772f443f73b559e2c668080733168236))
+- repair CLI, handle all schema and LSP errors
+  ([#1482](https://github.com/graphql/graphiql/issues/1482))
+  ([992f384](https://github.com/graphql/graphiql/commit/992f38494f20f5877bfd6ff54893854ac7a0eaa2))
 
 ### Features
 
-- Monaco Mode - Phase 2 - Mode & Worker ([#1459](https://github.com/graphql/graphiql/issues/1459)) ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
+- Monaco Mode - Phase 2 - Mode & Worker
+  ([#1459](https://github.com/graphql/graphiql/issues/1459))
+  ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
 
 ## [2.4.0-alpha.7](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.0-alpha.6...graphql-language-service-server@2.4.0-alpha.7) (2020-04-10)
 
@@ -597,17 +888,24 @@
 
 ### Features
 
-- upgrade to graphql@15.0.0 for [#1191](https://github.com/graphql/graphiql/issues/1191) ([#1204](https://github.com/graphql/graphiql/issues/1204)) ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
+- upgrade to graphql@15.0.0 for
+  [#1191](https://github.com/graphql/graphiql/issues/1191)
+  ([#1204](https://github.com/graphql/graphiql/issues/1204))
+  ([f13c8e9](https://github.com/graphql/graphiql/commit/f13c8e9d0e66df4b051b332c7d02f4bb83e07ffd))
 
 ## [2.4.0-alpha.4](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.0-alpha.3...graphql-language-service-server@2.4.0-alpha.4) (2020-04-03)
 
 ### Bug Fixes
 
-- make sure that custom parser is used if passed to process ([#1438](https://github.com/graphql/graphiql/issues/1438)) ([5e098a4](https://github.com/graphql/graphiql/commit/5e098a4a80a8e1cff4541ad34363ab2001fcda4a))
+- make sure that custom parser is used if passed to process
+  ([#1438](https://github.com/graphql/graphiql/issues/1438))
+  ([5e098a4](https://github.com/graphql/graphiql/commit/5e098a4a80a8e1cff4541ad34363ab2001fcda4a))
 
 ### Features
 
-- make sure @ triggers directive completion automatically ([#1441](https://github.com/graphql/graphiql/issues/1441)) ([935220a](https://github.com/graphql/graphiql/commit/935220a68641b94af2598840b0ced3fd945f86dd))
+- make sure @ triggers directive completion automatically
+  ([#1441](https://github.com/graphql/graphiql/issues/1441))
+  ([935220a](https://github.com/graphql/graphiql/commit/935220a68641b94af2598840b0ced3fd945f86dd))
 
 ## [2.4.0-alpha.3](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.4.0-alpha.2...graphql-language-service-server@2.4.0-alpha.3) (2020-03-20)
 
@@ -617,41 +915,67 @@
 
 ### Bug Fixes
 
-- eslint warnings ([#1360](https://github.com/graphql/graphiql/issues/1360)) ([84d4821](https://github.com/graphql/graphiql/commit/84d4821ee19030314666a46f11a4b69ffaddca45))
-- initial request cache set, import tsc bugs ([#1266](https://github.com/graphql/graphiql/issues/1266)) ([6b98f8a](https://github.com/graphql/graphiql/commit/6b98f8a442d4a8ea160fb90a29acf33f5382db2e))
-- restore error handling for server [#1306](https://github.com/graphql/graphiql/issues/1306) ([#1425](https://github.com/graphql/graphiql/issues/1425)) ([c12d975](https://github.com/graphql/graphiql/commit/c12d975027e4021bbea7ad54e7e0c19ac7943e6c))
-- type check ([#1374](https://github.com/graphql/graphiql/issues/1374)) ([84cc41e](https://github.com/graphql/graphiql/commit/84cc41ef1c5b56d26929edd9669c766cdf3628e8))
-- typo to fix hover ([#1426](https://github.com/graphql/graphiql/issues/1426)) ([1fdcb28](https://github.com/graphql/graphiql/commit/1fdcb28689bf85a31af10cbdc4648c5ed3013672))
+- eslint warnings ([#1360](https://github.com/graphql/graphiql/issues/1360))
+  ([84d4821](https://github.com/graphql/graphiql/commit/84d4821ee19030314666a46f11a4b69ffaddca45))
+- initial request cache set, import tsc bugs
+  ([#1266](https://github.com/graphql/graphiql/issues/1266))
+  ([6b98f8a](https://github.com/graphql/graphiql/commit/6b98f8a442d4a8ea160fb90a29acf33f5382db2e))
+- restore error handling for server
+  [#1306](https://github.com/graphql/graphiql/issues/1306)
+  ([#1425](https://github.com/graphql/graphiql/issues/1425))
+  ([c12d975](https://github.com/graphql/graphiql/commit/c12d975027e4021bbea7ad54e7e0c19ac7943e6c))
+- type check ([#1374](https://github.com/graphql/graphiql/issues/1374))
+  ([84cc41e](https://github.com/graphql/graphiql/commit/84cc41ef1c5b56d26929edd9669c766cdf3628e8))
+- typo to fix hover ([#1426](https://github.com/graphql/graphiql/issues/1426))
+  ([1fdcb28](https://github.com/graphql/graphiql/commit/1fdcb28689bf85a31af10cbdc4648c5ed3013672))
 
 ### Features
 
-- optionally provide LSP an instantiated GraphQLConfig ([#1432](https://github.com/graphql/graphiql/issues/1432)) ([012db2a](https://github.com/graphql/graphiql/commit/012db2a39bfcddde63ffd2e93dae0c158f8e73ed))
-- typescript, tsx, jsx support for LSP server using babel ([#1427](https://github.com/graphql/graphiql/issues/1427)) ([ee06123](https://github.com/graphql/graphiql/commit/ee061235489c8f5ed27c116c09b606e371ee40c5))
-- **graphql-config:** add graphql config extensions ([#1118](https://github.com/graphql/graphiql/issues/1118)) ([2a77e47](https://github.com/graphql/graphiql/commit/2a77e47719ec9181a00183a08ffa11287b8fd2f5))
-- Symbol support for single document ([#1244](https://github.com/graphql/graphiql/issues/1244)) ([f729f9a](https://github.com/graphql/graphiql/commit/f729f9a3c20362f4515bf3037347a07cc3690b38))
-- use new GraphQL Config ([#1342](https://github.com/graphql/graphiql/issues/1342)) ([e45838f](https://github.com/graphql/graphiql/commit/e45838f5ba579e05b20f1a147ce431478ffad9aa))
+- optionally provide LSP an instantiated GraphQLConfig
+  ([#1432](https://github.com/graphql/graphiql/issues/1432))
+  ([012db2a](https://github.com/graphql/graphiql/commit/012db2a39bfcddde63ffd2e93dae0c158f8e73ed))
+- typescript, tsx, jsx support for LSP server using babel
+  ([#1427](https://github.com/graphql/graphiql/issues/1427))
+  ([ee06123](https://github.com/graphql/graphiql/commit/ee061235489c8f5ed27c116c09b606e371ee40c5))
+- **graphql-config:** add graphql config extensions
+  ([#1118](https://github.com/graphql/graphiql/issues/1118))
+  ([2a77e47](https://github.com/graphql/graphiql/commit/2a77e47719ec9181a00183a08ffa11287b8fd2f5))
+- Symbol support for single document
+  ([#1244](https://github.com/graphql/graphiql/issues/1244))
+  ([f729f9a](https://github.com/graphql/graphiql/commit/f729f9a3c20362f4515bf3037347a07cc3690b38))
+- use new GraphQL Config
+  ([#1342](https://github.com/graphql/graphiql/issues/1342))
+  ([e45838f](https://github.com/graphql/graphiql/commit/e45838f5ba579e05b20f1a147ce431478ffad9aa))
 
 ## [2.4.0-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.3...graphql-language-service-server@2.4.0-alpha.1) (2020-01-18)
 
 ### Bug Fixes
 
-- linting issues, trailingCommas: all ([#1099](https://github.com/graphql/graphiql/issues/1099)) ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
+- linting issues, trailingCommas: all
+  ([#1099](https://github.com/graphql/graphiql/issues/1099))
+  ([de4005b](https://github.com/graphql/graphiql/commit/de4005b))
 
 ### Features
 
-- convert LSP Server to Typescript, remove watchman ([#1138](https://github.com/graphql/graphiql/issues/1138)) ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
+- convert LSP Server to Typescript, remove watchman
+  ([#1138](https://github.com/graphql/graphiql/issues/1138))
+  ([8e33dbb](https://github.com/graphql/graphiql/commit/8e33dbb))
 
 ## [2.3.3](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.2...graphql-language-service-server@2.3.3) (2019-12-09)
 
 ### Bug Fixes
 
-- a few more tweaks to babel ignore ([e0ad2c6](https://github.com/graphql/graphiql/commit/e0ad2c6))
+- a few more tweaks to babel ignore
+  ([e0ad2c6](https://github.com/graphql/graphiql/commit/e0ad2c6))
 
 ## [2.3.2](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.1...graphql-language-service-server@2.3.2) (2019-12-03)
 
 ### Bug Fixes
 
-- convert browserify build to webpack, fixes [#976](https://github.com/graphql/graphiql/issues/976) ([#1001](https://github.com/graphql/graphiql/issues/1001)) ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
+- convert browserify build to webpack, fixes
+  [#976](https://github.com/graphql/graphiql/issues/976)
+  ([#1001](https://github.com/graphql/graphiql/issues/1001))
+  ([3caf041](https://github.com/graphql/graphiql/commit/3caf041))
 
 ## [2.3.1](https://github.com/graphql/graphiql/compare/graphql-language-service-server@2.3.0...graphql-language-service-server@2.3.1) (2019-11-26)
 
@@ -661,7 +985,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 0.0.1 (2017-03-29)
 
@@ -669,7 +996,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 0.0.1 (2017-03-29)
 
@@ -677,7 +1007,10 @@
 
 ### Features
 
-- convert LSP from flow to typescript ([#957](https://github.com/graphql/graphiql/issues/957)) [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie) ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
+- convert LSP from flow to typescript
+  ([#957](https://github.com/graphql/graphiql/issues/957))
+  [@acao](https://github.com/acao) @Neitsch [@benjie](https://github.com/benjie)
+  ([36ed669](https://github.com/graphql/graphiql/commit/36ed669))
 
 ## 0.0.1 (2017-03-29)
 

--- a/packages/graphql-language-service/CHANGELOG.md
+++ b/packages/graphql-language-service/CHANGELOG.md
@@ -4,126 +4,214 @@
 
 ### Patch Changes
 
-- [#2986](https://github.com/graphql/graphiql/pull/2986) [`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c) Thanks [@bboure](https://github.com/bboure)! - Fix JSON schema for custom scalars validation
+- [#2986](https://github.com/graphql/graphiql/pull/2986)
+  [`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c)
+  Thanks [@bboure](https://github.com/bboure)! - Fix JSON schema for custom
+  scalars validation
 
-- [#2917](https://github.com/graphql/graphiql/pull/2917) [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b) Thanks [@woodensail](https://github.com/woodensail)! - Fix infinite recursiveness in getVariablesJSONSchema when the schema contains types that reference themselves
+- [#2917](https://github.com/graphql/graphiql/pull/2917)
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b)
+  Thanks [@woodensail](https://github.com/woodensail)! - Fix infinite
+  recursiveness in getVariablesJSONSchema when the schema contains types that
+  reference themselves
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- [#2962](https://github.com/graphql/graphiql/pull/2962) [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d) Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add `--max-warnings=0` and `--cache` flags
+- [#2962](https://github.com/graphql/graphiql/pull/2962)
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - clean all ESLint warnings, add
+  `--max-warnings=0` and `--cache` flags
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
 ## 5.1.1
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2941](https://github.com/graphql/graphiql/pull/2941) [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-logical-operator-over-ternary` rule
+- [#2941](https://github.com/graphql/graphiql/pull/2941)
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-logical-operator-over-ternary` rule
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2930](https://github.com/graphql/graphiql/pull/2930) [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9) Thanks [@B2o5T](https://github.com/B2o5T)! - remove `mapCat()` in favor of `Array#flatMap()`
+- [#2930](https://github.com/graphql/graphiql/pull/2930)
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - remove `mapCat()` in favor of
+  `Array#flatMap()`
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2936](https://github.com/graphql/graphiql/pull/2936) [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `lonely-if`/`unicorn/lonely-if` rules
+- [#2936](https://github.com/graphql/graphiql/pull/2936)
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `lonely-if`/`unicorn/lonely-if` rules
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
-- [#2938](https://github.com/graphql/graphiql/pull/2938) [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error` rule
+- [#2938](https://github.com/graphql/graphiql/pull/2938)
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error`
+  rule
 
 ## 5.1.0
 
 ### Minor Changes
 
-- [#2654](https://github.com/graphql/graphiql/pull/2654) [`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782) Thanks [@cshaver](https://github.com/cshaver)! - Provide autocomplete suggestions for documents with type definitions
+- [#2654](https://github.com/graphql/graphiql/pull/2654)
+  [`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)
+  Thanks [@cshaver](https://github.com/cshaver)! - Provide autocomplete
+  suggestions for documents with type definitions
 
 ## 5.0.6
 
 ### Patch Changes
 
-- [#2506](https://github.com/graphql/graphiql/pull/2506) [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c) Thanks [@acao](https://github.com/acao)! - Remove redundant check, trigger LSP release
+- [#2506](https://github.com/graphql/graphiql/pull/2506)
+  [`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)
+  Thanks [@acao](https://github.com/acao)! - Remove redundant check, trigger LSP
+  release
 
 ## 5.0.5
 
 ### Patch Changes
 
-- [#2486](https://github.com/graphql/graphiql/pull/2486) [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa) Thanks [@stonexer](https://github.com/stonexer)! - definition support for operation fields ✨
+- [#2486](https://github.com/graphql/graphiql/pull/2486)
+  [`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)
+  Thanks [@stonexer](https://github.com/stonexer)! - definition support for
+  operation fields ✨
 
-  you can now jump to the applicable object type definition for query/mutation/subscription fields!
+  you can now jump to the applicable object type definition for
+  query/mutation/subscription fields!
 
 ## 5.0.4
 
 ### Patch Changes
 
-- [#2378](https://github.com/graphql/graphiql/pull/2378) [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2) Thanks [@acao](https://github.com/acao)! - Trap all graphql parsing exceptions from (relatively) newly added logic. This should clear up bugs that have been plaguing users for two years now, sorry!
+- [#2378](https://github.com/graphql/graphiql/pull/2378)
+  [`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)
+  Thanks [@acao](https://github.com/acao)! - Trap all graphql parsing exceptions
+  from (relatively) newly added logic. This should clear up bugs that have been
+  plaguing users for two years now, sorry!
 
 ## 5.0.3
 
 ### Patch Changes
 
-- [#2291](https://github.com/graphql/graphiql/pull/2291) [`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902) Thanks [@retrodaredevil](https://github.com/retrodaredevil)! - Target es6 for the languages services
+- [#2291](https://github.com/graphql/graphiql/pull/2291)
+  [`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)
+  Thanks [@retrodaredevil](https://github.com/retrodaredevil)! - Target es6 for
+  the languages services
 
 ## 5.0.2
 
 ### Patch Changes
 
-- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f) Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to latest in server
-  - remove `graphql-config` dependency from `vscode-graphql` and `graphql-language-service`
-  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql` [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild` version
+- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)
+  Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to
+  latest in server
+  - remove `graphql-config` dependency from `vscode-graphql` and
+    `graphql-language-service`
+  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql`
+    [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild`
+    version
 
 ## 5.0.1
 
 ### Patch Changes
 
-- [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa) Thanks [@acao](https://github.com/acao)! - fix lockfile and imports from LSP merge
+- [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)
+  Thanks [@acao](https://github.com/acao)! - fix lockfile and imports from LSP
+  merge
 
-* [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa) Thanks [@acao](https://github.com/acao)! - default to es6 target across the language services, fix #2240
+* [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)
+  Thanks [@acao](https://github.com/acao)! - default to es6 target across the
+  language services, fix #2240
 
 ## 5.0.0
 
 ### Major Changes
 
-- [#2209](https://github.com/graphql/graphiql/pull/2209) [`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958) Thanks [@acao](https://github.com/acao)! - Retire parser, interface, utils and types packages, combine with graphql-language-service
+- [#2209](https://github.com/graphql/graphiql/pull/2209)
+  [`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)
+  Thanks [@acao](https://github.com/acao)! - Retire parser, interface, utils and
+  types packages, combine with graphql-language-service
 
 ## 4.1.5
 
 ### Patch Changes
 
-- [#2161](https://github.com/graphql/graphiql/pull/2161) [`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f) Thanks [@orta](https://github.com/orta)! - Do not log errors when a JS/TS file has no embedded graphql tags
+- [#2161](https://github.com/graphql/graphiql/pull/2161)
+  [`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f)
+  Thanks [@orta](https://github.com/orta)! - Do not log errors when a JS/TS file
+  has no embedded graphql tags
 
-* [#2176](https://github.com/graphql/graphiql/pull/2176) [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c) Thanks [@orta](https://github.com/orta)! - Update babel parser in the graphql language server
+* [#2176](https://github.com/graphql/graphiql/pull/2176)
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c)
+  Thanks [@orta](https://github.com/orta)! - Update babel parser in the graphql
+  language server
 
-- [#2175](https://github.com/graphql/graphiql/pull/2175) [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5) Thanks [@orta](https://github.com/orta)! - Better handling of unparsable babel JS/TS files
+- [#2175](https://github.com/graphql/graphiql/pull/2175)
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)
+  Thanks [@orta](https://github.com/orta)! - Better handling of unparsable babel
+  JS/TS files
 
 ## 4.1.4
 
 ### Patch Changes
 
-- Updated dependencies [[`d5fca9db`](https://github.com/graphql/graphiql/commit/d5fca9db067927446087717b84e0b2a3ff94bbe9)]:
+- Updated dependencies
+  [[`d5fca9db`](https://github.com/graphql/graphiql/commit/d5fca9db067927446087717b84e0b2a3ff94bbe9)]:
   - graphql-language-service-interface@2.10.2
 
 ## 4.1.3
 
 ### Patch Changes
 
-- [#2103](https://github.com/graphql/graphiql/pull/2103) [`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8) Thanks [@acao](https://github.com/acao)! - LanguageService should not be imported by `codemirror-graphql`, and thus `picomatch` should not be imported.
+- [#2103](https://github.com/graphql/graphiql/pull/2103)
+  [`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)
+  Thanks [@acao](https://github.com/acao)! - LanguageService should not be
+  imported by `codemirror-graphql`, and thus `picomatch` should not be imported.
 
 ## 4.1.2
 
 ### Patch Changes
 
-- [#2101](https://github.com/graphql/graphiql/pull/2101) [`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0) Thanks [@acao](https://github.com/acao)! - Fix picomatch bug by using a browser compatible fork
+- [#2101](https://github.com/graphql/graphiql/pull/2101)
+  [`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)
+  Thanks [@acao](https://github.com/acao)! - Fix picomatch bug by using a
+  browser compatible fork
 
 ## 4.1.1
 
 ### Patch Changes
 
-- Updated dependencies [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
+- Updated dependencies
+  [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
   - graphql-language-service-interface@2.10.1
   - graphql-language-service-utils@2.7.1
   - graphql-language-service-types@1.8.7
@@ -133,40 +221,67 @@
 
 ### Minor Changes
 
-- [#2086](https://github.com/graphql/graphiql/pull/2086) [`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3) Thanks [@acao](https://github.com/acao)! - Export all modules & types explicitly from `graphql-language-service`
+- [#2086](https://github.com/graphql/graphiql/pull/2086)
+  [`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)
+  Thanks [@acao](https://github.com/acao)! - Export all modules & types
+  explicitly from `graphql-language-service`
 
 ## 4.0.0
 
 ### Major Changes
 
-- [#1997](https://github.com/graphql/graphiql/pull/1997) [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3) Thanks [@acao](https://github.com/acao)! - This introduces some big changes to `monaco-graphql`, and some exciting features, including multi-model support, multi-schema support, and variables json language feature support 🎉.
+- [#1997](https://github.com/graphql/graphiql/pull/1997)
+  [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)
+  Thanks [@acao](https://github.com/acao)! - This introduces some big changes to
+  `monaco-graphql`, and some exciting features, including multi-model support,
+  multi-schema support, and variables json language feature support 🎉.
 
-  see [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql) to learn how to configure and use the new interface.
+  see
+  [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
+  to learn how to configure and use the new interface.
 
   #### 🚨 BREAKING CHANGES!! 🚨
 
-  - `monaco-graphql` 🚨 **no longer loads schemas using `fetch` introspection** 🚨, you must specify the schema in one of many ways statically or dynamically. specifying just a schema `uri` no longer works. see [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
-  - when specifying the language to an editor or model, **use `graphql` as the language id instead of `graphqlDev`**
-    - the mode now extends the default basic language support from `monaco-editor` itself
-    - when bundling, for syntax highlighting and basic language features, you must specify `graphql` in languages for your webpack or vite monaco plugins
-  - The exported mode api for configuration been entirely rewritten. It is simple for now, but we will add more powerful methods to the `monaco.languages.api` over time :)
+  - `monaco-graphql` 🚨 **no longer loads schemas using `fetch` introspection**
+    🚨, you must specify the schema in one of many ways statically or
+    dynamically. specifying just a schema `uri` no longer works. see
+    [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
+  - when specifying the language to an editor or model, **use `graphql` as the
+    language id instead of `graphqlDev`**
+    - the mode now extends the default basic language support from
+      `monaco-editor` itself
+    - when bundling, for syntax highlighting and basic language features, you
+      must specify `graphql` in languages for your webpack or vite monaco
+      plugins
+  - The exported mode api for configuration been entirely rewritten. It is
+    simple for now, but we will add more powerful methods to the
+    `monaco.languages.api` over time :)
 
   #### New Features
 
   this introduces many improvements:
 
-  - json language support, by mapping from each graphql model uri to a set of json variable model uris
+  - json language support, by mapping from each graphql model uri to a set of
+    json variable model uris
     - we generate a json schema definition for the json variables on the fly
     - it updates alongside editor validation as you type
-  - less redundant schema loading - schema is loaded in main process instead of in the webworker
-  - web worker stability has been improved by contributors in previous patches, but removing remote schema loading vastly simplifies worker creation
-  - the editor now supports multiple graphql models, configurable against multiple schema configurations
+  - less redundant schema loading - schema is loaded in main process instead of
+    in the webworker
+  - web worker stability has been improved by contributors in previous patches,
+    but removing remote schema loading vastly simplifies worker creation
+  - the editor now supports multiple graphql models, configurable against
+    multiple schema configurations
 
-  * You can now use `initializeMode()` to initialize the language mode & worker with the schema, but you can still lazily load it, and fall back on default monaco editor basic languages support
+  * You can now use `initializeMode()` to initialize the language mode & worker
+    with the schema, but you can still lazily load it, and fall back on default
+    monaco editor basic languages support
 
 ### Patch Changes
 
-- Updated dependencies [[`581df6d8`](https://github.com/graphql/graphiql/commit/581df6d83f4bc145de94e5d730b00e5b025907da), [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3), [`9b72af57`](https://github.com/graphql/graphiql/commit/9b72af57183f4435992c232e63506ad2f5a72576)]:
+- Updated dependencies
+  [[`581df6d8`](https://github.com/graphql/graphiql/commit/581df6d83f4bc145de94e5d730b00e5b025907da),
+  [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3),
+  [`9b72af57`](https://github.com/graphql/graphiql/commit/9b72af57183f4435992c232e63506ad2f5a72576)]:
   - graphql-language-service-interface@2.10.0
   - graphql-language-service-utils@2.7.0
 
@@ -174,16 +289,24 @@
 
 ### Patch Changes
 
-- [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1) [#2065](https://github.com/graphql/graphiql/pull/2065) Thanks [@acao](https://github.com/acao)! - Add an opt-in feature to generate markdown in hover elements, starting with highlighting type information. Enabled for the language server and also the language service and thus `monaco-graphql` as well.
+- [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)
+  [#2065](https://github.com/graphql/graphiql/pull/2065) Thanks
+  [@acao](https://github.com/acao)! - Add an opt-in feature to generate markdown
+  in hover elements, starting with highlighting type information. Enabled for
+  the language server and also the language service and thus `monaco-graphql` as
+  well.
 
-- Updated dependencies [[`989fca69`](https://github.com/graphql/graphiql/commit/989fca693385aa408bcfe18cde34934a5aea5dce), [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+- Updated dependencies
+  [[`989fca69`](https://github.com/graphql/graphiql/commit/989fca693385aa408bcfe18cde34934a5aea5dce),
+  [`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service-interface@2.9.5
 
 ## 3.2.4
 
 ### Patch Changes
 
-- Updated dependencies [[`a3782ff0`](https://github.com/graphql/graphiql/commit/a3782ff0ff0d7c321e6f70bea61b1969b1690f26)]:
+- Updated dependencies
+  [[`a3782ff0`](https://github.com/graphql/graphiql/commit/a3782ff0ff0d7c321e6f70bea61b1969b1690f26)]:
   - graphql-language-service-interface@2.9.4
   - graphql-language-service-types@1.8.6
   - graphql-language-service-parser@1.10.3
@@ -193,9 +316,14 @@
 
 ### Patch Changes
 
-- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf) [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks [@willstott101](https://github.com/willstott101)! - Source code included in all packages to fix source maps. codemirror-graphql includes esm build in package.
+- [`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)
+  [#2047](https://github.com/graphql/graphiql/pull/2047) Thanks
+  [@willstott101](https://github.com/willstott101)! - Source code included in
+  all packages to fix source maps. codemirror-graphql includes esm build in
+  package.
 
-- Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
+- Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
   - graphql-language-service-interface@2.9.3
   - graphql-language-service-parser@1.10.2
   - graphql-language-service-types@1.8.5
@@ -205,9 +333,13 @@
 
 ### Patch Changes
 
-- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
-- Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+- Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - graphql-language-service-interface@2.9.2
   - graphql-language-service-parser@1.10.1
   - graphql-language-service-types@1.8.4
@@ -217,9 +349,14 @@
 
 ### Patch Changes
 
-- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce) [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks [@PabloSzx](https://github.com/PabloSzx)! - Update utils
+- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)
+  [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks
+  [@PabloSzx](https://github.com/PabloSzx)! - Update utils
 
-- Updated dependencies [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce), [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce), [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
+- Updated dependencies
+  [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce),
+  [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce),
+  [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
   - graphql-language-service-utils@2.6.0
   - graphql-language-service-types@1.8.3
   - graphql-language-service-interface@2.9.1
@@ -228,11 +365,16 @@
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`8869c4b1`](https://github.com/graphql/graphiql/commit/8869c4b18c900b9b35556255587ef5130a96a4d5), [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`8869c4b1`](https://github.com/graphql/graphiql/commit/8869c4b18c900b9b35556255587ef5130a96a4d5),
+  [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - graphql-language-service-interface@2.9.0
   - graphql-language-service-parser@1.10.0
 
@@ -240,30 +382,46 @@
 
 ### Patch Changes
 
-- [`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb) [#1979](https://github.com/graphql/graphiql/pull/1979) Thanks [@iahu](https://github.com/iahu)! - fix: export `monaco-graphql` esm with esm modules, also fix issues with worker manager, resolves #1706 & #1791
+- [`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb)
+  [#1979](https://github.com/graphql/graphiql/pull/1979) Thanks
+  [@iahu](https://github.com/iahu)! - fix: export `monaco-graphql` esm with esm
+  modules, also fix issues with worker manager, resolves #1706 & #1791
 
-* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-* Updated dependencies [[`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+* Updated dependencies
+  [[`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service-parser@1.9.3
 
 ## 3.1.5
 
 ### Patch Changes
 
-- [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb) [#1941](https://github.com/graphql/graphiql/pull/1941) Thanks [@arcanis](https://github.com/arcanis)! - Adds support for `#graphql` and `/* GraphQL */` in the language server
+- [`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)
+  [#1941](https://github.com/graphql/graphiql/pull/1941) Thanks
+  [@arcanis](https://github.com/arcanis)! - Adds support for `#graphql` and
+  `/* GraphQL */` in the language server
 
 ## 3.1.4
 
 ### Patch Changes
 
-- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92) [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
+- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92)
+  [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks
+  [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
 
 ## 3.1.3
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## [3.1.2](https://github.com/graphql/graphiql/compare/graphql-language-service@3.1.1...graphql-language-service@3.1.2) (2021-01-07)
 
@@ -277,7 +435,10 @@
 
 ### Features
 
-- implied or external fragments, for [#612](https://github.com/graphql/graphiql/issues/612) ([#1750](https://github.com/graphql/graphiql/issues/1750)) ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
+- implied or external fragments, for
+  [#612](https://github.com/graphql/graphiql/issues/612)
+  ([#1750](https://github.com/graphql/graphiql/issues/1750))
+  ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
 
 ## [3.0.6](https://github.com/graphql/graphiql/compare/graphql-language-service@3.0.5...graphql-language-service@3.0.6) (2021-01-03)
 
@@ -307,7 +468,9 @@
 
 ### Bug Fixes
 
-- improve setSchema & schema loading, allow primitive schema ([#1648](https://github.com/graphql/graphiql/issues/1648)) ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
+- improve setSchema & schema loading, allow primitive schema
+  ([#1648](https://github.com/graphql/graphiql/issues/1648))
+  ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
 
 ## [3.0.2-alpha.1](https://github.com/graphql/graphiql/compare/graphql-language-service@3.0.2-alpha.0...graphql-language-service@3.0.2-alpha.1) (2020-08-12)
 
@@ -325,7 +488,9 @@
 
 ### Features
 
-- standalone monaco API ([#1575](https://github.com/graphql/graphiql/issues/1575)) ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
+- standalone monaco API
+  ([#1575](https://github.com/graphql/graphiql/issues/1575))
+  ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
 
 ## [3.0.0-alpha.4](https://github.com/graphql/graphiql/compare/graphql-language-service@3.0.0-alpha.3...graphql-language-service@3.0.0-alpha.4) (2020-06-04)
 
@@ -335,7 +500,8 @@
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
 
 ## [3.0.0-alpha.2](https://github.com/graphql/graphiql/compare/graphql-language-service@3.0.0-alpha.1...graphql-language-service@3.0.0-alpha.2) (2020-05-28)
 
@@ -349,6 +515,12 @@
 
 ### Features
 
-- Monaco Mode - Phase 2 - Mode & Worker ([#1459](https://github.com/graphql/graphiql/issues/1459)) ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
-- monaco-graphql docs, api, improvements ([#1521](https://github.com/graphql/graphiql/issues/1521)) ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))
-- new graphql-languageservice package ([#1485](https://github.com/graphql/graphiql/issues/1485)) ([6bb3ddd](https://github.com/graphql/graphiql/commit/6bb3dddf1f97db4bc193bb7fd9de1ada8d8c8ef9))
+- Monaco Mode - Phase 2 - Mode & Worker
+  ([#1459](https://github.com/graphql/graphiql/issues/1459))
+  ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
+- monaco-graphql docs, api, improvements
+  ([#1521](https://github.com/graphql/graphiql/issues/1521))
+  ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))
+- new graphql-languageservice package
+  ([#1485](https://github.com/graphql/graphiql/issues/1485))
+  ([6bb3ddd](https://github.com/graphql/graphiql/commit/6bb3dddf1f97db4bc193bb7fd9de1ada8d8c8ef9))

--- a/packages/monaco-graphql/CHANGELOG.md
+++ b/packages/monaco-graphql/CHANGELOG.md
@@ -4,156 +4,234 @@
 
 ### Patch Changes
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- Updated dependencies [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c), [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b), [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`e68cb8bc`](https://github.com/graphql/graphiql/commit/e68cb8bcaf9baddf6fca747abab871ecd1bc7a4c),
+  [`f788e65a`](https://github.com/graphql/graphiql/commit/f788e65aff267ec873237034831d1fd936222a9b),
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service@5.1.2
 
 ## 1.1.7
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2938](https://github.com/graphql/graphiql/pull/2938) [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error` rule
+- [#2938](https://github.com/graphql/graphiql/pull/2938)
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/throw-new-error`
+  rule
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`4a8b2e17`](https://github.com/graphql/graphiql/commit/4a8b2e1766a38eb4828cf9a81bf9d767070041de),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`c44ea4f1`](https://github.com/graphql/graphiql/commit/c44ea4f1917b97daac815c08299b934c8ca57ed9),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`6a9d913f`](https://github.com/graphql/graphiql/commit/6a9d913f0d1b847124286b3fa1f3a2649d315171)]:
   - graphql-language-service@5.1.1
 
 ## 1.1.6
 
 ### Patch Changes
 
-- [#2900](https://github.com/graphql/graphiql/pull/2900) [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a) Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser plugin so that all styles of decorator usage are supported
+- [#2900](https://github.com/graphql/graphiql/pull/2900)
+  [`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)
+  Thanks [@acao](https://github.com/acao)! - use decorators-legacy @babel/parser
+  plugin so that all styles of decorator usage are supported
 
 ## 1.1.5
 
 ### Patch Changes
 
-- [#2488](https://github.com/graphql/graphiql/pull/2488) [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf) Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by default
+- [#2488](https://github.com/graphql/graphiql/pull/2488)
+  [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)
+  Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by
+  default
 
-  Users found this generally annoying by default, especially when there are required arguments
+  Users found this generally annoying by default, especially when there are
+  required arguments
 
-  Without automatically prompting autocompletion of required arguments as well as lead expansion, it makes the extension harder to use
+  Without automatically prompting autocompletion of required arguments as well
+  as lead expansion, it makes the extension harder to use
 
   You can now supply this in your graphql config:
 
   `config.extensions.languageService.fillLeafsOnComplete`
 
-  Setting it to to `true` will enable this feature. Will soon add the ability to manually enable this in `monaco-graphql` as well.
+  Setting it to to `true` will enable this feature. Will soon add the ability to
+  manually enable this in `monaco-graphql` as well.
 
-  For both, this kind of behavior would be better as a keyboard command, context menu item &/or codelens prompt
+  For both, this kind of behavior would be better as a keyboard command, context
+  menu item &/or codelens prompt
 
 ## 1.1.4
 
 ### Patch Changes
 
-- [#2834](https://github.com/graphql/graphiql/pull/2834) [`0a950ea3`](https://github.com/graphql/graphiql/commit/0a950ea374504b13d39c042db1d495a79dff4d0d) Thanks [@acao](https://github.com/acao)! - prevent the mode from instantiating more than once in the main process. it should never need to!
+- [#2834](https://github.com/graphql/graphiql/pull/2834)
+  [`0a950ea3`](https://github.com/graphql/graphiql/commit/0a950ea374504b13d39c042db1d495a79dff4d0d)
+  Thanks [@acao](https://github.com/acao)! - prevent the mode from instantiating
+  more than once in the main process. it should never need to!
 
-  you can supply multiple `schemas` with uri path resolution rules that resolve globs in the browser even!
+  you can supply multiple `schemas` with uri path resolution rules that resolve
+  globs in the browser even!
 
 ## 1.1.3
 
 ### Patch Changes
 
-- Updated dependencies [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
+- Updated dependencies
+  [[`d6ff4d7a`](https://github.com/graphql/graphiql/commit/d6ff4d7a5d535a0c43fe5914016bac9ef0c2b782)]:
   - graphql-language-service@5.1.0
 
 ## 1.1.2
 
 ### Patch Changes
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service@5.0.6
 
 ## 1.1.1
 
 ### Patch Changes
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service@5.0.5
 
 ## 1.1.0
 
 ### Minor Changes
 
-- [#2457](https://github.com/graphql/graphiql/pull/2457) [`8241f56d`](https://github.com/graphql/graphiql/commit/8241f56d78642223949ae717c584accbbe844d17) Thanks [@B2o5T](https://github.com/B2o5T)! - fix typo in `externalFragmentDefinitions`
+- [#2457](https://github.com/graphql/graphiql/pull/2457)
+  [`8241f56d`](https://github.com/graphql/graphiql/commit/8241f56d78642223949ae717c584accbbe844d17)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - fix typo in
+  `externalFragmentDefinitions`
 
 ## 1.0.17
 
 ### Patch Changes
 
-- Updated dependencies [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - graphql-language-service@5.0.4
 
 ## 1.0.16
 
 ### Patch Changes
 
-- Updated dependencies [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
+- Updated dependencies
+  [[`45cbc759`](https://github.com/graphql/graphiql/commit/45cbc759c732999e8b1eb4714d6047ab77c17902)]:
   - graphql-language-service@5.0.3
 
 ## 1.0.15
 
 ### Patch Changes
 
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service@5.0.2
 
 ## 1.0.14
 
 ### Patch Changes
 
-- [#2253](https://github.com/graphql/graphiql/pull/2253) [`63177891`](https://github.com/graphql/graphiql/commit/63177891d7ea4e8a3824892baea45ebaba06eba8) Thanks [@acao](https://github.com/acao)! - fix worker + n problem when changing config (schema, etc) in `monaco-graphql`
+- [#2253](https://github.com/graphql/graphiql/pull/2253)
+  [`63177891`](https://github.com/graphql/graphiql/commit/63177891d7ea4e8a3824892baea45ebaba06eba8)
+  Thanks [@acao](https://github.com/acao)! - fix worker + n problem when
+  changing config (schema, etc) in `monaco-graphql`
 
 ## 1.0.13
 
 ### Patch Changes
 
-- Updated dependencies [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa), [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
+- Updated dependencies
+  [[`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa),
+  [`3626f8d5`](https://github.com/graphql/graphiql/commit/3626f8d5012ee77a39e984ae347396cb00fcc6fa)]:
   - graphql-language-service@5.0.1
 
 ## 1.0.12
 
 ### Patch Changes
 
-- Updated dependencies [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
+- Updated dependencies
+  [[`2502a364`](https://github.com/graphql/graphiql/commit/2502a364b74dc754d92baa1579b536cf42139958)]:
   - graphql-language-service@5.0.0
 
 ## 1.0.11
 
 ### Patch Changes
 
-- [#2222](https://github.com/graphql/graphiql/pull/2222) [`33f4bf97`](https://github.com/graphql/graphiql/commit/33f4bf977d2c9e831bf9c3acb9c16365b9de2750) Thanks [@acao](https://github.com/acao)! - fixed lost this handle while parsing schema, thanks @waterfoul
+- [#2222](https://github.com/graphql/graphiql/pull/2222)
+  [`33f4bf97`](https://github.com/graphql/graphiql/commit/33f4bf977d2c9e831bf9c3acb9c16365b9de2750)
+  Thanks [@acao](https://github.com/acao)! - fixed lost this handle while
+  parsing schema, thanks @waterfoul
 
 ## 1.0.10
 
 ### Patch Changes
 
-- Updated dependencies [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f), [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c), [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
+- Updated dependencies
+  [[`484c0523`](https://github.com/graphql/graphiql/commit/484c0523cdd529f9e261d61a38616b6745075c7f),
+  [`5852ba47`](https://github.com/graphql/graphiql/commit/5852ba47c720a2577817aed512bef9a262254f2c),
+  [`48c5df65`](https://github.com/graphql/graphiql/commit/48c5df654e323cee3b8c57d7414247465235d1b5)]:
   - graphql-language-service@4.1.5
 
 ## 1.0.9
 
 ### Patch Changes
 
-- [#2118](https://github.com/graphql/graphiql/pull/2118) [`0d1122f9`](https://github.com/graphql/graphiql/commit/0d1122f9c8600ddd86022e72c0fa3696bb1e8b33) Thanks [@acao](https://github.com/acao)! - fix: monaco `getModeId` bug for `monaco-editor@^0.30.0`
+- [#2118](https://github.com/graphql/graphiql/pull/2118)
+  [`0d1122f9`](https://github.com/graphql/graphiql/commit/0d1122f9c8600ddd86022e72c0fa3696bb1e8b33)
+  Thanks [@acao](https://github.com/acao)! - fix: monaco `getModeId` bug for
+  `monaco-editor@^0.30.0`
 
-  We fixed this already, but we reverted it because folks were having issues with older versions. This fix works for all versions of `monaco-editor` that we support!
+  We fixed this already, but we reverted it because folks were having issues
+  with older versions. This fix works for all versions of `monaco-editor` that
+  we support!
 
 ## 1.0.8
 
 ### Patch Changes
 
-- [#2116](https://github.com/graphql/graphiql/pull/2116) [`65a51d04`](https://github.com/graphql/graphiql/commit/65a51d04876d56560d3453a09eb93f2e296f462a) Thanks [@acao](https://github.com/acao)! - - `picomatch-browser` fork no longer uses `path`. these changes to remove node dependencies from `picomatch`, 99% of them are by another contributor, will eventually be merged into the actual `picomatch`
-  - no `onLanguage` for `initializeMode` - always instantiate the mode when this is called directly! Fixes some editor creation race condition issues
-  - introduce a demo using react + vite and minimal config, no workarounds! This will help us prototype for `@graphiql/react`
-  - use `schemaValidation: 'error'` by default. allow user to override `validate` if they want.
-  - always re-register providers on schema config changes. seems to fix some issues on lazy instantiation
+- [#2116](https://github.com/graphql/graphiql/pull/2116)
+  [`65a51d04`](https://github.com/graphql/graphiql/commit/65a51d04876d56560d3453a09eb93f2e296f462a)
+  Thanks [@acao](https://github.com/acao)! - - `picomatch-browser` fork no
+  longer uses `path`. these changes to remove node dependencies from
+  `picomatch`, 99% of them are by another contributor, will eventually be merged
+  into the actual `picomatch`
+  - no `onLanguage` for `initializeMode` - always instantiate the mode when this
+    is called directly! Fixes some editor creation race condition issues
+  - introduce a demo using react + vite and minimal config, no workarounds! This
+    will help us prototype for `@graphiql/react`
+  - use `schemaValidation: 'error'` by default. allow user to override
+    `validate` if they want.
+  - always re-register providers on schema config changes. seems to fix some
+    issues on lazy instantiation
 
 ## 1.0.7
 
@@ -166,35 +244,47 @@
 
 ### Patch Changes
 
-- [#2105](https://github.com/graphql/graphiql/pull/2105) [`f7dc1f12`](https://github.com/graphql/graphiql/commit/f7dc1f1299cee06e20b65f8e457d74bf1cb6f76f) Thanks [@acao](https://github.com/acao)! - Fix a bug where `_cacheSchemas()` was not being called by the language service
+- [#2105](https://github.com/graphql/graphiql/pull/2105)
+  [`f7dc1f12`](https://github.com/graphql/graphiql/commit/f7dc1f1299cee06e20b65f8e457d74bf1cb6f76f)
+  Thanks [@acao](https://github.com/acao)! - Fix a bug where `_cacheSchemas()`
+  was not being called by the language service
 
 ## 1.0.5
 
 ### Patch Changes
 
-- [#2103](https://github.com/graphql/graphiql/pull/2103) [`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8) Thanks [@acao](https://github.com/acao)! - LanguageService should not be imported by `codemirror-graphql`, and thus `picomatch` should not be imported.
+- [#2103](https://github.com/graphql/graphiql/pull/2103)
+  [`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)
+  Thanks [@acao](https://github.com/acao)! - LanguageService should not be
+  imported by `codemirror-graphql`, and thus `picomatch` should not be imported.
 
-- Updated dependencies [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
+- Updated dependencies
+  [[`a44772d6`](https://github.com/graphql/graphiql/commit/a44772d6af97254c4f159ea7237e842a3e3719e8)]:
   - graphql-language-service@4.1.3
 
 ## 1.0.4
 
 ### Patch Changes
 
-- Updated dependencies [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
+- Updated dependencies
+  [[`e20760fb`](https://github.com/graphql/graphiql/commit/e20760fbd95c13d6d549cba3faa15a59aee9a2c0)]:
   - graphql-language-service@4.1.2
 
 ## 1.0.3
 
 ### Patch Changes
 
-- [#2093](https://github.com/graphql/graphiql/pull/2093) [`c875412f`](https://github.com/graphql/graphiql/commit/c875412faaf0e1fb374c27ddd26d7f9795003675) Thanks [@acao](https://github.com/acao)! - export LANGUAGE_ID from monaco-graphql again
+- [#2093](https://github.com/graphql/graphiql/pull/2093)
+  [`c875412f`](https://github.com/graphql/graphiql/commit/c875412faaf0e1fb374c27ddd26d7f9795003675)
+  Thanks [@acao](https://github.com/acao)! - export LANGUAGE_ID from
+  monaco-graphql again
 
 ## 1.0.2
 
 ### Patch Changes
 
-- Updated dependencies [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
+- Updated dependencies
+  [[`ff9cebe5`](https://github.com/graphql/graphiql/commit/ff9cebe515a3539f85b9479954ae644dfeb68b63)]:
   - graphql-language-service-utils@2.7.1
   - graphql-language-service@4.1.1
 
@@ -202,41 +292,64 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
+- Updated dependencies
+  [[`0f1f90ce`](https://github.com/graphql/graphiql/commit/0f1f90ce8f4a25ddebdaf7a9ddbe136214aa64a3)]:
   - graphql-language-service@4.1.0
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#1997](https://github.com/graphql/graphiql/pull/1997) [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3) Thanks [@acao](https://github.com/acao)! - This introduces some big changes to `monaco-graphql`, and some exciting features, including multi-model support, multi-schema support, and variables json language feature support 🎉.
+- [#1997](https://github.com/graphql/graphiql/pull/1997)
+  [`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)
+  Thanks [@acao](https://github.com/acao)! - This introduces some big changes to
+  `monaco-graphql`, and some exciting features, including multi-model support,
+  multi-schema support, and variables json language feature support 🎉.
 
-  see [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql) to learn how to configure and use the new interface.
+  see
+  [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
+  to learn how to configure and use the new interface.
 
   #### 🚨 BREAKING CHANGES!! 🚨
 
-  - `monaco-graphql` 🚨 **no longer loads schemas using `fetch` introspection** 🚨, you must specify the schema in one of many ways statically or dynamically. specifying just a schema `uri` no longer works. see [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
-  - when specifying the language to an editor or model, **use `graphql` as the language id instead of `graphqlDev`**
-    - the mode now extends the default basic language support from `monaco-editor` itself
-    - when bundling, for syntax highlighting and basic language features, you must specify `graphql` in languages for your webpack or vite monaco plugins
-  - The exported mode api for configuration been entirely rewritten. It is simple for now, but we will add more powerful methods to the `monaco.languages.api` over time :)
+  - `monaco-graphql` 🚨 **no longer loads schemas using `fetch` introspection**
+    🚨, you must specify the schema in one of many ways statically or
+    dynamically. specifying just a schema `uri` no longer works. see
+    [the readme](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql#monaco-graphql)
+  - when specifying the language to an editor or model, **use `graphql` as the
+    language id instead of `graphqlDev`**
+    - the mode now extends the default basic language support from
+      `monaco-editor` itself
+    - when bundling, for syntax highlighting and basic language features, you
+      must specify `graphql` in languages for your webpack or vite monaco
+      plugins
+  - The exported mode api for configuration been entirely rewritten. It is
+    simple for now, but we will add more powerful methods to the
+    `monaco.languages.api` over time :)
 
   #### New Features
 
   this introduces many improvements:
 
-  - json language support, by mapping from each graphql model uri to a set of json variable model uris
+  - json language support, by mapping from each graphql model uri to a set of
+    json variable model uris
     - we generate a json schema definition for the json variables on the fly
     - it updates alongside editor validation as you type
-  - less redundant schema loading - schema is loaded in main process instead of in the webworker
-  - web worker stability has been improved by contributors in previous patches, but removing remote schema loading vastly simplifies worker creation
-  - the editor now supports multiple graphql models, configurable against multiple schema configurations
+  - less redundant schema loading - schema is loaded in main process instead of
+    in the webworker
+  - web worker stability has been improved by contributors in previous patches,
+    but removing remote schema loading vastly simplifies worker creation
+  - the editor now supports multiple graphql models, configurable against
+    multiple schema configurations
 
-  * You can now use `initializeMode()` to initialize the language mode & worker with the schema, but you can still lazily load it, and fall back on default monaco editor basic languages support
+  * You can now use `initializeMode()` to initialize the language mode & worker
+    with the schema, but you can still lazily load it, and fall back on default
+    monaco editor basic languages support
 
 ### Patch Changes
 
-- Updated dependencies [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
+- Updated dependencies
+  [[`9df315b4`](https://github.com/graphql/graphiql/commit/9df315b44896efa313ed6744445fc8f9e702ebc3)]:
   - graphql-language-service-utils@2.7.0
   - graphql-language-service@4.0.0
 
@@ -244,9 +357,14 @@
 
 ### Patch Changes
 
-- [`989fca69`](https://github.com/graphql/graphiql/commit/989fca693385aa408bcfe18cde34934a5aea5dce) [#2070](https://github.com/graphql/graphiql/pull/2070) Thanks [@acao](https://github.com/acao)! - Fix a bug with variable completion with duplicate `$` across the ecosystem. Introduce more `triggerCharacters` across monaco and the LSP server for autocompletion in far more cases
+- [`989fca69`](https://github.com/graphql/graphiql/commit/989fca693385aa408bcfe18cde34934a5aea5dce)
+  [#2070](https://github.com/graphql/graphiql/pull/2070) Thanks
+  [@acao](https://github.com/acao)! - Fix a bug with variable completion with
+  duplicate `$` across the ecosystem. Introduce more `triggerCharacters` across
+  monaco and the LSP server for autocompletion in far more cases
 
-- Updated dependencies [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
+- Updated dependencies
+  [[`df57cd25`](https://github.com/graphql/graphiql/commit/df57cd2556302d6aa5dd140e7bee3f7bdab4deb1)]:
   - graphql-language-service@3.2.5
 
 ## 0.6.4
@@ -261,7 +379,8 @@
 
 ### Patch Changes
 
-- Updated dependencies [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
+- Updated dependencies
+  [[`bdd57312`](https://github.com/graphql/graphiql/commit/bdd573129844168749aba0aaa20e31b9da81aacf)]:
   - graphql-language-service@3.2.3
   - graphql-language-service-utils@2.6.2
 
@@ -269,9 +388,13 @@
 
 ### Patch Changes
 
-- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf) [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks [@acao](https://github.com/acao)! - fix graphql-js peer dependencies - [#2044](https://github.com/graphql/graphiql/pull/2044)
+- [`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)
+  [#2045](https://github.com/graphql/graphiql/pull/2045) Thanks
+  [@acao](https://github.com/acao)! - fix graphql-js peer dependencies -
+  [#2044](https://github.com/graphql/graphiql/pull/2044)
 
-- Updated dependencies [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
+- Updated dependencies
+  [[`858907d2`](https://github.com/graphql/graphiql/commit/858907d2106742a65ec52eb017f2e91268cc37bf)]:
   - graphql-language-service@3.2.2
   - graphql-language-service-utils@2.6.1
 
@@ -279,9 +402,13 @@
 
 ### Patch Changes
 
-- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce) [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks [@PabloSzx](https://github.com/PabloSzx)! - Update utils
+- [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)
+  [#2013](https://github.com/graphql/graphiql/pull/2013) Thanks
+  [@PabloSzx](https://github.com/PabloSzx)! - Update utils
 
-- Updated dependencies [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce), [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
+- Updated dependencies
+  [[`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce),
+  [`9a6ed03f`](https://github.com/graphql/graphiql/commit/9a6ed03fbe4de9652ff5d81a8f584234995dd2ce)]:
   - graphql-language-service-utils@2.6.0
   - graphql-language-service@3.2.1
 
@@ -289,46 +416,70 @@
 
 ### Minor Changes
 
-- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a) [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks [@acao](https://github.com/acao)! - upgrade to `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
+- [`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)
+  [#2010](https://github.com/graphql/graphiql/pull/2010) Thanks
+  [@acao](https://github.com/acao)! - upgrade to
+  `graphql@16.0.0-experimental-stream-defer.5`. thanks @saihaj!
 
 ### Patch Changes
 
-- Updated dependencies [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
+- Updated dependencies
+  [[`716cf786`](https://github.com/graphql/graphiql/commit/716cf786aea6af42ea637ca3c56ae6c6ebc17c7a)]:
   - graphql-language-service@3.2.0
 
 ## 0.5.1
 
 ### Patch Changes
 
-- [`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb) [#1979](https://github.com/graphql/graphiql/pull/1979) Thanks [@iahu](https://github.com/iahu)! - fix: export `monaco-graphql` esm with esm modules, also fix issues with worker manager, resolves #1706 & #1791
+- [`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb)
+  [#1979](https://github.com/graphql/graphiql/pull/1979) Thanks
+  [@iahu](https://github.com/iahu)! - fix: export `monaco-graphql` esm with esm
+  modules, also fix issues with worker manager, resolves #1706 & #1791
 
-* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8) [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for variables in language parser
+* [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)
+  [#1777](https://github.com/graphql/graphiql/pull/1777) Thanks
+  [@dwwoelfel](https://github.com/dwwoelfel)! - adopt block string parsing for
+  variables in language parser
 
-* Updated dependencies [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb), [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
+* Updated dependencies
+  [[`0e2c1a02`](https://github.com/graphql/graphiql/commit/0e2c1a020cc2761155f7c9467d3ed4cb45941aeb),
+  [`75dbb0b1`](https://github.com/graphql/graphiql/commit/75dbb0b18e2102d271a5cfe78faf54fe22e83ac8)]:
   - graphql-language-service@3.1.6
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [`fec37c6b`](https://github.com/graphql/graphiql/commit/fec37c6b2953e177bea99d4cbf993c9b253198ba) [#1952](https://github.com/graphql/graphiql/pull/1952) Thanks [@Nishchit14](https://github.com/Nishchit14)! - devDependency and peerDependency of monaco-graphql has been upgraded for monaco-editor. monaco-graphql is now supporting latest version of monaco-editor which is v0.27.0
+- [`fec37c6b`](https://github.com/graphql/graphiql/commit/fec37c6b2953e177bea99d4cbf993c9b253198ba)
+  [#1952](https://github.com/graphql/graphiql/pull/1952) Thanks
+  [@Nishchit14](https://github.com/Nishchit14)! - devDependency and
+  peerDependency of monaco-graphql has been upgraded for monaco-editor.
+  monaco-graphql is now supporting latest version of monaco-editor which is
+  v0.27.0
 
 ### Patch Changes
 
-- Updated dependencies [[`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
+- Updated dependencies
+  [[`2fd5bf72`](https://github.com/graphql/graphiql/commit/2fd5bf7239edb78339e5ac7211f09c245e47c3bb)]:
   - graphql-language-service@3.1.5
 
 ## 0.4.4
 
 ### Patch Changes
 
-- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92) [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
+- [`5b8a057d`](https://github.com/graphql/graphiql/commit/5b8a057dd64ebecc391be32176a2403bb9d9ff92)
+  [#1838](https://github.com/graphql/graphiql/pull/1838) Thanks
+  [@acao](https://github.com/acao)! - Set all cross-runtime build targets to es6
 
 ## 0.4.3
 
 ### Patch Changes
 
-- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a) [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14 & 15. `14.5.0` minimum is for built-in typescript types, and another method only available in `14.4.0`
+- [`6869ce77`](https://github.com/graphql/graphiql/commit/6869ce7767050787db5f1017abf82fa5a52fc97a)
+  [#1816](https://github.com/graphql/graphiql/pull/1816) Thanks
+  [@acao](https://github.com/acao)! - improve peer resolutions for graphql 14
+  & 15. `14.5.0` minimum is for built-in typescript types, and another method
+  only available in `14.4.0`
 
 ## [0.4.2](https://github.com/graphql/graphiql/compare/monaco-graphql@0.4.1...monaco-graphql@0.4.2) (2021-01-07)
 
@@ -342,7 +493,10 @@
 
 ### Features
 
-- implied or external fragments, for [#612](https://github.com/graphql/graphiql/issues/612) ([#1750](https://github.com/graphql/graphiql/issues/1750)) ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
+- implied or external fragments, for
+  [#612](https://github.com/graphql/graphiql/issues/612)
+  ([#1750](https://github.com/graphql/graphiql/issues/1750))
+  ([cfed265](https://github.com/graphql/graphiql/commit/cfed265e3cf31875b39ea517781a217fcdfcadc2))
 
 ## [0.3.5](https://github.com/graphql/graphiql/compare/monaco-graphql@0.3.4...monaco-graphql@0.3.5) (2021-01-03)
 
@@ -356,7 +510,9 @@
 
 ### Bug Fixes
 
-- GraphQLAPI.setSchemaConfig README example ([#1726](https://github.com/graphql/graphiql/issues/1726)) ([01a1ff7](https://github.com/graphql/graphiql/commit/01a1ff74b0568229318339f9b026d99c117bd218))
+- GraphQLAPI.setSchemaConfig README example
+  ([#1726](https://github.com/graphql/graphiql/issues/1726))
+  ([01a1ff7](https://github.com/graphql/graphiql/commit/01a1ff74b0568229318339f9b026d99c117bd218))
 
 ## [0.3.2](https://github.com/graphql/graphiql/compare/monaco-graphql@0.3.1...monaco-graphql@0.3.2) (2020-11-28)
 
@@ -374,7 +530,9 @@
 
 ### Bug Fixes
 
-- improve setSchema & schema loading, allow primitive schema ([#1648](https://github.com/graphql/graphiql/issues/1648)) ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
+- improve setSchema & schema loading, allow primitive schema
+  ([#1648](https://github.com/graphql/graphiql/issues/1648))
+  ([975f29e](https://github.com/graphql/graphiql/commit/975f29ed6e21c7354c42ed778dfd1b52287f70c6))
 
 ## [0.3.1-alpha.1](https://github.com/graphql/graphiql/compare/monaco-graphql@0.3.1-alpha.0...monaco-graphql@0.3.1-alpha.1) (2020-08-12)
 
@@ -388,13 +546,17 @@
 
 ### Features
 
-- [RFC] GraphiQL rewrite for monaco editor, react context and redesign, i18n ([#1523](https://github.com/graphql/graphiql/issues/1523)) ([ad730cd](https://github.com/graphql/graphiql/commit/ad730cdc2e3cb7216d821a01725c60475989ee20))
+- [RFC] GraphiQL rewrite for monaco editor, react context and redesign, i18n
+  ([#1523](https://github.com/graphql/graphiql/issues/1523))
+  ([ad730cd](https://github.com/graphql/graphiql/commit/ad730cdc2e3cb7216d821a01725c60475989ee20))
 
 # [0.2.0](https://github.com/graphql/graphiql/compare/monaco-graphql@0.1.4...monaco-graphql@0.2.0) (2020-06-11)
 
 ### Features
 
-- standalone monaco API ([#1575](https://github.com/graphql/graphiql/issues/1575)) ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
+- standalone monaco API
+  ([#1575](https://github.com/graphql/graphiql/issues/1575))
+  ([954aa3d](https://github.com/graphql/graphiql/commit/954aa3d7159fd26bba9650824e0f668e417ca64f))
 
 ## [0.1.4](https://github.com/graphql/graphiql/compare/monaco-graphql@0.1.3...monaco-graphql@0.1.4) (2020-06-04)
 
@@ -404,7 +566,8 @@
 
 ### Bug Fixes
 
-- cleanup cache entry from lerna publish ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
+- cleanup cache entry from lerna publish
+  ([4a26218](https://github.com/graphql/graphiql/commit/4a2621808a1aea8b30d5d27b8d86a60bf2b44b01))
 
 ## [0.1.2](https://github.com/graphql/graphiql/compare/monaco-graphql@0.1.1...monaco-graphql@0.1.2) (2020-05-28)
 
@@ -418,5 +581,9 @@
 
 ### Features
 
-- Monaco Mode - Phase 2 - Mode & Worker ([#1459](https://github.com/graphql/graphiql/issues/1459)) ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
-- monaco-graphql docs, api, improvements ([#1521](https://github.com/graphql/graphiql/issues/1521)) ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))
+- Monaco Mode - Phase 2 - Mode & Worker
+  ([#1459](https://github.com/graphql/graphiql/issues/1459))
+  ([bc95fb4](https://github.com/graphql/graphiql/commit/bc95fb46459a4437ff9471ff43c98e1c5c50f51e))
+- monaco-graphql docs, api, improvements
+  ([#1521](https://github.com/graphql/graphiql/issues/1521))
+  ([c79158c](https://github.com/graphql/graphiql/commit/c79158c72e976ab286e7ec3fded7f3e2d24e50d0))

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -31,12 +31,12 @@
   },
   "devDependencies": {
     "graphql": "^16.4.0",
-    "monaco-editor": "^0.31.0",
+    "monaco-editor": "^0.36.1",
     "vscode-languageserver-types": "^3.17.1"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0",
-    "monaco-editor": "^0.20.0",
+    "monaco-editor": ">= 0.20.0 < 1",
     "prettier": "^2.8.0 || ^3.0.0"
   }
 }

--- a/packages/monaco-graphql/src/typings/refs.d.ts
+++ b/packages/monaco-graphql/src/typings/refs.d.ts
@@ -1,2 +1,1 @@
-/// <reference path='../../../../node_modules/monaco-editor/monaco.d.ts'/>
-/// <reference path='./monaco.d.ts'/>
+/// <reference path='../../node_modules/monaco-editor/monaco.d.ts'/>

--- a/packages/vscode-graphql-execution/CHANGELOG.md
+++ b/packages/vscode-graphql-execution/CHANGELOG.md
@@ -4,62 +4,111 @@
 
 ### Patch Changes
 
-- [#2993](https://github.com/graphql/graphiql/pull/2993) [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4) Thanks [@B2o5T](https://github.com/B2o5T)! - add `unicorn/consistent-destructuring` rule
+- [#2993](https://github.com/graphql/graphiql/pull/2993)
+  [`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - add
+  `unicorn/consistent-destructuring` rule
 
-- [#3038](https://github.com/graphql/graphiql/pull/3038) [`708c428c`](https://github.com/graphql/graphiql/commit/708c428c9f7260989891db6ea37d1bc9ba5a439a) Thanks [@B2o5T](https://github.com/B2o5T)! - remove unused collection `operationNames` in `executeOperation()`
+- [#3038](https://github.com/graphql/graphiql/pull/3038)
+  [`708c428c`](https://github.com/graphql/graphiql/commit/708c428c9f7260989891db6ea37d1bc9ba5a439a)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - remove unused collection
+  `operationNames` in `executeOperation()`
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
 ## 0.1.7
 
 ### Patch Changes
 
-- [#2931](https://github.com/graphql/graphiql/pull/2931) [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and `no-else-return` rules
+- [#2931](https://github.com/graphql/graphiql/pull/2931)
+  [`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `no-negated-condition` and
+  `no-else-return` rules
 
-- [#2922](https://github.com/graphql/graphiql/pull/2922) [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b) Thanks [@B2o5T](https://github.com/B2o5T)! - extends `plugin:import/recommended` and fix warnings
+- [#2922](https://github.com/graphql/graphiql/pull/2922)
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - extends
+  `plugin:import/recommended` and fix warnings
 
-- [#2966](https://github.com/graphql/graphiql/pull/2966) [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch` and `sonarjs/no-duplicated-branches` rules
+- [#2966](https://github.com/graphql/graphiql/pull/2966)
+  [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `sonarjs/no-small-switch`
+  and `sonarjs/no-duplicated-branches` rules
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- [#2965](https://github.com/graphql/graphiql/pull/2965) [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-optional-catch-binding` rule
+- [#2965](https://github.com/graphql/graphiql/pull/2965)
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-optional-catch-binding` rule
 
-- [#2936](https://github.com/graphql/graphiql/pull/2936) [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `lonely-if`/`unicorn/lonely-if` rules
+- [#2936](https://github.com/graphql/graphiql/pull/2936)
+  [`18f8e80a`](https://github.com/graphql/graphiql/commit/18f8e80ae12edfd0c36adcb300cf9e06ac27ea49)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `lonely-if`/`unicorn/lonely-if` rules
 
-- [#2963](https://github.com/graphql/graphiql/pull/2963) [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring` rule
+- [#2963](https://github.com/graphql/graphiql/pull/2963)
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `prefer-destructuring`
+  rule
 
 ## 0.1.6
 
 ### Patch Changes
 
-- [#2884](https://github.com/graphql/graphiql/pull/2884) [`74ea4ce1`](https://github.com/graphql/graphiql/commit/74ea4ce1cd1209b86cbf08bbece658c2b800617f) Thanks [@B2o5T](https://github.com/B2o5T)! - change severity of `radix` rule to `error` to clean up eslint output
+- [#2884](https://github.com/graphql/graphiql/pull/2884)
+  [`74ea4ce1`](https://github.com/graphql/graphiql/commit/74ea4ce1cd1209b86cbf08bbece658c2b800617f)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - change severity of `radix` rule
+  to `error` to clean up eslint output
 
 ## 0.1.5
 
 ### Patch Changes
 
-- [#2812](https://github.com/graphql/graphiql/pull/2812) [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd) Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode, rolling back graphql-config upgrade
+- [#2812](https://github.com/graphql/graphiql/pull/2812)
+  [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)
+  Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode,
+  rolling back graphql-config upgrade
 
 ## 0.1.4
 
 ### Patch Changes
 
-- [#2810](https://github.com/graphql/graphiql/pull/2810) [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662) Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade `graphql-config`, fix issue with graphql-config cosmiconfig typescript config loader.
+- [#2810](https://github.com/graphql/graphiql/pull/2810)
+  [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)
+  Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade
+  `graphql-config`, fix issue with graphql-config cosmiconfig typescript config
+  loader.
 
 ## 0.1.3
 
 ### Patch Changes
 
-- [#2805](https://github.com/graphql/graphiql/pull/2805) [`e93a1484`](https://github.com/graphql/graphiql/commit/e93a1484683dc4011eb1c80f29c86ae12ba56b9f) Thanks [@acao](https://github.com/acao)! - ensure all node_modules resolve for exec extension with nohoist
+- [#2805](https://github.com/graphql/graphiql/pull/2805)
+  [`e93a1484`](https://github.com/graphql/graphiql/commit/e93a1484683dc4011eb1c80f29c86ae12ba56b9f)
+  Thanks [@acao](https://github.com/acao)! - ensure all node_modules resolve for
+  exec extension with nohoist
 
 ## 0.1.2
 
 ### Patch Changes
 
-- [#2802](https://github.com/graphql/graphiql/pull/2802) [`d291b768`](https://github.com/graphql/graphiql/commit/d291b768203e59bb80ec5312563fdc16bd16aeae) Thanks [@acao](https://github.com/acao)! - fix bug with vscode-graphql-execution
+- [#2802](https://github.com/graphql/graphiql/pull/2802)
+  [`d291b768`](https://github.com/graphql/graphiql/commit/d291b768203e59bb80ec5312563fdc16bd16aeae)
+  Thanks [@acao](https://github.com/acao)! - fix bug with
+  vscode-graphql-execution
 
 ## 0.1.1
 
 ### Patch Changes
 
-- [#2665](https://github.com/graphql/graphiql/pull/2665) [`324fbedb`](https://github.com/graphql/graphiql/commit/324fbedb96839cff105a28fce4be0757044ba5a9) Thanks [@acao](https://github.com/acao)! - Port the inline query execution capability from the original `vscode-graphql` repository as promised. More improvements to come!
+- [#2665](https://github.com/graphql/graphiql/pull/2665)
+  [`324fbedb`](https://github.com/graphql/graphiql/commit/324fbedb96839cff105a28fce4be0757044ba5a9)
+  Thanks [@acao](https://github.com/acao)! - Port the inline query execution
+  capability from the original `vscode-graphql` repository as promised. More
+  improvements to come!

--- a/packages/vscode-graphql-syntax/CHANGELOG.md
+++ b/packages/vscode-graphql-syntax/CHANGELOG.md
@@ -4,34 +4,76 @@
 
 ### Minor Changes
 
-- [#3019](https://github.com/graphql/graphiql/pull/3019) [`ae43add6`](https://github.com/graphql/graphiql/commit/ae43add68c39825580fc8fc63a0b4c55f9fb70ad) Thanks [@mjmahone](https://github.com/mjmahone)! - Adds syntax highlighting for arguments on fragment spreads as well as variable definitions on fragments.
+- [#3019](https://github.com/graphql/graphiql/pull/3019)
+  [`ae43add6`](https://github.com/graphql/graphiql/commit/ae43add68c39825580fc8fc63a0b4c55f9fb70ad)
+  Thanks [@mjmahone](https://github.com/mjmahone)! - Adds syntax highlighting
+  for arguments on fragment spreads as well as variable definitions on
+  fragments.
 
 ## 1.0.6
 
 ### Patch Changes
 
-- [#2926](https://github.com/graphql/graphiql/pull/2926) [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772) Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts file extensions
+- [#2926](https://github.com/graphql/graphiql/pull/2926)
+  [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772)
+  Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts
+  file extensions
 
 ## 1.0.5
 
 ### Patch Changes
 
-- [#2849](https://github.com/graphql/graphiql/pull/2849) [`9b98c1b6`](https://github.com/graphql/graphiql/commit/9b98c1b63a184385d22a8457cfdfebf01387697f) Thanks [@acao](https://github.com/acao)! - docs typo bug - `/* GraphQL */` (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` & `vscode-graphql` language support
+- [#2849](https://github.com/graphql/graphiql/pull/2849)
+  [`9b98c1b6`](https://github.com/graphql/graphiql/commit/9b98c1b63a184385d22a8457cfdfebf01387697f)
+  Thanks [@acao](https://github.com/acao)! - docs typo bug - `/* GraphQL */`
+  (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` &
+  `vscode-graphql` language support
 
 ## 1.0.4
 
 ### Patch Changes
 
-- [#2573](https://github.com/graphql/graphiql/pull/2573) [`a358ac1d`](https://github.com/graphql/graphiql/commit/a358ac1d00082643e124085bca09992adeef212a) Thanks [@acao](https://github.com/acao)! - ## Enhancement
+- [#2573](https://github.com/graphql/graphiql/pull/2573)
+  [`a358ac1d`](https://github.com/graphql/graphiql/commit/a358ac1d00082643e124085bca09992adeef212a)
+  Thanks [@acao](https://github.com/acao)! - ## Enhancement
 
-  Here we move vscode grammars and basic language support to a new [`GraphQL.vscode-graphql-syntax`](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax) extension. `GraphQL.vscode-graphql` now depends on this new syntax extension. This constitutes no breaking change for `vscode-graphql` users, as this extension will be installed automatically as an `extensionDependency` for `vscode-graphql`. Both extensions will now have independent release lifecycles, but vscode will keep them both up to date for you :)
+  Here we move vscode grammars and basic language support to a new
+  [`GraphQL.vscode-graphql-syntax`](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax)
+  extension. `GraphQL.vscode-graphql` now depends on this new syntax extension.
+  This constitutes no breaking change for `vscode-graphql` users, as this
+  extension will be installed automatically as an `extensionDependency` for
+  `vscode-graphql`. Both extensions will now have independent release
+  lifecycles, but vscode will keep them both up to date for you :)
 
-  Firstly, this allows users to only install the syntax highlighting extension if they don't need LSP server features.
+  Firstly, this allows users to only install the syntax highlighting extension
+  if they don't need LSP server features.
 
-  Secondly, this subtle but important change allows alternative LSP servers and non-LSP graphql extensions to use (and contribute!) to our shared, graphql community syntax highlighting. In some ways, it acts as a shared tooling & annotation spec, though it is intended just for vscode, it perhaps can be used as a point of reference for others implementing (embedded) graphql syntax highlighting elsewhere!
+  Secondly, this subtle but important change allows alternative LSP servers and
+  non-LSP graphql extensions to use (and contribute!) to our shared, graphql
+  community syntax highlighting. In some ways, it acts as a shared tooling &
+  annotation spec, though it is intended just for vscode, it perhaps can be used
+  as a point of reference for others implementing (embedded) graphql syntax
+  highlighting elsewhere!
 
-  If your language and/or library and/or framework would like vscode highlighting, come [join the party](https://github.com/graphql/graphiql/tree/main/packages/vscode-graphql-syntax#contributing)!
+  If your language and/or library and/or framework would like vscode
+  highlighting, come
+  [join the party](https://github.com/graphql/graphiql/tree/main/packages/vscode-graphql-syntax#contributing)!
 
-  If you use relay, we would highly reccomend using the `relay-compiler lsp` extension for vscode [Relay Graphql](https://marketplace.visualstudio.com/items?itemName=meta.relay) (`meta.relay`). They will be [using the new standalone syntax extension](https://github.com/facebook/relay/pull/4032) very soon!
+  If you use relay, we would highly reccomend using the `relay-compiler lsp`
+  extension for vscode
+  [Relay Graphql](https://marketplace.visualstudio.com/items?itemName=meta.relay)
+  (`meta.relay`). They will be
+  [using the new standalone syntax extension](https://github.com/facebook/relay/pull/4032)
+  very soon!
 
-  Even non-relay users may want to try this extension as an alternative to our reference implementation, as relay's configuration has relative similarity with `graphql-config`'s format, and doesn't necessitate the use of relay client afaik. We are working hard to optimize and improve `graphql-language-service-server` as a typescript reference implementation, and have some exciting features coming soon, however it's hard to offer more than a brand new & highly performant graphql LSP server written in Rust based on the latest graphql spec with a (mostly) paid team and dedicated open source ecosystem community of co-maintainers! And their implementation appears to allow you to opt out of any relay-specific conventions if you need more flexibility.
+  Even non-relay users may want to try this extension as an alternative to our
+  reference implementation, as relay's configuration has relative similarity
+  with `graphql-config`'s format, and doesn't necessitate the use of relay
+  client afaik. We are working hard to optimize and improve
+  `graphql-language-service-server` as a typescript reference implementation,
+  and have some exciting features coming soon, however it's hard to offer more
+  than a brand new & highly performant graphql LSP server written in Rust based
+  on the latest graphql spec with a (mostly) paid team and dedicated open source
+  ecosystem community of co-maintainers! And their implementation appears to
+  allow you to opt out of any relay-specific conventions if you need more
+  flexibility.

--- a/packages/vscode-graphql/CHANGELOG.md
+++ b/packages/vscode-graphql/CHANGELOG.md
@@ -4,155 +4,246 @@
 
 ### Patch Changes
 
-- [#2940](https://github.com/graphql/graphiql/pull/2940) [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-node-protocol` rule
+- [#2940](https://github.com/graphql/graphiql/pull/2940)
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable
+  `unicorn/prefer-node-protocol` rule
 
-- Updated dependencies [[`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4), [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d), [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9), [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
+- Updated dependencies
+  [[`bdc966cb`](https://github.com/graphql/graphiql/commit/bdc966cba6134a72ff7fe40f76543c77ba15d4a4),
+  [`db2a0982`](https://github.com/graphql/graphiql/commit/db2a0982a17134f0069483ab283594eb64735b7d),
+  [`90350022`](https://github.com/graphql/graphiql/commit/90350022334d9fcce0f4b72b3b0f7a12d21f78f9),
+  [`8725d1b6`](https://github.com/graphql/graphiql/commit/8725d1b6b686139286cf05dec6a84d89942128ba)]:
   - graphql-language-service-server@2.9.6
 
 ## 0.8.5
 
 ### Patch Changes
 
-- [#2926](https://github.com/graphql/graphiql/pull/2926) [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772) Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts file extensions
+- [#2926](https://github.com/graphql/graphiql/pull/2926)
+  [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772)
+  Thanks [@elijaholmos](https://github.com/elijaholmos)! - support cts and mts
+  file extensions
 
-- [#2937](https://github.com/graphql/graphiql/pull/2937) [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9) Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
+- [#2937](https://github.com/graphql/graphiql/pull/2937)
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9)
+  Thanks [@B2o5T](https://github.com/B2o5T)! - enable `unicorn/prefer-includes`
 
-- Updated dependencies [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147), [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b), [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde), [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772), [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9), [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d), [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913), [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215), [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
+- Updated dependencies
+  [[`f7addb20`](https://github.com/graphql/graphiql/commit/f7addb20c4a558fbfb4112c8ff095bbc8f9d9147),
+  [`d1fcad72`](https://github.com/graphql/graphiql/commit/d1fcad72607e2789517dfe4936b5ec604e46762b),
+  [`f9aa87dc`](https://github.com/graphql/graphiql/commit/f9aa87dc6a88ed8a8a0a94de520c7a41fff8ffde),
+  [`10e97bbe`](https://github.com/graphql/graphiql/commit/10e97bbe6c9ff81bae73b11ba81ac2b69eca2772),
+  [`c70d9165`](https://github.com/graphql/graphiql/commit/c70d9165cc1ef8eb1cd0d6b506ced98c626597f9),
+  [`d502a33b`](https://github.com/graphql/graphiql/commit/d502a33b4332f1025e947c02d7cfdc5799365c8d),
+  [`0669767e`](https://github.com/graphql/graphiql/commit/0669767e1e2196a78cbefe3679a52bcbb341e913),
+  [`f263f778`](https://github.com/graphql/graphiql/commit/f263f778cb95b9f413bd09ca56a43f5b9c2f6215),
+  [`4ff2794c`](https://github.com/graphql/graphiql/commit/4ff2794c8b6032168e27252096cb276ce712878e)]:
   - graphql-language-service-server@2.9.5
 
 ## 0.8.4
 
 ### Patch Changes
 
-- [#2901](https://github.com/graphql/graphiql/pull/2901) [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f) Thanks [@acao](https://github.com/acao)! - Reload the language service when a legacy format .graphqlconfig file has changed
+- [#2901](https://github.com/graphql/graphiql/pull/2901)
+  [`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)
+  Thanks [@acao](https://github.com/acao)! - Reload the language service when a
+  legacy format .graphqlconfig file has changed
 
-- Updated dependencies [[`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)]:
+- Updated dependencies
+  [[`eff4fd6b`](https://github.com/graphql/graphiql/commit/eff4fd6b9087c2d9cdb260ee2502a31d23769c3f)]:
   - graphql-language-service-server@2.9.4
 
 ## 0.8.3
 
 ### Patch Changes
 
-- Updated dependencies [[`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)]:
+- Updated dependencies
+  [[`8989ffce`](https://github.com/graphql/graphiql/commit/8989ffce7d6beca874e70f5a1ff066102580173a)]:
   - graphql-language-service-server@2.9.3
 
 ## 0.8.2
 
 ### Patch Changes
 
-- [#2861](https://github.com/graphql/graphiql/pull/2861) [`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274) Thanks [@aloker](https://github.com/aloker)! - add missing pieces for svelte language support
+- [#2861](https://github.com/graphql/graphiql/pull/2861)
+  [`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274)
+  Thanks [@aloker](https://github.com/aloker)! - add missing pieces for svelte
+  language support
 
-* [#2488](https://github.com/graphql/graphiql/pull/2488) [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf) Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by default
+* [#2488](https://github.com/graphql/graphiql/pull/2488)
+  [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)
+  Thanks [@acao](https://github.com/acao)! - Disable`fillLeafsOnComplete` by
+  default
 
-  Users found this generally annoying by default, especially when there are required arguments
+  Users found this generally annoying by default, especially when there are
+  required arguments
 
-  Without automatically prompting autocompletion of required arguments as well as lead expansion, it makes the extension harder to use
+  Without automatically prompting autocompletion of required arguments as well
+  as lead expansion, it makes the extension harder to use
 
   You can now supply this in your graphql config:
 
   `config.extensions.languageService.fillLeafsOnComplete`
 
-  Setting it to to `true` will enable this feature. Will soon add the ability to manually enable this in `monaco-graphql` as well.
+  Setting it to to `true` will enable this feature. Will soon add the ability to
+  manually enable this in `monaco-graphql` as well.
 
-  For both, this kind of behavior would be better as a keyboard command, context menu item &/or codelens prompt
+  For both, this kind of behavior would be better as a keyboard command, context
+  menu item &/or codelens prompt
 
-- [#2849](https://github.com/graphql/graphiql/pull/2849) [`9b98c1b6`](https://github.com/graphql/graphiql/commit/9b98c1b63a184385d22a8457cfdfebf01387697f) Thanks [@acao](https://github.com/acao)! - docs typo bug - `/* GraphQL */` (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` & `vscode-graphql` language support
+- [#2849](https://github.com/graphql/graphiql/pull/2849)
+  [`9b98c1b6`](https://github.com/graphql/graphiql/commit/9b98c1b63a184385d22a8457cfdfebf01387697f)
+  Thanks [@acao](https://github.com/acao)! - docs typo bug - `/* GraphQL */`
+  (not `/* GraphiQL */`) is the delimiter for `vscode-graphql-syntax` &
+  `vscode-graphql` language support
 
-- Updated dependencies [[`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274), [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)]:
+- Updated dependencies
+  [[`bdd1bd04`](https://github.com/graphql/graphiql/commit/bdd1bd045fc6610ccaae4745b8ecc10004594274),
+  [`967006a6`](https://github.com/graphql/graphiql/commit/967006a68e56f8f3a605c69fee5f920afdb6d8cf)]:
   - graphql-language-service-server@2.9.2
 
 ## 0.8.1
 
 ### Patch Changes
 
-- [#2829](https://github.com/graphql/graphiql/pull/2829) [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10) Thanks [@acao](https://github.com/acao)! - major bugfixes with `onDidChange` and `onDidChangeWatchedFiles` events
+- [#2829](https://github.com/graphql/graphiql/pull/2829)
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)
+  Thanks [@acao](https://github.com/acao)! - major bugfixes with `onDidChange`
+  and `onDidChangeWatchedFiles` events
 
-* [#2829](https://github.com/graphql/graphiql/pull/2829) [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10) Thanks [@acao](https://github.com/acao)! - svelte language support, using the vue sfc parser introduced for vue support
+* [#2829](https://github.com/graphql/graphiql/pull/2829)
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)
+  Thanks [@acao](https://github.com/acao)! - svelte language support, using the
+  vue sfc parser introduced for vue support
 
-* Updated dependencies [[`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10), [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)]:
+* Updated dependencies
+  [[`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10),
+  [`c835ca87`](https://github.com/graphql/graphiql/commit/c835ca87e93e00713fbbbb2f4448db03f6b97b10)]:
   - graphql-language-service-server@2.9.1
 
 ## 0.8.0
 
 ### Minor Changes
 
-- [#2827](https://github.com/graphql/graphiql/pull/2827) [`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708) Thanks [@acao](https://github.com/acao)! - Introducing vue.js support for intellisense! Thanks @AumyF
+- [#2827](https://github.com/graphql/graphiql/pull/2827)
+  [`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)
+  Thanks [@acao](https://github.com/acao)! - Introducing vue.js support for
+  intellisense! Thanks @AumyF
 
 ### Patch Changes
 
-- Updated dependencies [[`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)]:
+- Updated dependencies
+  [[`b422003c`](https://github.com/graphql/graphiql/commit/b422003c2403072e96d14f920a3f0f1dc1f4f708)]:
   - graphql-language-service-server@2.9.0
 
 ## 0.7.13
 
 ### Patch Changes
 
-- [#2818](https://github.com/graphql/graphiql/pull/2818) [`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67) Thanks [@acao](https://github.com/acao)! - Workspaces support introduced a regression for no-config scenario. Reverting to fix bugs with no graphql config crashing the server.
+- [#2818](https://github.com/graphql/graphiql/pull/2818)
+  [`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)
+  Thanks [@acao](https://github.com/acao)! - Workspaces support introduced a
+  regression for no-config scenario. Reverting to fix bugs with no graphql
+  config crashing the server.
 
-- Updated dependencies [[`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)]:
+- Updated dependencies
+  [[`929152f8`](https://github.com/graphql/graphiql/commit/929152f8ea076ffa3bf34b83445473331c3bdb67)]:
   - graphql-language-service-server@2.8.9
 
 ## 0.7.12
 
 ### Patch Changes
 
-- [#2812](https://github.com/graphql/graphiql/pull/2812) [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd) Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode, rolling back graphql-config upgrade
+- [#2812](https://github.com/graphql/graphiql/pull/2812)
+  [`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)
+  Thanks [@acao](https://github.com/acao)! - fix a bundling bug for vscode,
+  rolling back graphql-config upgrade
 
-- Updated dependencies [[`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)]:
+- Updated dependencies
+  [[`cf2e3061`](https://github.com/graphql/graphiql/commit/cf2e3061f67ef5cf6b890e217d20915d0eaec1bd)]:
   - graphql-language-service-server@2.8.8
 
 ## 0.7.11
 
 ### Patch Changes
 
-- [#2810](https://github.com/graphql/graphiql/pull/2810) [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662) Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade `graphql-config`, fix issue with graphql-config cosmiconfig typescript config loader.
+- [#2810](https://github.com/graphql/graphiql/pull/2810)
+  [`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)
+  Thanks [@acao](https://github.com/acao)! - fix graphql exec extension, upgrade
+  `graphql-config`, fix issue with graphql-config cosmiconfig typescript config
+  loader.
 
-- Updated dependencies [[`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)]:
+- Updated dependencies
+  [[`f688422e`](https://github.com/graphql/graphiql/commit/f688422ed87ddd411cf3552fa6d9a5a367cd8662)]:
   - graphql-language-service-server@2.8.7
 
 ## 0.7.10
 
 ### Patch Changes
 
-- [#2808](https://github.com/graphql/graphiql/pull/2808) [`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6) Thanks [@acao](https://github.com/acao)! - fix graphql config init bug
+- [#2808](https://github.com/graphql/graphiql/pull/2808)
+  [`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)
+  Thanks [@acao](https://github.com/acao)! - fix graphql config init bug
 
-- Updated dependencies [[`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)]:
+- Updated dependencies
+  [[`a2071504`](https://github.com/graphql/graphiql/commit/a20715046fe7684bb9b17fbc9f5637b44e5210d6)]:
   - graphql-language-service-server@2.8.6
 
 ## 0.7.9
 
 ### Patch Changes
 
-- [#2806](https://github.com/graphql/graphiql/pull/2806) [`5b991dc9`](https://github.com/graphql/graphiql/commit/5b991dc9540b5cd2204428e7c3f684480d498908) Thanks [@acao](https://github.com/acao)! - disable exec extension in vscode-graphql until stable
+- [#2806](https://github.com/graphql/graphiql/pull/2806)
+  [`5b991dc9`](https://github.com/graphql/graphiql/commit/5b991dc9540b5cd2204428e7c3f684480d498908)
+  Thanks [@acao](https://github.com/acao)! - disable exec extension in
+  vscode-graphql until stable
 
 ## 0.7.8
 
 ### Patch Changes
 
-- [#2616](https://github.com/graphql/graphiql/pull/2616) [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5) Thanks [@acao](https://github.com/acao)! - support vscode multi-root workspaces! creates an LSP server instance for each workspace.
+- [#2616](https://github.com/graphql/graphiql/pull/2616)
+  [`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)
+  Thanks [@acao](https://github.com/acao)! - support vscode multi-root
+  workspaces! creates an LSP server instance for each workspace.
 
-  WARNING: large-scale vscode workspaces usage, and this in tandem with `graphql.config.*` multi-project configs could lead to excessive system resource usage. Optimizations coming soon.
+  WARNING: large-scale vscode workspaces usage, and this in tandem with
+  `graphql.config.*` multi-project configs could lead to excessive system
+  resource usage. Optimizations coming soon.
 
-- Updated dependencies [[`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)]:
+- Updated dependencies
+  [[`b0d7f06c`](https://github.com/graphql/graphiql/commit/b0d7f06cf9ec6fd6b1dcb61dd0273e37dd546ed5)]:
   - graphql-language-service-server@2.8.5
 
 ## 0.7.7
 
 ### Patch Changes
 
-- [#2802](https://github.com/graphql/graphiql/pull/2802) [`d291b768`](https://github.com/graphql/graphiql/commit/d291b768203e59bb80ec5312563fdc16bd16aeae) Thanks [@acao](https://github.com/acao)! - fix bug with vscode-graphql-execution
+- [#2802](https://github.com/graphql/graphiql/pull/2802)
+  [`d291b768`](https://github.com/graphql/graphiql/commit/d291b768203e59bb80ec5312563fdc16bd16aeae)
+  Thanks [@acao](https://github.com/acao)! - fix bug with
+  vscode-graphql-execution
 
 ## 0.7.6
 
 ### Patch Changes
 
-- [#2665](https://github.com/graphql/graphiql/pull/2665) [`324fbedb`](https://github.com/graphql/graphiql/commit/324fbedb96839cff105a28fce4be0757044ba5a9) Thanks [@acao](https://github.com/acao)! - Port the inline query execution capability from the original `vscode-graphql` repository as promised. More improvements to come!
+- [#2665](https://github.com/graphql/graphiql/pull/2665)
+  [`324fbedb`](https://github.com/graphql/graphiql/commit/324fbedb96839cff105a28fce4be0757044ba5a9)
+  Thanks [@acao](https://github.com/acao)! - Port the inline query execution
+  capability from the original `vscode-graphql` repository as promised. More
+  improvements to come!
 
 ## 0.7.5
 
 ### Patch Changes
 
-- [#2759](https://github.com/graphql/graphiql/pull/2759) [`67b1e5e9`](https://github.com/graphql/graphiql/commit/67b1e5e933e3ca9e1f88d3ed6e1c70537c491e77) Thanks [@acao](https://github.com/acao)! - Fixes #2671 bug for SDL schema support and `.graphql` files! pin `vscode-languageclient` to 8.0.2 version. Thanks [@MariaSolOs](https://github.com/MariaSolOs) for the fix!
+- [#2759](https://github.com/graphql/graphiql/pull/2759)
+  [`67b1e5e9`](https://github.com/graphql/graphiql/commit/67b1e5e933e3ca9e1f88d3ed6e1c70537c491e77)
+  Thanks [@acao](https://github.com/acao)! - Fixes #2671 bug for SDL schema
+  support and `.graphql` files! pin `vscode-languageclient` to 8.0.2 version.
+  Thanks [@MariaSolOs](https://github.com/MariaSolOs) for the fix!
 
 ## 0.7.4
 
@@ -165,158 +256,254 @@
 
 ### Patch Changes
 
-- [#2664](https://github.com/graphql/graphiql/pull/2664) [`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee) Thanks [@acao](https://github.com/acao)! - This reverts the bugfix for .graphqlrc.ts users, which broke the extension for schema url users
+- [#2664](https://github.com/graphql/graphiql/pull/2664)
+  [`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)
+  Thanks [@acao](https://github.com/acao)! - This reverts the bugfix for
+  .graphqlrc.ts users, which broke the extension for schema url users
 
-- Updated dependencies [[`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)]:
+- Updated dependencies
+  [[`721425b3`](https://github.com/graphql/graphiql/commit/721425b3382e68dd4c7b883473e3eda38a9816ee)]:
   - graphql-language-service-server@2.8.3
 
 ## 0.7.2
 
 ### Patch Changes
 
-- [#2660](https://github.com/graphql/graphiql/pull/2660) [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf) Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also bumps to the latest patch releases of `graphql-config` fixed several issues with TypeScript loading ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2), [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)). We tested manually, but please open a bug if you encounter any with schema-as-url configs & schema introspection.
+- [#2660](https://github.com/graphql/graphiql/pull/2660)
+  [`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)
+  Thanks [@acao](https://github.com/acao)! - bump `ts-node` to 10.x, so that
+  TypeScript based configs (i.e. `.graphqlrc.ts`) will continue to work. It also
+  bumps to the latest patch releases of `graphql-config` fixed several issues
+  with TypeScript loading
+  ([v4.3.2](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.2),
+  [v4.3.3](https://github.com/kamilkisiela/graphql-config/releases/tag/v4.3.3)).
+  We tested manually, but please open a bug if you encounter any with
+  schema-as-url configs & schema introspection.
 
-- Updated dependencies [[`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)]:
+- Updated dependencies
+  [[`34d31fbc`](https://github.com/graphql/graphiql/commit/34d31fbce6c49c929b48bdf1a6b0cebc33d8bbbf)]:
   - graphql-language-service-server@2.8.2
 
 ## 0.7.1
 
 ### Patch Changes
 
-- [#2623](https://github.com/graphql/graphiql/pull/2623) [`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb) Thanks [@acao](https://github.com/acao)! - In #2624, fix introspection schema fetching regression in lsp server, and fix for users writing new .gql/.graphql files
+- [#2623](https://github.com/graphql/graphiql/pull/2623)
+  [`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)
+  Thanks [@acao](https://github.com/acao)! - In #2624, fix introspection schema
+  fetching regression in lsp server, and fix for users writing new .gql/.graphql
+  files
 
-- Updated dependencies [[`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)]:
+- Updated dependencies
+  [[`12cf4db0`](https://github.com/graphql/graphiql/commit/12cf4db006d1c058460bc04f51d8743fe1ac63bb)]:
   - graphql-language-service-server@2.8.1
 
 ## 0.7.0
 
 ### Minor Changes
 
-- [#2573](https://github.com/graphql/graphiql/pull/2573) [`a358ac1d`](https://github.com/graphql/graphiql/commit/a358ac1d00082643e124085bca09992adeef212a) Thanks [@acao](https://github.com/acao)! - ## Enhancement
+- [#2573](https://github.com/graphql/graphiql/pull/2573)
+  [`a358ac1d`](https://github.com/graphql/graphiql/commit/a358ac1d00082643e124085bca09992adeef212a)
+  Thanks [@acao](https://github.com/acao)! - ## Enhancement
 
-  Here we move vscode grammars and basic language support to a new [`GraphQL.vscode-graphql-syntax`](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax) extension. `GraphQL.vscode-graphql` now depends on this new syntax extension. This constitutes no breaking change for `vscode-graphql` users, as this extension will be installed automatically as an `extensionDependency` for `vscode-graphql`. Both extensions will now have independent release lifecycles, but vscode will keep them both up to date for you :)
+  Here we move vscode grammars and basic language support to a new
+  [`GraphQL.vscode-graphql-syntax`](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax)
+  extension. `GraphQL.vscode-graphql` now depends on this new syntax extension.
+  This constitutes no breaking change for `vscode-graphql` users, as this
+  extension will be installed automatically as an `extensionDependency` for
+  `vscode-graphql`. Both extensions will now have independent release
+  lifecycles, but vscode will keep them both up to date for you :)
 
-  Firstly, this allows users to only install the syntax highlighting extension if they don't need LSP server features.
+  Firstly, this allows users to only install the syntax highlighting extension
+  if they don't need LSP server features.
 
-  Secondly, this subtle but important change allows alternative LSP servers and non-LSP graphql extensions to use (and contribute!) to our shared, graphql community syntax highlighting. In some ways, it acts as a shared tooling & annotation spec, though it is intended just for vscode, it perhaps can be used as a point of reference for others implementing (embedded) graphql syntax highlighting elsewhere!
+  Secondly, this subtle but important change allows alternative LSP servers and
+  non-LSP graphql extensions to use (and contribute!) to our shared, graphql
+  community syntax highlighting. In some ways, it acts as a shared tooling &
+  annotation spec, though it is intended just for vscode, it perhaps can be used
+  as a point of reference for others implementing (embedded) graphql syntax
+  highlighting elsewhere!
 
-  If your language and/or library and/or framework would like vscode highlighting, come [join the party](https://github.com/graphql/graphiql/tree/main/packages/vscode-graphql-syntax#contributing)!
+  If your language and/or library and/or framework would like vscode
+  highlighting, come
+  [join the party](https://github.com/graphql/graphiql/tree/main/packages/vscode-graphql-syntax#contributing)!
 
-  If you use relay, we would highly reccomend using the `relay-compiler lsp` extension for vscode [Relay Graphql](https://marketplace.visualstudio.com/items?itemName=meta.relay) (`meta.relay`). They will be [using the new standalone syntax extension](https://github.com/facebook/relay/pull/4032) very soon!
+  If you use relay, we would highly reccomend using the `relay-compiler lsp`
+  extension for vscode
+  [Relay Graphql](https://marketplace.visualstudio.com/items?itemName=meta.relay)
+  (`meta.relay`). They will be
+  [using the new standalone syntax extension](https://github.com/facebook/relay/pull/4032)
+  very soon!
 
-  Even non-relay users may want to try this extension as an alternative to our reference implementation, as relay's configuration has relative similarity with `graphql-config`'s format, and doesn't necessitate the use of relay client afaik. We are working hard to optimize and improve `graphql-language-service-server` as a typescript reference implementation, and have some exciting features coming soon, however it's hard to offer more than a brand new & highly performant graphql LSP server written in Rust based on the latest graphql spec with a (mostly) paid team and dedicated open source ecosystem community of co-maintainers! And their implementation appears to allow you to opt out of any relay-specific conventions if you need more flexibility.
+  Even non-relay users may want to try this extension as an alternative to our
+  reference implementation, as relay's configuration has relative similarity
+  with `graphql-config`'s format, and doesn't necessitate the use of relay
+  client afaik. We are working hard to optimize and improve
+  `graphql-language-service-server` as a typescript reference implementation,
+  and have some exciting features coming soon, however it's hard to offer more
+  than a brand new & highly performant graphql LSP server written in Rust based
+  on the latest graphql spec with a (mostly) paid team and dedicated open source
+  ecosystem community of co-maintainers! And their implementation appears to
+  allow you to opt out of any relay-specific conventions if you need more
+  flexibility.
 
 ## 0.6.0
 
 ### Minor Changes
 
-- [#2556](https://github.com/graphql/graphiql/pull/2556) [`e04dd9c7`](https://github.com/graphql/graphiql/commit/e04dd9c774cfdb2897e48a67ab854c4a4bdaa9ef) Thanks [@qw-in](https://github.com/qw-in)! - Add support for syntax highlighting in python files
+- [#2556](https://github.com/graphql/graphiql/pull/2556)
+  [`e04dd9c7`](https://github.com/graphql/graphiql/commit/e04dd9c774cfdb2897e48a67ab854c4a4bdaa9ef)
+  Thanks [@qw-in](https://github.com/qw-in)! - Add support for syntax
+  highlighting in python files
 
 ## 0.5.0
 
 ### Minor Changes
 
-- [#2557](https://github.com/graphql/graphiql/pull/2557) [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9) Thanks [@acao](https://github.com/acao)! - upgrades the `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the lsp server to the latest. also upgrades `vscode-languageclient` in `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in `vscode-graphql` at least!
+- [#2557](https://github.com/graphql/graphiql/pull/2557)
+  [`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)
+  Thanks [@acao](https://github.com/acao)! - upgrades the
+  `vscode-languageserver` and `vscode-jsonrpc` reference implementations for the
+  lsp server to the latest. also upgrades `vscode-languageclient` in
+  `vscode-graphql` to the latest 8.0.1. seems to work fine for IPC in
+  `vscode-graphql` at least!
 
   hopefully this solves #2230 once and for all!
 
 ### Patch Changes
 
-- Updated dependencies [[`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)]:
+- Updated dependencies
+  [[`3304606d`](https://github.com/graphql/graphiql/commit/3304606d5130a745cbdab0e6c9182e75101ddde9)]:
   - graphql-language-service-server@2.8.0
 
 ## 0.4.15
 
 ### Patch Changes
 
-- Updated dependencies [[`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)]:
+- Updated dependencies
+  [[`edc1c964`](https://github.com/graphql/graphiql/commit/edc1c96477cc2fbc2b6ac5d6195b8f9766a8c5d4)]:
   - graphql-language-service-server@2.7.29
 
 ## 0.4.14
 
 ### Patch Changes
 
-- [#2519](https://github.com/graphql/graphiql/pull/2519) [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8) Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode by default in the LSP server
+- [#2519](https://github.com/graphql/graphiql/pull/2519)
+  [`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8)
+  Thanks [@acao](https://github.com/acao)! - enable graphql-config legacy mode
+  by default in the LSP server
 
-* [#2509](https://github.com/graphql/graphiql/pull/2509) [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea) Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `, ` graphql(``) ` call expressions support for highlighting & language
+* [#2509](https://github.com/graphql/graphiql/pull/2509)
+  [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)
+  Thanks [@Chnapy](https://github.com/Chnapy)! - Add ` gql(``) `,
+  ` graphql(``) ` call expressions support for highlighting & language
 
-* Updated dependencies [[`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8), [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)]:
+* Updated dependencies
+  [[`de5d5a07`](https://github.com/graphql/graphiql/commit/de5d5a07891fd49241a5abbb17eaf377a015a0a8),
+  [`737d4184`](https://github.com/graphql/graphiql/commit/737d4184f3af1d8fe9d64eb1b7e23dfcfbe640ea)]:
   - graphql-language-service-server@2.7.28
 
 ## 0.4.13
 
 ### Patch Changes
 
-- Updated dependencies [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
+- Updated dependencies
+  [[`cccefa70`](https://github.com/graphql/graphiql/commit/cccefa70c0466d60e8496e1df61aeb1490af723c)]:
   - graphql-language-service-server@2.7.27
 
 ## 0.4.12
 
 ### Patch Changes
 
-- Updated dependencies [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
+- Updated dependencies
+  [[`c9c51b8a`](https://github.com/graphql/graphiql/commit/c9c51b8a98e1f0427272d3e9ad60989b32f1a1aa)]:
   - graphql-language-service-server@2.7.26
 
 ## 0.4.11
 
 ### Patch Changes
 
-- Updated dependencies [[`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99)]:
+- Updated dependencies
+  [[`cf092f59`](https://github.com/graphql/graphiql/commit/cf092f5960eae250bb193b9011b2fb883f797a99)]:
   - graphql-language-service-server@2.7.25
 
 ## 0.4.10
 
 ### Patch Changes
 
-- [#2474](https://github.com/graphql/graphiql/pull/2474) [`70bc61ee`](https://github.com/graphql/graphiql/commit/70bc61ee78787132d5572ef5d1e81e7d6e3b13d2) Thanks [@acao](https://github.com/acao)! - Fix bug with typed parameters on the gql/graphql/etc tagged templates!
+- [#2474](https://github.com/graphql/graphiql/pull/2474)
+  [`70bc61ee`](https://github.com/graphql/graphiql/commit/70bc61ee78787132d5572ef5d1e81e7d6e3b13d2)
+  Thanks [@acao](https://github.com/acao)! - Fix bug with typed parameters on
+  the gql/graphql/etc tagged templates!
 
 ## 0.4.8
 
 ### Patch Changes
 
-- [#2470](https://github.com/graphql/graphiql/pull/2470) [`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b) Thanks [@acao](https://github.com/acao)! - Aims to resolve #2421
+- [#2470](https://github.com/graphql/graphiql/pull/2470)
+  [`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)
+  Thanks [@acao](https://github.com/acao)! - Aims to resolve #2421
 
   - graphql config errors only log to output channel, no longer crash the LSP
   - more performant LSP request no-ops for failing/missing config
 
-  this used to fail silently in the output channel, but vscode introduced a new retry and notification for this
+  this used to fail silently in the output channel, but vscode introduced a new
+  retry and notification for this
 
-  would like to provide more helpful graphql config DX in the future but this should be better for now
+  would like to provide more helpful graphql config DX in the future but this
+  should be better for now
 
-- Updated dependencies [[`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)]:
+- Updated dependencies
+  [[`d0017a93`](https://github.com/graphql/graphiql/commit/d0017a93b818cf3119e51c2b6c4a19004f98e29b)]:
   - graphql-language-service-server@2.7.24
 
 ## 0.4.7
 
 ### Patch Changes
 
-- [#2417](https://github.com/graphql/graphiql/pull/2417) [`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2) Thanks [@acao](https://github.com/acao)! - fix annoying trigger character on newline issue #2182
+- [#2417](https://github.com/graphql/graphiql/pull/2417)
+  [`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)
+  Thanks [@acao](https://github.com/acao)! - fix annoying trigger character on
+  newline issue #2182
 
-- Updated dependencies [[`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)]:
+- Updated dependencies
+  [[`6ca6a92d`](https://github.com/graphql/graphiql/commit/6ca6a92d0fd12af974683de9706c8e8e06c751c2)]:
   - graphql-language-service-server@2.7.23
 
 ## 0.4.6
 
 ### Patch Changes
 
-- [#2395](https://github.com/graphql/graphiql/pull/2395) [`f7f1e900`](https://github.com/graphql/graphiql/commit/f7f1e9001ba773bdccb29e513a188384cd805834) Thanks [@acao](https://github.com/acao)! - Release `vscode-graphql` changes since publishing was broken
+- [#2395](https://github.com/graphql/graphiql/pull/2395)
+  [`f7f1e900`](https://github.com/graphql/graphiql/commit/f7f1e9001ba773bdccb29e513a188384cd805834)
+  Thanks [@acao](https://github.com/acao)! - Release `vscode-graphql` changes
+  since publishing was broken
 
 ## 0.4.5
 
 ### Patch Changes
 
-- [#2382](https://github.com/graphql/graphiql/pull/2382) [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a) Thanks [@acao](https://github.com/acao)! - allow disabling query/SDL validation with `graphql-config` setting `{ extensions: { languageService: { enableValidation: false } } }`.
+- [#2382](https://github.com/graphql/graphiql/pull/2382)
+  [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)
+  Thanks [@acao](https://github.com/acao)! - allow disabling query/SDL
+  validation with `graphql-config` setting
+  `{ extensions: { languageService: { enableValidation: false } } }`.
 
-  Currently, users receive duplicate validation messages when using our LSP alongside existing validation tools like `graphql-eslint`, and this allows them to disable the LSP feature in that case.
+  Currently, users receive duplicate validation messages when using our LSP
+  alongside existing validation tools like `graphql-eslint`, and this allows
+  them to disable the LSP feature in that case.
 
-- Updated dependencies [[`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8), [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)]:
+- Updated dependencies
+  [[`6db28447`](https://github.com/graphql/graphiql/commit/6db284479a14873fea3e359efd71be0b15ab3ee8),
+  [`1bea864d`](https://github.com/graphql/graphiql/commit/1bea864d05dee04bb20c06dc3c3d68675b87a50a)]:
   - graphql-language-service-server@2.7.22
 
 ## 0.4.4
 
 ### Patch Changes
 
-- Updated dependencies [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
+- Updated dependencies
+  [[`d22f6111`](https://github.com/graphql/graphiql/commit/d22f6111a60af25727d8dbc1058c79607df76af2)]:
   - graphql-language-service-server@2.7.21
 
 ## 0.4.3
@@ -330,55 +517,88 @@
 
 ### Patch Changes
 
-- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f) Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to latest in server
-  - remove `graphql-config` dependency from `vscode-graphql` and `graphql-language-service`
-  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql` [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild` version
-- Updated dependencies [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
+- [`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)
+  Thanks [@acao](https://github.com/acao)! - - upgrade `graphql-config` to
+  latest in server
+  - remove `graphql-config` dependency from `vscode-graphql` and
+    `graphql-language-service`
+  - fix `vscode-graphql` esbuild bundling bug in `vscode-graphql`
+    [#2269](https://github.com/graphql/graphiql/issues/2269) by fixing `esbuild`
+    version
+- Updated dependencies
+  [[`c36504a8`](https://github.com/graphql/graphiql/commit/c36504a804d8cc54a5136340152999b4a1a2c69f)]:
   - graphql-language-service-server@2.7.19
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [#2276](https://github.com/graphql/graphiql/pull/2276) [`6973a20b`](https://github.com/graphql/graphiql/commit/6973a20bcd12a599acca7c5d6671ac49def2768c) Thanks [@acao](https://github.com/acao)! - Simplified, merged with monorepo, dropped operation execution feature, we will recommend an alternative instead.
+- [#2276](https://github.com/graphql/graphiql/pull/2276)
+  [`6973a20b`](https://github.com/graphql/graphiql/commit/6973a20bcd12a599acca7c5d6671ac49def2768c)
+  Thanks [@acao](https://github.com/acao)! - Simplified, merged with monorepo,
+  dropped operation execution feature, we will recommend an alternative instead.
 
 ### Patch Changes
 
-- Updated dependencies [[`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae)]:
+- Updated dependencies
+  [[`e15d1dae`](https://github.com/graphql/graphiql/commit/e15d1dae399a7d43d8d98f2ce431a9a1f0ba84ae)]:
   - graphql-language-service-server@2.7.18
 
 ## 0.3.52
 
 ### Patch Changes
 
-- [#452](https://github.com/graphql/vscode-graphql/pull/452) [`8878e42`](https://github.com/graphql/vscode-graphql/commit/8878e428c83eed4f53510f9071e9964f48b5d214) Thanks [@acao](https://github.com/acao)! - Limit activation events for package.json file provided `graphql-config`
+- [#452](https://github.com/graphql/vscode-graphql/pull/452)
+  [`8878e42`](https://github.com/graphql/vscode-graphql/commit/8878e428c83eed4f53510f9071e9964f48b5d214)
+  Thanks [@acao](https://github.com/acao)! - Limit activation events for
+  package.json file provided `graphql-config`
 
 ## 0.3.50
 
 ### Patch Changes
 
-- [#448](https://github.com/graphql/vscode-graphql/pull/448) [`f894dad`](https://github.com/graphql/vscode-graphql/commit/f894daddfe7382f7eb8e9c921c54904255a3557c) Thanks [@acao](https://github.com/acao)! - upgrade graphql-language-service-server to the latest patch version for windows path fix
+- [#448](https://github.com/graphql/vscode-graphql/pull/448)
+  [`f894dad`](https://github.com/graphql/vscode-graphql/commit/f894daddfe7382f7eb8e9c921c54904255a3557c)
+  Thanks [@acao](https://github.com/acao)! - upgrade
+  graphql-language-service-server to the latest patch version for windows path
+  fix
 
-* [#436](https://github.com/graphql/vscode-graphql/pull/436) [`2370607`](https://github.com/graphql/vscode-graphql/commit/23706071c6338c05e951783a3e7dfd5000da6d02) Thanks [@orta](https://github.com/orta)! - Adds support for making clicking on the graphql status item show the output channel
+* [#436](https://github.com/graphql/vscode-graphql/pull/436)
+  [`2370607`](https://github.com/graphql/vscode-graphql/commit/23706071c6338c05e951783a3e7dfd5000da6d02)
+  Thanks [@orta](https://github.com/orta)! - Adds support for making clicking on
+  the graphql status item show the output channel
 
-- [#277](https://github.com/graphql/vscode-graphql/pull/277) [`6017872`](https://github.com/graphql/vscode-graphql/commit/6017872b7f19ef5c3fcad404fca9ffd5b8ba5d87) Thanks [@AumyF](https://github.com/AumyF)! - provide 'Execute Query' for `/* GraphQL */` templates
+- [#277](https://github.com/graphql/vscode-graphql/pull/277)
+  [`6017872`](https://github.com/graphql/vscode-graphql/commit/6017872b7f19ef5c3fcad404fca9ffd5b8ba5d87)
+  Thanks [@AumyF](https://github.com/AumyF)! - provide 'Execute Query' for
+  `/* GraphQL */` templates
 
-* [#422](https://github.com/graphql/vscode-graphql/pull/422) [`0e2235d`](https://github.com/graphql/vscode-graphql/commit/0e2235d7fa229b78fb330c337d14fabf679884c2) Thanks [@orta](https://github.com/orta)! - Use the vscode theme API to set the right colours for the status bar item
+* [#422](https://github.com/graphql/vscode-graphql/pull/422)
+  [`0e2235d`](https://github.com/graphql/vscode-graphql/commit/0e2235d7fa229b78fb330c337d14fabf679884c2)
+  Thanks [@orta](https://github.com/orta)! - Use the vscode theme API to set the
+  right colours for the status bar item
 
 ## 0.3.48
 
 ### Patch Changes
 
-- [#402](https://github.com/graphql/vscode-graphql/pull/402) [`a97e5df`](https://github.com/graphql/vscode-graphql/commit/a97e5df9933dfc79b06e5202c84216cfe2d5f865) Thanks [@acao](https://github.com/acao)! - thanks @markusjwetzel! Add directive highlighting for type system directives. [https://github.com/graphql/vscode-graphql/pull/326](https://github.com/graphql/vscode-graphql/pull/326)
+- [#402](https://github.com/graphql/vscode-graphql/pull/402)
+  [`a97e5df`](https://github.com/graphql/vscode-graphql/commit/a97e5df9933dfc79b06e5202c84216cfe2d5f865)
+  Thanks [@acao](https://github.com/acao)! - thanks @markusjwetzel! Add
+  directive highlighting for type system directives.
+  [https://github.com/graphql/vscode-graphql/pull/326](https://github.com/graphql/vscode-graphql/pull/326)
 
 ## 0.3.43
 
 ### Patch Changes
 
-- [#391](https://github.com/graphql/vscode-graphql/pull/391) [`6be5593`](https://github.com/graphql/vscode-graphql/commit/6be5593a45a4629f3438f59223ecb04949cb48d2) Thanks [@acao](https://github.com/acao)! - LSP upgrades:
+- [#391](https://github.com/graphql/vscode-graphql/pull/391)
+  [`6be5593`](https://github.com/graphql/vscode-graphql/commit/6be5593a45a4629f3438f59223ecb04949cb48d2)
+  Thanks [@acao](https://github.com/acao)! - LSP upgrades:
 
   - bugfix for `insertText` & completion on invalid list types
-  - add support for template strings and tags with replacement expressions, so strings like these should work now:
+  - add support for template strings and tags with replacement expressions, so
+    strings like these should work now:
 
   ```ts
   const = /*GraphiQL*/
@@ -403,37 +623,54 @@
       `
   ```
 
-All notable changes to the "vscode-graphql" extension will be manually documented in this file.
+All notable changes to the "vscode-graphql" extension will be manually
+documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how
+to structure this file.
 
-The git log should show a fairly clean view of each of these new versions, and the issues/PRs associated.
+The git log should show a fairly clean view of each of these new versions, and
+the issues/PRs associated.
 
 # 0.3.25
 
-Remove `node_modules` from bundle after adding `esbuild` to make the extension bundle smaller
+Remove `node_modules` from bundle after adding `esbuild` to make the extension
+bundle smaller
 
 # 0.3.24
 
-Add highlighting and language support for `.mjs`, `.cjs`, `.es6`, `.esm` and other similar extensions
+Add highlighting and language support for `.mjs`, `.cjs`, `.es6`, `.esm` and
+other similar extensions
 
 # 0.3.23
 
-Major bugfixes for language features. Most bugs with language features not working should be resolved.
+Major bugfixes for language features. Most bugs with language features not
+working should be resolved.
 
-The `useSchemaFileDefinition` setting was deprecated, and SDL-driven projects work by default. If you want to opt-into an experimental feature to cache graphql-config schema result for definitions (useful for remote schemas), consult the readme on how to configure `cacheSchemaFileForLookup` option in vscode settings, or graphql config (yes you can enable/disable it per-project!)
+The `useSchemaFileDefinition` setting was deprecated, and SDL-driven projects
+work by default. If you want to opt-into an experimental feature to cache
+graphql-config schema result for definitions (useful for remote schemas),
+consult the readme on how to configure `cacheSchemaFileForLookup` option in
+vscode settings, or graphql config (yes you can enable/disable it per-project!)
 
-Definition lookup works by default with SDL file schemas. `cacheSchemaFileForLookup` must be enabled if you have a remote schema want definition lookup for input types, etc in queries
+Definition lookup works by default with SDL file schemas.
+`cacheSchemaFileForLookup` must be enabled if you have a remote schema want
+definition lookup for input types, etc in queries
 
 # 0.3.19
 
-- support `graphql-config` for `.ts` and `.toml` files by upgrading `graphql-config` & `graphql-language-service-server`
-- use `*` activation event, because `graphql-config` in `package.json` is impossible to detect otherwise using vscode `activationEvents`
-- support additional language features in `graphql-language-service-server` such as interface implements interfaces, etc
-- upgrade operation execution to use a new graphql client and support subscriptions
+- support `graphql-config` for `.ts` and `.toml` files by upgrading
+  `graphql-config` & `graphql-language-service-server`
+- use `*` activation event, because `graphql-config` in `package.json` is
+  impossible to detect otherwise using vscode `activationEvents`
+- support additional language features in `graphql-language-service-server` such
+  as interface implements interfaces, etc
+- upgrade operation execution to use a new graphql client and support
+  subscriptions
 - fix openvsx & vscode publish by re-creating PATs and signing new agreements
 
-Note: there are still some known bugs in the language server we will be fixing soon:
+Note: there are still some known bugs in the language server we will be fixing
+soon:
 
 - if you don't see editor output, please check your config
 - output channel may show errors even after your configuration works
@@ -448,15 +685,20 @@ LSP bugfixes:
 
 # 0.3.8
 
-- require `dotenv` in the server runtime (for loading graphql config values), and allow a `graphql-config.dotEnvPath` configuration to specify specific paths
+- require `dotenv` in the server runtime (for loading graphql config values),
+  and allow a `graphql-config.dotEnvPath` configuration to specify specific
+  paths
 - reload server on workspace configuration changes
-- reload sever-side `graphql-config` and language service on config file changes. definitions cache/etc will be rebuilt
-  - note: client not configured to reload on graphql config changes yet (i.e endpoints)
+- reload sever-side `graphql-config` and language service on config file
+  changes. definitions cache/etc will be rebuilt
+  - note: client not configured to reload on graphql config changes yet (i.e
+    endpoints)
 - accept all `graphql-config.loadConfig()` options
 
 # 0.3.7
 
-- update underlying `graphql-language-service-server` to allow .gql, .graphqls extensions
+- update underlying `graphql-language-service-server` to allow .gql, .graphqls
+  extensions
 
 # 0.3.6
 
@@ -465,11 +707,14 @@ LSP bugfixes:
 # 0.3.5
 
 - readme documentation improvements, more examples, FAQ, known issues
-- bump `graphql-language-service-server` to allow implicit fragment completion (non-inline fragments). just include your fragments file or string in the graphql-config `documents`
+- bump `graphql-language-service-server` to allow implicit fragment completion
+  (non-inline fragments). just include your fragments file or string in the
+  graphql-config `documents`
 
 # 0.3.4
 
-- remove insiders announcement until tooling is properly in place, and insiders extension is up to date
+- remove insiders announcement until tooling is properly in place, and insiders
+  extension is up to date
 
 # 0.3.3
 
@@ -487,7 +732,8 @@ LSP bugfixes:
   - remove watchman dependency 🎉
   - introduce workspace symbol lookup, outline
   - validation and completion for input variables
-  - generate a schema output by default, for code-first schemas. SDL first schemas have an override option now
+  - generate a schema output by default, for code-first schemas. SDL first
+    schemas have an override option now
 
 ## Historical 0.2.x versions
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12420,11 +12420,6 @@ monaco-editor-webpack-plugin@^7.0.1:
   dependencies:
     loader-utils "^2.0.2"
 
-monaco-editor@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.31.0.tgz#ec53566e40b612a96c0d54f77d37acef6d9dd70e"
-  integrity sha512-H3QmysEwxxY8oxmFhIFcY9JkuwilUDa6txdAxb797cVr7XFZX27a3SDwcGJmTlV9iGPwdh132r3KKCS5aNL4Gg==
-
 monaco-editor@^0.36.0:
   version "0.36.0"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.36.0.tgz#8e7dba92f8110b369fdbc2312366184216419fc7"
@@ -12433,6 +12428,11 @@ monaco-editor@^0.36.0:
     "@types/shelljs" "^0.8.11"
     pin-github-action "^1.8.0"
     shelljs "^0.8.5"
+
+monaco-editor@^0.36.1:
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.36.1.tgz#aad528c815605307473a1634612946921d8079b5"
+  integrity sha512-/CaclMHKQ3A6rnzBzOADfwdSJ25BFoFT0Emxsc4zYVyav5SkK9iA6lEtIeuN/oRYbwPgviJT+t3l+sjFa28jYg==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
- fix monaco peer dependencies
- fix linting issue with nextjs example
- run `yarn format`

note - it seems we need to run `yarn format` after changelogs are generated