### PR TITLE
fix: reload schema when a change to the schema file is detected

### DIFF
--- a/.changeset/soft-dingos-report.md
+++ b/.changeset/soft-dingos-report.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+fix: reload schema when a change to the schema file is detected

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -671,7 +671,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     return schema;
   };
 
-  _invalidateSchemaCacheForProject(projectConfig: GraphQLProjectConfig) {
+  invalidateSchemaCacheForProject(projectConfig: GraphQLProjectConfig) {
     const schemaKey = this._getSchemaCacheKeyForProject(
       projectConfig,
     ) as string;

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -665,6 +665,8 @@ export class MessageProcessor {
           await this._updateObjectTypeDefinition(uri, contents);
 
           const project = this._graphQLCache.getProjectForFile(uri);
+          await this._updateSchemaIfChanged(project, uri);
+
           let diagnostics: Diagnostic[] = [];
 
           if (
@@ -1136,6 +1138,18 @@ export class MessageProcessor {
     const rootDir = this._graphQLCache.getGraphQLConfig().dirpath;
 
     await this._graphQLCache.updateFragmentDefinition(rootDir, uri, contents);
+  }
+
+  async _updateSchemaIfChanged(
+    project: GraphQLProjectConfig,
+    uri: Uri,
+  ): Promise<void> {
+    const { dirpath, schema } = project;
+    const schemaFilePath = path.resolve(dirpath, schema as string);
+    const uriFilePath = URI.parse(uri).fsPath;
+    if (uriFilePath === schemaFilePath) {
+      await this._graphQLCache.invalidateSchemaCacheForProject(project);
+    }
   }
 
   async _updateObjectTypeDefinition(

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(context: ExtensionContext) {
         // TODO: load ignore
         // These ignore node_modules and .git by default
         workspace.createFileSystemWatcher(
-          '**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue,*.svelte,*.cts,*.mts}',
+          '**/{*.graphql,*.graphqls,*.gql,*.js,*.mjs,*.cjs,*.esm,*.es,*.es6,*.jsx,*.ts,*.tsx,*.vue,*.svelte,*.cts,*.mts,*.json}',
         ),
       ],
     },


### PR DESCRIPTION
# Summay
Currently, the schema is cached permanently and never reloaded. This makes it very awkward when you're developing the graphql api and the front-end at the same time, as the auto completion and validation will rely on incorrect data.

## Notes
I found a function named `_invalidateSchemaCacheForProject` that did what I needed, however it's not actually used anywhere. I assume this was removed by accident, so I found somewhere I think is appropriate to invoke it.

## Changes
* Invalidate the schema cache when changed in handleWatchedFilesChangedNotification
* Add .json to watched files so it will pick up changes to introspection files
