### PR TITLE
fix: script offset if vue-sfc contains template above

### DIFF
--- a/.changeset/thin-poems-search.md
+++ b/.changeset/thin-poems-search.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+fixed wrong script tag offset for vue-sfc

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -238,6 +238,25 @@ query {id}
     const contents = findGraphQLTags(text, '.vue');
     expect(contents[0].template).toEqual(`
 query {id}`);
+    expect(contents[0].range.start.line).toEqual(2);
+    expect(contents[0].range.end.line).toEqual(4);
+  });
+
+  it('finds queries in tagged templates in Vue SFC using <script setup> and template above', async () => {
+    const text = `<template>
+      <div/>
+    </template>
+<script setup lang="ts">
+gql\`
+query {id}
+\`;
+</script>
+`;
+    const contents = findGraphQLTags(text, '.vue');
+    expect(contents[0].template).toEqual(`
+query {id}`);
+    expect(contents[0].range.start.line).toEqual(4);
+    expect(contents[0].range.end.line).toEqual(6);
   });
 
   it('finds queries in tagged templates in Vue SFC using normal <script>', async () => {
@@ -251,6 +270,23 @@ query {id}
     const contents = findGraphQLTags(text, '.vue');
     expect(contents[0].template).toEqual(`
 query {id}`);
+  });
+
+  it('finds queries in tagged templates in Vue SFC using normal <script> and template above', async () => {
+    const text = `<template>
+    <div/>
+  </template>
+<script lang="ts">
+gql\`
+query {id}
+\`;
+</script>
+`;
+    const contents = findGraphQLTags(text, '.vue');
+    expect(contents[0].template).toEqual(`
+query {id}`);
+    expect(contents[0].range.start.line).toEqual(4);
+    expect(contents[0].range.end.line).toEqual(6);
   });
 
   it('finds queries in tagged templates in Vue SFC using <script lang="tsx">', async () => {

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -270,6 +270,8 @@ query {id}
     const contents = findGraphQLTags(text, '.vue');
     expect(contents[0].template).toEqual(`
 query {id}`);
+    expect(contents[0].range.start.line).toEqual(2);
+    expect(contents[0].range.end.line).toEqual(4);
   });
 
   it('finds queries in tagged templates in Vue SFC using normal <script> and template above', async () => {

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -106,7 +106,7 @@ function parseVueSFC(source: string): ParseVueSFCResult {
 
   return {
     type: 'ok',
-    scriptOffset: scriptBlock.loc.start.line,
+    scriptOffset: scriptBlock.loc.start.line - 1,
     scriptSetupAst: scriptBlock?.scriptSetupAst,
     scriptAst: scriptBlock?.scriptAst,
   };
@@ -147,7 +147,7 @@ export function findGraphQLTags(
       parsedASTs.push(...parseVueSFCResult.scriptSetupAst);
     }
 
-    scriptOffset = parseVueSFCResult.scriptOffset - 1;
+    scriptOffset = parseVueSFCResult.scriptOffset;
   } else {
     const isTypeScript = ['.ts', '.tsx', '.cts', '.mts'].includes(ext);
     if (isTypeScript) {

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -99,6 +99,7 @@ function parseVueSFC(source: string): ParseVueSFCResult {
         type: 'ok',
         scriptSetupAst: [],
         scriptAst: [],
+        scriptOffset: 0
       };
     }
     return { type: 'error', errors: [error as Error] };


### PR DESCRIPTION
closes https://github.com/graphql/graphiql/issues/3115

Related:
https://github.com/graphql/graphiql/pull/2827#issuecomment-1333707395

Description:
This fixes Intellisense for Vue SFC files which contain template code above the script (both setup and normal). The issue was that the line locations inside the ASTs returned from `compileScript` where relative to the start of the script tag and not the start of the file. This lead to intellisense and errors working with the wrong line information when the file contained a template above the script.
The fix returns a `scriptOffset` from `parseVueSFC`, which should contain the correct offset of the script tag
I added some tests and also tested it visually with a project for which i had problems with.