### PR TITLE
enable `@typescript-eslint/consistent-type-assertions`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -328,6 +328,7 @@ module.exports = {
         '@typescript-eslint/no-unnecessary-type-assertion': 'error',
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/non-nullable-type-assertion-style': 'error',
+        '@typescript-eslint/consistent-type-assertions': 'error',
         // TODO: Fix all errors for the following rules included in recommended config
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',

--- a/packages/monaco-graphql/src/initializeMode.ts
+++ b/packages/monaco-graphql/src/initializeMode.ts
@@ -26,7 +26,7 @@ export function initializeMode(
 ): MonacoGraphQLAPI {
   if (!api) {
     api = createMonacoGraphQLAPI(LANGUAGE_ID, config);
-    (<any>languages).graphql = { api };
+    (languages as any).graphql = { api };
     // export to the global monaco API
 
     // eslint-disable-next-line promise/prefer-await-to-then -- ignore to leave initializeMode sync
@@ -35,6 +35,7 @@ export function initializeMode(
 
   return api;
 }
+
 function getMode(): Promise<typeof GraphQLMode> {
   return import('./graphqlMode');
 }

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -298,9 +298,9 @@ export class HoverAdapter implements monaco.languages.HoverProvider {
     const hoverItem = await worker.doHover(resource.toString(), position);
 
     if (hoverItem) {
-      return <monaco.languages.Hover>{
+      return {
         range: hoverItem.range,
-        contents: [{ value: hoverItem.content }],
+        contents: [{ value: hoverItem.content as string }],
       };
     }
 

--- a/packages/monaco-graphql/src/monaco.contribution.ts
+++ b/packages/monaco-graphql/src/monaco.contribution.ts
@@ -25,7 +25,7 @@ export { LANGUAGE_ID };
 languages.onLanguage(LANGUAGE_ID, () => {
   const api = initializeMode();
 
-  (<any>languages).graphql = { api };
+  (languages as any).graphql = { api };
 });
 /**
  * Register the language mode without schema or any settings, so you can configure them asynchronously.


### PR DESCRIPTION
in The Guild we use this rule to prevent `<...>` assertions