### PR TITLE
replace rest of `event.keyCode` usages by `event.code`

### DIFF
--- a/.changeset/shaggy-chairs-explode.md
+++ b/.changeset/shaggy-chairs-explode.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+replace rest of `event.keyCode` usages by `event.code`

--- a/packages/graphiql-react/src/editor/header-editor.ts
+++ b/packages/graphiql-react/src/editor/header-editor.ts
@@ -98,8 +98,8 @@ export function useHeaderEditor(
       newEditor.on('keyup', (editorInstance, event) => {
         const { code, key, shiftKey } = event;
         const isLetter = code.startsWith('Key');
-        const isNumber = code.startsWith('Digit');
-        if (isLetter || (!shiftKey && isNumber) || key === '_' || key === '"') {
+        const isNumber = !shiftKey && code.startsWith('Digit');
+        if (isLetter || isNumber || key === '_' || key === '"') {
           editorInstance.execCommand('autocomplete');
         }
       });

--- a/packages/graphiql-react/src/editor/header-editor.ts
+++ b/packages/graphiql-react/src/editor/header-editor.ts
@@ -96,9 +96,9 @@ export function useHeaderEditor(
       });
 
       newEditor.on('keyup', (editorInstance, event) => {
-        const { keyCode, key, shiftKey } = event;
-        const isLetter = keyCode >= 65 && keyCode <= 90;
-        const isNumber = keyCode >= 48 && keyCode <= 57;
+        const { code, key, shiftKey } = event;
+        const isLetter = code.startsWith('Key');
+        const isNumber = code.startsWith('Digit');
         if (isLetter || (!shiftKey && isNumber) || key === '_' || key === '"') {
           editorInstance.execCommand('autocomplete');
         }

--- a/packages/graphiql-react/src/editor/variable-editor.ts
+++ b/packages/graphiql-react/src/editor/variable-editor.ts
@@ -118,8 +118,8 @@ export function useVariableEditor(
       newEditor.on('keyup', (editorInstance, event) => {
         const { code, key, shiftKey } = event;
         const isLetter = code.startsWith('Key');
-        const isNumber = code.startsWith('Digit');
-        if (isLetter || (!shiftKey && isNumber) || key === '_' || key === '"') {
+        const isNumber = !shiftKey && code.startsWith('Digit');
+        if (isLetter || isNumber || key === '_' || key === '"') {
           editorInstance.execCommand('autocomplete');
         }
       });

--- a/packages/graphiql-react/src/editor/variable-editor.ts
+++ b/packages/graphiql-react/src/editor/variable-editor.ts
@@ -116,9 +116,9 @@ export function useVariableEditor(
       });
 
       newEditor.on('keyup', (editorInstance, event) => {
-        const { keyCode, key, shiftKey } = event;
-        const isLetter = keyCode >= 65 && keyCode <= 90;
-        const isNumber = keyCode >= 48 && keyCode <= 57;
+        const { code, key, shiftKey } = event;
+        const isLetter = code.startsWith('Key');
+        const isNumber = code.startsWith('Digit');
         if (isLetter || (!shiftKey && isNumber) || key === '_' || key === '"') {
           editorInstance.execCommand('autocomplete');
         }


### PR DESCRIPTION
related https://github.com/graphql/graphiql/pull/3126

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/7361780/232170791-4348db53-8a9b-400a-95d5-007561fecb85.png">
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/7361780/232170812-e2f79f18-d702-4cf4-9a83-32206f4cfd29.png">
also, it could catch cyrillic chars too

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/7361780/232170878-87ad8a5d-951d-4369-8f7c-524a5dab1097.png">
