### PR TITLE
fix(graphql-language-service-server): allow getDefinition to work for unions

### DIFF
--- a/.changeset/many-sloths-shop.md
+++ b/.changeset/many-sloths-shop.md
@@ -1,0 +1,15 @@
+---
+"graphql-language-service-server": patch
+"graphql-language-service": patch
+---
+
+fix(graphql-language-service-server): allow getDefinition to work for unions
+
+Fixes the issue where a schema like the below won't allow you to click through to X.
+
+```graphql```
+union X = A | B
+type A { x: String }
+type B { x: String }
+type Query { a: X }
+```

--- a/.changeset/many-sloths-shop.md
+++ b/.changeset/many-sloths-shop.md
@@ -5,7 +5,7 @@
 
 fix(graphql-language-service-server): allow getDefinition to work for unions
 
-Fixes the issue where a schema like the below won't allow you to click through to X.
+Fixes the issue where a schema like the one below won't allow you to click through to X.
 
 ```graphql```
 union X = A | B

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -403,7 +403,8 @@ export class GraphQLLanguageService {
         definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
         definition.kind === Kind.ENUM_TYPE_DEFINITION ||
         definition.kind === Kind.SCALAR_TYPE_DEFINITION ||
-        definition.kind === Kind.INTERFACE_TYPE_DEFINITION,
+        definition.kind === Kind.INTERFACE_TYPE_DEFINITION ||
+        definition.kind === Kind.UNION_TYPE_DEFINITION,
     );
 
     const typeCastedDefs =

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -19,6 +19,7 @@ import {
   Kind,
   parse,
   print,
+  isTypeDefinitionNode,
 } from 'graphql';
 
 import {
@@ -397,26 +398,13 @@ export class GraphQLLanguageService {
         objectTypeDefinitions,
       );
 
-    const localObjectTypeDefinitions = ast.definitions.filter(
-      definition =>
-        definition.kind === Kind.OBJECT_TYPE_DEFINITION ||
-        definition.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
-        definition.kind === Kind.ENUM_TYPE_DEFINITION ||
-        definition.kind === Kind.SCALAR_TYPE_DEFINITION ||
-        definition.kind === Kind.INTERFACE_TYPE_DEFINITION ||
-        definition.kind === Kind.UNION_TYPE_DEFINITION,
-    );
-
-    const typeCastedDefs =
-      localObjectTypeDefinitions as any as Array<TypeDefinitionNode>;
-
-    const localOperationDefinitionInfos = typeCastedDefs.map(
-      (definition: TypeDefinitionNode) => ({
+    const localOperationDefinitionInfos = ast.definitions
+      .filter(isTypeDefinitionNode)
+      .map((definition: TypeDefinitionNode) => ({
         filePath,
         content: query,
         definition,
-      }),
-    );
+      }));
 
     const result = await getDefinitionQueryResultForNamedType(
       query,

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
@@ -163,8 +163,7 @@ describe('GraphQLLanguageService', () => {
       { line: 0, character: 28 } as Position,
       './queries/definitionQuery.graphql',
     );
-    // @ts-ignore
-    expect(definitionQueryResult.definitions.length).toEqual(1);
+    expect(definitionQueryResult?.definitions.length).toEqual(1);
   });
 
   it('runs definition service on field as expected', async () => {
@@ -173,8 +172,18 @@ describe('GraphQLLanguageService', () => {
       { line: 0, character: 21 } as Position,
       './queries/definitionQuery.graphql',
     );
-    // @ts-ignore
-    expect(definitionQueryResult.definitions.length).toEqual(1);
+    expect(definitionQueryResult?.definitions.length).toEqual(1);
+  });
+
+  it('can find a definition for a union', async () => {
+    const query =
+      'union X = A | B\ntype A { x: String }\ntype B { x: String }\ntype Query { a: X }';
+    const definitionQueryResult = await languageService.getDefinition(
+      query,
+      { line: 3, character: 16 } as Position,
+      './queries/definitionQuery.graphql',
+    );
+    expect(definitionQueryResult?.definitions.length).toEqual(1);
   });
 
   it('runs hover service as expected', async () => {


### PR DESCRIPTION
Fixes: https://github.com/graphql/graphiql/issues/2575

Fixes the issue where a schema like 

```graphql
union X = A | B
type A { x: String }
type B { x: String }
type Query { a: X }
```

won't allow you to click through to X. 

Also fixes the case where this is split across two files (e.g. `type Query { a: X }` is in one file and the rest are in another)