### PR TITLE
fix umd build names `graphiql-plugin-code-exporter.umd.js` and `graphiql-plugin-explorer.umd.js`

### DIFF
--- a/.changeset/stale-llamas-invite.md
+++ b/.changeset/stale-llamas-invite.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-explorer': patch
+---
+
+fix umd build names `graphiql-plugin-code-exporter.umd.js` and `graphiql-plugin-explorer.umd.js`

--- a/packages/graphiql-plugin-code-exporter/vite.config.ts
+++ b/packages/graphiql-plugin-code-exporter/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     emptyOutDir: !IS_UMD,
     lib: {
       entry: 'src/index.tsx',
-      fileName: 'index',
+      fileName: IS_UMD ? 'graphiql-plugin-code-exporter' : 'index',
       name: 'GraphiQLPluginCodeExporter',
       formats: IS_UMD ? ['umd'] : ['cjs', 'es'],
     },

--- a/packages/graphiql-plugin-explorer/vite.config.ts
+++ b/packages/graphiql-plugin-explorer/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     emptyOutDir: !IS_UMD,
     lib: {
       entry: 'src/index.tsx',
-      fileName: 'index',
+      fileName: IS_UMD ? 'graphiql-plugin-explorer' : 'index',
       name: 'GraphiQLPluginExplorer',
       formats: IS_UMD ? ['umd'] : ['cjs', 'es'],
     },


### PR DESCRIPTION
fixes https://github.com/graphql/graphiql/issues/3291

<img width="295" alt="image" src="https://github.com/graphql/graphiql/assets/7361780/0dbd8daf-24ec-4b57-b2fc-e7556a320f24">

<img width="338" alt="image" src="https://github.com/graphql/graphiql/assets/7361780/26c35441-baad-4193-ade3-d4c7ebdf3a1a">

no need to change for `cjs` and `esm` it declared fine in `package.json`