### PR TITLE
Add full support for 'go to references'

### DIFF
--- a/.changeset/forty-llamas-beg.md
+++ b/.changeset/forty-llamas-beg.md
@@ -1,0 +1,7 @@
+---
+'graphql-language-service': minor
+'graphql-language-service-server': minor
+'graphql-language-service-cli': minor
+---
+
+Add basic support for 'go to references'

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -6,6 +6,10 @@ module.exports = (dir, env = 'jsdom') => {
   if (env === 'jsdom') {
     setupFilesAfterEnv.push(path.join(__dirname, '/resources/test.config.js'));
   }
+  const testPathIgnorePatterns = ['node_modules', 'dist', 'cypress'];
+  if (process.env.IGNORE_CM6) {
+    testPathIgnorePatterns.push('cm6-graphql');
+  }
   return {
     globals: {
       'ts-jest': {
@@ -33,7 +37,7 @@ module.exports = (dir, env = 'jsdom') => {
     },
     testMatch: ['**/*[-.](spec|test).[jt]s?(x)', '!**/cypress/**'],
     testEnvironment: env,
-    testPathIgnorePatterns: ['node_modules', 'dist', 'cypress'],
+    testPathIgnorePatterns,
     collectCoverageFrom: ['**/src/**/*.{js,jsx,ts,tsx}'],
     coveragePathIgnorePatterns: [
       'dist',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "e2e:build": "yarn build && yarn workspace graphiql build-bundles-min",
     "eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --max-warnings=0 --cache .",
     "format": "yarn eslint --fix && yarn pretty",
-    "jest": "jest --testPathIgnorePatterns cm6-graphql",
+    "jest": "IGNORE_CM6=true jest",
     "license-check": "jsgl --local ./",
     "lint": "yarn eslint && yarn lint-check && yarn pretty-check && yarn lint-cspell",
     "lint-check": "eslint-config-prettier .eslintrc.js",

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -71,7 +71,6 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _graphQLFileListCache: Map<Uri, Map<string, GraphQLFileInfo>>;
   _graphQLConfig: GraphQLConfig;
   _schemaMap: Map<Uri, GraphQLSchema>;
-  _schemaDocumentNodeMap: Map<Uri, DocumentNode>;
   _typeExtensionMap: Map<Uri, number>;
   _fragmentDefinitionsCache: Map<Uri, Map<string, FragmentInfo>>;
   _typeDefinitionsCache: Map<Uri, Map<string, ObjectTypeInfo>>;
@@ -93,7 +92,6 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._graphQLConfig = config;
     this._graphQLFileListCache = new Map();
     this._schemaMap = new Map();
-    this._schemaDocumentNodeMap = new Map();
     this._fragmentDefinitionsCache = new Map();
     this._typeDefinitionsCache = new Map();
     this._typeExtensionMap = new Map();

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -71,6 +71,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _graphQLFileListCache: Map<Uri, Map<string, GraphQLFileInfo>>;
   _graphQLConfig: GraphQLConfig;
   _schemaMap: Map<Uri, GraphQLSchema>;
+  _schemaDocumentNodeMap: Map<Uri, DocumentNode>;
   _typeExtensionMap: Map<Uri, number>;
   _fragmentDefinitionsCache: Map<Uri, Map<string, FragmentInfo>>;
   _typeDefinitionsCache: Map<Uri, Map<string, ObjectTypeInfo>>;
@@ -92,6 +93,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     this._graphQLConfig = config;
     this._graphQLFileListCache = new Map();
     this._schemaMap = new Map();
+    this._schemaDocumentNodeMap = new Map();
     this._fragmentDefinitionsCache = new Map();
     this._typeDefinitionsCache = new Map();
     this._typeExtensionMap = new Map();
@@ -668,6 +670,37 @@ export class GraphQLCache implements GraphQLCacheInterface {
     if (schemaCacheKey) {
       this._schemaMap.set(schemaCacheKey, schema);
     }
+    return schema;
+  };
+
+  getSchemaDocumentNode = async (
+    appName?: string,
+  ): Promise<DocumentNode | null> => {
+    const projectConfig = this._graphQLConfig.getProject(appName);
+
+    if (!projectConfig) {
+      return null;
+    }
+
+    const schemaPath = projectConfig.schema as string;
+    const schemaKey = this._getSchemaCacheKeyForProject(projectConfig);
+
+    let schemaCacheKey = null;
+    let schema = null;
+
+    if (schemaPath && schemaKey) {
+      schemaCacheKey = schemaKey as string;
+
+      if (this._schemaDocumentNodeMap.has(schemaCacheKey)) {
+        schema = this._schemaDocumentNodeMap.get(schemaCacheKey);
+        if (schema) {
+          return schema;
+        }
+      }
+
+      schema = await projectConfig.getSchema('DocumentNode');
+    }
+
     return schema;
   };
 

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -673,37 +673,6 @@ export class GraphQLCache implements GraphQLCacheInterface {
     return schema;
   };
 
-  getSchemaDocumentNode = async (
-    appName?: string,
-  ): Promise<DocumentNode | null> => {
-    const projectConfig = this._graphQLConfig.getProject(appName);
-
-    if (!projectConfig) {
-      return null;
-    }
-
-    const schemaPath = projectConfig.schema as string;
-    const schemaKey = this._getSchemaCacheKeyForProject(projectConfig);
-
-    let schemaCacheKey = null;
-    let schema = null;
-
-    if (schemaPath && schemaKey) {
-      schemaCacheKey = schemaKey as string;
-
-      if (this._schemaDocumentNodeMap.has(schemaCacheKey)) {
-        schema = this._schemaDocumentNodeMap.get(schemaCacheKey);
-        if (schema) {
-          return schema;
-        }
-      }
-
-      schema = await projectConfig.getSchema('DocumentNode');
-    }
-
-    return schema;
-  };
-
   invalidateSchemaCacheForProject(projectConfig: GraphQLProjectConfig) {
     const schemaKey = this._getSchemaCacheKeyForProject(
       projectConfig,

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -404,10 +404,7 @@ export class GraphQLLanguageService {
       return [];
     }
 
-    const schema = await this._graphQLCache.getSchemaDocumentNode(
-      projectConfig.name,
-    );
-
+    const schema = await projectConfig.getSchema('DocumentNode');
     if (!schema) {
       return [];
     }
@@ -436,6 +433,18 @@ export class GraphQLLanguageService {
         });
       }
     };
+    // TODO: check fragment and type definition caches
+    // instead of this workaround that only works for a single
+    // file and schema
+    // the proper solution requires searching all documents in the cache
+    visit(parse(document), {
+      FragmentSpread(node) {
+        matchNodeByName(node);
+      },
+      NamedType(node) {
+        matchNodeByName(node);
+      },
+    });
 
     visit(schema, {
       FragmentSpread(node) {

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -20,6 +20,7 @@ import {
   parse,
   print,
   isTypeDefinitionNode,
+  visit,
 } from 'graphql';
 
 import {
@@ -45,6 +46,9 @@ import {
   getASTNodeAtPosition,
   getTokenAtPosition,
   getTypeInfo,
+  Reference,
+  Range,
+  Position,
 } from 'graphql-language-service';
 
 import { GraphQLConfig, GraphQLProjectConfig } from 'graphql-config';
@@ -250,7 +254,7 @@ export class GraphQLLanguageService {
   }
 
   public async getHoverInformation(
-    query: string,
+    document: string,
     position: IPosition,
     filePath: Uri,
     options?: HoverConfig,
@@ -262,13 +266,19 @@ export class GraphQLLanguageService {
     const schema = await this._graphQLCache.getSchema(projectConfig.name);
 
     if (schema) {
-      return getHoverInformation(schema, query, position, undefined, options);
+      return getHoverInformation(
+        schema,
+        document,
+        position,
+        undefined,
+        options,
+      );
     }
     return '';
   }
 
   public async getDefinition(
-    query: string,
+    document: string,
     position: IPosition,
     filePath: Uri,
   ): Promise<DefinitionQueryResult | null> {
@@ -279,17 +289,17 @@ export class GraphQLLanguageService {
 
     let ast;
     try {
-      ast = parse(query);
+      ast = parse(document);
     } catch {
       return null;
     }
 
-    const node = getASTNodeAtPosition(query, ast, position);
+    const node = getASTNodeAtPosition(document, ast, position);
     if (node) {
       switch (node.kind) {
         case Kind.FRAGMENT_SPREAD:
           return this._getDefinitionForFragmentSpread(
-            query,
+            document,
             ast,
             node,
             filePath,
@@ -300,13 +310,13 @@ export class GraphQLLanguageService {
         case Kind.OPERATION_DEFINITION:
           return getDefinitionQueryResultForDefinitionNode(
             filePath,
-            query,
+            document,
             node,
           );
 
         case Kind.NAMED_TYPE:
           return this._getDefinitionForNamedType(
-            query,
+            document,
             ast,
             node,
             filePath,
@@ -315,7 +325,7 @@ export class GraphQLLanguageService {
 
         case Kind.FIELD:
           return this._getDefinitionForField(
-            query,
+            document,
             ast,
             node,
             filePath,
@@ -350,14 +360,14 @@ export class GraphQLLanguageService {
       }
 
       output.push({
-        // @ts-ignore
+        // @ts-expect-error
         name: tree.representativeName,
         kind: getKind(tree),
         location: {
           uri: filePath,
           range: {
             start: tree.startPosition,
-            // @ts-ignore
+            // @ts-expect-error
             end: tree.endPosition,
           },
         },
@@ -367,17 +377,74 @@ export class GraphQLLanguageService {
     }
     return output;
   }
-  //
-  // public async getReferences(
-  //   document: string,
-  //   position: Position,
-  //   filePath: Uri,
-  // ): Promise<Location[]> {
-  //
-  // }
+
+  public async getReferences(
+    document: string,
+    position: IPosition,
+    filePath: Uri,
+  ): Promise<Reference[] | []> {
+    const projectConfig = this.getConfigForURI(filePath);
+    if (!projectConfig) {
+      return [];
+    }
+
+    let ast;
+    try {
+      ast = parse(document);
+    } catch {
+      return [];
+    }
+
+    const definitionNode = getASTNodeAtPosition(document, ast, position);
+
+    if (!definitionNode || !isTypeDefinitionNode(definitionNode)) {
+      return [];
+    }
+
+    const schema = await this._graphQLCache.getSchemaDocumentNode(
+      projectConfig.name,
+    );
+
+    if (!schema) {
+      return [];
+    }
+
+    const references: Reference[] = [];
+
+    visit(schema, {
+      NamedType(node) {
+        if (!node.loc?.source) {
+          return;
+        }
+
+        if (
+          node.name.value.toLowerCase() ===
+          definitionNode.name.value.toLowerCase()
+        ) {
+          references.push({
+            location: {
+              uri: node.loc.source.name,
+              range: new Range(
+                new Position(
+                  node.loc.startToken.line - 1,
+                  node.loc.startToken.column - 1,
+                ),
+                new Position(
+                  node.loc.endToken.line - 1,
+                  node.loc.endToken.column - 1,
+                ),
+              ),
+            },
+          });
+        }
+      },
+    });
+
+    return references;
+  }
 
   async _getDefinitionForNamedType(
-    query: string,
+    document: string,
     ast: DocumentNode,
     node: NamedTypeNode,
     filePath: Uri,
@@ -396,12 +463,12 @@ export class GraphQLLanguageService {
       .filter(isTypeDefinitionNode)
       .map((definition: TypeDefinitionNode) => ({
         filePath,
-        content: query,
+        content: document,
         definition,
       }));
 
     const result = await getDefinitionQueryResultForNamedType(
-      query,
+      document,
       node,
       dependencies.concat(localOperationDefinitionInfos),
     );
@@ -410,14 +477,14 @@ export class GraphQLLanguageService {
   }
 
   async _getDefinitionForField(
-    query: string,
+    document: string,
     _ast: DocumentNode,
     _node: FieldNode,
     _filePath: Uri,
     projectConfig: GraphQLProjectConfig,
     position: IPosition,
   ) {
-    const token = getTokenAtPosition(query, position);
+    const token = getTokenAtPosition(document, position);
     const schema = await this._graphQLCache.getSchema(projectConfig.name);
 
     const typeInfo = getTypeInfo(schema!, token.state);
@@ -445,7 +512,7 @@ export class GraphQLLanguageService {
   }
 
   async _getDefinitionForFragmentSpread(
-    query: string,
+    document: string,
     ast: DocumentNode,
     node: FragmentSpreadNode,
     filePath: Uri,
@@ -470,20 +537,20 @@ export class GraphQLLanguageService {
     const localFragInfos = typeCastedDefs.map(
       (definition: FragmentDefinitionNode) => ({
         filePath,
-        content: query,
+        content: document,
         definition,
       }),
     );
 
     const result = await getDefinitionQueryResultForFragmentSpread(
-      query,
+      document,
       node,
       dependencies.concat(localFragInfos),
     );
 
     return result;
   }
-  async getOutline(documentText: string): Promise<Outline | null> {
-    return getOutline(documentText);
+  async getOutline(document: string): Promise<Outline | null> {
+    return getOutline(document);
   }
 }

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService-test.ts
@@ -14,7 +14,6 @@ import { GraphQLLanguageService } from '../GraphQLLanguageService';
 import { SymbolKind } from 'vscode-languageserver-protocol';
 import { Position } from 'graphql-language-service';
 import { NoopLogger } from '../Logger';
-import { parse } from 'graphql';
 
 const simplify = (data: unknown) => JSON.parse(JSON.stringify(data));
 
@@ -27,8 +26,6 @@ const MOCK_CONFIG = {
 };
 
 describe('GraphQLLanguageService', () => {
-  let mockGetSchemaDocumentNode;
-
   const mockCache = {
     async getSchema() {
       const config = this.getGraphQLConfig();
@@ -121,10 +118,6 @@ describe('GraphQLLanguageService', () => {
         },
       ];
     },
-
-    getSchemaDocumentNode() {
-      return mockGetSchemaDocumentNode;
-    },
   };
 
   let languageService: GraphQLLanguageService;
@@ -133,7 +126,6 @@ describe('GraphQLLanguageService', () => {
       mockCache as any,
       new NoopLogger(),
     );
-    mockGetSchemaDocumentNode = languageService._graphQLConfig.project;
   });
 
   it('runs diagnostic service as expected', async () => {
@@ -199,7 +191,7 @@ describe('GraphQLLanguageService', () => {
   it('can find references for an object type', async () => {
     const document =
       'union X = A | B\ntype A { x: String }\ntype B { x: String }\ntype Query { a: X\n z: A }';
-    mockGetSchemaDocumentNode = parse(document);
+    // mockGetSchemaDocumentNode = parse(document);
 
     const references = await languageService.getReferences(
       document,
@@ -222,7 +214,7 @@ describe('GraphQLLanguageService', () => {
     const document =
       'fragment Example on Character {name}\nquery A { hero {...Example}}\nquery B { hero {...Example }}';
 
-    mockGetSchemaDocumentNode = parse(document);
+    // mockGetSchemaDocumentNode = parse(document);
 
     const references = await languageService.getReferences(
       document,
@@ -245,7 +237,7 @@ describe('GraphQLLanguageService', () => {
     const document =
       'fragment ExampleA on Character {name}\nquery A { hero {...Example}}\nquery B { hero {...Example }}';
 
-    mockGetSchemaDocumentNode = parse(document);
+    // mockGetSchemaDocumentNode = parse(document);
 
     const references = await languageService.getReferences(
       document,

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -38,6 +38,7 @@ import {
   WorkspaceSymbolRequest,
   createConnection,
   Connection,
+  ReferencesRequest,
 } from 'vscode-languageserver/node';
 
 import { Logger } from './Logger';
@@ -333,6 +334,10 @@ async function addHandlers({
 
   connection.onRequest(DefinitionRequest.type, params =>
     messageProcessor.handleDefinitionRequest(params),
+  );
+
+  connection.onRequest(ReferencesRequest.type, params =>
+    messageProcessor.handleReferencesRequest(params),
   );
 
   connection.onRequest(HoverRequest.type, params =>

--- a/packages/graphql-language-service/src/index.ts
+++ b/packages/graphql-language-service/src/index.ts
@@ -97,6 +97,7 @@ export type {
   FileChangeType,
   GraphQLCache,
   GraphQLExtensionDeclaration,
+  Reference,
 } from './types';
 
 export { CompletionItemKind, FileChangeTypeKind } from './types';

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -109,6 +109,8 @@ export interface GraphQLCache {
     appName?: string,
     queryHasExtensions?: boolean,
   ) => Promise<GraphQLSchema | null>;
+
+  getSchemaDocumentNode: (appName?: string) => Promise<DocumentNode | null>;
 }
 
 // online-parser related
@@ -207,6 +209,13 @@ export type Definition = {
   name?: string;
   language?: string;
   projectRoot?: Uri;
+};
+
+export type Reference = {
+  location: {
+    uri: Uri;
+    range: IRange;
+  };
 };
 
 // Outline view

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -109,8 +109,6 @@ export interface GraphQLCache {
     appName?: string,
     queryHasExtensions?: boolean,
   ) => Promise<GraphQLSchema | null>;
-
-  getSchemaDocumentNode: (appName?: string) => Promise<DocumentNode | null>;
 }
 
 // online-parser related


### PR DESCRIPTION
clone of #3250 with some desired changes and merging upstream

- [x] add more tests
- [x] add support for fragments
- [x] add support for searching both the current document and the schema for references
   - [ ] add support for searching all files for references
   - [ ] refactor graphql cache to cache documents instead of MessageProcessor? (big undertaking!) OR just move this logic to MessageProcessor as with getDefinitions
 - [ ] add tests for message processor