### PR TITLE
replace `express-graphql` with `graphql-http`

### DIFF
--- a/functions/schema-demo.js
+++ b/functions/schema-demo.js
@@ -1,7 +1,7 @@
 /* example using https://github.com/awslabs/aws-serverless-express */
 const express = require('express');
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { createHandler } from 'graphql-http/lib/use/express';
+const { createHandler } = require('graphql-http/lib/use/express');
 const awsServerlessExpress = require('aws-serverless-express');
 const schema = require('../packages/graphiql/test/schema');
 const cors = require('cors');

--- a/functions/schema-demo.js
+++ b/functions/schema-demo.js
@@ -1,7 +1,7 @@
 /* example using https://github.com/awslabs/aws-serverless-express */
 const express = require('express');
 // eslint-disable-next-line import/no-extraneous-dependencies
-const { graphqlHTTP } = require('express-graphql');
+import { createHandler } from 'graphql-http/lib/use/express';
 const awsServerlessExpress = require('aws-serverless-express');
 const schema = require('../packages/graphiql/test/schema');
 const cors = require('cors');
@@ -31,7 +31,7 @@ app.all('/graphql', (req, res) => res.redirect('/'));
 // Finally, serve up the GraphQL Schema itself
 app.use(
   '/',
-  graphqlHTTP(() => ({ schema })),
+  createHandler(() => ({ schema })),
 );
 
 const server = awsServerlessExpress.createServer(app, null, binaryMimeTypes);

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "eslint-plugin-sonarjs": "^0.19.0",
     "eslint-plugin-unicorn": "^47.0.0",
     "execa": "^6.0.0",
-    "express": "^4.17.3",
+    "express": "^4.18.2",
     "fetch-mock": "6.5.2",
     "husky": "^4.2.3",
     "jest": "^27.5.1",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -73,7 +73,7 @@
     "cssnano": "^5.1.15",
     "cypress": "^12.6.0",
     "express": "^4.17.3",
-    "express-graphql": "experimental-stream-defer",
+    "graphql-http": "^1.19.0",
     "fork-ts-checker-webpack-plugin": "7.3.0",
     "graphql": "^16.4.0",
     "graphql-subscriptions": "^2.0.0",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -72,7 +72,7 @@
     "css-loader": "^6.7.3",
     "cssnano": "^5.1.15",
     "cypress": "^12.6.0",
-    "express": "^4.17.3",
+    "express": "^4.18.2",
     "graphql-http": "^1.19.0",
     "fork-ts-checker-webpack-plugin": "7.3.0",
     "graphql": "^16.4.0",

--- a/packages/graphiql/resources/webpack.config.js
+++ b/packages/graphiql/resources/webpack.config.js
@@ -32,7 +32,6 @@ const resultConfig = {
     allowedHosts: ['local.example.com', 'graphiql.com'],
     setupMiddlewares(middlewares, devServer) {
       require('../test/beforeDevServer')(devServer.app);
-      require('../test/afterDevServer')();
 
       return middlewares;
     },

--- a/packages/graphiql/test/beforeDevServer.js
+++ b/packages/graphiql/test/beforeDevServer.js
@@ -7,14 +7,14 @@
 
 const express = require('express');
 const path = require('node:path');
-const { graphqlHTTP } = require('express-graphql');
+const { createHandler } = require('graphql-http/lib/use/express');
 const schema = require('./schema');
 const { schema: badSchema } = require('./bad-schema');
 
 module.exports = function beforeDevServer(app, _server, _compiler) {
   // GraphQL Server
-  app.post('/graphql', graphqlHTTP({ schema }));
-  app.get('/graphql', graphqlHTTP({ schema }));
+  app.post('/graphql', createHandler({ schema }));
+  app.get('/graphql', createHandler({ schema }));
 
   app.post('/bad/graphql', (_req, res, next) => {
     res.json({ data: badSchema });

--- a/packages/graphiql/test/e2e-server.js
+++ b/packages/graphiql/test/e2e-server.js
@@ -8,7 +8,7 @@
 /* eslint-disable no-console */
 const express = require('express');
 const path = require('node:path');
-const { graphqlHTTP } = require('express-graphql');
+const { createHandler } = require('graphql-http/lib/use/express');
 const { GraphQLError } = require('graphql');
 const schema = require('./schema');
 const app = express();
@@ -16,11 +16,11 @@ const { schema: badSchema } = require('./bad-schema');
 const WebSocketsServer = require('./afterDevServer');
 
 // Server
-app.post('/graphql', graphqlHTTP({ schema }));
+app.post('/graphql', createHandler({ schema }));
 
 app.get(
   '/graphql',
-  graphqlHTTP({
+  createHandler({
     schema,
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9493,7 +9493,7 @@ expect@^29.0.0:
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
 
-express@^4.16.3:
+express@^4.16.3, express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5506,7 +5506,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
+accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -6534,11 +6534,6 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-bytes@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
-  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
-
 bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -7302,7 +7297,7 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@^1.0.4, content-type@~1.0.4:
+content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -9498,16 +9493,6 @@ expect@^29.0.0:
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
 
-express-graphql@experimental-stream-defer:
-  version "0.12.0-experimental-stream-defer.1"
-  resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.12.0-experimental-stream-defer.1.tgz#1723f400cd94065e9a584ad4677a0d2ce4a7e7d1"
-  integrity sha512-VqSOUgN00Sbs+OO7sYWvZVtGwkLbWK6D71N07Q8iuM9NcJOSQH/g0UvODd1eXLq/nEOQTWLyd7W1s9n1UWxZsA==
-  dependencies:
-    accepts "^1.3.7"
-    content-type "^1.0.4"
-    http-errors "1.8.0"
-    raw-body "^2.4.1"
-
 express@^4.16.3:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
@@ -10662,6 +10647,11 @@ graphql-config@5.0.2:
     string-env-interpolation "^1.0.1"
     tslib "^2.4.0"
 
+graphql-http@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/graphql-http/-/graphql-http-1.19.0.tgz#6f0fff0dbd9a8e797c99b5ac0ca160566e7927da"
+  integrity sha512-fOD3hfp/G+Lhx2FWW5HsfmtJSsw6CikcpOboG7/mFo/pPUzn3yOwKdTFRnJ8MVY4ru69MT1nSPr/1gI/iuGNlw==
+
 graphql-subscriptions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz#11ec181d475852d8aec879183e8e1eb94f2eb79a"
@@ -10952,28 +10942,6 @@ http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
   integrity sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=
-
-http-errors@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
-  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
-
-http-errors@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
-  integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.2.0"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
 
 http-errors@1.8.1:
   version "1.8.1"
@@ -15848,16 +15816,6 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
-  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
-  dependencies:
-    bytes "3.1.0"
-    http-errors "1.7.3"
-    iconv-lite "0.4.24"
-    unpipe "1.0.0"
-
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -16881,11 +16839,6 @@ setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
-
-setprototypeof@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
-  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -17919,11 +17872,6 @@ toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
-
-toidentifier@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
-  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 toidentifier@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`express-graphql` has been deprecated. `graphql-http` is now the transport wg reference implementation. because we are a reference implementation of a reference implementation, we should be using this library instead, or whatever the wg is using.