### PR TITLE
fix search dropdown click

### DIFF
--- a/.changeset/lemon-snakes-exist.md
+++ b/.changeset/lemon-snakes-exist.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Fix search result bug on select, #33307

--- a/packages/graphiql-react/src/explorer/components/search.tsx
+++ b/packages/graphiql-react/src/explorer/components/search.tsx
@@ -70,9 +70,12 @@ export function Search() {
     [push],
   );
   const [isFocused, setIsFocused] = useState(false);
-  const handleFocus: FocusEventHandler = useCallback(e => {
-    setIsFocused(e.type === 'focus');
-  }, []);
+  const handleFocus: FocusEventHandler = useCallback(
+    e => {
+      setIsFocused(e.type === 'focus');
+    },
+    [setIsFocused],
+  );
 
   const shouldSearchBoxAppear =
     explorerNavStack.length === 1 ||
@@ -101,7 +104,8 @@ export function Search() {
         <Combobox.Input
           autoComplete="off"
           onFocus={handleFocus}
-          onBlur={handleFocus}
+          // TODO: find a better way to handle onBlur
+          // onBlur={handleFocus}
           onChange={event => setSearchValue(event.target.value)}
           placeholder="&#x2318; K"
           ref={inputRef}
@@ -110,7 +114,7 @@ export function Search() {
         />
       </div>
 
-      {/* hide on blur */}
+      {/* display on focus */}
       {isFocused && (
         <Combobox.Options data-cy="doc-explorer-list">
           {results.within.length +

--- a/packages/graphiql-react/src/explorer/components/search.tsx
+++ b/packages/graphiql-react/src/explorer/components/search.tsx
@@ -69,13 +69,10 @@ export function Search() {
     },
     [push],
   );
-  const [isFocused, setIsFocused] = useState(false);
-  const handleFocus: FocusEventHandler = useCallback(
-    e => {
-      setIsFocused(e.type === 'focus');
-    },
-    [setIsFocused],
-  );
+  const isFocused = useRef(false);
+  const handleFocus: FocusEventHandler = useCallback(e => {
+    isFocused.current = e.type === 'focus';
+  }, []);
 
   const shouldSearchBoxAppear =
     explorerNavStack.length === 1 ||
@@ -105,7 +102,7 @@ export function Search() {
           autoComplete="off"
           onFocus={handleFocus}
           // TODO: find a better way to handle onBlur
-          // onBlur={handleFocus}
+          onBlur={handleFocus}
           onChange={event => setSearchValue(event.target.value)}
           placeholder="&#x2318; K"
           ref={inputRef}
@@ -115,7 +112,7 @@ export function Search() {
       </div>
 
       {/* display on focus */}
-      {isFocused && (
+      {isFocused.current && (
         <Combobox.Options data-cy="doc-explorer-list">
           {results.within.length +
             results.types.length +

--- a/packages/graphiql-react/src/explorer/components/search.tsx
+++ b/packages/graphiql-react/src/explorer/components/search.tsx
@@ -101,7 +101,6 @@ export function Search() {
         <Combobox.Input
           autoComplete="off"
           onFocus={handleFocus}
-          // TODO: find a better way to handle onBlur
           onBlur={handleFocus}
           onChange={event => setSearchValue(event.target.value)}
           placeholder="&#x2318; K"

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -46,6 +46,8 @@ describe('GraphiQL DocExplorer - search', () => {
   });
 
   it('Closes popover when blurring input', () => {
+    cy.dataCy('doc-explorer-input').focus();
+    cy.dataCy('doc-explorer-input').type('list');
     cy.dataCy('doc-explorer-input').blur();
     cy.dataCy('doc-explorer-list').should('not.exist');
   });

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -45,7 +45,7 @@ describe('GraphiQL DocExplorer - search', () => {
     cy.dataCy('doc-explorer-option').contains('hasArgs');
   });
 
-  it('Closes popover when blurring input', () => {
+  it.skip('Closes popover when blurring input', () => {
     cy.dataCy('doc-explorer-input').blur();
     cy.dataCy('doc-explorer-list').should('not.exist');
   });

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -45,7 +45,7 @@ describe('GraphiQL DocExplorer - search', () => {
     cy.dataCy('doc-explorer-option').contains('hasArgs');
   });
 
-  it.skip('Closes popover when blurring input', () => {
+  it('Closes popover when blurring input', () => {
     cy.dataCy('doc-explorer-input').blur();
     cy.dataCy('doc-explorer-list').should('not.exist');
   });


### PR DESCRIPTION
Fixes #3307 

Temporarily disable the `onBlur` behavior, because it's more important to have the search results clickable than to dismiss the dropdown `onBlur` - already, simply by clicking outside the dropdown, you can dismiss it.