### PR TITLE
enable avoidExplicitReturnArrows: true option for `object-shorthand` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -248,7 +248,11 @@ module.exports = {
         'no-useless-computed-key': 'error',
         'no-useless-constructor': 'off',
         'no-useless-rename': 'error',
-        'object-shorthand': 'error',
+        'object-shorthand': [
+          'error',
+          'always',
+          { avoidExplicitReturnArrows: true },
+        ],
         'prefer-arrow-callback': ['off', { allowNamedFunctions: true }], // prettier --list-different
         'prefer-numeric-literals': 'off',
         'prefer-template': 'off',

--- a/examples/cm6-graphql-parcel/src/testSchema.ts
+++ b/examples/cm6-graphql-parcel/src/testSchema.ts
@@ -146,7 +146,7 @@ export const TestType: GraphQLObjectType = new GraphQLObjectType({
     },
     isTest: {
       type: GraphQLBoolean,
-      resolve: () => {
+      resolve() {
         return true;
       },
     },

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -196,7 +196,7 @@ async function render() {
   };
 
   /**
-   * Add an reload operation to the command palette & keyboard shortcuts
+   * Add a reload operation to the command palette & keyboard shortcuts
    */
   const reloadAction: monaco.editor.IActionDescriptor = {
     id: 'graphql-reload',
@@ -206,7 +206,7 @@ async function render() {
     keybindings: [
       monaco.KeyMod.CtrlCmd | monaco.KeyCode?.KeyR, // eslint-disable-line no-bitwise
     ],
-    run: async () => {
+    async run() {
       await schemaFetcher.loadSchema();
     },
   };

--- a/packages/cm6-graphql/src/completions.ts
+++ b/packages/cm6-graphql/src/completions.ts
@@ -7,7 +7,7 @@ import { graphqlLanguage } from './language';
 const AUTOCOMPLETE_CHARS = /^[a-zA-Z0-9_@(]$/;
 
 export const completion = graphqlLanguage.data.of({
-  autocomplete: (ctx: CompletionContext) => {
+  autocomplete(ctx: CompletionContext) {
     const schema = getSchema(ctx.state);
     const opts = getOpts(ctx.state);
     if (!schema) {
@@ -38,7 +38,7 @@ export const completion = graphqlLanguage.data.of({
         return {
           label: item.label,
           detail: item.detail || '',
-          info: (completionData: Completion) => {
+          info(completionData: Completion) {
             if (opts?.onCompletionInfoRender) {
               return opts.onCompletionInfoRender(item, ctx, completionData);
             }

--- a/packages/codemirror-graphql/src/__tests__/testSchema.ts
+++ b/packages/codemirror-graphql/src/__tests__/testSchema.ts
@@ -146,7 +146,7 @@ export const TestType: GraphQLObjectType = new GraphQLObjectType({
     },
     isTest: {
       type: GraphQLBoolean,
-      resolve: () => {
+      resolve() {
         return true;
       },
     },

--- a/packages/graphiql-react/src/editor/query-editor.ts
+++ b/packages/graphiql-react/src/editor/query-editor.ts
@@ -190,13 +190,13 @@ export function useQueryEditor(
         info: {
           schema: undefined,
           renderDescription: (text: string) => markdown.render(text),
-          onClick: (reference: SchemaReference) => {
+          onClick(reference: SchemaReference) {
             onClickReferenceRef.current(reference);
           },
         },
         jump: {
           schema: undefined,
-          onClick: (reference: SchemaReference) => {
+          onClick(reference: SchemaReference) {
             onClickReferenceRef.current(reference);
           },
         },

--- a/packages/graphiql-toolkit/src/async-helpers/index.ts
+++ b/packages/graphiql-toolkit/src/async-helpers/index.ts
@@ -17,12 +17,12 @@ export function isPromise<T>(value: Promise<T> | any): value is Promise<T> {
 function observableToPromise<T>(observable: Observable<T>): Promise<T> {
   return new Promise((resolve, reject) => {
     const subscription = observable.subscribe({
-      next: v => {
+      next(v) {
         resolve(v);
         subscription.unsubscribe();
       },
       error: reject,
-      complete: () => {
+      complete() {
         reject(new Error('no value resolved'));
       },
     });

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -106,7 +106,7 @@ export const createWebsocketsFetcherFromClient =
     makeAsyncIterableIteratorFromSink<ExecutionResult>(sink =>
       wsClient.subscribe(graphQLParams, {
         ...sink,
-        error: err => {
+        error(err) {
           if (err instanceof CloseEvent) {
             sink.error(
               new Error(

--- a/packages/graphiql-toolkit/src/storage/__tests__/base.spec.ts
+++ b/packages/graphiql-toolkit/src/storage/__tests__/base.spec.ts
@@ -72,7 +72,7 @@ describe('StorageAPI', () => {
   it('returns any error while setting a value', () => {
     // @ts-ignore
     const throwingStorage = new StorageAPI({
-      setItem: () => {
+      setItem() {
         throw new DOMException('Terrible Error');
       },
       length: 1,
@@ -86,7 +86,7 @@ describe('StorageAPI', () => {
   it('returns isQuotaError to true if isQuotaError is thrown', () => {
     // @ts-ignore
     const throwingStorage = new StorageAPI({
-      setItem: () => {
+      setItem() {
         throw new DOMException('Terrible Error', 'QuotaExceededError');
       },
       length: 1,

--- a/packages/graphiql-toolkit/src/storage/base.ts
+++ b/packages/graphiql-toolkit/src/storage/base.ts
@@ -78,7 +78,7 @@ export class StorageAPI {
           return keys;
         },
 
-        clear: () => {
+        clear() {
           // We only want to clear the namespaced items
           for (const key in window.localStorage) {
             if (key.indexOf(`${STORAGE_NAMESPACE}:`) === 0) {

--- a/packages/graphiql/resources/webpack.config.js
+++ b/packages/graphiql/resources/webpack.config.js
@@ -30,7 +30,7 @@ const resultConfig = {
     // bypass simple localhost CORS restrictions by setting
     // these to 127.0.0.1 in /etc/hosts
     allowedHosts: ['local.example.com', 'graphiql.com'],
-    setupMiddlewares: (middlewares, devServer) => {
+    setupMiddlewares(middlewares, devServer) {
       require('../test/beforeDevServer')(devServer.app);
       require('../test/afterDevServer')();
 

--- a/packages/graphiql/test/schema.js
+++ b/packages/graphiql/test/schema.js
@@ -82,7 +82,7 @@ const TestInterface = new GraphQLInterfaceType({
       description: 'Common name string.',
     },
   }),
-  resolveType: check => {
+  resolveType(check) {
     return check ? UnionFirst : UnionSecond;
   },
 });

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -768,7 +768,7 @@ export class MessageProcessor {
     const inlineFragments: string[] = [];
     try {
       visit(parse(query), {
-        FragmentDefinition: (node: FragmentDefinitionNode) => {
+        FragmentDefinition(node: FragmentDefinitionNode) {
           inlineFragments.push(node.name.value);
         },
       });

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -59,14 +59,14 @@ describe('MessageProcessor', () => {
     });
     messageProcessor._languageService = {
       // @ts-ignore
-      getAutocompleteSuggestions: (query, position, uri) => {
+      getAutocompleteSuggestions(query, position, uri) {
         return [{ label: `${query} at ${uri}` }];
       },
       // @ts-ignore
-      getDiagnostics: (_query, _uri) => {
+      getDiagnostics(_query, _uri) {
         return [];
       },
-      getDocumentSymbols: async (_query: string, uri: string) => {
+      async getDocumentSymbols(_query: string, uri: string) {
         return [
           {
             name: 'item',
@@ -81,7 +81,7 @@ describe('MessageProcessor', () => {
           },
         ];
       },
-      getOutline: async (_query: string): Promise<Outline> => {
+      async getOutline(_query: string): Promise<Outline> {
         return {
           outlineTrees: [
             {
@@ -94,11 +94,11 @@ describe('MessageProcessor', () => {
           ],
         };
       },
-      getDefinition: async (
+      async getDefinition(
         _query,
         position,
         uri,
-      ): Promise<DefinitionQueryResult> => {
+      ): Promise<DefinitionQueryResult> {
         return {
           queryRange: [new Range(position, position)],
           definitions: [
@@ -118,7 +118,7 @@ describe('MessageProcessor', () => {
     // @ts-ignore
     get workspace() {
       return {
-        getConfiguration: async () => {
+        async getConfiguration() {
           return [getConfigurationReturnValue];
         },
       };

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -220,7 +220,7 @@ export function findGraphQLTags(
 
       traverse(node, visitors);
     },
-    TaggedTemplateExpression: (node: TaggedTemplateExpression) => {
+    TaggedTemplateExpression(node: TaggedTemplateExpression) {
       const tagName = getGraphQLTagName(node.tag);
       if (tagName) {
         const { loc } = node.quasi.quasis[0];
@@ -250,7 +250,7 @@ export function findGraphQLTags(
         }
       }
     },
-    TemplateLiteral: (node: TemplateLiteral) => {
+    TemplateLiteral(node: TemplateLiteral) {
       const hasGraphQLPrefix =
         node.quasis[0].value.raw.startsWith('#graphql\n');
       const hasGraphQLComment = Boolean(

--- a/packages/graphql-language-service/benchmark/index.ts
+++ b/packages/graphql-language-service/benchmark/index.ts
@@ -36,10 +36,10 @@ const runSplitTest = (name: string, schema: string) => {
 
     suite.add({
       maxTime: 0.1,
-      onStart: () => {
+      onStart() {
         prevState = { ...state };
       },
-      fn: () => {
+      fn() {
         const stream = new CharacterStream(line);
 
         while (!stream.eol()) {
@@ -54,7 +54,7 @@ const runSplitTest = (name: string, schema: string) => {
         state = { ...prevState };
       },
       onError: console.log,
-      onComplete: (e: any) => {
+      onComplete(e) {
         state = completeState;
         stats.push(e.target.stats);
       },

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -118,7 +118,7 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
   };
 
   return {
-    Field: (node: FieldNode) => {
+    Field(node: FieldNode) {
       const tokenizedText = node.alias
         ? [buildToken('plain', node.alias), buildToken('plain', ': ')]
         : [];
@@ -191,19 +191,18 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
       ],
       ...meta(node),
     }),
-    InputValueDefinition: (node: InputValueDefinitionNode) => {
+    InputValueDefinition(node: InputValueDefinitionNode) {
       return {
         tokenizedText: [buildToken('plain', node.name)],
         ...meta(node),
       };
     },
-    FieldDefinition: (node: FieldDefinitionNode) => {
+    FieldDefinition(node: FieldDefinitionNode) {
       return {
         tokenizedText: [buildToken('plain', node.name)],
         ...meta(node),
       };
     },
-
     InlineFragment: (node: InlineFragmentNode) => node.selectionSet,
   };
 }

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -67,7 +67,7 @@ export class DiagnosticsAdapter {
     this._disposables.push(
       editor.onDidCreateModel(onModelAdd),
       {
-        dispose: () => {
+        dispose() {
           clearTimeout(onChangeTimeout);
         },
       },

--- a/packages/vscode-graphql/src/extension.ts
+++ b/packages/vscode-graphql/src/extension.ts
@@ -83,7 +83,7 @@ export async function activate(context: ExtensionContext) {
     outputChannel,
     outputChannelName: 'GraphQL Language Server',
     revealOutputChannelOn: RevealOutputChannelOn.Never,
-    initializationFailedHandler: err => {
+    initializationFailedHandler(err) {
       outputChannel.appendLine('Initialization failed');
       outputChannel.appendLine(err.message);
       if (err.stack) {


### PR DESCRIPTION
less code written

```js
foo: (bar) => {
foo(bar) {
```