### PR TITLE
fix(graphiql-plugin-explorer): Use named `Explorer` import from `graphiql-explorer`

### DIFF
--- a/.changeset/shaggy-eyes-melt.md
+++ b/.changeset/shaggy-eyes-melt.md
@@ -1,0 +1,5 @@
+---
+"@graphiql/plugin-explorer": patch
+---
+
+fix(graphiql-plugin-explorer): Use `preferDefault` helper to correctly import `graphiql-explorer`

--- a/.changeset/shaggy-eyes-melt.md
+++ b/.changeset/shaggy-eyes-melt.md
@@ -2,4 +2,4 @@
 "@graphiql/plugin-explorer": patch
 ---
 
-fix(graphiql-plugin-explorer): Use `preferDefault` helper to correctly import `graphiql-explorer`
+Use named `Explorer` import from `graphiql-explorer` to fix an issue where the bundler didn't correctly choose either the `default` or `Explorer` import. This change should ensure that `@graphiql/plugin-explorer` works correctly without `graphiql-explorer` being bundled.

--- a/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
+++ b/packages/graphiql-plugin-explorer/src/graphiql-explorer.d.ts
@@ -61,5 +61,7 @@ declare module 'graphiql-explorer' {
     defaultValue: (arg: GraphQLLeafType) => ValueNode;
   };
 
+  export { GraphiQLExplorer as Explorer };
+
   export default GraphiQLExplorer;
 }

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -4,11 +4,14 @@ import {
   useExecutionContext,
   useSchemaContext,
 } from '@graphiql/react';
-import GraphiQLExplorer, { GraphiQLExplorerProps } from 'graphiql-explorer';
+import type { GraphiQLExplorerProps } from 'graphiql-explorer';
+import GraphiQLExplorerImport from 'graphiql-explorer';
 import React, { useCallback, useRef } from 'react';
 
 import './graphiql-explorer.d.ts';
 import './index.css';
+
+const preferDefault = (m: any): any => m?.default || m;
 
 const colors = {
   keyword: 'hsl(var(--color-primary))',
@@ -71,6 +74,7 @@ const checkboxUnchecked = (
     <circle cx="7.5" cy="7.5" r="6" stroke="currentColor" fill="none" />
   </svg>
 );
+
 const checkboxChecked = (
   <svg
     viewBox="0 0 15 15"
@@ -110,6 +114,8 @@ const styles = {
     fontSize: '1em',
   },
 };
+
+const GraphiQLExplorer = preferDefault(GraphiQLExplorerImport);
 
 function ExplorerPlugin(props: GraphiQLExplorerProps) {
   const { setOperationName } = useEditorContext({ nonNull: true });

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -4,8 +4,7 @@ import {
   useExecutionContext,
   useSchemaContext,
 } from '@graphiql/react';
-import type { GraphiQLExplorerProps } from 'graphiql-explorer';
-import GraphiQLExplorerImport from 'graphiql-explorer';
+import { Explorer as GraphiQLExplorer, GraphiQLExplorerProps } from 'graphiql-explorer';
 import React, { useCallback, useRef } from 'react';
 
 import './graphiql-explorer.d.ts';

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -4,13 +4,14 @@ import {
   useExecutionContext,
   useSchemaContext,
 } from '@graphiql/react';
-import { Explorer as GraphiQLExplorer, GraphiQLExplorerProps } from 'graphiql-explorer';
+import {
+  Explorer as GraphiQLExplorer,
+  GraphiQLExplorerProps,
+} from 'graphiql-explorer';
 import React, { useCallback, useRef } from 'react';
 
 import './graphiql-explorer.d.ts';
 import './index.css';
-
-const preferDefault = (m: any): any => m?.default || m;
 
 const colors = {
   keyword: 'hsl(var(--color-primary))',
@@ -113,8 +114,6 @@ const styles = {
     fontSize: '1em',
   },
 };
-
-const GraphiQLExplorer = preferDefault(GraphiQLExplorerImport);
 
 function ExplorerPlugin(props: GraphiQLExplorerProps) {
   const { setOperationName } = useEditorContext({ nonNull: true });


### PR DESCRIPTION
Hi!

While working on https://github.com/gatsbyjs/gatsby/pull/38279 I saw failures in our E2E testing suite.

We use the GraphiQL explorer plugin and when opening that tab the page just got blank and the console threw an error:

![image](https://github.com/graphql/graphiql/assets/16143594/76fdd779-df01-44d4-8f49-6ccc162c87ee)

It errors at this call:

https://github.com/graphql/graphiql/blob/2f15e202b194387a1bd78fc778268fb9b8c0fa12/packages/graphiql-plugin-explorer/src/index.tsx#L130

Because the import is an object with `Explorer` and `default`.

If I compare https://unpkg.com/browse/@graphiql/plugin-explorer@0.1.22/dist/index.mjs with https://unpkg.com/browse/@graphiql/plugin-explorer@0.1.20/dist/graphiql-plugin-explorer.es.js you can see that older versions had helper functions to pick `.default` if available.