### PR TITLE
[ESLint] enable `unicorn/prefer-dom-node-append`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -268,6 +268,7 @@ module.exports = {
     'unicorn/throw-new-error': 'error',
     'unicorn/prefer-includes': 'error',
     'unicorn/no-array-for-each': 'error',
+    'unicorn/prefer-dom-node-append': 'error',
     'no-lonely-if': 'error',
     'unicorn/no-lonely-if': 'error',
     'unicorn/prefer-optional-catch-binding': 'error',

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -227,7 +227,7 @@ function renderToolbar(toolbar: HTMLElement) {
   const executionTray = document.createElement('div');
 
   executionTray.id = 'execution-tray';
-  executionTray.appendChild(executeOpButton);
+  executionTray.append(executeOpButton);
   executionTray.classList.add('align-right');
 
   executeOpButton.id = 'execute-op';
@@ -241,12 +241,12 @@ function renderToolbar(toolbar: HTMLElement) {
   schemaStatus.id = 'schema-status';
   schemaStatus.innerHTML = `Schema Empty`;
 
-  toolbar.appendChild(schemaPicker);
-
-  toolbar.appendChild(schemaReloadButton);
-  toolbar.appendChild(schemaStatus);
-
-  toolbar?.appendChild(executeOpButton);
+  toolbar.append(
+    schemaPicker,
+    schemaReloadButton,
+    schemaStatus,
+    executeOpButton,
+  );
   return { schemaReloadButton, executeOpButton, schemaStatus, schemaPicker };
 }
 
@@ -261,7 +261,7 @@ function getSchemaPicker(): HTMLSelectElement {
     if (option.default) {
       optEl.selected = true;
     }
-    schemaPicker.appendChild(optEl);
+    schemaPicker.append(optEl);
   }
 
   return schemaPicker;
@@ -295,7 +295,7 @@ export function renderGithubLoginButton() {
     const toolbar = document.getElementById('toolbar');
     toolbar?.appendChild(logoutButton);
   } else {
-    githubLoginWrapper.appendChild(githubButton);
+    githubLoginWrapper.append(githubButton);
     document.getElementById('flex-wrapper')?.prepend(githubLoginWrapper);
   }
 

--- a/packages/codemirror-graphql/src/info.ts
+++ b/packages/codemirror-graphql/src/info.ts
@@ -75,7 +75,7 @@ CodeMirror.registerHelper(
       header.className = 'CodeMirror-info-header';
       renderField(header, typeInfo, options);
       const into = document.createElement('div');
-      into.appendChild(header);
+      into.append(header);
       renderDescription(into, options, typeInfo.fieldDef as any);
       return into;
     }
@@ -84,7 +84,7 @@ CodeMirror.registerHelper(
       header.className = 'CodeMirror-info-header';
       renderDirective(header, typeInfo, options);
       const into = document.createElement('div');
-      into.appendChild(header);
+      into.append(header);
       renderDescription(into, options, typeInfo.directiveDef);
       return into;
     }
@@ -93,7 +93,7 @@ CodeMirror.registerHelper(
       header.className = 'CodeMirror-info-header';
       renderArg(header, typeInfo, options);
       const into = document.createElement('div');
-      into.appendChild(header);
+      into.append(header);
       renderDescription(into, options, typeInfo.argDef);
       return into;
     }
@@ -106,7 +106,7 @@ CodeMirror.registerHelper(
       header.className = 'CodeMirror-info-header';
       renderEnumValue(header, typeInfo, options);
       const into = document.createElement('div');
-      into.appendChild(header);
+      into.append(header);
       renderDescription(into, options, typeInfo.enumValue);
       return into;
     }
@@ -119,7 +119,7 @@ CodeMirror.registerHelper(
       header.className = 'CodeMirror-info-header';
       renderType(header, typeInfo, options, typeInfo.type);
       const into = document.createElement('div');
-      into.appendChild(header);
+      into.append(header);
       renderDescription(into, options, typeInfo.type);
       return into;
     }
@@ -198,7 +198,7 @@ function renderTypeAnnotation(
       getTypeReference(typeInfo, t),
     );
   }
-  into.appendChild(typeSpan);
+  into.append(typeSpan);
 }
 
 function renderType(
@@ -242,9 +242,9 @@ function renderDescription(
     if (options.renderDescription) {
       descriptionDiv.innerHTML = options.renderDescription(description);
     } else {
-      descriptionDiv.appendChild(document.createTextNode(description));
+      descriptionDiv.append(document.createTextNode(description));
     }
-    into.appendChild(descriptionDiv);
+    into.append(descriptionDiv);
   }
 
   renderDeprecation(into, options, def);
@@ -264,21 +264,21 @@ function renderDeprecation(
   if (reason) {
     const deprecationDiv = document.createElement('div');
     deprecationDiv.className = 'info-deprecation';
-    into.appendChild(deprecationDiv);
+    into.append(deprecationDiv);
 
     const label = document.createElement('span');
     label.className = 'info-deprecation-label';
-    label.appendChild(document.createTextNode('Deprecated'));
-    deprecationDiv.appendChild(label);
+    label.append(document.createTextNode('Deprecated'));
+    deprecationDiv.append(label);
 
     const reasonDiv = document.createElement('div');
     reasonDiv.className = 'info-deprecation-reason';
     if (options.renderDescription) {
       reasonDiv.innerHTML = options.renderDescription(reason);
     } else {
-      reasonDiv.appendChild(document.createTextNode(reason));
+      reasonDiv.append(document.createTextNode(reason));
     }
-    deprecationDiv.appendChild(reasonDiv);
+    deprecationDiv.append(reasonDiv);
   }
 }
 
@@ -305,9 +305,9 @@ function text(
       node = document.createElement('span');
     }
     node.className = className;
-    node.appendChild(document.createTextNode(content));
-    into.appendChild(node);
+    node.append(document.createTextNode(content));
+    into.append(node);
   } else {
-    into.appendChild(document.createTextNode(content));
+    into.append(document.createTextNode(content));
   }
 }

--- a/packages/codemirror-graphql/src/utils/info-addon.ts
+++ b/packages/codemirror-graphql/src/utils/info-addon.ts
@@ -112,8 +112,8 @@ function onMouseHover(cm: CodeMirror.Editor, box: DOMRect) {
 function showPopup(cm: CodeMirror.Editor, box: DOMRect, info: HTMLDivElement) {
   const popup = document.createElement('div');
   popup.className = 'CodeMirror-info';
-  popup.appendChild(info);
-  document.body.appendChild(popup);
+  popup.append(info);
+  document.body.append(popup);
 
   const popupBox = popup.getBoundingClientRect();
   const popupStyle = window.getComputedStyle(popup);

--- a/packages/graphiql-react/src/editor/completion.ts
+++ b/packages/graphiql-react/src/editor/completion.ts
@@ -49,50 +49,50 @@ export function onHasCompletion(
           // highlighted typeahead option.
           information = document.createElement('div');
           information.className = 'CodeMirror-hint-information';
-          hintsUl.appendChild(information);
+          hintsUl.append(information);
 
           const header = document.createElement('header');
           header.className = 'CodeMirror-hint-information-header';
-          information.appendChild(header);
+          information.append(header);
 
           fieldName = document.createElement('span');
           fieldName.className = 'CodeMirror-hint-information-field-name';
-          header.appendChild(fieldName);
+          header.append(fieldName);
 
           typeNamePill = document.createElement('span');
           typeNamePill.className = 'CodeMirror-hint-information-type-name-pill';
-          header.appendChild(typeNamePill);
+          header.append(typeNamePill);
 
           typeNamePrefix = document.createElement('span');
-          typeNamePill.appendChild(typeNamePrefix);
+          typeNamePill.append(typeNamePrefix);
 
           typeName = document.createElement('a');
           typeName.className = 'CodeMirror-hint-information-type-name';
           typeName.href = 'javascript:void 0'; // eslint-disable-line no-script-url
           typeName.addEventListener('click', onClickHintInformation);
-          typeNamePill.appendChild(typeName);
+          typeNamePill.append(typeName);
 
           typeNameSuffix = document.createElement('span');
-          typeNamePill.appendChild(typeNameSuffix);
+          typeNamePill.append(typeNameSuffix);
 
           description = document.createElement('div');
           description.className = 'CodeMirror-hint-information-description';
-          information.appendChild(description);
+          information.append(description);
 
           deprecation = document.createElement('div');
           deprecation.className = 'CodeMirror-hint-information-deprecation';
-          information.appendChild(deprecation);
+          information.append(deprecation);
 
           const deprecationLabel = document.createElement('span');
           deprecationLabel.className =
             'CodeMirror-hint-information-deprecation-label';
           deprecationLabel.innerText = 'Deprecated';
-          deprecation.appendChild(deprecationLabel);
+          deprecation.append(deprecationLabel);
 
           deprecationReason = document.createElement('div');
           deprecationReason.className =
             'CodeMirror-hint-information-deprecation-reason';
-          deprecation.appendChild(deprecationReason);
+          deprecation.append(deprecationReason);
 
           /**
            * This is a bit hacky: By default, codemirror renders all hints

--- a/packages/graphiql/__mocks__/@graphiql/react.tsx
+++ b/packages/graphiql/__mocks__/@graphiql/react.tsx
@@ -173,10 +173,9 @@ function useMockedEditor(name: Name, onEdit?: (newValue: string) => void) {
     mockTextArea.className = 'mockCodeMirror';
 
     const mockWrapper = document.createElement('div');
-    mockWrapper.appendChild(mockGutter);
-    mockWrapper.appendChild(mockTextArea);
+    mockWrapper.append(mockGutter, mockTextArea);
 
-    ref.current.appendChild(mockWrapper);
+    ref.current.append(mockWrapper);
 
     setEditor({
       getValue() {

--- a/packages/graphiql/__mocks__/codemirror.ts
+++ b/packages/graphiql/__mocks__/codemirror.ts
@@ -9,9 +9,8 @@ function CodeMirror(node: HTMLElement, { value, ...options }) {
     _emit('change', e);
   });
   mockTextArea.value = value;
-  mockWrapper.appendChild(mockGutter);
-  mockWrapper.appendChild(mockTextArea);
-  node.appendChild(mockWrapper);
+  mockWrapper.append(mockGutter, mockTextArea);
+  node.append(mockWrapper);
 
   function _emit(event, data) {
     if (_eventListeners[event]) {


### PR DESCRIPTION
Enforces the use of, for example, `document.body.append(div)`; over `document.body.appendChild(div)`; for DOM nodes. There are [some advantages of using Node#append()](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append), like the ability to append multiple nodes and to append both [DOMString](https://developer.mozilla.org/en-US/docs/Web/API/DOMString) and DOM node objects.

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md