### PR TITLE
Avoid creating new tabs on header state

### DIFF
--- a/.changeset/sour-maps-ring.md
+++ b/.changeset/sour-maps-ring.md
@@ -1,0 +1,12 @@
+---
+'@graphiql/react': patch
+'graphiql': patch
+---
+
+Solves #2825, an old bug where new tabs were created on every refresh
+
+the bug occurred when:
+
+1. `shouldPersistHeaders` is not set to true
+2. `headers` or `defaultHeaders` are provided as props
+3. the user refreshes the browser

--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -311,6 +311,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       defaultQuery: props.defaultQuery || DEFAULT_QUERY,
       defaultHeaders: props.defaultHeaders,
       storage,
+      shouldPersistHeaders,
     });
     storeTabs(tabState);
 

--- a/packages/graphiql-react/src/editor/tabs.ts
+++ b/packages/graphiql-react/src/editor/tabs.ts
@@ -72,6 +72,7 @@ export function getDefaultTabState({
   query,
   variables,
   storage,
+  shouldPersistHeaders,
 }: {
   defaultQuery: string;
   defaultHeaders?: string;
@@ -80,6 +81,7 @@ export function getDefaultTabState({
   query: string | null;
   variables: string | null;
   storage: StorageAPI | null;
+  shouldPersistHeaders?: boolean;
 }) {
   const storedState = storage?.get(STORAGE_KEY);
   try {
@@ -87,8 +89,15 @@ export function getDefaultTabState({
       throw new Error('Storage for tabs is empty');
     }
     const parsed = JSON.parse(storedState);
+    // if headers are not persisted, do not derive the hash using default headers state
+    // or else you will get new tabs on every refresh
+    const headersForHash = shouldPersistHeaders ? headers : undefined;
     if (isTabsState(parsed)) {
-      const expectedHash = hashFromTabContents({ query, variables, headers });
+      const expectedHash = hashFromTabContents({
+        query,
+        variables,
+        headers: headersForHash,
+      });
       let matchingTabIndex = -1;
 
       for (let index = 0; index < parsed.tabs.length; index++) {


### PR DESCRIPTION
Solves #2825, an old bug where new tabs were created on every refresh

the bug occurred when:

1. `shouldPersistHeaders` is not set to true
2. `headers` or `defaultHeaders` are provided as props
3. the user refreshes the browser

I could not get cypress to re-create the bug, but I was able to manually confirm the fix