### PR TITLE
add GITHUB_TOKEN to canary release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -232,6 +232,8 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           npm-script: 'yarn release:canary'
           changesets: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a message
         if: steps.canary.outputs.released == 'true'
         uses: 'dotansimha/pr-comment@master'

--- a/scripts/canary-release.js
+++ b/scripts/canary-release.js
@@ -73,7 +73,7 @@ async function updateVersions() {
   const changesets = (await readChangesets(cwd)).filter(change =>
     modifiedChangesets.includes(change.id),
   );
-  const isMain = process.env.GITHUB_REF_NAME?.includes('main');
+  // const isMain = process.env.GITHUB_REF_NAME?.includes('main');
 
   let vscodeRelease = false;
 


### PR DESCRIPTION
it seems `GITHUB_TOKEN` env variable is also missing from this step