### PR TITLE
[tooling] use cspell `--no-must-find-files` on git hooks, simplify output

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "eslint --fix",
       "prettier --write",
       "jest --passWithNoTests",
-      "yarn cspell lint --gitignore --no-progress --no-must-find-files"
+      "yarn cspell lint . --gitignore --no-progress --no-must-find-files"
     ],
     "*.{md,html,json,css}": [
       "prettier --write",
-      "yarn cspell lint --gitignore --no-progress --no-must-find-files"
+      "yarn cspell lint . --gitignore --no-progress --no-must-find-files"
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jest": "jest --testPathIgnorePatterns cm6-graphql",
     "license-check": "jsgl --local ./",
     "lint": "yarn eslint && yarn pretty-check && yarn lint-cspell",
-    "lint-cspell": "cspell --unique --gitignore --no-progress --no-must-find-files",
+    "lint-cspell": "cspell --unique --no-progress --no-must-find-files",
     "lint-fix": "yarn eslint --fix",
     "postbuild": "yarn workspace codemirror-graphql run postbuild",
     "prebuild-bundles": "yarn build-bundles-clean",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "eslint --fix",
       "prettier --write",
       "jest --passWithNoTests",
-      "cspell lint . --gitignore --no-progress --no-must-find-files"
+      "cspell --gitignore --no-progress --no-must-find-files"
     ],
     "*.{md,html,json,css}": [
       "prettier --write",
-      "cspell lint . --gitignore --no-progress --no-must-find-files"
+      "cspell --gitignore --no-progress --no-must-find-files"
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "eslint --fix",
       "prettier --write",
       "jest --passWithNoTests",
-      "yarn cspell --gitignore"
+      "yarn cspell lint --gitignore --no-progress --no-must-find-files"
     ],
     "*.{md,html,json,css}": [
       "prettier --write",
-      "yarn cspell --gitignore"
+      "yarn cspell lint --gitignore --no-progress --no-must-find-files"
     ]
   },
   "husky": {
@@ -59,7 +59,7 @@
     "jest": "jest --testPathIgnorePatterns cm6-graphql",
     "license-check": "jsgl --local ./",
     "lint": "yarn eslint && yarn pretty-check && yarn lint-cspell",
-    "lint-cspell": "cspell --unique",
+    "lint-cspell": "cspell --unique --gitignore --no-progress --no-must-find-files",
     "lint-fix": "yarn eslint --fix",
     "postbuild": "yarn workspace codemirror-graphql run postbuild",
     "prebuild-bundles": "yarn build-bundles-clean",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "eslint --fix",
       "prettier --write",
       "jest --passWithNoTests",
-      "cspell --gitignore --no-progress --no-must-find-files"
+      "yarn lint-cspell"
     ],
     "*.{md,html,json,css}": [
       "prettier --write",
-      "cspell --gitignore --no-progress --no-must-find-files"
+      "yarn lint-cspell"
     ]
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
       "eslint --fix",
       "prettier --write",
       "jest --passWithNoTests",
-      "yarn cspell lint . --gitignore --no-progress --no-must-find-files"
+      "cspell lint . --gitignore --no-progress --no-must-find-files"
     ],
     "*.{md,html,json,css}": [
       "prettier --write",
-      "yarn cspell lint . --gitignore --no-progress --no-must-find-files"
+      "cspell lint . --gitignore --no-progress --no-must-find-files"
     ]
   },
   "husky": {


### PR DESCRIPTION
- fixes a false positive non 0 exit error on husky git commit hooks when no files are found with [--no-must-find-files](https://github.com/streetsidesoftware/cspell/issues/2594#issuecomment-1072751914)
- `--no-progress` makes output easier to read locally and in CI

![image](https://github.com/graphql/graphiql/assets/1368727/8debf6aa-aeda-4d3a-b367-b9b93b7c562c)


Notes:
- it would be nice to add these to the config file, but reading the code for `cspell`, it appears these flags are used by the CLI only, thus why they aren't configurable in the config file
- in another PR, we should consider replacing husky with [lefthook](https://www.npmjs.com/package/lefthook), or upgrading husky. this version is not compatible with `pnpm`, and the compatible upgrade will require config changes