### PR TITLE
fix code exporter on early init, new hooks: useOperationsEditorState()

### DIFF
--- a/.changeset/six-bears-smile.md
+++ b/.changeset/six-bears-smile.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-explorer': patch
+'@graphiql/react': patch
+---
+
+Fix code exporter plugin on early init, add hooks

--- a/packages/graphiql-plugin-code-exporter/src/index.tsx
+++ b/packages/graphiql-plugin-code-exporter/src/index.tsx
@@ -1,4 +1,4 @@
-import { useEditorContext, type GraphiQLPlugin } from '@graphiql/react';
+import { useOperationsEditorState, type GraphiQLPlugin } from '@graphiql/react';
 import React from 'react';
 import GraphiQLCodeExporter, {
   GraphiQLCodeExporterProps,
@@ -10,13 +10,12 @@ import './index.css';
 type GraphiQLCodeExporterPluginProps = Omit<GraphiQLCodeExporterProps, 'query'>;
 
 function GraphiQLCodeExporterPlugin(props: GraphiQLCodeExporterPluginProps) {
-  const { queryEditor } = useEditorContext({ nonNull: true });
-
+  const [operationsString] = useOperationsEditorState();
   return (
     <GraphiQLCodeExporter
       codeMirrorTheme="graphiql"
       {...props}
-      query={queryEditor!.getValue()}
+      query={operationsString}
     />
   );
 }

--- a/packages/graphiql-plugin-code-exporter/vite.config.ts
+++ b/packages/graphiql-plugin-code-exporter/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       output: {
         chunkFileNames: '[name].[format].js',
         globals: {
+          '@graphiql/react': 'GraphiQL.React',
           graphql: 'GraphiQL.GraphQL',
           react: 'React',
           'react-dom': 'ReactDOM',

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -3,7 +3,7 @@ import type { EditorChange, EditorConfiguration } from 'codemirror';
 import type { SchemaReference } from 'codemirror-graphql/utils/SchemaReference';
 import copyToClipboard from 'copy-to-clipboard';
 import { parse, print } from 'graphql';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useExplorerContext } from '../explorer';
 import { usePluginContext } from '../plugin';
@@ -331,4 +331,48 @@ export function useAutoCompleteLeafs({
 
     return result;
   }, [getDefaultFieldNames, queryEditor, schema]);
+}
+
+// https://react.dev/learn/you-might-not-need-an-effect
+
+/**
+ * useState-like hook for current tab operations editor state
+ */
+export function useOperationsEditorState(): [
+  opString: string,
+  handleEditOperations: (content: string) => void,
+] {
+  const { queryEditor } = useEditorContext({
+    nonNull: true,
+  });
+  const opString = queryEditor?.getValue() ?? '';
+  const handleEditOperations = useCallback(
+    (value: string) => queryEditor?.setValue(value),
+    [queryEditor],
+  );
+  return useMemo(
+    () => [opString, handleEditOperations],
+    [opString, handleEditOperations],
+  );
+}
+
+/**
+ * useState-like hook for variables tab operations editor state
+ */
+export function useVariablesEditorState(): [
+  varsString: string,
+  handleEditVariables: (content: string) => void,
+] {
+  const { variableEditor } = useEditorContext({
+    nonNull: true,
+  });
+  const varsString = variableEditor?.getValue() ?? '';
+  const handleEditVariables = useCallback(
+    (value: string) => variableEditor?.setValue(value),
+    [variableEditor],
+  );
+  return useMemo(
+    () => [varsString, handleEditVariables],
+    [varsString, handleEditVariables],
+  );
 }

--- a/packages/graphiql-react/src/editor/index.ts
+++ b/packages/graphiql-react/src/editor/index.ts
@@ -16,6 +16,8 @@ export {
   useCopyQuery,
   useMergeQuery,
   usePrettifyEditors,
+  useOperationsEditorState,
+  useVariablesEditorState,
 } from './hooks';
 export { useQueryEditor } from './query-editor';
 export { useResponseEditor } from './response-editor';

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -16,6 +16,8 @@ export {
   useQueryEditor,
   useResponseEditor,
   useVariableEditor,
+  useOperationsEditorState,
+  useVariablesEditorState,
   VariableEditor,
 } from './editor';
 export {


### PR DESCRIPTION
this abstracts away some editor specific details
until we can leverage `<Suspense />`

- add `useOperationsEditorState()`
- add `useVariablesEditorState()`
- match up `@graphiql/react` globals
- simplify plugin implementations