### PR TITLE
feat: Add support for custom scalar validation

### DIFF
--- a/.changeset/few-hats-move.md
+++ b/.changeset/few-hats-move.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Fix Variables JSON Schema for null values

--- a/.changeset/tame-lions-teach.md
+++ b/.changeset/tame-lions-teach.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service': minor
+'monaco-graphql': minor
+---
+
+Add support for custom scalars

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -9,6 +9,7 @@ scalar EmailAddress
 scalar Even
 scalar SpecialScalar
 scalar SpecialDate
+scalar FooBar
 
 """
 An input type with custom scalars

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -6,6 +6,14 @@ directive @test(testArg: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 scalar SomeCustomScalar
 
+"""
+An email address. exmaple: hello@example.com
+"""
+scalar EmailAddress
+scalar Even
+scalar SpecialScalar
+scalar SpecialDate
+
 enum Episode {
   NEWHOPE
   EMPIRE

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -4,6 +4,8 @@ schema {
 
 directive @test(testArg: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+scalar SomeCustomScalar
+
 enum Episode {
   NEWHOPE
   EMPIRE

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -10,6 +10,7 @@ scalar Even
 scalar SpecialScalar
 scalar SpecialDate
 scalar FooBar
+scalar Foo
 
 """
 An input type with custom scalars

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -10,6 +10,20 @@ scalar Even
 scalar SpecialScalar
 scalar SpecialDate
 
+"""
+An input type with custom scalars
+"""
+input CustomScalarsInput {
+  """
+  example email
+  """
+  email: EmailAddress
+  """
+  example even
+  """
+  even: Even
+}
+
 enum Episode {
   NEWHOPE
   EMPIRE

--- a/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
+++ b/packages/graphql-language-service/src/utils/__tests__/__schema__/StarWarsSchema.graphql
@@ -5,10 +5,6 @@ schema {
 directive @test(testArg: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 scalar SomeCustomScalar
-
-"""
-An email address. exmaple: hello@example.com
-"""
 scalar EmailAddress
 scalar Even
 scalar SpecialScalar

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -84,6 +84,8 @@ describe('getVariablesJSONSchema', () => {
           $optionalSpecial: SpecialScalar,
           $specialDate: SpecialDate!,
           $optionalSpecialDate: SpecialDate,
+          $foobar: FooBar!,
+          $optionalFoobar: FooBar,
           $customInput: CustomScalarsInput!,
           $optionalCustomInput: CustomScalarsInput
         ) {
@@ -108,6 +110,9 @@ describe('getVariablesJSONSchema', () => {
           type: ['string'],
           minLength: 5,
         },
+        FooBar: {
+          enum: ['foo', 'bar'],
+        },
         SpecialDate: {
           description: 'A date or date time.',
           oneOf: [
@@ -129,6 +134,7 @@ describe('getVariablesJSONSchema', () => {
       'evenNumber',
       'special',
       'specialDate',
+      'foobar',
       'customInput',
     ]);
 
@@ -182,6 +188,14 @@ describe('getVariablesJSONSchema', () => {
         type: ['string', 'null'],
         minLength: 5,
         description: 'SpecialScalar',
+      },
+      foobar: {
+        enum: ['foo', 'bar'],
+        description: 'FooBar!',
+      },
+      optionalFoobar: {
+        enum: ['foo', 'bar', null],
+        description: 'FooBar',
       },
       specialDate: {
         description: 'SpecialDate!\nA date or date time.',

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -86,6 +86,8 @@ describe('getVariablesJSONSchema', () => {
           $optionalSpecialDate: SpecialDate,
           $foobar: FooBar!,
           $optionalFoobar: FooBar,
+          $foo: Foo!,
+          $optionalFoo: Foo,
           $customInput: CustomScalarsInput!,
           $optionalCustomInput: CustomScalarsInput
         ) {
@@ -113,6 +115,9 @@ describe('getVariablesJSONSchema', () => {
         FooBar: {
           enum: ['foo', 'bar'],
         },
+        Foo: {
+          const: 'foo',
+        },
         SpecialDate: {
           description: 'A date or date time.',
           oneOf: [
@@ -135,6 +140,7 @@ describe('getVariablesJSONSchema', () => {
       'special',
       'specialDate',
       'foobar',
+      'foo',
       'customInput',
     ]);
 
@@ -196,6 +202,14 @@ describe('getVariablesJSONSchema', () => {
       optionalFoobar: {
         enum: ['foo', 'bar', null],
         description: 'FooBar',
+      },
+      foo: {
+        const: 'foo',
+        description: 'Foo!',
+      },
+      optionalFoo: {
+        oneOf: [{ const: 'foo' }, { type: 'null' }],
+        description: 'Foo',
       },
       specialDate: {
         description: 'SpecialDate!\nA date or date time.',

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -275,6 +275,7 @@ describe('getVariablesJSONSchema', () => {
           exampleList: {
             type: ['array', 'null'],
             items: {
+              description: 'ChildInputType',
               oneOf: [
                 { $ref: '#/definitions/ChildInputType' },
                 { type: 'null' },
@@ -387,6 +388,8 @@ describe('getVariablesJSONSchema', () => {
           exampleList: {
             type: ['array', 'null'],
             items: {
+              description: 'ChildInputType',
+              markdownDescription: '```graphql\nChildInputType\n```',
               oneOf: [
                 { $ref: '#/definitions/ChildInputType' },
                 { type: 'null' },

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -94,7 +94,7 @@ describe('getVariablesJSONSchema', () => {
     );
 
     const jsonSchema = getVariablesJSONSchema(variableToType, {
-      customScalarSchemas: {
+      scalarSchemas: {
         EmailAddress: {
           type: 'string',
           format: 'email',

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.spec.ts
@@ -83,7 +83,9 @@ describe('getVariablesJSONSchema', () => {
           $special: SpecialScalar!,
           $optionalSpecial: SpecialScalar,
           $specialDate: SpecialDate!,
-          $optionalSpecialDate: SpecialDate
+          $optionalSpecialDate: SpecialDate,
+          $customInput: CustomScalarsInput!,
+          $optionalCustomInput: CustomScalarsInput
         ) {
         characters{
           name
@@ -92,7 +94,7 @@ describe('getVariablesJSONSchema', () => {
     );
 
     const jsonSchema = getVariablesJSONSchema(variableToType, {
-      customScalarSchemaMappings: {
+      customScalarSchemas: {
         EmailAddress: {
           type: 'string',
           format: 'email',
@@ -127,7 +129,28 @@ describe('getVariablesJSONSchema', () => {
       'evenNumber',
       'special',
       'specialDate',
+      'customInput',
     ]);
+
+    expect(jsonSchema.definitions).toEqual({
+      CustomScalarsInput: {
+        description: 'CustomScalarsInput\nAn input type with custom scalars',
+        properties: {
+          email: {
+            description: 'example email\n\nEmailAddress',
+            format: 'email',
+            type: ['string', 'null'],
+          },
+          even: {
+            description: 'example even\n\nEven\nAn even number.',
+            multipleOf: 2,
+            type: ['integer', 'null'],
+          },
+        },
+        required: [],
+        type: 'object',
+      },
+    });
 
     expect(jsonSchema.properties).toEqual({
       email: {
@@ -143,12 +166,12 @@ describe('getVariablesJSONSchema', () => {
       evenNumber: {
         type: 'integer',
         multipleOf: 2,
-        description: 'An even number.\nEven!',
+        description: 'Even!\nAn even number.',
       },
       optionalEvenNumber: {
         type: ['integer', 'null'],
         multipleOf: 2,
-        description: 'An even number.\nEven',
+        description: 'Even\nAn even number.',
       },
       special: {
         type: ['string'],
@@ -161,7 +184,7 @@ describe('getVariablesJSONSchema', () => {
         description: 'SpecialScalar',
       },
       specialDate: {
-        description: 'A date or date time.\nSpecialDate!',
+        description: 'SpecialDate!\nA date or date time.',
         oneOf: [
           {
             type: 'string',
@@ -174,7 +197,7 @@ describe('getVariablesJSONSchema', () => {
         ],
       },
       optionalSpecialDate: {
-        description: 'A date or date time.\nSpecialDate',
+        description: 'SpecialDate\nA date or date time.',
         oneOf: [
           {
             type: 'string',
@@ -183,6 +206,21 @@ describe('getVariablesJSONSchema', () => {
           {
             type: 'string',
             format: 'date',
+          },
+          {
+            type: 'null',
+          },
+        ],
+      },
+      customInput: {
+        $ref: '#/definitions/CustomScalarsInput',
+        description: 'CustomScalarsInput!\nAn input type with custom scalars',
+      },
+      optionalCustomInput: {
+        description: 'CustomScalarsInput\nAn input type with custom scalars',
+        oneOf: [
+          {
+            $ref: '#/definitions/CustomScalarsInput',
           },
           {
             type: 'null',
@@ -209,30 +247,30 @@ describe('getVariablesJSONSchema', () => {
     expect(jsonSchema.properties).toEqual({
       input: {
         $ref: '#/definitions/InputType',
-        description: 'example input type\nInputType!',
+        description: 'InputType!\nexample input type',
       },
       anotherInput: {
         oneOf: [{ $ref: '#/definitions/InputType' }, { type: 'null' }],
-        description: 'example input type\nInputType',
+        description: 'InputType\nexample input type',
       },
     });
     expect(jsonSchema.definitions).toEqual({
       InputType: {
         type: 'object',
-        description: 'example input type\nInputType',
+        description: 'InputType\nexample input type',
         properties: {
           key: {
-            description: 'example key\nString!',
+            description: 'example key\n\nString!',
             type: 'string',
           },
           value: {
-            description: 'example value\nInt',
+            description: 'example value\n\nInt',
             type: ['integer', 'null'],
             default: 42,
           },
           exampleObject: {
             $ref: '#/definitions/ChildInputType',
-            description: 'nesting a whole object!\nChildInputType!',
+            description: 'nesting a whole object!\n\nChildInputType!',
           },
           exampleList: {
             type: ['array', 'null'],
@@ -242,7 +280,7 @@ describe('getVariablesJSONSchema', () => {
                 { type: 'null' },
               ],
             },
-            description: 'list type with default\n[ChildInputType]',
+            description: 'list type with default\n\n[ChildInputType]',
             default: [
               {
                 isChild: false,
@@ -273,7 +311,7 @@ describe('getVariablesJSONSchema', () => {
           },
           favoriteBook: {
             type: ['string', 'null'],
-            description: 'favorite book\nString',
+            description: 'favorite book\n\nString',
             default: 'Where the wild things are',
           },
         },
@@ -303,13 +341,13 @@ describe('getVariablesJSONSchema', () => {
     expect(jsonSchema.properties).toEqual({
       input: {
         $ref: '#/definitions/InputType',
-        description: 'example input type\nInputType!',
-        markdownDescription: 'example input type\n```graphql\nInputType!\n```',
+        description: 'InputType!\nexample input type',
+        markdownDescription: '```graphql\nInputType!\n```\nexample input type',
       },
       anotherInput: {
         oneOf: [{ $ref: '#/definitions/InputType' }, { type: 'null' }],
-        description: 'example input type\nInputType',
-        markdownDescription: 'example input type\n```graphql\nInputType\n```',
+        description: 'InputType\nexample input type',
+        markdownDescription: '```graphql\nInputType\n```\nexample input type',
       },
       episode: {
         enum: ['NEWHOPE', 'EMPIRE', 'JEDI', null],
@@ -325,23 +363,23 @@ describe('getVariablesJSONSchema', () => {
     expect(jsonSchema.definitions).toEqual({
       InputType: {
         type: 'object',
-        description: 'example input type\nInputType',
-        markdownDescription: `example input type\n${mdTicks('InputType')}`,
+        description: 'InputType\nexample input type',
+        markdownDescription: `${mdTicks('InputType')}\nexample input type`,
         properties: {
           key: {
-            description: 'example key\nString!',
-            markdownDescription: `example key\n${mdTicks('String!')}`,
+            description: 'example key\n\nString!',
+            markdownDescription: `example key\n\n${mdTicks('String!')}`,
             type: 'string',
           },
           value: {
-            description: 'example value\nInt',
-            markdownDescription: `example value\n${mdTicks('Int')}`,
+            description: 'example value\n\nInt',
+            markdownDescription: `example value\n\n${mdTicks('Int')}`,
             type: ['integer', 'null'],
             default: 42,
           },
           exampleObject: {
-            description: 'nesting a whole object!\nChildInputType!',
-            markdownDescription: `nesting a whole object!\n${mdTicks(
+            description: 'nesting a whole object!\n\nChildInputType!',
+            markdownDescription: `nesting a whole object!\n\n${mdTicks(
               'ChildInputType!',
             )}`,
             $ref: '#/definitions/ChildInputType',
@@ -354,8 +392,8 @@ describe('getVariablesJSONSchema', () => {
                 { type: 'null' },
               ],
             },
-            description: 'list type with default\n[ChildInputType]',
-            markdownDescription: `list type with default\n${mdTicks(
+            description: 'list type with default\n\n[ChildInputType]',
+            markdownDescription: `list type with default\n\n${mdTicks(
               '[ChildInputType]',
             )}`,
             default: [
@@ -385,8 +423,8 @@ describe('getVariablesJSONSchema', () => {
         properties: {
           favoriteBook: {
             default: 'Where the wild things are',
-            description: 'favorite book\nString',
-            markdownDescription: 'favorite book\n```graphql\nString\n```',
+            description: 'favorite book\n\nString',
+            markdownDescription: 'favorite book\n\n```graphql\nString\n```',
             type: ['string', 'null'],
           },
           isChild: {

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -200,6 +200,8 @@ function getJSONSchemaFromGraphQLType(
         definition.type.push('null');
       } else if (definition.type) {
         definition.type = [definition.type, 'null'];
+      } else if (definition.enum) {
+        definition.enum.push(null);
       } else if (definition.oneOf) {
         definition.oneOf.push({ type: 'null' });
       } else {

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -46,7 +46,7 @@ export type JSONSchemaOptions = {
   /**
    * Custom scalar schema mappings.
    */
-  customScalarSchemaMappings?: Record<string, JSONSchema6>;
+  customScalarSchemas?: Record<string, JSONSchema6>;
 };
 type JSONSchemaRunningOptions = JSONSchemaOptions & {
   definitionMarker: Marker;
@@ -161,10 +161,10 @@ function getJSONSchemaFromGraphQLType(
         definition.type = [scalarTypesMap[type.name], 'null'];
       }
     } else {
-      if (options?.customScalarSchemaMappings?.[type.name]) {
+      if (options?.customScalarSchemas?.[type.name]) {
         // deep clone
         definition = JSON.parse(
-          JSON.stringify(options.customScalarSchemaMappings[type.name]),
+          JSON.stringify(options.customScalarSchemas[type.name]),
         );
       } else {
         definition.type = ['string', 'number', 'boolean', 'integer'];

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -184,13 +184,6 @@ function getJSONSchemaFromGraphQLType(
   const baseType = isNonNullType(type) ? type.ofType : type;
   const required = isNonNullType(type);
 
-  if (isEnumType(baseType)) {
-    definition.enum = baseType.getValues().map(val => val.name);
-    if (!required) {
-      definition.enum.push(null);
-    }
-  }
-
   if (isScalarType(baseType)) {
     //  scalars
     if (options?.scalarSchemas?.[baseType.name]) {
@@ -215,9 +208,12 @@ function getJSONSchemaFromGraphQLType(
         };
       }
     }
-  }
-
-  if (isListType(baseType)) {
+  } else if (isEnumType(baseType)) {
+    definition.enum = baseType.getValues().map(val => val.name);
+    if (!required) {
+      definition.enum.push(null);
+    }
+  } else if (isListType(baseType)) {
     if (required) {
       definition.type = 'array';
     } else {
@@ -240,9 +236,7 @@ function getJSONSchemaFromGraphQLType(
         definitions[defName] = defs[defName];
       }
     }
-  }
-
-  if (isInputObjectType(baseType)) {
+  } else if (isInputObjectType(baseType)) {
     if (required) {
       definition.$ref = `#/definitions/${baseType.name}`;
     } else {
@@ -292,7 +286,6 @@ function getJSONSchemaFromGraphQLType(
     }
   }
 
-  // TODO: test that this works?
   if ('defaultValue' in fieldOrType && fieldOrType.defaultValue !== undefined) {
     definition.default = fieldOrType.defaultValue as
       | JSONSchema4Type

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -114,7 +114,7 @@ function renderDefinitionDescription(
     text(into, '\n');
     text(into, type.description);
   } else if (
-    isNonNullType(type) &&
+    'ofType' in type &&
     !isScalarType(type.ofType) &&
     'description' in type.ofType &&
     type.ofType.description
@@ -224,13 +224,9 @@ function getJSONSchemaFromGraphQLType(
       baseType.ofType,
       options,
     );
-    if (def.$ref) {
-      definition.items = { $ref: def.$ref };
-    } else if (def.oneOf) {
-      definition.items = { oneOf: def.oneOf };
-    } else {
-      definition.items = def;
-    }
+
+    definition.items = def;
+
     if (defs) {
       for (const defName of Object.keys(defs)) {
         definitions[defName] = defs[defName];

--- a/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
+++ b/packages/graphql-language-service/src/utils/getVariablesJSONSchema.ts
@@ -349,7 +349,7 @@ export function getVariablesJSONSchema(
   options?: JSONSchemaOptions,
 ): JSONSchema6 {
   const jsonSchema: PropertiedJSON6 = {
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $schema: 'http://json-schema.org/draft-04/schema',
     type: 'object',
     properties: {},
     required: [],

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -276,7 +276,7 @@ export class LanguageService {
         if (operationFacts?.variableToType) {
           return getVariablesJSONSchema(operationFacts.variableToType, {
             ...options,
-            customScalarSchemas: schema.customScalarSchemas,
+            scalarSchemas: schema.customScalarSchemas,
           });
         }
       } catch {}

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -274,7 +274,10 @@ export class LanguageService {
         const documentAST = this.parse(documentText);
         const operationFacts = getOperationASTFacts(documentAST, schema.schema);
         if (operationFacts?.variableToType) {
-          return getVariablesJSONSchema(operationFacts.variableToType, options);
+          return getVariablesJSONSchema(operationFacts.variableToType, {
+            ...options,
+            customScalarSchemas: schema.customScalarSchemas,
+          });
         }
       } catch {}
     }

--- a/packages/monaco-graphql/src/typings/index.ts
+++ b/packages/monaco-graphql/src/typings/index.ts
@@ -9,6 +9,7 @@ import {
   ValidationRule,
   FragmentDefinitionNode,
 } from 'graphql';
+import { JSONSchema6 } from 'graphql-language-service';
 import type { Options as PrettierConfig } from 'prettier';
 
 export type BaseSchemaConfig = {
@@ -64,6 +65,19 @@ export type SchemaConfig = {
    * A stringified introspection JSON result
    */
   introspectionJSONString?: string;
+  /**
+   * JSON schemas ued for custom scalars
+   * @example
+   * ```ts
+   * {
+   *  customScalarSchemas: {
+   *    DateTime: {
+   *      type": "string",
+   *      format": "date-time"
+   *    }
+   *  }
+   */
+  customScalarSchemas?: Record<string, JSONSchema6>;
 };
 
 /**


### PR DESCRIPTION
This PR fixes the following issues:

- In GraphQL, optional input variables and types are also nullable.
- in the JSON Schema, `enum` should not be combined with `type` (removed)
- custom scalars should only accept basic primitives (i.e. no objects, arrays, etc)
