### PR TITLE
Ensure diagnostics get regenerated on schema save

### DIFF
--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -340,8 +340,17 @@ async function addHandlers({
     messageProcessor.handleHoverRequest(params),
   );
 
-  connection.onNotification(DidChangeWatchedFilesNotification.type, params =>
-    messageProcessor.handleWatchedFilesChangedNotification(params),
+  connection.onNotification(
+    DidChangeWatchedFilesNotification.type,
+    async params => {
+      const allDiagnostics =
+        await messageProcessor.handleWatchedFilesChangedNotification(params);
+      if (allDiagnostics) {
+        for (const diagnostics of allDiagnostics) {
+          reportDiagnostics(diagnostics, connection);
+        }
+      }
+    },
   );
 
   connection.onRequest(DocumentSymbolRequest.type, params =>


### PR DESCRIPTION
First of all, thank you for all of this great work!

I just installed the `GraphQL.vscode-graphql` extension yesterday and noticed that when I update the GraphQL schema and save it, diagnostics for queries / mutations do not get updated. For example, say I have a mutation using a field that no longer exists in the new schema; diagnostics would not show up for that mutation until I switch to the file containing the mutation and edit it.

I was also thinking that it may be a good idea to separate the cached documents according to project since with the current way cached documents are stored, there seems to be no way to differentiate between documents belonging to different projects.

I am not very familiar with the overall structure of the project or the API as I just learned about this extension yesterday, so any advice regarding potentially better caching behavior, or any existing implementation details, would be appreciated.

Thank you again!