### PR TITLE
fix: run tests for commits that include markdown, etc changes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,10 +4,10 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize]
-    paths-ignore:
-      - '**.md'
-      - 'examples'
-      - '!examples/monaco-graphql-webpack'
+#     paths-ignore:
+#       - '**.md'
+#       - 'examples'
+#       - '!examples/monaco-graphql-webpack'
 jobs:
   unit:
     name: Unit Tests


### PR DESCRIPTION
previously, if you opened a PR that included any markdown changes, even if there were also code changes, the ci would skip tests

essentially, `paths-ignore` does not work the way we hope