### PR TITLE
fix: html examples

### DIFF
--- a/packages/graphiql-plugin-code-exporter/examples/index.html
+++ b/packages/graphiql-plugin-code-exporter/examples/index.html
@@ -44,8 +44,14 @@
     ></script>
 
     <script
+      src="https://unpkg.com/regenerator-runtime@0.13.11/runtime.js"
+      integrity="sha512-fY3ctp4t405NhHJPeqLELqA6qmP96VaiY7ZsmZq3MZBPPz1t734NOWSAfKa4yTPvlGTxBlut7BOrV5CZ4eZEuQ=="
+      crossorigin="anonymous"
+    ></script>
+
+    <script
       src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha512-FmqQBx9FVDKvUNDuimXswv4o1eqQUqzQYIuEoIkmkDaoXMUvmD9fKQXYSrSEMf5LQUEZr5EEMesxUzex2wS/hg=="
+      integrity="sha512-5YC23rtERQz8Y2RQmdhcffi7DaRUvjJ7tvU54JKatms2pSCld7Z6am1/WcP+BpHtYeGyXBdifBBdFT3zypHmng=="
       crossorigin="anonymous"
     ></script>
     <script

--- a/packages/graphiql-plugin-code-exporter/examples/index.html
+++ b/packages/graphiql-plugin-code-exporter/examples/index.html
@@ -51,12 +51,12 @@
 
     <script
       src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha512-5YC23rtERQz8Y2RQmdhcffi7DaRUvjJ7tvU54JKatms2pSCld7Z6am1/WcP+BpHtYeGyXBdifBBdFT3zypHmng=="
+      integrity="sha512-O/IUgl7xtok0iv0A3+iaIRIuDdeRGEd/emCf7D6NDb1qeGUGhFKQccs5/IzuAVUr8b4DOxej0JTOY6e3/o8U+w=="
       crossorigin="anonymous"
     ></script>
     <script
       src="https://unpkg.com/@graphiql/plugin-code-exporter/dist/graphiql-plugin-code-exporter.umd.js"
-      integrity="sha512-NwP+k36ExLYeIqp2lniZCblbz/FLJ/lQlBV55B6vafZWIYppwHUp1gCdvlaaUjV95RWPInQy4z/sIa56psJy/g=="
+      integrity="sha512-bZesuT5p2QZ6cSlpgPxI83Db5G3Bw35RTKz+Z+kc6RUu4/PtPkNddzax0VWA6VoXvIwT8s4i5nQklZ+AGJQD2Q=="
       crossorigin="anonymous"
     ></script>
 

--- a/packages/graphiql-plugin-explorer/examples/index.html
+++ b/packages/graphiql-plugin-explorer/examples/index.html
@@ -45,7 +45,7 @@
 
     <script
       src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha512-FVCV2//UVo1qJ3Kg6kkHLe0Hg+IJhjrGa+aYHh8xD4KmwbbjthIzvaAcCJsQgA43+k+6u7HqORKXMyMt82Srfw=="
+      integrity="sha512-5YC23rtERQz8Y2RQmdhcffi7DaRUvjJ7tvU54JKatms2pSCld7Z6am1/WcP+BpHtYeGyXBdifBBdFT3zypHmng=="
       crossorigin="anonymous"
     ></script>
     <script

--- a/packages/graphiql-plugin-explorer/examples/index.html
+++ b/packages/graphiql-plugin-explorer/examples/index.html
@@ -45,7 +45,7 @@
 
     <script
       src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha512-5YC23rtERQz8Y2RQmdhcffi7DaRUvjJ7tvU54JKatms2pSCld7Z6am1/WcP+BpHtYeGyXBdifBBdFT3zypHmng=="
+      integrity="sha512-O/IUgl7xtok0iv0A3+iaIRIuDdeRGEd/emCf7D6NDb1qeGUGhFKQccs5/IzuAVUr8b4DOxej0JTOY6e3/o8U+w=="
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
I tried to use `packages/graphiql-plugin-code-exporter/examples/index.html` and `packages/graphiql-plugin-explorer/examples/index.html` examples, but it turned out that they don't work.

- Updated integrity attribute of `https://unpkg.com/graphiql/graphiql.min.js`
- Added `regenerator-runtime` script in `graphiql-plugin-code-exporter`