### PR TITLE
fix: vue & svelte wo script tag

### DIFF
--- a/.changeset/eight-swans-destroy.md
+++ b/.changeset/eight-swans-destroy.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+fix: vue and svelte files doesn't log errors anymore when parsing with no script tag (#2836)

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -333,7 +333,7 @@ query {id}`);
     consoleErrorSpy.mockRestore();
   });
 
-  it('no crash in Svelte files with empty <script>', async () => {
+  it('no crash in Svelte files with empty <script> (typescript)', async () => {
     const text = `<script lang="ts"></script>`;
 
     const consoleErrorSpy = jest

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 
 import { findGraphQLTags as baseFindGraphQLTags } from '../findGraphQLTags';
 
-// jest.mock('../Logger');
+jest.mock('../Logger');
 
 import { Logger } from '../Logger';
 

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 
 import { findGraphQLTags as baseFindGraphQLTags } from '../findGraphQLTags';
 
-jest.mock('../Logger');
+// jest.mock('../Logger');
 
 import { Logger } from '../Logger';
 
@@ -287,6 +287,72 @@ query {id}
     const contents = findGraphQLTags(text, '.svelte');
     expect(contents[0].template).toEqual(`
 query {id}`);
+  });
+
+  it('no crash in Svelte files without <script>', async () => {
+    const text = ``;
+
+    const consoleErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    const contents = baseFindGraphQLTags(
+      text,
+      '.svelte',
+      '',
+      new Logger(tmpdir(), false),
+    );
+    // We should have no contents
+    expect(contents).toMatchObject([]);
+
+    // Nothing should be logged as it's a managed error
+    expect(consoleErrorSpy.mock.calls.length).toBe(0);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('no crash in Svelte files with empty <script>', async () => {
+    const text = `<script></script>`;
+
+    const consoleErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    const contents = baseFindGraphQLTags(
+      text,
+      '.svelte',
+      '',
+      new Logger(tmpdir(), false),
+    );
+    // We should have no contents
+    expect(contents).toMatchObject([]);
+
+    // Nothing should be logged as it's a managed error
+    expect(consoleErrorSpy.mock.calls.length).toBe(0);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('no crash in Svelte files with empty <script>', async () => {
+    const text = `<script lang="ts"></script>`;
+
+    const consoleErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    const contents = baseFindGraphQLTags(
+      text,
+      '.svelte',
+      '',
+      new Logger(tmpdir(), false),
+    );
+    // We should have no contents
+    expect(contents).toMatchObject([]);
+
+    // Nothing should be logged as it's a managed error
+    expect(consoleErrorSpy.mock.calls.length).toBe(0);
+
+    consoleErrorSpy.mockRestore();
   });
 
   it('finds multiple queries in a single file', async () => {

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -90,18 +90,16 @@ function parseVueSFC(source: string): ParseVueSFCResult {
   try {
     scriptBlock = VueParser.compileScript(descriptor, { id: 'foobar' });
   } catch (error) {
-    if (error instanceof Error) {
-      if (
-        error.message === '[@vue/compiler-sfc] SFC contains no <script> tags.'
-      ) {
-        return {
-          type: 'ok',
-          scriptSetupAst: [],
-          scriptAst: [],
-        };
-      }
+    if (
+      error instanceof Error &&
+      error.message === '[@vue/compiler-sfc] SFC contains no <script> tags.'
+    ) {
+      return {
+        type: 'ok',
+        scriptSetupAst: [],
+        scriptAst: [],
+      };
     }
-
     return { type: 'error', errors: [error as Error] };
   }
 

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -130,7 +130,7 @@ export function findGraphQLTags(
     const parseVueSFCResult = parseVueSFC(text);
     if (parseVueSFCResult.type === 'error') {
       logger.error(
-        `Could not parse the ${ext} file at ${uri} to extract the graphql tags:`,
+        `Could not parse the "${ext}" file at ${uri} to extract the graphql tags:`,
       );
       for (const error of parseVueSFCResult.errors) {
         logger.error(String(error));

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -90,6 +90,18 @@ function parseVueSFC(source: string): ParseVueSFCResult {
   try {
     scriptBlock = VueParser.compileScript(descriptor, { id: 'foobar' });
   } catch (error) {
+    if (error instanceof Error) {
+      if (
+        error.message === '[@vue/compiler-sfc] SFC contains no <script> tags.'
+      ) {
+        return {
+          type: 'ok',
+          scriptSetupAst: [],
+          scriptAst: [],
+        };
+      }
+    }
+
     return { type: 'error', errors: [error as Error] };
   }
 
@@ -118,7 +130,7 @@ export function findGraphQLTags(
     const parseVueSFCResult = parseVueSFC(text);
     if (parseVueSFCResult.type === 'error') {
       logger.error(
-        `Could not parse the Vue file at ${uri} to extract the graphql tags:`,
+        `Could not parse the ${ext} file at ${uri} to extract the graphql tags:`,
       );
       for (const error of parseVueSFCResult.errors) {
         logger.error(String(error));


### PR DESCRIPTION
fixes: [#2836](https://github.com/graphql/graphiql/issues/2836)

When there is no `<script>` tag in the file, it's ok. We will not have any `graphql`.
Let's not log an error in this situation.