### PR TITLE
[ESLint] enable `unicorn/prefer-dom-node-remove`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -213,7 +213,7 @@ module.exports = {
     'sort-vars': 0,
     'spaced-comment': ['error', 'always', { markers: ['/'] }],
     'wrap-regex': 0,
-
+    'unicorn/prefer-dom-node-remove': 'error',
     // ECMAScript 6 (http://eslint.org/docs/rules/#ecmascript-6)
     'arrow-body-style': 0,
     'no-duplicate-imports': 0,

--- a/packages/codemirror-graphql/src/utils/info-addon.ts
+++ b/packages/codemirror-graphql/src/utils/info-addon.ts
@@ -169,11 +169,11 @@ function showPopup(cm: CodeMirror.Editor, box: DOMRect, info: HTMLDivElement) {
       popup.style.opacity = '0';
       setTimeout(() => {
         if (popup.parentNode) {
-          popup.parentNode.removeChild(popup);
+          popup.remove();
         }
       }, 600);
     } else if (popup.parentNode) {
-      popup.parentNode.removeChild(popup);
+      popup.remove();
     }
   };
 

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
@@ -128,7 +128,7 @@ describe('TypeDocumentation', () => {
     const deprecatedTitle = container.querySelectorAll(
       '.graphiql-doc-explorer-section-title',
     )[1];
-    deprecatedTitle.removeChild(deprecatedTitle.childNodes[0]);
+    deprecatedTitle.childNodes[0].remove();
     expect(deprecatedTitle).toHaveTextContent('Deprecated Enum Values');
 
     enums = container.querySelectorAll('.graphiql-doc-explorer-enum-value');

--- a/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
+++ b/packages/graphiql-react/src/explorer/components/__tests__/type-documentation.spec.tsx
@@ -85,7 +85,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title?.removeChild(title?.childNodes[0]);
+    title?.childNodes[0].remove();
     expect(title).toHaveTextContent('Possible Types');
   });
 
@@ -96,7 +96,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title?.removeChild(title?.childNodes[0]);
+    title?.childNodes[0].remove();
     expect(title).toHaveTextContent('Enum Values');
     const enums = container.querySelectorAll(
       '.graphiql-doc-explorer-enum-value',
@@ -115,7 +115,7 @@ describe('TypeDocumentation', () => {
     const title = container.querySelector(
       '.graphiql-doc-explorer-section-title',
     );
-    title?.removeChild(title?.childNodes[0]);
+    title?.childNodes[0].remove();
     expect(title).toHaveTextContent('Enum Values');
 
     let enums = container.querySelectorAll('.graphiql-doc-explorer-enum-value');


### PR DESCRIPTION
Enforces the use of, for example, `child.remove();` over `child.parentNode.removeChild(child);`. The DOM function [`Node#remove()`](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove) is preferred over the indirect removal of an object with [`Node#removeChild()`](https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild).

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md