### PR TITLE
feat: support queries for multiple schemas in the same file

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -48,14 +48,15 @@ import glob from 'glob';
 import { LoadConfigOptions } from './types';
 import { URI } from 'vscode-uri';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
+import { EXTENSION_NAME } from './GraphQLLanguageService';
 
-const LanguageServiceExtension: GraphQLExtensionDeclaration = api => {
+export const LanguageServiceExtension: GraphQLExtensionDeclaration = api => {
   // For schema
   api.loaders.schema.register(new CodeFileLoader());
   // For documents
   api.loaders.documents.register(new CodeFileLoader());
 
-  return { name: 'languageService' };
+  return { name: EXTENSION_NAME };
 };
 
 // Maximum files to read when processing GraphQL files.

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor-test.ts
@@ -66,6 +66,12 @@ describe('MessageProcessor', () => {
       getDiagnostics(_query, _uri) {
         return [];
       },
+      getAllProjectsForFile(uri: string) {
+        return [messageProcessor._graphQLCache.getProjectForFile(uri)];
+      },
+      getProjectForQuery(_query: string, uri: string) {
+        return this.getAllProjectsForFile(uri)[0];
+      },
       async getDocumentSymbols(_query: string, uri: string) {
         return [
           {

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -254,8 +254,7 @@ export function findGraphQLTags(
       }
     },
     TemplateLiteral(node: TemplateLiteral) {
-      const hasGraphQLPrefix =
-        node.quasis[0].value.raw.startsWith('#graphql\n');
+      const hasGraphQLPrefix = node.quasis[0].value.raw.startsWith('#graphql');
       const hasGraphQLComment = Boolean(
         node.leadingComments?.[0]?.value.match(/^\s*GraphQL\s*$/),
       );


### PR DESCRIPTION
Hi 👋  First of all, thanks so much for the active maintenance of these packages!

While working on [shopify/hydrogen](https://github.com/shopify/hydrogen) I noticed that the GraphQL Language Service Server so far only supports 1 schema per file. However, we are introducing multiple GraphQL APIs and it would be nicer for DX to combine queries in the same file instead of separating them in different files.

This is an attempt to implement that. I was just trying to see if it was possible at all to open an issue, but it actually works so I'm just opening a PR instead 😅  -- feel free to discuss this feature completely!

The idea is that you need a config like the following with 2 projects pointing to the same files. Then, you can pass an option to set a "gql annotation suffix" in `extensions.languageService.gqlTagOptions.annotationSuffix`:

<img width="600" alt="image" src="https://github.com/graphql/graphiql/assets/1634092/8573cf3e-489e-4ef7-b9e8-021cfb164685">


Then, in a given file that matches the pattern for both projects, you can choose to which GraphQL API/schema each of the queries points to with a modifier of the GraphQL annotation: `#graphql:<suffix>`


<img width="400" alt="image" src="https://github.com/graphql/graphiql/assets/1634092/a177fa2d-760f-4a5b-a2af-7910d9383ca3">
<img width="400" alt="image" src="https://github.com/graphql/graphiql/assets/1634092/d109a441-e603-4954-8a97-7f714b81b676">

---

This whole thing also works with GraphQL Codegen by using [`documentTransforms`](https://the-guild.dev/graphql/codegen/docs/advanced/document-transform). Also, noticed that syntax highlights already works due to how the [match](https://github.com/graphql/graphiql/blob/57b5fcd8749bd1c54f4a6a04a9ab07316fd05e71/packages/vscode-graphql-syntax/grammars/graphql.js.json#L75) happens in that package (doesn't end in `\n`).

This feature at the moment only works when using the in-query comment `#graphql`. It doesn't work with `gql` tag or the leading comment `/* GraphQL */` because there's no access to that information where it's needed (maybe that could be changed? Unsure).
Another option is to just read a different comment inside the query, like `#project:storefront` and make it independent from the `#graphql` comment.

Thanks for checking it!
