### PR TITLE
[tooling] combine webpack builds for faster builds & simpler tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "cypress-open": "yarn workspace graphiql cypress-open",
     "dev-graphiql": "yarn workspace graphiql dev",
     "e2e": "yarn run e2e:build && yarn workspace graphiql e2e",
-    "e2e:build": "yarn build && yarn workspace graphiql build-bundles-min",
+    "e2e:build": "yarn build && yarn workspace graphiql build-bundles",
     "eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --max-warnings=0 --ignore-path .gitignore --cache .",
     "format": "yarn eslint --fix && yarn pretty",
     "jest": "jest --testPathIgnorePatterns cm6-graphql",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -31,12 +31,11 @@
     "graphiql.min.css.map"
   ],
   "scripts": {
-    "analyze-bundle": "cross-env NODE_ENV=production CDN=1 ANALYZE=1 yarn webpack -p",
+    "analyze-bundle": "cross-env NODE_ENV=production ANALYZE=1 yarn webpack -p",
     "build": "yarn build-clean && yarn build-cjs && yarn build-esm",
-    "build-bundles": "yarn build-bundles-clean && yarn build-bundles-dev && yarn build-bundles-min",
+    "build-bundles": "yarn build-bundles-clean && yarn build-bundles-webpack",
     "build-bundles-clean": "rimraf 'graphiql.*{js,css}' *.html",
-    "build-bundles-dev": "cross-env NODE_ENV=development BABEL_ENV=development CDN=1 yarn webpack --mode development --bail",
-    "build-bundles-min": "cross-env ANALYZE=1 NODE_ENV=production CDN=1 yarn webpack --mode production --bail",
+    "build-bundles-webpack": "cross-env yarn webpack --mode development --bail",
     "build-cjs": "tsc",
     "build-clean": "rimraf esm dist webpack *.html",
     "build-esm": "tsc --project ./tsconfig.esm.json",

--- a/packages/graphiql/resources/webpack.config.js
+++ b/packages/graphiql/resources/webpack.config.js
@@ -8,118 +8,123 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const graphql = require('graphql');
 const rimraf = require('rimraf');
 
-const isDev = process.env.NODE_ENV === 'development';
-const isHMR = Boolean(isDev && process.env.WEBPACK_DEV_SERVER);
-
 const relPath = (...args) => path.resolve(__dirname, ...args);
 const rootPath = (...args) => relPath('../', ...args);
 
-const resultConfig = {
-  mode: process.env.NODE_ENV,
-  entry: './cdn.ts',
-  context: rootPath('src'),
-  output: {
-    path: rootPath(),
-    library: 'GraphiQL',
-    libraryTarget: 'window',
-    libraryExport: 'default',
-    filename: isDev ? 'graphiql.js' : 'graphiql.min.js',
-  },
-  devServer: {
-    hot: true,
-    // bypass simple localhost CORS restrictions by setting
-    // these to 127.0.0.1 in /etc/hosts
-    allowedHosts: ['local.example.com', 'graphiql.com'],
-    setupMiddlewares(middlewares, devServer) {
-      require('../test/beforeDevServer')(devServer.app);
+const resultConfig = ({ isDev }) => {
+  const isHMR = Boolean(isDev && process.env.WEBPACK_DEV_SERVER);
 
-      return middlewares;
+  const config = {
+    mode: isDev ? 'development' : 'production',
+    entry: './cdn.ts',
+    context: rootPath('src'),
+    output: {
+      path: rootPath(),
+      library: 'GraphiQL',
+      libraryTarget: 'window',
+      libraryExport: 'default',
+      filename: isDev ? 'graphiql.js' : 'graphiql.min.js',
     },
-  },
-  devtool: isDev ? 'cheap-module-source-map' : 'source-map',
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
+    devServer: {
+      hot: true,
+      // bypass simple localhost CORS restrictions by setting
+      // these to 127.0.0.1 in /etc/hosts
+      allowedHosts: ['local.example.com', 'graphiql.com'],
+      setupMiddlewares(middlewares, devServer) {
+        require('../test/beforeDevServer')(devServer.app);
 
-  module: {
-    rules: [
-      // for graphql module, which uses .mjs
-      {
-        type: 'javascript/auto',
-        test: /\.mjs$/,
-        use: [],
-        include: /node_modules/,
-        exclude: /\.(ts|d\.ts|d\.ts\.map)$/,
+        return middlewares;
       },
-      // i think we need to add another rule for
-      // codemirror-graphql esm.js files to load
-      {
-        test: /\.(js|jsx|ts|tsx)$/,
-        use: [{ loader: 'babel-loader' }],
-        exclude: /\.(d\.ts|d\.ts\.map|spec\.tsx)$/,
-      },
-      {
-        test: /\.css$/,
-        use: [{ loader: MiniCssExtractPlugin.loader }, 'css-loader'],
-      },
-      {
-        test: /\.css$/,
-        exclude: /graphiql-react/,
-        use: ['postcss-loader'],
-      },
+    },
+    devtool: isDev ? 'cheap-module-source-map' : 'source-map',
+    externals: {
+      react: 'React',
+      'react-dom': 'ReactDOM',
+    },
+
+    module: {
+      rules: [
+        // for graphql module, which uses .mjs
+        {
+          type: 'javascript/auto',
+          test: /\.mjs$/,
+          use: [],
+          include: /node_modules/,
+          exclude: /\.(ts|d\.ts|d\.ts\.map)$/,
+        },
+        // i think we need to add another rule for
+        // codemirror-graphql esm.js files to load
+        {
+          test: /\.(js|jsx|ts|tsx|mjs)$/,
+          use: [{ loader: 'babel-loader' }],
+          exclude: /\.(d\.ts|d\.ts\.map|spec\.tsx)$/,
+        },
+        {
+          test: /\.css$/,
+          use: [{ loader: MiniCssExtractPlugin.loader }, 'css-loader'],
+        },
+        {
+          test: /\.css$/,
+          exclude: /graphiql-react/,
+          use: ['postcss-loader'],
+        },
+      ],
+    },
+
+    plugins: [
+      // in order to prevent async modules for CDN builds
+      // until we can guarantee it will work with the CDN properly
+      // and so that graphiql.min.js can retain parity
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
+
+      new HtmlWebpackPlugin({
+        template: relPath('index.html.ejs'),
+        inject: 'head',
+        filename: isDev && !isHMR ? 'dev.html' : 'index.html',
+        graphqlVersion: JSON.stringify(graphql.version),
+      }),
+      new MiniCssExtractPlugin({
+        // Options similar to the same options in webpackOptions.output
+        // both options are optional
+        filename: isDev ? 'graphiql.css' : 'graphiql.min.css',
+        chunkFilename: '[id].css',
+      }),
+      new ForkTsCheckerWebpackPlugin({
+        async: isDev,
+        typescript: {
+          configFile: rootPath('tsconfig.json'),
+        },
+      }),
+      new (class {
+        apply(compiler) {
+          compiler.hooks.done.tap('Remove LICENSE', () => {
+            console.log('Remove LICENSE.txt');
+            rimraf.sync('./*.LICENSE.txt');
+          });
+        }
+      })(),
     ],
-  },
+    resolve: {
+      extensions: ['.mjs', '.js', '.json', '.jsx', '.css', '.ts', '.tsx'],
+      modules: [
+        rootPath('node_modules'),
+        rootPath('../', '../', 'node_modules'),
+      ],
+    },
+  };
 
-  plugins: [
-    // in order to prevent async modules for CDN builds
-    // until we can guarantee it will work with the CDN properly
-    // and so that graphiql.min.js can retain parity
-    new webpack.optimize.LimitChunkCountPlugin({
-      maxChunks: 1,
-    }),
-
-    new HtmlWebpackPlugin({
-      template: relPath('index.html.ejs'),
-      inject: 'head',
-      filename: isDev && !isHMR ? 'dev.html' : 'index.html',
-      graphqlVersion: JSON.stringify(graphql.version),
-    }),
-    new MiniCssExtractPlugin({
-      // Options similar to the same options in webpackOptions.output
-      // both options are optional
-      filename: isDev ? 'graphiql.css' : 'graphiql.min.css',
-      chunkFilename: '[id].css',
-    }),
-    new ForkTsCheckerWebpackPlugin({
-      async: isDev,
-      typescript: {
-        configFile: rootPath('tsconfig.json'),
-      },
-    }),
-    new (class {
-      apply(compiler) {
-        compiler.hooks.done.tap('Remove LICENSE', () => {
-          console.log('Remove LICENSE.txt');
-          rimraf.sync('./*.LICENSE.txt');
-        });
-      }
-    })(),
-  ],
-  resolve: {
-    extensions: ['.mjs', '.js', '.json', '.jsx', '.css', '.ts', '.tsx'],
-    modules: [rootPath('node_modules'), rootPath('../', '../', 'node_modules')],
-  },
+  if (process.env.ANALYZE) {
+    config.plugins.push(
+      new BundleAnalyzerPlugin({
+        analyzerMode: 'static',
+        openAnalyzer: false,
+        reportFilename: rootPath('analyzer.html'),
+      }),
+    );
+  }
+  return config;
 };
 
-if (process.env.ANALYZE) {
-  resultConfig.plugins.push(
-    new BundleAnalyzerPlugin({
-      analyzerMode: 'static',
-      openAnalyzer: false,
-      reportFilename: rootPath('analyzer.html'),
-    }),
-  );
-}
-
-module.exports = resultConfig;
+module.exports = [resultConfig({ isDev: true }), resultConfig()];

--- a/packages/graphiql/resources/webpack.config.js
+++ b/packages/graphiql/resources/webpack.config.js
@@ -11,7 +11,7 @@ const rimraf = require('rimraf');
 const relPath = (...args) => path.resolve(__dirname, ...args);
 const rootPath = (...args) => relPath('../', ...args);
 
-const resultConfig = ({ isDev }) => {
+const resultConfig = ({ isDev = false }) => {
   const isHMR = Boolean(isDev && process.env.WEBPACK_DEV_SERVER);
 
   const config = {
@@ -127,4 +127,7 @@ const resultConfig = ({ isDev }) => {
   return config;
 };
 
-module.exports = [resultConfig({ isDev: true }), resultConfig()];
+module.exports = [
+  resultConfig({ isDev: true }),
+  resultConfig({ isDev: false }),
+];


### PR DESCRIPTION
this we should've done a long time ago!

by combining the webpack dev and production builds, we reduce build time overall, as the dependency build happens only once

![image](https://github.com/graphql/graphiql/assets/1368727/f8981a26-7ae6-4569-8e2e-59157422d7c2)

the first of many PRs pieced out from the #3306 effort
