### PR TITLE
fix canary releases

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -2,8 +2,6 @@ name: Canary Release
 
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - 'examples'


### PR DESCRIPTION
canary releases should happen even with `paths-ignore` according to the actions documentation