### PR TITLE
Fix crash when when editing a file that doesn't belong to a project

### DIFF
--- a/.changeset/slimy-needles-taste.md
+++ b/.changeset/slimy-needles-taste.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Fix crash when editing a file that does not belong to a project

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -124,15 +124,14 @@ export class GraphQLCache implements GraphQLCacheInterface {
 
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;
 
-  getProjectForFile = (uri: string): GraphQLProjectConfig => {
+  getProjectForFile = (uri: string): GraphQLProjectConfig | void => {
     try {
       return this._graphQLConfig.getProjectForFile(URI.parse(uri).fsPath);
     } catch (err) {
       this._logger.error(
         `there was an error loading the project config for this file ${err}`,
       );
-      // @ts-expect-error
-      return null;
+      return;
     }
   };
 

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -665,7 +665,9 @@ export class MessageProcessor {
           await this._updateObjectTypeDefinition(uri, contents);
 
           const project = this._graphQLCache.getProjectForFile(uri);
-          await this._updateSchemaIfChanged(project, uri);
+          if (project) {
+            await this._updateSchemaIfChanged(project, uri);
+          }
 
           let diagnostics: Diagnostic[] = [];
 


### PR DESCRIPTION
When loading `vscode-graphql` it constantly crashes.

<img width="490" alt="Screenshot 2023-09-22 at 09 47 06" src="https://github.com/graphql/graphiql/assets/227292/812d0368-b17c-4e4a-991d-7acfcbdc44b6">


In the output there's lots of

```
[Error - 8:27:20 AM] there was an error loading the project config for this file YDe: File '[SNIPPED OUT FILENAME HERE].json' doesn't match any project
/Users/ben/.vscode/extensions/graphql.vscode-graphql-0.8.18/out/server/index.js:4640
 '${t.documents}'`),this._logger.error(String(r))}}async _cacheAllProjectFiles(t){if(t?.projects)return Promise.all(Object.keys(t.projects).map(async r=>{let n=t.getProject(r);await this._cacheSchemaFilesForProject(n),await this._cacheDocumentFilesforProject(n)}))}_isRelayCompatMode(t){return t.includes("RelayCompat")||t.includes("react-relay/compat")}async _updateFragmentDefinition(t,r){let n=this._graphQLCache.getGraphQLConfig().dirpath;await this._graphQLCache.updateFragmentDefinition(n,t,r)}async _updateSchemaIfChanged(t,r){await Promise.all(this._unwrapProjectSchema(t).map(async n=>{let i=Dx.resolve(t.dirpath,n);uV.URI.parse(r).fsPath===i&&await this._graphQLCache.invalidateSchemaCacheForProject(t)}))}_unwrapProjectSchema(t){let r=t.schema,n=[];if(typeof r=="string")n.push(r);else if(Array.isArray(r))for(let i of r)typeof i=="string"?n.push(i):i&&n.push(...Object.keys(i));else n.push(...Object.keys(r));return n}async _updateObjectTypeDefinition(t,r){let n=this._graphQLCache.getGraphQLConfig().dirpath;await this._graphQLCache.updateObjectTypeDefinition(n,t,r)}_getCachedDocument(t){if(this._textDocumentCache.has(t)){let r=this._textDocumentCache.get(t);if(r)return r}return null}async _invalidateCache(t,r,n){var i;if(this._textDocumentCache.has(r)){let a=this._textDocumentCache.get(r);if(a&&t&&t?.version&&a.version<t.version)return this._textDocumentCache.set(r,{version:t.version,contents:n})}return this._textDocumentCache.set(r,{version:(i=t.version)!==null&&i!==void 0?i:0,contents:n})}};kx.MessageProcessor=QGe;function YGe(e,t,r){let n=t.split(`
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ^

TypeError: Cannot read properties of null (reading 'schema')
    at QGe._unwrapProjectSchema (/Users/ben/.vscode/extensions/graphql.vscode-graphql-0.8.18/out/server/index.js:4640:749)
    at QGe._updateSchemaIfChanged (/Users/ben/.vscode/extensions/graphql.vscode-graphql-0.8.18/out/server/index.js:4640:558)
    at /Users/ben/.vscode/extensions/graphql.vscode-graphql-0.8.18/out/server/index.js:4635:5332
    at async Promise.all (index 0)

[Error - 8:27:20 AM] The vscode-graphql server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
```

---


#3216 Introduced reloading the schema when a change is detected, however if you modify a file that does not belong to a schema then the project can be absent. Passing null/undefined into `_updateSchemaIfChanged` throws an error and crashes the language-service-server.

This PR wraps the call to ` await this._updateSchemaIfChanged(project, uri);` in a check to ensure that the project exists. This was not caught in the initial PR because the type for `getProjectForFile` is incorrect - it claims it will always return a project config, but that is not true.

The `GraphQLCacheInterface` suggests that when a project is absent then the return type of `getProjectForFile` should be `void`, but the concrete implementation returns `null`. I've changed the implementation to match the interface rather than the other way around to ensure the smallest impact area.

I'd argue that changing the interface to `getProjectForFile: (uri: string) => GraphQLProjectConfig | null;` would make the most sense but that change to the interface is strictly a breaking change and I'd rather avoid that in a bugfix PR.

