### PR TITLE
always bundle `package.json#dependencies` for UMD for `@graphiql/plugin-code-exporter` and `@graphiql/plugin-explorer`

### DIFF
--- a/.changeset/nice-sheep-fold.md
+++ b/.changeset/nice-sheep-fold.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-explorer': patch
+---
+
+always bundle `package.json#dependencies` for `@graphiql/plugin-code-exporter` and `@graphiql/plugin-explorer`

--- a/.changeset/nice-sheep-fold.md
+++ b/.changeset/nice-sheep-fold.md
@@ -3,4 +3,4 @@
 '@graphiql/plugin-explorer': patch
 ---
 
-always bundle `package.json#dependencies` for `@graphiql/plugin-code-exporter` and `@graphiql/plugin-explorer`
+always bundle `package.json#dependencies` for UMD build for `@graphiql/plugin-code-exporter` and `@graphiql/plugin-explorer`

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc --emitDeclarationOnly && node resources/copy-types.mjs && vite build",
+    "build": "tsc --emitDeclarationOnly && node resources/copy-types.mjs && vite build && UMD=true vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/graphiql-plugin-code-exporter/vite.config.ts
+++ b/packages/graphiql-plugin-code-exporter/vite.config.ts
@@ -2,21 +2,24 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import packageJSON from './package.json';
 
-// https://vitejs.dev/config/
+const IS_UMD = process.env.UMD === 'true';
+
 export default defineConfig({
   plugins: [react({ jsxRuntime: 'classic' })],
   build: {
+    // avoid clean cjs/es builds
+    emptyOutDir: !IS_UMD,
     lib: {
       entry: 'src/index.tsx',
       fileName: 'index',
       name: 'GraphiQLPluginCodeExporter',
-      formats: ['cjs', 'es', 'umd'],
+      formats: IS_UMD ? ['umd'] : ['cjs', 'es'],
     },
     rollupOptions: {
       external: [
         // Exclude peer dependencies and dependencies from bundle
         ...Object.keys(packageJSON.peerDependencies),
-        ...Object.keys(packageJSON.dependencies),
+        ...(IS_UMD ? [] : Object.keys(packageJSON.dependencies)),
       ],
       output: {
         chunkFileNames: '[name].[format].js',

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc --emitDeclarationOnly && node resources/copy-types.mjs && vite build",
+    "build": "tsc --emitDeclarationOnly && node resources/copy-types.mjs && vite build && UMD=true vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/packages/graphiql-plugin-explorer/vite.config.ts
+++ b/packages/graphiql-plugin-explorer/vite.config.ts
@@ -2,21 +2,24 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import packageJSON from './package.json';
 
-// https://vitejs.dev/config/
+const IS_UMD = process.env.UMD === 'true';
+
 export default defineConfig({
   plugins: [react({ jsxRuntime: 'classic' })],
   build: {
+    // avoid clean cjs/es builds
+    emptyOutDir: !IS_UMD,
     lib: {
       entry: 'src/index.tsx',
       fileName: 'index',
       name: 'GraphiQLPluginExplorer',
-      formats: ['cjs', 'es', 'umd'],
+      formats: IS_UMD ? ['umd'] : ['cjs', 'es'],
     },
     rollupOptions: {
       external: [
         // Exclude peer dependencies and dependencies from bundle
         ...Object.keys(packageJSON.peerDependencies),
-        ...Object.keys(packageJSON.dependencies),
+        ...(IS_UMD ? [] : Object.keys(packageJSON.dependencies)),
       ],
       output: {
         chunkFileNames: '[name].[format].js',


### PR DESCRIPTION
fix https://github.com/graphql/graphiql/issues/3242