### PR TITLE
feat: add syntax highlighting in Scala

### DIFF
--- a/.changeset/tasty-socks-swim.md
+++ b/.changeset/tasty-socks-swim.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': minor
+---
+
+Add syntax highlighting in Scala

--- a/packages/vscode-graphql-syntax/README.md
+++ b/packages/vscode-graphql-syntax/README.md
@@ -9,6 +9,7 @@ matching.
 - Python
 - PHP
 - [Markdown](#markdown)
+- [Scala](#scala)
 
 You'll want to install this if you do not use `graphql-config`, or want to use
 the highlighting with other extensions than `vscode-graphql`
@@ -139,6 +140,30 @@ string : X = gql`
 }
 ```
 ````
+
+#### Scala
+
+Using a `graphql`, `gql` or `schema` string interpolator:
+
+```scala
+val query = graphql"""
+  { id }
+"""
+val query2 = gql"""
+  { id }
+"""
+val query3 = schema"""
+  { id }
+"""
+```
+
+Using a comment-delimited pattern:
+
+```scala
+val query = """#graphql
+ { id }
+"""
+```
 
 ## Other languages
 

--- a/packages/vscode-graphql-syntax/grammars/graphql.scala.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.scala.json
@@ -1,0 +1,75 @@
+{
+  "fileTypes": ["scala"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(gql|graphql|schema)(\"\"\")",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.interpolation.scala"
+        },
+        "2": {
+          "name": "string.quoted.triple.scala"
+        }
+      },
+      "end": "(\"\"\")",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.triple.scala"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "(gql|graphql|schema)(\")",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.interpolation.scala"
+        },
+        "2": {
+          "name": "string.quoted.double.scala"
+        }
+      },
+      "end": "(\")",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.double.scala"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "begin": "(\"\"\")(#graphql)",
+      "beginCaptures": {
+        "1": {
+          "name": "string.quoted.triple.scala"
+        },
+        "2": {
+          "name": "comment.line.graphql.js"
+        }
+      },
+      "end": "(\"\"\")",
+      "endCaptures": {
+        "1": {
+          "name": "string.quoted.triple.scala"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.graphql.scala"
+}

--- a/packages/vscode-graphql-syntax/package.json
+++ b/packages/vscode-graphql-syntax/package.json
@@ -110,6 +110,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.graphql": "graphql"
         }
+      },
+      {
+        "injectTo": [
+          "source.scala"
+        ],
+        "scopeName": "inline.graphql.scala",
+        "path": "./grammars/graphql.scala.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.graphql": "graphql"
+        }
       }
     ]
   },


### PR DESCRIPTION
Adds syntax highlighting for graphql\gql strings in Scala
<img width="899" alt="image" src="https://user-images.githubusercontent.com/10114577/226348102-748150a8-fc35-4f1c-a2c7-2f54f8695df5.png">

