### PR TITLE
use eslint cache on pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [
-      "eslint --fix",
+      "eslint --cache --fix",
       "prettier --write --ignore-path .eslintignore",
       "jest --passWithNoTests",
       "yarn lint-cspell"


### PR DESCRIPTION
this makes pre-commit much faster if you have a cache already