### PR TITLE
update the highest traffic examples

### DIFF
--- a/examples/graphiql-cdn/README.md
+++ b/examples/graphiql-cdn/README.md
@@ -1,7 +1,8 @@
 # GraphiQL CDN Example
 
-This example uses the CDN bundles to show the most simple example possible. It
-uses the latest version published on npm, via unpkg
+This example uses the CDN bundles to show a simple graphiql example, with explorer plugin.
+
+It uses the latest version published on npm, via unpkg
 
 ### Setup
 

--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -37,7 +37,14 @@
       crossorigin
       src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"
     ></script>
-
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script
+      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+      crossorigin
+    ></script>
     <!--
       These two files can be found in the npm module, however you may wish to
       copy them directly into your environment, or perhaps include them in your
@@ -48,18 +55,18 @@
 
   <body>
     <div id="graphiql">Loading...</div>
-    <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      type="application/javascript"
-    ></script>
     <script>
       const root = ReactDOM.createRoot(document.getElementById('graphiql'));
+      const fetcher = GraphiQL.createFetcher({
+        url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
+        headers: { 'X-Example-Header': 'foo' },
+      });
+      const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
       root.render(
         React.createElement(GraphiQL, {
-          fetcher: GraphiQL.createFetcher({
-            url: 'https://swapi-graphql.netlify.app/.netlify/functions/index',
-          }),
+          fetcher,
           defaultEditorToolsVisibility: true,
+          plugins: [explorerPlugin],
         }),
       );
     </script>

--- a/packages/graphiql-plugin-explorer/examples/index.html
+++ b/packages/graphiql-plugin-explorer/examples/index.html
@@ -47,7 +47,7 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.12/dist/index.umd.js"
+      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
       integrity="sha512-Fjas/uSkzvsFjbv4jqU9nt4ulU7LDjiMAXW2YFTYD96NgKS1fhhAsGR4b2k2VaVLsE29aia3vyobAq9TNzusvA=="
       crossorigin="anonymous"
     ></script>


### PR DESCRIPTION
- cleanup cdn examples
- add a plugin import  and headers (the most requested customizations) to examples/graphiql-cdn which is one of the highest traffic visits after the readme! 👀 
- remove a static version from the explorer example, many less web oriented server/framework devs are not aware that you can request the latest version by omitting one it seems