### PR TITLE
remove `propsRef.current`

### DIFF
--- a/.changeset/sixty-toys-wave.md
+++ b/.changeset/sixty-toys-wave.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-explorer': patch
+---
+
+remove propsRef.current

--- a/packages/graphiql-plugin-code-exporter/src/index.tsx
+++ b/packages/graphiql-plugin-code-exporter/src/index.tsx
@@ -8,9 +8,6 @@ import './graphiql-code-exporter.d.ts';
 import './index.css';
 
 export function useExporterPlugin(props: GraphiQLCodeExporterProps) {
-  const propsRef = useRef(props);
-  propsRef.current = props;
-
   const pluginRef = useRef<GraphiQLPlugin>();
   pluginRef.current ||= {
     title: 'GraphiQL Code Exporter',
@@ -30,7 +27,7 @@ export function useExporterPlugin(props: GraphiQLCodeExporterProps) {
       </svg>
     ),
     content: () => (
-      <GraphiQLCodeExporter codeMirrorTheme="graphiql" {...propsRef.current} />
+      <GraphiQLCodeExporter codeMirrorTheme="graphiql" {...props} />
     ),
   };
 

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -127,9 +127,6 @@ function ExplorerPlugin(props: GraphiQLExplorerProps) {
 }
 
 export function useExplorerPlugin(props: GraphiQLExplorerProps) {
-  const propsRef = useRef(props);
-  propsRef.current = props;
-
   const pluginRef = useRef<GraphiQLPlugin>();
   pluginRef.current ||= {
     title: 'GraphiQL Explorer',
@@ -155,7 +152,7 @@ export function useExplorerPlugin(props: GraphiQLExplorerProps) {
         />
       </svg>
     ),
-    content: () => <ExplorerPlugin {...propsRef.current} />,
+    content: () => <ExplorerPlugin {...props} />,
   };
   return pluginRef.current;
 }


### PR DESCRIPTION
there is no reason to do it, even before when we stored the plugin with `useMemo`