### PR TITLE
fix canary w/ fetch depth

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,6 +206,8 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
re-add `fetch-depth: 0` to get canary releases working again