### PR TITLE
[ESLint] replace `.forEach` with `for..of`

### DIFF
--- a/.changeset/breezy-laws-sneeze.md
+++ b/.changeset/breezy-laws-sneeze.md
@@ -1,0 +1,12 @@
+---
+'codemirror-graphql': patch
+'graphiql': patch
+'@graphiql/react': patch
+'@graphiql/toolkit': patch
+'graphql-language-service': patch
+'graphql-language-service-server': patch
+'monaco-graphql': patch
+'vscode-graphql-execution': patch
+---
+
+replace `.forEach` with `for..of`

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -268,6 +268,7 @@ module.exports = {
     'unicorn/prefer-export-from': ['error', { ignoreUsedVariables: true }],
     'unicorn/throw-new-error': 'error',
     'unicorn/prefer-includes': 'error',
+    'unicorn/no-array-for-each': 'error',
     'no-lonely-if': 'error',
     'unicorn/no-lonely-if': 'error',
     'unicorn/prefer-optional-catch-binding': 'error',

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -256,7 +256,7 @@ function getSchemaPicker(): HTMLSelectElement {
   const schemaPicker = document.createElement('select');
   schemaPicker.id = 'schema-picker';
 
-  schemaOptions.forEach(option => {
+  for (const option of schemaOptions) {
     const optEl = document.createElement('option');
     optEl.value = option.value;
     optEl.label = option.label;
@@ -264,7 +264,7 @@ function getSchemaPicker(): HTMLSelectElement {
       optEl.selected = true;
     }
     schemaPicker.appendChild(optEl);
-  });
+  }
 
   return schemaPicker;
 }

--- a/packages/codemirror-graphql/src/utils/collectVariables.ts
+++ b/packages/codemirror-graphql/src/utils/collectVariables.ts
@@ -22,18 +22,18 @@ export default function collectVariables(
   documentAST: DocumentNode,
 ) {
   const variableToType = Object.create(null);
-  documentAST.definitions.forEach(definition => {
+  for (const definition of documentAST.definitions) {
     if (definition.kind === 'OperationDefinition') {
       const { variableDefinitions } = definition;
       if (variableDefinitions) {
-        variableDefinitions.forEach(({ variable, type }) => {
+        for (const { variable, type } of variableDefinitions) {
           const inputType = typeFromAST(schema, type as NamedTypeNode);
           if (inputType) {
             variableToType[variable.name.value] = inputType;
           }
-        });
+        }
       }
     }
-  });
+  }
   return variableToType;
 }

--- a/packages/codemirror-graphql/src/utils/runParser.ts
+++ b/packages/codemirror-graphql/src/utils/runParser.ts
@@ -23,11 +23,11 @@ export default function runParser(
   const state = parser.startState();
   const lines = sourceText.split('\n');
 
-  lines.forEach(line => {
+  for (const line of lines) {
     const stream = new CharacterStream(line);
     while (!stream.eol()) {
       const style = parser.token(stream, state);
       callbackFn(stream, state, style);
     }
-  });
+  }
 }

--- a/packages/codemirror-graphql/src/variables/lint.ts
+++ b/packages/codemirror-graphql/src/variables/lint.ts
@@ -85,14 +85,14 @@ function validateVariables(
 ) {
   const errors: CodeMirror.Annotation[] = [];
 
-  variablesAST.members.forEach(member => {
+  for (const member of variablesAST.members) {
     if (member) {
       const variableName = member.key?.value;
       const type = variableToType[variableName];
       if (type) {
-        validateValue(type, member.value).forEach(([node, message]) => {
+        for (const [node, message] of validateValue(type, member.value)) {
           errors.push(lintError(editor, node, message));
-        });
+        }
       } else {
         errors.push(
           lintError(
@@ -103,7 +103,7 @@ function validateVariables(
         );
       }
     }
-  });
+  }
 
   return errors;
 }
@@ -169,7 +169,7 @@ function validateValue(
     );
 
     // Look for missing non-nullable fields.
-    Object.keys(type.getFields()).forEach(fieldName => {
+    for (const fieldName of Object.keys(type.getFields())) {
       const field = type.getFields()[fieldName];
       if (
         !providedFields[fieldName] &&
@@ -181,7 +181,7 @@ function validateValue(
           `Object of type "${type}" is missing required field "${fieldName}".`,
         ]);
       }
-    });
+    }
 
     return fieldErrors;
   }

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -314,13 +314,13 @@ export function useAutoCompleteLeafs({
             },
           ),
         );
-        setTimeout(() => markers.forEach(marker => marker.clear()), 7000);
+        setTimeout(() => { for (const marker of markers) {marker.clear()} }, 7000);
         let newCursorIndex = cursorIndex;
-        insertions.forEach(({ index, string }) => {
+        for (const { index, string } of insertions) {
           if (index < cursorIndex) {
             newCursorIndex += string.length;
           }
-        });
+        }
         queryEditor.setCursor(queryEditor.posFromIndex(newCursorIndex));
       });
     }

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -314,7 +314,11 @@ export function useAutoCompleteLeafs({
             },
           ),
         );
-        setTimeout(() => { for (const marker of markers) {marker.clear()} }, 7000);
+        setTimeout(() => {
+          for (const marker of markers) {
+            marker.clear();
+          }
+        }, 7000);
         let newCursorIndex = cursorIndex;
         for (const { index, string } of insertions) {
           if (index < cursorIndex) {

--- a/packages/graphiql-toolkit/src/graphql-helpers/auto-complete.ts
+++ b/packages/graphiql-toolkit/src/graphql-helpers/auto-complete.ts
@@ -109,11 +109,11 @@ function defaultGetDefaultFieldNames(type: GraphQLType) {
 
   // Include all leaf-type fields.
   const leafFieldNames: Array<string> = [];
-  Object.keys(fields).forEach(fieldName => {
+  for (const fieldName of Object.keys(fields)) {
     if (isLeafType(fields[fieldName].type)) {
       leafFieldNames.push(fieldName);
     }
-  });
+  }
   return leafFieldNames;
 }
 
@@ -174,10 +174,10 @@ function withInsertions(initial: string, insertions: Insertion[]) {
   }
   let edited = '';
   let prevIndex = 0;
-  insertions.forEach(({ index, string }) => {
+  for (const { index, string } of insertions) {
     edited += initial.slice(prevIndex, index) + string;
     prevIndex = index;
-  });
+  }
   edited += initial.slice(prevIndex);
   return edited;
 }

--- a/packages/graphiql/cypress/e2e/init.cy.ts
+++ b/packages/graphiql/cypress/e2e/init.cy.ts
@@ -38,7 +38,9 @@ describe('GraphiQL On Initialization', () => {
     ];
     cy.visit(`/`);
     cy.get('.graphiql-query-editor').contains('# Welcome to GraphiQL');
-    for (const cSelector of containers) {cy.get(cSelector).should('be.visible');}
+    for (const cSelector of containers) {
+      cy.get(cSelector).should('be.visible');
+    }
   });
 
   it('Executes a GraphQL query over HTTP that has the expected result', () => {

--- a/packages/graphiql/cypress/e2e/init.cy.ts
+++ b/packages/graphiql/cypress/e2e/init.cy.ts
@@ -38,7 +38,7 @@ describe('GraphiQL On Initialization', () => {
     ];
     cy.visit(`/`);
     cy.get('.graphiql-query-editor').contains('# Welcome to GraphiQL');
-    containers.forEach(cSelector => cy.get(cSelector).should('be.visible'));
+    for (const cSelector of containers) {cy.get(cSelector).should('be.visible');}
   });
 
   it('Executes a GraphQL query over HTTP that has the expected result', () => {

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -14,16 +14,14 @@
 
 // Parse the search string to get url parameters.
 var parameters = {};
-for (const entry of window.location.search
-  .slice(1)
-  .split('&')) {
-    var eq = entry.indexOf('=');
-    if (eq >= 0) {
-      parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
-        entry.slice(eq + 1),
-      );
-    }
+for (const entry of window.location.search.slice(1).split('&')) {
+  var eq = entry.indexOf('=');
+  if (eq >= 0) {
+    parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
+      entry.slice(eq + 1),
+    );
   }
+}
 
 // When the query and variables string is edited, update the URL bar so
 // that it can be easily shared.

--- a/packages/graphiql/resources/renderExample.js
+++ b/packages/graphiql/resources/renderExample.js
@@ -14,17 +14,16 @@
 
 // Parse the search string to get url parameters.
 var parameters = {};
-window.location.search
+for (const entry of window.location.search
   .slice(1)
-  .split('&')
-  .forEach(function (entry) {
+  .split('&')) {
     var eq = entry.indexOf('=');
     if (eq >= 0) {
       parameters[decodeURIComponent(entry.slice(0, eq))] = decodeURIComponent(
         entry.slice(eq + 1),
       );
     }
-  });
+  }
 
 // When the query and variables string is edited, update the URL bar so
 // that it can be easily shared.

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -151,15 +151,15 @@ export class GraphQLCache implements GraphQLCacheInterface {
     });
 
     const asts = new Set<FragmentInfo>();
-    referencedFragNames.forEach(name => {
+    for (const name of referencedFragNames) {
       if (!existingFrags.has(name) && fragmentDefinitions.has(name)) {
         asts.add(nullthrows(fragmentDefinitions.get(name)));
       }
-    });
+    }
 
     const referencedFragments: FragmentInfo[] = [];
 
-    asts.forEach(ast => {
+    for (const ast of asts) {
       visit(ast.definition, {
         FragmentSpread(node) {
           if (
@@ -174,7 +174,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       if (!existingFrags.has(ast.definition.name.value)) {
         referencedFragments.push(ast);
       }
-    });
+    }
 
     return referencedFragments;
   };
@@ -252,15 +252,15 @@ export class GraphQLCache implements GraphQLCacheInterface {
     });
 
     const asts = new Set<ObjectTypeInfo>();
-    referencedObjectTypes.forEach(name => {
+    for (const name of referencedObjectTypes) {
       if (!existingObjectTypes.has(name) && objectTypeDefinitions.has(name)) {
         asts.add(nullthrows(objectTypeDefinitions.get(name)));
       }
-    });
+    }
 
     const referencedObjects: ObjectTypeInfo[] = [];
 
-    asts.forEach(ast => {
+    for (const ast of asts) {
       visit(ast.definition, {
         NamedType(node) {
           if (
@@ -275,7 +275,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
       if (!existingObjectTypes.has(ast.definition.name.value)) {
         referencedObjects.push(ast);
       }
-    });
+    }
 
     return referencedObjects;
   };
@@ -412,16 +412,16 @@ export class GraphQLCache implements GraphQLCacheInterface {
     });
     if (cache) {
       // first go through the fragment list to delete the ones from this file
-      cache.forEach((value, key) => {
+      for (const [key, value] of cache.entries()) {
         if (value.filePath === filePath) {
           cache.delete(key);
         }
-      });
-      asts.forEach(({ ast, query }) => {
+      }
+      for (const { ast, query } of asts) {
         if (!ast) {
-          return;
+          continue;
         }
-        ast.definitions.forEach(definition => {
+        for (const definition of ast.definitions) {
           if (definition.kind === Kind.FRAGMENT_DEFINITION) {
             cache.set(definition.name.value, {
               filePath,
@@ -429,8 +429,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
               definition,
             });
           }
-        });
-      });
+        }
+      }
     }
   }
 
@@ -474,16 +474,16 @@ export class GraphQLCache implements GraphQLCacheInterface {
     });
     if (cache) {
       // first go through the types list to delete the ones from this file
-      cache.forEach((value, key) => {
+      for (const [key, value] of cache.entries()) {
         if (value.filePath === filePath) {
           cache.delete(key);
         }
-      });
-      asts.forEach(({ ast, query }) => {
+      }
+      for (const { ast, query } of asts) {
         if (!ast) {
-          return;
+          continue;
         }
-        ast.definitions.forEach(definition => {
+        for (const definition of ast.definitions) {
           if (
             definition.kind === Kind.OBJECT_TYPE_DEFINITION ||
             definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
@@ -495,8 +495,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
               definition,
             });
           }
-        });
-      });
+        }
+      }
     }
   }
 
@@ -537,12 +537,12 @@ export class GraphQLCache implements GraphQLCacheInterface {
     if (!graphQLFileMap) {
       return schema;
     }
-    graphQLFileMap.forEach(({ filePath, asts }) => {
-      asts.forEach(ast => {
+    for (const { filePath, asts } of graphQLFileMap.values()) {
+      for (const ast of asts) {
         if (filePath === schemaPath) {
-          return;
+          continue;
         }
-        ast.definitions.forEach(definition => {
+        for (const definition of ast.definitions) {
           switch (definition.kind) {
             case Kind.OBJECT_TYPE_DEFINITION:
             case Kind.INTERFACE_TYPE_DEFINITION:
@@ -560,9 +560,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
               typeExtensions.push(definition);
               break;
           }
-        });
-      });
-    });
+        }
+      }
+    }
 
     if (schemaCacheKey) {
       const sorted = typeExtensions.sort((a: any, b: any) => {
@@ -723,12 +723,12 @@ export class GraphQLCache implements GraphQLCacheInterface {
     const fragmentDefinitions = new Map();
     const graphQLFileMap = new Map();
 
-    responses.forEach(response => {
+    for (const response of responses) {
       const { filePath, content, asts, mtime, size } = response;
 
       if (asts) {
-        asts.forEach(ast => {
-          ast.definitions.forEach(definition => {
+        for (const ast of asts) {
+          for (const definition of ast.definitions) {
             if (definition.kind === Kind.FRAGMENT_DEFINITION) {
               fragmentDefinitions.set(definition.name.value, {
                 filePath,
@@ -747,8 +747,8 @@ export class GraphQLCache implements GraphQLCacheInterface {
                 definition,
               });
             }
-          });
-        });
+          }
+        }
       }
 
       // Relay the previous object whether or not ast exists.
@@ -759,7 +759,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
         mtime,
         size,
       });
-    });
+    }
 
     return {
       objectTypeDefinitions,
@@ -794,7 +794,9 @@ export class GraphQLCache implements GraphQLCacheInterface {
           };
         }
 
-        queries.forEach(({ query }) => asts.push(parse(query)));
+        for (const { query } of queries) {
+          asts.push(parse(query));
+        }
         return {
           filePath,
           content,

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -293,11 +293,11 @@ function traverse(node: { [key: string]: any }, visitors: TagVisitors) {
     if (prop && typeof prop === 'object' && typeof prop.type === 'string') {
       visit(prop, visitors);
     } else if (Array.isArray(prop)) {
-      prop.forEach(item => {
+      for (const item of prop) {
         if (item && typeof item === 'object' && typeof item.type === 'string') {
           visit(item, visitors);
         }
-      });
+      }
     }
   }
 }

--- a/packages/graphql-language-service/benchmark/index.ts
+++ b/packages/graphql-language-service/benchmark/index.ts
@@ -30,7 +30,7 @@ const runSplitTest = (name: string, schema: string) => {
   const parser = onlineParser();
   let state: any = parser.startState();
 
-  schema.split('\n').forEach((line, index) => {
+  for (const [index, line] of schema.split('\n').entries()) {
     let prevState: any;
     let completeState: any;
 
@@ -59,7 +59,7 @@ const runSplitTest = (name: string, schema: string) => {
         stats.push(e.target.stats);
       },
     });
-  });
+  }
 
   console.log(`Started test suite: ${name}`);
 

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -746,11 +746,11 @@ function getSuggestionsForFragmentTypeConditions(
       // they implement.
       const possibleObjTypes = schema.getPossibleTypes(abstractType);
       const possibleIfaceMap = Object.create(null);
-      possibleObjTypes.forEach(type => {
-        type.getInterfaces().forEach(iface => {
+      for (const type of possibleObjTypes) {
+        for (const iface of type.getInterfaces()) {
           possibleIfaceMap[iface.name] = iface;
-        });
-      });
+        }
+      }
       possibleTypes = possibleObjTypes.concat(objectValues(possibleIfaceMap));
     } else {
       // The parent type is a non-abstract Object type, so the only possible

--- a/packages/graphql-language-service/src/interface/getDefinition.ts
+++ b/packages/graphql-language-service/src/interface/getDefinition.ts
@@ -87,19 +87,19 @@ export async function getDefinitionQueryResultForField(
 
   const definitions: Array<Definition> = [];
 
-  defNodes.forEach(({ filePath, content, definition }) => {
+  for (const { filePath, content, definition } of defNodes) {
     const fieldDefinition = (
       definition as ObjectTypeDefinitionNode
     ).fields?.find(item => item.name.value === fieldName);
 
     if (fieldDefinition == null) {
-      return null;
+      continue;
     }
 
     definitions.push(
       getDefinitionForFieldDefinition(filePath || '', content, fieldDefinition),
     );
-  });
+  }
 
   return {
     definitions,

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -138,7 +138,7 @@ function annotations(
     return [];
   }
   const highlightedNodes: Diagnostic[] = [];
-  error.nodes.forEach((node, i) => {
+  for (const [i, node] of error.nodes.entries()) {
     const highlightNode =
       node.kind !== 'Variable' && 'name' in node && node.name !== undefined
         ? node.name
@@ -166,7 +166,7 @@ function annotations(
         ),
       });
     }
-  });
+  }
   return highlightedNodes;
 }
 

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
@@ -142,14 +142,14 @@ export const expectVarsDef = (
 ) => {
   t.punctuation(/\(/, { kind: 'VariableDefinitions' });
 
-  vars.forEach(variable => {
+  for (const variable of vars) {
     t.variable('$', { kind: 'Variable' });
     t.variable(variable.name);
     t.punctuation(':', { kind: 'VariableDefinition' });
     t.name(variable.type, { kind: 'NamedType' });
 
     stream.eatWhile(/(,|\s)/);
-  });
+  }
 
   t.punctuation(/\)/, { kind: onKind });
 };
@@ -160,7 +160,7 @@ export const expectArgs = (
 ) => {
   t.punctuation(/\(/, { kind: 'Arguments' });
 
-  args.forEach(arg => {
+  for (const arg of args) {
     t.attribute(arg.name, { kind: 'Argument' });
     t.punctuation(':');
     if (arg.isVariable) {
@@ -177,7 +177,7 @@ export const expectArgs = (
     }
 
     stream.eatWhile(/(,|\s)/);
-  });
+  }
 
   t.punctuation(/\)/, { kind: onKind });
 };

--- a/packages/graphql-language-service/src/utils/collectVariables.ts
+++ b/packages/graphql-language-service/src/utils/collectVariables.ts
@@ -26,11 +26,11 @@ export function collectVariables(
 ): VariableToType {
   const variableToType: VariableToType = Object.create(null);
   // it would be more ideal to use visitWithTypeInfo here but it's very simple
-  documentAST.definitions.forEach(definition => {
+  for (const definition of documentAST.definitions) {
     if (definition.kind === 'OperationDefinition') {
       const { variableDefinitions } = definition;
       if (variableDefinitions) {
-        variableDefinitions.forEach(({ variable, type }) => {
+        for (const { variable, type } of variableDefinitions) {
           const inputType = typeFromAST(
             schema,
             type as NamedTypeNode,
@@ -44,9 +44,9 @@ export function collectVariables(
           ) {
             variableToType[variable.name.value] = GraphQLFloat;
           }
-        });
+        }
       }
     }
-  });
+  }
   return variableToType;
 }

--- a/packages/graphql-language-service/src/utils/fragmentDependencies.ts
+++ b/packages/graphql-language-service/src/utils/fragmentDependencies.ts
@@ -51,15 +51,15 @@ export const getFragmentDependenciesForAST = (
   });
 
   const asts = new Set<FragmentDefinitionNode>();
-  referencedFragNames.forEach(name => {
+  for (const name of referencedFragNames) {
     if (!existingFrags.has(name) && fragmentDefinitions.has(name)) {
       asts.add(nullthrows(fragmentDefinitions.get(name)));
     }
-  });
+  }
 
   const referencedFragments: FragmentDefinitionNode[] = [];
 
-  asts.forEach(ast => {
+  for (const ast of asts) {
     visit(ast, {
       FragmentSpread(node) {
         if (
@@ -74,7 +74,7 @@ export const getFragmentDependenciesForAST = (
     if (!existingFrags.has(ast.name.value)) {
       referencedFragments.push(ast);
     }
-  });
+  }
 
   return referencedFragments;
 };

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -158,9 +158,9 @@ function getJSONSchemaFromGraphQLType(
       definition.items = def;
     }
     if (defs) {
-      Object.keys(defs).forEach(defName => {
+      for (const defName of Object.keys(defs)) {
         definitions[defName] = defs[defName];
-      });
+      }
     }
   }
   if (isNonNullType(type)) {
@@ -171,9 +171,9 @@ function getJSONSchemaFromGraphQLType(
     );
     definition = def;
     if (defs) {
-      Object.keys(defs).forEach(defName => {
+      for (const defName of Object.keys(defs)) {
         definitions[defName] = defs[defName];
-      });
+      }
     }
   }
   if (isInputObjectType(type)) {
@@ -202,7 +202,7 @@ function getJSONSchemaFromGraphQLType(
         }
       }
 
-      Object.keys(fields).forEach(fieldName => {
+      for (const fieldName of Object.keys(fields)) {
         const field = fields[fieldName];
         const {
           required: fieldRequired,
@@ -242,7 +242,7 @@ function getJSONSchemaFromGraphQLType(
             definitions[defName] = typeDefinitions[defName];
           });
         }
-      });
+      }
       definitions[type.name] = fieldDef;
     }
   }
@@ -324,7 +324,7 @@ export function getVariablesJSONSchema(
 
   if (variableToType) {
     // I would use a reduce here, but I wanted it to be readable.
-    Object.entries(variableToType).forEach(([variableName, type]) => {
+    for (const [variableName, type] of Object.entries(variableToType)) {
       const { definition, required, definitions } =
         getJSONSchemaFromGraphQLType(type, runtimeOptions);
       jsonSchema.properties[variableName] = definition;
@@ -334,7 +334,7 @@ export function getVariablesJSONSchema(
       if (definitions) {
         jsonSchema.definitions = { ...jsonSchema?.definitions, ...definitions };
       }
-    });
+    }
   }
   return jsonSchema;
 }

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -85,7 +85,9 @@ export class LanguageService {
   }
 
   private _cacheSchemas() {
-    for (const schema of this._schemas) {this._cacheSchema(schema);}
+    for (const schema of this._schemas) {
+      this._cacheSchema(schema);
+    }
   }
 
   private _cacheSchema(schemaConfig: SchemaConfig) {

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -85,7 +85,7 @@ export class LanguageService {
   }
 
   private _cacheSchemas() {
-    this._schemas.forEach(schema => this._cacheSchema(schema));
+    for (const schema of this._schemas) {this._cacheSchema(schema);}
   }
 
   private _cacheSchema(schemaConfig: SchemaConfig) {

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -94,12 +94,12 @@ export class DiagnosticsAdapter {
         },
       },
       defaults.onDidChange(() => {
-        editor.getModels().forEach(model => {
+        for (const model of editor.getModels()) {
           if (getModelLanguageId(model) === this.defaults.languageId) {
             onModelRemoved(model);
             onModelAdd(model);
           }
-        });
+        }
       }),
     );
 
@@ -107,7 +107,7 @@ export class DiagnosticsAdapter {
   }
 
   public dispose(): void {
-    this._disposables.forEach(d => d?.dispose());
+    for (const d of this._disposables) {d?.dispose();}
     this._disposables = [];
   }
 

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -107,7 +107,9 @@ export class DiagnosticsAdapter {
   }
 
   public dispose(): void {
-    for (const d of this._disposables) {d?.dispose();}
+    for (const d of this._disposables) {
+      d?.dispose();
+    }
     this._disposables = [];
   }
 

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -103,7 +103,9 @@ export class DiagnosticsAdapter {
       }),
     );
 
-    editor.getModels().forEach(onModelAdd);
+    for (const model of editor.getModels()) {
+      onModelAdd(model);
+    }
   }
 
   public dispose(): void {

--- a/packages/vscode-graphql-execution/src/helpers/network.ts
+++ b/packages/vscode-graphql-execution/src/helpers/network.ts
@@ -128,9 +128,9 @@ export class NetworkHelper {
       fragmentDefinitions,
     );
 
-    fragmentInfos.forEach(fragmentInfo => {
+    for (const fragmentInfo of fragmentInfos) {
       literal.content = fragmentInfo.content + '\n' + literal.content;
-    });
+    }
 
     const parsedOperation = gql`
       ${literal.content}

--- a/packages/vscode-graphql-execution/src/helpers/source.ts
+++ b/packages/vscode-graphql-execution/src/helpers/source.ts
@@ -187,7 +187,8 @@ export class SourceHelper {
       const operations = ast.definitions.filter(
         def => def.kind === 'OperationDefinition',
       );
-      operations.forEach((op: any) => {
+      for (const operation of operations) {
+        const op = operation as any
         const filteredAst = {
           ...ast,
           definitions: ast.definitions.filter(def => {
@@ -204,7 +205,7 @@ export class SourceHelper {
           definition: op,
           ast: filteredAst,
         });
-      });
+      }
       // no-op, so that non-parse-able source files
       // don't break the extension while editing
     }

--- a/packages/vscode-graphql-execution/src/helpers/source.ts
+++ b/packages/vscode-graphql-execution/src/helpers/source.ts
@@ -127,7 +127,7 @@ export class SourceHelper {
     const sources = await projectConfig.getDocuments();
     const { fragmentDefinitions } = this;
 
-    sources.forEach(source => {
+    for (const source of sources) {
       visit(source.document as DocumentNode, {
         FragmentDefinition(node) {
           const existingDef = fragmentDefinitions.get(node.name.value);
@@ -141,7 +141,7 @@ export class SourceHelper {
           }
         },
       });
-    });
+    }
     return fragmentDefinitions;
   }
 
@@ -160,7 +160,7 @@ export class SourceHelper {
       } catch {}
     }
 
-    tags.forEach(tag => {
+    for (const tag of tags) {
       // https://regex101.com/r/Pd5PaU/2
       const regExpGQL = new RegExp(tag + '\\s*`([\\s\\S]+?)`', 'mg');
 
@@ -179,7 +179,7 @@ export class SourceHelper {
           // don't break the extension while editing
         } catch {}
       }
-    });
+    }
     return documents;
 
     function processGraphQLString(textString: string, offset: number) {
@@ -265,15 +265,15 @@ export const getFragmentDependenciesForAST = async (
   });
 
   const asts = new Set<FragmentInfo>();
-  referencedFragNames.forEach(name => {
+  for (const name of referencedFragNames) {
     if (!existingFrags.has(name) && fragmentDefinitions.has(name)) {
       asts.add(nullthrows(fragmentDefinitions.get(name)));
     }
-  });
+  }
 
   const referencedFragments: FragmentInfo[] = [];
 
-  asts.forEach(ast => {
+  for (const ast of asts) {
     visit(ast.definition, {
       FragmentSpread(node) {
         if (
@@ -288,7 +288,7 @@ export const getFragmentDependenciesForAST = async (
     if (!existingFrags.has(ast.definition.name.value)) {
       referencedFragments.push(ast);
     }
-  });
+  }
 
   return referencedFragments;
 };

--- a/packages/vscode-graphql-execution/src/helpers/source.ts
+++ b/packages/vscode-graphql-execution/src/helpers/source.ts
@@ -188,7 +188,7 @@ export class SourceHelper {
         def => def.kind === 'OperationDefinition',
       );
       for (const operation of operations) {
-        const op = operation as any
+        const op = operation as any;
         const filteredAst = {
           ...ast,
           definitions: ast.definitions.filter(def => {

--- a/scripts/buildFlow.js
+++ b/scripts/buildFlow.js
@@ -13,10 +13,10 @@ const { join } = require('node:path');
 const { cp } = require('./util');
 
 // Non-recursively copy src/*.js to dist/*.js.flow:
-readdirSync('src').forEach(entry => {
+for (const entry of readdirSync('src')) {
   if (entry.endsWith('.js')) {
     const source = join('src', entry);
     const destination = join(process.argv[2] || 'dist', `${entry}.flow`);
     cp(source, destination);
   }
-});
+}

--- a/scripts/renameFileExtensions.js
+++ b/scripts/renameFileExtensions.js
@@ -32,7 +32,7 @@ if (tempPath) {
     if (error) {
       throw error;
     }
-    files.forEach(file => {
+    for (const file of files) {
       if (file.dest) {
         const srcExt = path.parse(file.dest).ext;
         const destinationPath = path.resolve(
@@ -45,7 +45,7 @@ if (tempPath) {
         // move the files and rename them... by renaming them :)
         fs.renameSync(file.dest, destinationPath);
       }
-    });
+    }
     // should cleanup temp directory after renaming
     // every file to the destination path
     rimraf.sync(tempRenamePath);


### PR DESCRIPTION
A "for-of" loop is faster, as it doesn't need to execute the body function for each iteration (it's just a scope). This especially matters if the loop body is complex. https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1522#issuecomment-917831928

also, GitHub has its own rule that does the same that unicorn plugin https://github.com/github/eslint-plugin-github/blob/main/docs/rules/array-foreach.md

I explicitly added a changeset