### PR TITLE
fix: Hover docs were offset one position

### DIFF
--- a/.changeset/metal-cats-hammer.md
+++ b/.changeset/metal-cats-hammer.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Fix hover docs being off by one position.

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -165,7 +165,7 @@ export function getAutocompleteSuggestions(
     schema,
   };
   const token: ContextToken =
-    contextToken || getTokenAtPosition(queryText, cursor);
+    contextToken || getTokenAtPosition(queryText, cursor, 1);
 
   const state =
     token.state.kind === 'Invalid' ? token.state.prevState : token.state;
@@ -963,6 +963,7 @@ function getSuggestionsForDirective(
 export function getTokenAtPosition(
   queryText: string,
   cursor: IPosition,
+  offset = 0,
 ): ContextToken {
   let styleAtCursor = null;
   let stateAtCursor = null;
@@ -970,7 +971,7 @@ export function getTokenAtPosition(
   const token = runOnlineParser(queryText, (stream, state, style, index) => {
     if (
       index === cursor.line &&
-      stream.getCurrentPosition() >= cursor.character
+      stream.getCurrentPosition() + offset >= cursor.character + 1
     ) {
       styleAtCursor = style;
       stateAtCursor = { ...state };


### PR DESCRIPTION
Fixes https://github.com/graphql/graphiql/issues/2874

The hover docs were off by one position. This was due to autocomplete suggestions and hover docs using the same `getTokenAtPosition` function. For autocomplete, the behavior of the function was expected since your cursor is _after_ the token you want to get when requesting autocomplete results, but with hover docs you want the cursor _at_ the cursor position.