### PR TITLE
 Fix incorrectly using 0-indexed number where 1-indexed number is expected

### DIFF
--- a/.changeset/little-hats-explain.md
+++ b/.changeset/little-hats-explain.md
@@ -2,4 +2,4 @@
 'monaco-graphql': patch
 ---
 
-Fixes an off-by-one bug that caused console spam when hovering over things in the first line of a graphql file with monaco because `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.
+Fixes an off-by-one bug that caused console spam when hovering over things in the first line of a graphql file with monaco, because `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.

--- a/.changeset/little-hats-explain.md
+++ b/.changeset/little-hats-explain.md
@@ -2,4 +2,4 @@
 'monaco-graphql': patch
 ---
 
-Fixes an off-by-one bug that caused console spam when hovering things in the first line of a graphql file with monaco because `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.
+Fixes an off-by-one bug that caused console spam when hovering over things in the first line of a graphql file with monaco because `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.

--- a/.changeset/little-hats-explain.md
+++ b/.changeset/little-hats-explain.md
@@ -1,0 +1,5 @@
+---
+'monaco-graphql': patch
+---
+
+Fixes an off-by-one bug that caused console spam when hovering things in the first line of a graphql file with monaco because `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -51,5 +51,3 @@ jobs:
           files: coverage/lcov.info
           fail_ci_if_error: true
           verbose: true
-
-

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -30,6 +30,8 @@ module.exports = (dir, env = 'jsdom') => {
       '^cm6-graphql\\/src\\/([^]+)': `${__dirname}/packages/cm6-graphql/dist/$1`,
       '^example-([^/]+)': `${__dirname}/examples/$1/src`,
       '^-!svg-react-loader.*$': '<rootDir>/resources/jest/svgImportMock.js',
+      // because of the svelte compiler's export patterns i guess?
+      'svelte/compiler': `${__dirname}/node_modules/svelte/compiler.cjs`,
     },
     testMatch: ['**/*[-.](spec|test).[jt]s?(x)', '!**/cypress/**'],
     testEnvironment: env,

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -50,12 +50,13 @@
     "mkdirp": "^1.0.4",
     "node-abort-controller": "^3.0.1",
     "nullthrows": "^1.0.0",
-    "svelte": "^4.0.0",
-    "svelte2tsx": "^0.6.16",
     "vscode-jsonrpc": "^8.0.1",
     "vscode-languageserver": "^8.0.1",
-    "vscode-languageserver-types": "^3.17.1",
-    "vscode-uri": "^3.0.2"
+    "vscode-languageserver-types": "^3.17.2",
+    "vscode-uri": "^3.0.2",
+    "svelte2tsx": "^0.6.19",
+    "svelte": "^4.1.1",
+    "source-map-js": "1.0.2"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -27,7 +27,6 @@ import type {
   ObjectTypeInfo,
   Uri,
 } from 'graphql-language-service';
-import type { Logger } from 'vscode-languageserver';
 
 import * as fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
@@ -48,6 +47,11 @@ import glob from 'glob';
 import { LoadConfigOptions } from './types';
 import { URI } from 'vscode-uri';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
+import {
+  DEFAULT_SUPPORTED_EXTENSIONS,
+  DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
+} from './constants';
+import { NoopLogger, Logger } from './Logger';
 
 const LanguageServiceExtension: GraphQLExtensionDeclaration = api => {
   // For schema
@@ -68,7 +72,7 @@ export async function getGraphQLCache({
   config,
 }: {
   parser: typeof parseDocument;
-  logger: Logger;
+  logger: Logger | NoopLogger;
   loadConfigOptions: LoadConfigOptions;
   config?: GraphQLConfig;
 }): Promise<GraphQLCache> {
@@ -98,7 +102,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
   _fragmentDefinitionsCache: Map<Uri, Map<string, FragmentInfo>>;
   _typeDefinitionsCache: Map<Uri, Map<string, ObjectTypeInfo>>;
   _parser: typeof parseDocument;
-  _logger: Logger;
+  _logger: Logger | NoopLogger;
 
   constructor({
     configDir,
@@ -109,7 +113,7 @@ export class GraphQLCache implements GraphQLCacheInterface {
     configDir: Uri;
     config: GraphQLConfig;
     parser: typeof parseDocument;
-    logger: Logger;
+    logger: Logger | NoopLogger;
   }) {
     this._configDir = configDir;
     this._graphQLConfig = config;
@@ -827,7 +831,13 @@ export class GraphQLCache implements GraphQLCacheInterface {
     let queries: CachedContent[] = [];
     if (content.trim().length !== 0) {
       try {
-        queries = this._parser(content, filePath);
+        queries = this._parser(
+          content,
+          filePath,
+          DEFAULT_SUPPORTED_EXTENSIONS,
+          DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
+          this._logger,
+        );
         if (queries.length === 0) {
           // still resolve with an empty ast
           return {

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -35,7 +35,6 @@ describe('MessageProcessor', () => {
     // @ts-ignore
     connection: {},
     logger,
-    fileExtensions: ['js'],
     graphqlFileExtensions: ['graphql'],
     loadConfigOptions: { rootDir: __dirname },
   });
@@ -56,6 +55,7 @@ describe('MessageProcessor', () => {
       configDir: __dirname,
       config: gqlConfig,
       parser: parseDocument,
+      logger: new NoopLogger(),
     });
     messageProcessor._languageService = {
       // @ts-ignore
@@ -484,6 +484,7 @@ export function Example(arg: string) {
 }`;
 
     const contents = parseDocument(text, 'test.tsx');
+
     expect(contents[0].query).toEqual(`
 query Test {
   test {

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -1,0 +1,100 @@
+import type { ParserOptions, ParserPlugin } from '@babel/parser';
+// Attempt to be as inclusive as possible of source text.
+export const PARSER_OPTIONS: ParserOptions = {
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  allowSuperOutsideMethod: true,
+  allowAwaitOutsideFunction: true,
+  // important! this allows babel to keep parsing when there are issues
+  errorRecovery: true,
+  sourceType: 'module',
+  strictMode: false,
+};
+
+/**
+ * .graphql is the officially recommended extension for graphql files
+ *
+ * .gql and .graphqls are included for compatibility for commonly used extensions
+ *
+ * GQL is a registered trademark of Google, and refers to Google Query Language.
+ * GraphQL Foundation does *not* recommend using this extension or acronym for
+ * referring to GraphQL.
+ *
+ * any changes should also be reflected in vscode-graphql-syntax textmate grammar & package.json
+ */
+export const DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS = [
+  '.graphql',
+  '.graphqls',
+  '.gql',
+];
+
+/**
+ * default tag delimiters to use when parsing GraphQL strings (for js/ts/vue/svelte)
+ * any changes should also be reflected in vscode-graphql-syntax textmate grammar
+ */
+export const TAG_MAP: Record<string, true> = {
+  graphql: true,
+  gql: true,
+  graphqls: true,
+};
+
+/**
+ * default extensions to use when parsing for GraphQL strings
+ * any changes should also be reflected in vscode-graphql-syntax textmate grammar & package.json
+ */
+export const DEFAULT_SUPPORTED_EXTENSIONS = [
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.es',
+  '.esm',
+  '.es6',
+  '.ts',
+  '.jsx',
+  '.tsx',
+  '.vue',
+  '.svelte',
+  '.cts',
+  '.mts',
+] as const;
+export type SupportedExtensions = typeof DEFAULT_SUPPORTED_EXTENSIONS;
+export type SupportedExtensionsEnum =
+  (typeof DEFAULT_SUPPORTED_EXTENSIONS)[number];
+
+/**
+ * default plugins to use with babel parser
+ */
+export const BABEL_PLUGINS: ParserPlugin[] = [
+  'asyncDoExpressions',
+  'asyncGenerators',
+  'bigInt',
+  'classProperties',
+  'classPrivateProperties',
+  'classPrivateMethods',
+  'classStaticBlock',
+  'doExpressions',
+  'decimal',
+  'decorators-legacy',
+  'destructuringPrivate',
+  'dynamicImport',
+  'exportDefaultFrom',
+  'exportNamespaceFrom',
+  'functionBind',
+  'functionSent',
+  'importMeta',
+  'importAssertions',
+  'jsx',
+  'logicalAssignment',
+  'moduleBlocks',
+  'moduleStringNames',
+  'nullishCoalescingOperator',
+  'numericSeparator',
+  'objectRestSpread',
+  'optionalCatchBinding',
+  'optionalChaining',
+  // ['pipelineOperator', { proposal: 'hack' }],
+  'privateIn',
+  'regexpUnicodeSets',
+  'throwExpressions',
+  'topLevelAwait',
+];

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -15,24 +15,12 @@ import {
 
 import { Position, Range } from 'graphql-language-service';
 
-import { parse, ParserOptions, ParserPlugin } from '@babel/parser';
-import * as VueParser from '@vue/compiler-sfc';
-import type { Logger } from 'vscode-languageserver';
-
-// Attempt to be as inclusive as possible of source text.
-const PARSER_OPTIONS: ParserOptions = {
-  allowImportExportEverywhere: true,
-  allowReturnOutsideFunction: true,
-  allowSuperOutsideMethod: true,
-  allowAwaitOutsideFunction: true,
-  // important! this allows babel to keep parsing when there are issues
-  errorRecovery: true,
-  sourceType: 'module',
-  strictMode: false,
-};
-
-const DEFAULT_STABLE_TAGS = ['graphql', 'graphqls', 'gql'];
-export const DEFAULT_TAGS = [...DEFAULT_STABLE_TAGS, 'graphql.experimental'];
+import { TAG_MAP } from './constants';
+import { ecmaParser, tsParser } from './parsers/babel';
+import { svelteParser } from './parsers/svelte';
+import { vueParser } from './parsers/vue';
+import type { Logger, NoopLogger } from './Logger';
+import { RangeMapper } from './parsers/types';
 
 type TagResult = { tag: string; template: string; range: Range };
 
@@ -40,167 +28,48 @@ interface TagVisitors {
   [type: string]: (node: any) => void;
 }
 
-const BABEL_PLUGINS: ParserPlugin[] = [
-  'asyncDoExpressions',
-  'asyncGenerators',
-  'bigInt',
-  'classProperties',
-  'classPrivateProperties',
-  'classPrivateMethods',
-  'classStaticBlock',
-  'doExpressions',
-  'decimal',
-  'decorators-legacy',
-  'destructuringPrivate',
-  'dynamicImport',
-  'exportDefaultFrom',
-  'exportNamespaceFrom',
-  'functionBind',
-  'functionSent',
-  'importMeta',
-  'importAssertions',
-  'jsx',
-  'logicalAssignment',
-  'moduleBlocks',
-  'moduleStringNames',
-  'nullishCoalescingOperator',
-  'numericSeparator',
-  'objectRestSpread',
-  'optionalCatchBinding',
-  'optionalChaining',
-  // ['pipelineOperator', { proposal: 'hack' }],
-  'privateIn',
-  'regexpUnicodeSets',
-  'throwExpressions',
-  'topLevelAwait',
-];
-
-type ParseVueSFCResult =
-  | { type: 'error'; errors: Error[] }
-  | {
-      type: 'ok';
-      scriptOffset: number;
-      scriptSetupAst?: import('@babel/types').Statement[];
-      scriptAst?: import('@babel/types').Statement[];
-    };
-
-function parseVueSFC(source: string): ParseVueSFCResult {
-  const { errors, descriptor } = VueParser.parse(source);
-
-  if (errors.length !== 0) {
-    return { type: 'error', errors };
-  }
-
-  let scriptBlock: VueParser.SFCScriptBlock | null = null;
-  try {
-    scriptBlock = VueParser.compileScript(descriptor, { id: 'foobar' });
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === '[@vue/compiler-sfc] SFC contains no <script> tags.'
-    ) {
-      return {
-        type: 'ok',
-        scriptSetupAst: [],
-        scriptAst: [],
-        scriptOffset: 0,
-      };
-    }
-    return { type: 'error', errors: [error as Error] };
-  }
-
-  return {
-    type: 'ok',
-    scriptOffset: scriptBlock.loc.start.line - 1,
-    scriptSetupAst: scriptBlock?.scriptSetupAst,
-    scriptAst: scriptBlock?.scriptAst,
-  };
-}
+const parserMap = {
+  '.js': ecmaParser,
+  '.jsx': ecmaParser,
+  '.mjs': ecmaParser,
+  '.es': ecmaParser,
+  '.es6': ecmaParser,
+  '.esm': ecmaParser,
+  '.cjs': ecmaParser,
+  '.ts': tsParser,
+  '.tsx': tsParser,
+  '.cts': tsParser,
+  '.mts': tsParser,
+  '.svelte': svelteParser,
+  '.vue': vueParser,
+};
 
 export function findGraphQLTags(
   text: string,
-  ext: string,
+  ext: keyof typeof parserMap,
   uri: string,
-  logger: Logger,
+  logger: Logger | NoopLogger,
 ): TagResult[] {
   const result: TagResult[] = [];
 
-  const plugins = BABEL_PLUGINS.slice(0, BABEL_PLUGINS.length);
+  let rangeMapper = (range: Range) => range;
 
-  const isVueLike = ext === '.vue' || ext === '.svelte';
-
-  let parsedASTs: { [key: string]: any }[] = [];
-
-  let scriptOffset = 0;
-
-  if (isVueLike) {
-    const parseVueSFCResult = parseVueSFC(text);
-    if (parseVueSFCResult.type === 'error') {
-      logger.error(
-        `Could not parse the "${ext}" file at ${uri} to extract the graphql tags:`,
-      );
-      for (const error of parseVueSFCResult.errors) {
-        logger.error(String(error));
-      }
-      return [];
-    }
-
-    if (parseVueSFCResult.scriptAst !== undefined) {
-      parsedASTs.push(...parseVueSFCResult.scriptAst);
-    }
-    if (parseVueSFCResult.scriptSetupAst !== undefined) {
-      parsedASTs.push(...parseVueSFCResult.scriptSetupAst);
-    }
-
-    scriptOffset = parseVueSFCResult.scriptOffset;
-  } else {
-    const isTypeScript = ['.ts', '.tsx', '.cts', '.mts'].includes(ext);
-    if (isTypeScript) {
-      plugins?.push('typescript');
-    } else {
-      plugins?.push('flow', 'flowComments');
-    }
-    PARSER_OPTIONS.plugins = plugins;
-
-    try {
-      parsedASTs = [parse(text, PARSER_OPTIONS)];
-    } catch (error) {
-      const type = isTypeScript ? 'TypeScript' : 'JavaScript';
-      logger.error(
-        `Could not parse the ${type} file at ${uri} to extract the graphql tags:`,
-      );
-      logger.error(String(error));
-      return [];
-    }
+  const parser = parserMap[ext];
+  if (!parser) {
+    return [];
+  }
+  const parserResult = parser(text, uri, logger);
+  if (!parserResult) {
+    return [];
+  }
+  if (parserResult?.rangeMapper) {
+    rangeMapper = parserResult.rangeMapper;
   }
 
-  const asts = parsedASTs;
-
-  const parseTemplateLiteral = (node: TemplateLiteral) => {
-    const { loc } = node.quasis[0];
-    if (loc) {
-      if (node.quasis.length > 1) {
-        const last = node.quasis.pop();
-        if (last?.loc?.end) {
-          loc.end = last.loc.end;
-        }
-      }
-      const template =
-        node.quasis.length > 1
-          ? node.quasis.map(quasi => quasi.value.raw).join('')
-          : node.quasis[0].value.raw;
-      const range = new Range(
-        new Position(loc.start.line - 1 + scriptOffset, loc.start.column),
-        new Position(loc.end.line - 1 + scriptOffset, loc.end.column),
-      );
-
-      result.push({
-        tag: '',
-        template,
-        range,
-      });
-    }
-  };
+  const { asts } = parserResult;
+  if (!asts) {
+    return [];
+  }
 
   const visitors = {
     CallExpression(node: Expression) {
@@ -216,7 +85,10 @@ export function findGraphQLTags(
       ) {
         const templateLiteral = node.arguments[0];
         if (templateLiteral && templateLiteral.type === 'TemplateLiteral') {
-          parseTemplateLiteral(templateLiteral);
+          const parsed = parseTemplateLiteral(templateLiteral, rangeMapper);
+          if (parsed) {
+            result.push(parsed);
+          }
           return;
         }
       }
@@ -238,9 +110,11 @@ export function findGraphQLTags(
           }
         }
         if (loc) {
-          const range = new Range(
-            new Position(loc.start.line - 1 + scriptOffset, loc.start.column),
-            new Position(loc.end.line - 1 + scriptOffset, loc.end.column),
+          const range = rangeMapper(
+            new Range(
+              new Position(loc.start.line - 1, loc.start.column),
+              new Position(loc.end.line - 1, loc.end.column),
+            ),
           );
 
           result.push({
@@ -254,13 +128,18 @@ export function findGraphQLTags(
       }
     },
     TemplateLiteral(node: TemplateLiteral) {
+      // check if the template literal is prefixed with #graphql
       const hasGraphQLPrefix =
         node.quasis[0].value.raw.startsWith('#graphql\n');
+      // check if the template expression has
       const hasGraphQLComment = Boolean(
         node.leadingComments?.[0]?.value.match(/^\s*GraphQL\s*$/),
       );
       if (hasGraphQLPrefix || hasGraphQLComment) {
-        parseTemplateLiteral(node);
+        const parsed = parseTemplateLiteral(node, rangeMapper);
+        if (parsed) {
+          result.push(parsed);
+        }
       }
     },
   };
@@ -271,19 +150,39 @@ export function findGraphQLTags(
   return result;
 }
 
-const IGNORED_KEYS: { [key: string]: boolean } = {
-  comments: true,
-  end: true,
-  leadingComments: true,
-  loc: true,
-  name: true,
-  start: true,
-  trailingComments: true,
-  type: true,
-};
+/**
+ * Parses a Babel AST template literal into a GraphQL tag.
+ */
+function parseTemplateLiteral(node: TemplateLiteral, rangeMapper: RangeMapper) {
+  const { loc } = node.quasis[0];
+  if (loc) {
+    if (node.quasis.length > 1) {
+      const last = node.quasis.pop();
+      if (last?.loc?.end) {
+        loc.end = last.loc.end;
+      }
+    }
+    const template =
+      node.quasis.length > 1
+        ? node.quasis.map(quasi => quasi.value.raw).join('')
+        : node.quasis[0].value.raw;
+    const range = rangeMapper(
+      new Range(
+        new Position(loc.start.line - 1, loc.start.column),
+        new Position(loc.end.line - 1, loc.end.column),
+      ),
+    );
+
+    return {
+      tag: '',
+      template,
+      range,
+    };
+  }
+}
 
 function getGraphQLTagName(tag: Expression): string | null {
-  if (tag.type === 'Identifier' && DEFAULT_STABLE_TAGS.includes(tag.name)) {
+  if (tag.type === 'Identifier' && TAG_MAP[tag.name]) {
     return tag.name;
   }
   if (
@@ -306,6 +205,16 @@ function visit(node: { [key: string]: any }, visitors: TagVisitors) {
   }
   traverse(node, visitors);
 }
+const IGNORED_KEYS: { [key: string]: boolean } = {
+  comments: true,
+  end: true,
+  leadingComments: true,
+  loc: true,
+  name: true,
+  start: true,
+  trailingComments: true,
+  type: true,
+};
 
 function traverse(node: { [key: string]: any }, visitors: TagVisitors) {
   for (const key in node) {

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -1,41 +1,15 @@
 import { extname } from 'node:path';
 import type { CachedContent } from 'graphql-language-service';
 import { Range, Position } from 'graphql-language-service';
-import type { Logger } from 'vscode-languageserver';
+import type { Logger } from './Logger';
 
-import { findGraphQLTags, DEFAULT_TAGS } from './findGraphQLTags';
+import { findGraphQLTags } from './findGraphQLTags';
+import {
+  DEFAULT_SUPPORTED_EXTENSIONS,
+  DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
+  SupportedExtensionsEnum,
+} from './constants';
 import { NoopLogger } from './Logger';
-
-export const DEFAULT_SUPPORTED_EXTENSIONS = [
-  '.js',
-  '.cjs',
-  '.mjs',
-  '.es',
-  '.esm',
-  '.es6',
-  '.ts',
-  '.jsx',
-  '.tsx',
-  '.vue',
-  '.svelte',
-  '.cts',
-  '.mts',
-];
-
-/**
- * .graphql is the officially recommended extension for graphql files
- *
- * .gql and .graphqls are included for compatibility for commonly used extensions
- *
- * GQL is a registered trademark of Google, and refers to Google Query Language.
- * GraphQL Foundation does *not* recommend using this extension or acronym for
- * referring to GraphQL.
- */
-export const DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS = [
-  '.graphql',
-  '.graphqls',
-  '.gql',
-];
 
 /**
  * Helper functions to perform requested services from client/server.
@@ -47,17 +21,16 @@ export const DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS = [
 export function parseDocument(
   text: string,
   uri: string,
-  fileExtensions: string[] = DEFAULT_SUPPORTED_EXTENSIONS,
+  fileExtensions: ReadonlyArray<SupportedExtensionsEnum> = DEFAULT_SUPPORTED_EXTENSIONS,
   graphQLFileExtensions: string[] = DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
-  logger: Logger = new NoopLogger(),
+  logger: Logger | NoopLogger = new NoopLogger(),
 ): CachedContent[] {
-  // Check if the text content includes a GraphQLV query.
+  // Check if the text content includes a GraphQL query.
   // If the text doesn't include GraphQL queries, do not proceed.
-  const ext = extname(uri);
+  const ext = extname(
+    uri,
+  ) as unknown as (typeof DEFAULT_SUPPORTED_EXTENSIONS)[number];
   if (fileExtensions.includes(ext)) {
-    if (DEFAULT_TAGS.includes(text)) {
-      return [];
-    }
     const templates = findGraphQLTags(text, ext, uri, logger);
     return templates.map(({ template, range }) => ({ query: template, range }));
   }

--- a/packages/graphql-language-service-server/src/parsers/babel.ts
+++ b/packages/graphql-language-service-server/src/parsers/babel.ts
@@ -1,0 +1,36 @@
+import { parse, ParserPlugin } from '@babel/parser';
+import { BABEL_PLUGINS, PARSER_OPTIONS } from '../constants';
+import { SourceParser } from './types';
+
+export const babelParser = (text: string, plugins?: ParserPlugin[]) => {
+  const babelPlugins = BABEL_PLUGINS.slice(0, BABEL_PLUGINS.length);
+  if (plugins) {
+    babelPlugins.push(...plugins);
+  }
+  PARSER_OPTIONS.plugins = babelPlugins;
+  return parse(text, PARSER_OPTIONS);
+};
+
+export const ecmaParser: SourceParser = (text, uri, logger) => {
+  try {
+    return { asts: [babelParser(text, ['flow', 'flowComments'])] };
+  } catch (error) {
+    logger.error(
+      `Could not parse the JavaScript file at ${uri} to extract the graphql tags:`,
+    );
+    logger.error(String(error));
+    return null;
+  }
+};
+
+export const tsParser: SourceParser = (text, uri, logger) => {
+  try {
+    return { asts: [babelParser(text, ['typescript'])] };
+  } catch (error) {
+    logger.error(
+      `Could not parse the TypeScript file at ${uri} to extract the graphql tags:`,
+    );
+    logger.error(String(error));
+    return null;
+  }
+};

--- a/packages/graphql-language-service-server/src/parsers/svelte.ts
+++ b/packages/graphql-language-service-server/src/parsers/svelte.ts
@@ -1,0 +1,46 @@
+import { babelParser } from './babel';
+import { svelte2tsx } from 'svelte2tsx';
+import { SourceMapConsumer } from 'source-map-js';
+import { Position, Range } from 'graphql-language-service';
+import type { RangeMapper, SourceParser } from './types';
+
+export const svelteParser: SourceParser = (text, uri, logger) => {
+  const svelteResult = svelte2tsx(text, {
+    filename: uri,
+  });
+
+  const consumer = new SourceMapConsumer({
+    ...svelteResult.map,
+    version: String(svelteResult.map.version),
+  });
+
+  const rangeMapper: RangeMapper = range => {
+    const start = consumer.originalPositionFor({
+      line: range.start.line,
+      column: range.start.character,
+    });
+
+    const end = consumer.originalPositionFor({
+      line: range.end.line,
+      column: range.end.character,
+    });
+
+    return new Range(
+      new Position(start.line, start.column),
+      new Position(end.line, end.column),
+    );
+  };
+
+  try {
+    return {
+      asts: [babelParser(svelteResult.code, ['typescript'])],
+      rangeMapper,
+    };
+  } catch (error) {
+    logger.error(
+      `Could not parse the Svelte file at ${uri} to extract the graphql tags:`,
+    );
+    logger.error(String(error));
+    return null;
+  }
+};

--- a/packages/graphql-language-service-server/src/parsers/types.ts
+++ b/packages/graphql-language-service-server/src/parsers/types.ts
@@ -1,0 +1,10 @@
+import type { Range } from 'graphql-language-service';
+import type { NoopLogger, Logger } from '../Logger';
+
+export type RangeMapper = (range: Range) => Range;
+
+export type SourceParser = (
+  text: string,
+  uri: string,
+  logger: Logger | NoopLogger,
+) => null | { asts: any[]; rangeMapper?: RangeMapper };

--- a/packages/graphql-language-service-server/src/parsers/vue.ts
+++ b/packages/graphql-language-service-server/src/parsers/vue.ts
@@ -1,0 +1,80 @@
+import { parse, compileScript, SFCScriptBlock } from '@vue/compiler-sfc';
+import { RangeMapper, SourceParser } from './types';
+import { Position, Range } from 'graphql-language-service';
+
+type ParseVueSFCResult =
+  | { type: 'error'; errors: Error[] }
+  | {
+      type: 'ok';
+      scriptOffset: number;
+      scriptSetupAst?: import('@babel/types').Statement[];
+      scriptAst?: import('@babel/types').Statement[];
+    };
+
+export function parseVueSFC(source: string): ParseVueSFCResult {
+  const { errors, descriptor } = parse(source);
+
+  if (errors.length !== 0) {
+    return { type: 'error', errors };
+  }
+
+  let scriptBlock: SFCScriptBlock | null = null;
+  try {
+    scriptBlock = compileScript(descriptor, { id: 'foobar' });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === '[@vue/compiler-sfc] SFC contains no <script> tags.'
+    ) {
+      return {
+        type: 'ok',
+        scriptSetupAst: [],
+        scriptAst: [],
+        scriptOffset: 0,
+      };
+    }
+    return { type: 'error', errors: [error as Error] };
+  }
+
+  return {
+    type: 'ok',
+    scriptOffset: scriptBlock.loc.start.line - 1,
+    scriptSetupAst: scriptBlock?.scriptSetupAst,
+    scriptAst: scriptBlock?.scriptAst,
+  };
+}
+
+export const vueParser: SourceParser = (text, uri, logger) => {
+  const asts = [];
+  const parseVueSFCResult = parseVueSFC(text);
+  if (parseVueSFCResult.type === 'error') {
+    logger.error(
+      `Could not parse the vue file at ${uri} to extract the graphql tags:`,
+    );
+    for (const error of parseVueSFCResult.errors) {
+      logger.error(String(error));
+    }
+    return null;
+  }
+
+  if (parseVueSFCResult.scriptAst !== undefined) {
+    asts.push(...parseVueSFCResult.scriptAst);
+  }
+  if (parseVueSFCResult.scriptSetupAst !== undefined) {
+    asts.push(...parseVueSFCResult.scriptSetupAst);
+  }
+
+  const rangeMapper: RangeMapper = range => {
+    return new Range(
+      new Position(
+        range.start.line + parseVueSFCResult.scriptOffset,
+        range.start.character,
+      ),
+      new Position(
+        range.end.line + parseVueSFCResult.scriptOffset,
+        range.end.character,
+      ),
+    );
+  };
+  return { asts, rangeMapper };
+};

--- a/packages/graphql-language-service-server/src/startServer.ts
+++ b/packages/graphql-language-service-server/src/startServer.ts
@@ -41,11 +41,12 @@ import {
 } from 'vscode-languageserver/node';
 
 import { Logger } from './Logger';
+import { parseDocument } from './parseDocument';
 import {
-  parseDocument,
   DEFAULT_SUPPORTED_EXTENSIONS,
   DEFAULT_SUPPORTED_GRAPHQL_EXTENSIONS,
-} from './parseDocument';
+  SupportedExtensionsEnum,
+} from './constants';
 import { LoadConfigOptions } from './types';
 
 export interface ServerOptions {
@@ -81,7 +82,7 @@ export interface ServerOptions {
    * note that with vscode, this is also controlled by manifest and client configurations.
    * do not put full-file graphql extensions here!
    */
-  fileExtensions?: string[];
+  fileExtensions?: ReadonlyArray<SupportedExtensionsEnum>;
   /**
    * default: ['graphql'] - allowed file extensions for graphql, used by the parser
    */
@@ -245,7 +246,7 @@ type HandlerOptions = {
   logger: Logger;
   config?: GraphQLConfig;
   parser?: typeof parseDocument;
-  fileExtensions?: string[];
+  fileExtensions?: ReadonlyArray<SupportedExtensionsEnum>;
   graphqlFileExtensions?: string[];
   tmpDir?: string;
   loadConfigOptions: LoadConfigOptions;

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -74,13 +74,16 @@ export class GraphQLWorker {
     }
   }
 
-  public async doHover(uri: string, position: monaco.Position) {
+  public async doHover(uri: string, position: Position) {
+    // `position` is 1-indexed
     try {
       const documentModel = this._getTextModel(uri);
       const document = documentModel?.getValue();
       if (!document) {
         return null;
       }
+      // `toGraphQLPosition()` subtracts one from both the line and the character
+      // so `graphQLPosition` is now 0-indexed
       const graphQLPosition = toGraphQLPosition(position);
 
       const hover = this._languageService.getHover(
@@ -94,8 +97,9 @@ export class GraphQLWorker {
         range: toMonacoRange(
           getRange(
             {
-              column: graphQLPosition.character,
-              line: graphQLPosition.line,
+              // we add one here because `getRange()` expects a 1-indexed position
+              column: graphQLPosition.character + 1,
+              line: graphQLPosition.line + 1,
             },
             document,
           ),

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -74,7 +74,7 @@ export class GraphQLWorker {
     }
   }
 
-  public async doHover(uri: string, position: Position) {
+  public async doHover(uri: string, position: monaco.Position) {
     // `position` is 1-indexed
     try {
       const documentModel = this._getTextModel(uri);

--- a/packages/vscode-graphql-execution/package.json
+++ b/packages/vscode-graphql-execution/package.json
@@ -112,10 +112,10 @@
     "graphql": "^16.4.0",
     "graphql-config": "5.0.2",
     "graphql-tag": "2.12.6",
-    "graphql-ws": "^5.5.5",
-    "nullthrows": "^1.0.0",
-    "svelte": "^4.0.0",
+    "graphql-ws": "5.10.0",
+    "svelte": "^4.1.1",
     "svelte2tsx": "^0.6.16",
-    "ws": "8.8.1"
+    "ws": "8.8.1",
+    "nullthrows": "1.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6592,10 +6592,17 @@ aria-query@5.1.3, aria-query@^5.0.0:
   dependencies:
     deep-equal "^2.0.5"
 
-aria-query@^5.1.3, aria-query@^5.2.1:
+aria-query@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.2.1.tgz#bc285d9d654d1df121bcd0c134880d415ca67c15"
   integrity sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==
+  dependencies:
+    dequal "^2.0.3"
+
+aria-query@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
   dependencies:
     dequal "^2.0.3"
 
@@ -11288,6 +11295,11 @@ graphql-tag@2.12.6:
   dependencies:
     tslib "^2.1.0"
 
+graphql-ws@5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.0.tgz#3fb47a4e809e0d2e7c197f1bca754fa9f31b940e"
+  integrity sha512-ewbPzHQdRZgNCPDH9Yr6xccSeZfk3fmpO/AGGGg4KkM5gc6oAOJQ10Oui1EqprhVOyRbOll9bw2qAkOiOwfTag==
+
 graphql-ws@5.14.0:
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.14.0.tgz#766f249f3974fc2c48fae0d1fb20c2c4c79cd591"
@@ -14909,7 +14921,7 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-nullthrows@^1.0.0:
+nullthrows@1.1.1, nullthrows@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
@@ -17730,7 +17742,7 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@1.0.2, source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -18313,16 +18325,24 @@ svelte2tsx@^0.6.16:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.0.0.tgz#ecb79e4d6abe1658ddf7422227a731bc835a1484"
-  integrity sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==
+svelte2tsx@^0.6.19:
+  version "0.6.19"
+  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.6.19.tgz#0c1fe8432643dd2962d373243e3b8b39b559e9b2"
+  integrity sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==
+  dependencies:
+    dedent-js "^1.0.1"
+    pascal-case "^3.1.1"
+
+svelte@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.1.1.tgz#468ed0377d3cae542b35df8a22a3ca188d93272a"
+  integrity sha512-Enick5fPFISLoVy0MFK45cG+YlQt6upw8skEK9zzTpJnH1DqEv8xOZwizCGSo3Q6HZ7KrZTM0J18poF7aQg5zw==
   dependencies:
     "@ampproject/remapping" "^2.2.1"
     "@jridgewell/sourcemap-codec" "^1.4.15"
     "@jridgewell/trace-mapping" "^0.3.18"
-    acorn "^8.8.2"
-    aria-query "^5.2.1"
+    acorn "^8.9.0"
+    aria-query "^5.3.0"
     axobject-query "^3.2.1"
     code-red "^1.0.3"
     css-tree "^2.3.1"
@@ -19542,6 +19562,11 @@ vscode-languageserver-types@3.17.2:
   version "3.17.2"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
   integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+
+vscode-languageserver-types@^3.17.2:
+  version "3.17.5"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
+  integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
 
 vscode-languageserver@^8.0.1:
   version "8.0.1"


### PR DESCRIPTION
This pr causes console spam in our case for when we hover a comment on the first line. See https://github.com/obi1kenobi/trustfall/issues/285 for more context.

What does this pr do?

Fixes an off-by-one bug that caused console spam when hovering things in the first line of a graphql file. This occurs because monaco's `toGraphQLPosition()` from `monaco-graphql` returns 0-based line/col numbers and `getRange()` from `graphql-language-service` expects 1-based line/col numbers.

Why is this the right fix?
We have a 0-indexed row/col. To see this for myself, I put a `console.log()` [after this line](https://github.com/graphql/graphiql/pull/3397/files#diff-864a2605362ad715bfa1b09cd9cbf18396a38b11c4a09b28a05dd1e831aed2aaR87). I then hovered the first character on the first line. I see 0,0 printed, and this is after we subtract 1 from both line/col in `toGraphQLPosition()`, so we definitely have a 0-indexed number.

`getRange()` takes in a `SourceLocation`, however that's an interface, so it's not really obvious whether the line/col is 0-based or 1-based. However, there is a function `getLocation()` that returns a `SourceLocation` declared in the same `location.d.ts` from within the `graphql/language` repo. So taking a look at their `getLocation()` function, it looks like this:
```js
function getLocation(source, position) {
  let lastLineStart = 0;
  let line = 1;

  for (const match of source.body.matchAll(LineRegExp)) {
    typeof match.index === 'number' || (0, _invariant.invariant)(false);

    if (match.index >= position) {
      break;
    }

    lastLineStart = match.index + match[0].length;
    line += 1;
  }

  return {
    line,
    column: position + 1 - lastLineStart,
  };
}
```

When I saw that, it became clear that this line is 1-indexed, and the `+ 1` in the column leads me to believe this number is 1-based too. (if this isn't, please tell me!)