### PR TITLE
Disable document symbol request for files over 1MB

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -837,6 +837,22 @@ export class MessageProcessor {
       return [];
     }
 
+    if (
+      this._settings.largeFileThreshold !== undefined &&
+      this._settings.largeFileThreshold <
+        cachedDocument.contents[0].query.length
+    ) {
+      return [];
+    }
+
+    this._logger.log(
+      JSON.stringify({
+        type: 'usage',
+        messageType: 'textDocument/documentSymbol',
+        fileName: textDocument.uri,
+      }),
+    );
+
     return this._languageService.getDocumentSymbols(
       cachedDocument.contents[0].query,
       textDocument.uri,

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -97,7 +97,7 @@
           "type": [
             "number"
           ],
-          "description": "Disables outlining and other expensive operations for files larger than this threshold (in bytes). Defaults to 1000000.",
+          "description": "Disables outlining and other expensive operations for files larger than this threshold (in bytes). Defaults to 1000000 (one million).",
           "default": 1000000
         },
         "vscode-graphql.rejectUnauthorized": {

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -93,6 +93,13 @@
           ],
           "description": "Use a cached file output of your graphql-config schema result for definition lookups, symbols, outline, etc. Disabled by default."
         },
+        "vscode-graphql.largeFileThreshold": {
+          "type": [
+            "number"
+          ],
+          "description": "Disables outlining and other expensive operations for files larger than this threshold (in bytes). Defaults to 1000000.",
+          "default": 1000000
+        },
         "vscode-graphql.rejectUnauthorized": {
           "type": [
             "boolean"


### PR DESCRIPTION
I ran into a problem similar to https://github.com/graphql/graphiql/issues/2985 with a massive schema graphql file (~2MB file). The performance was fine when the schema is not opened (e.g, hovering for type definintions and autocomplete), but the LSP was stuck at 100% as soon as I opened the schema. It looks like the language server was stuck in `getOutline`, which is called by `textDocument/documentSymbol`. I'm not sure why this is so slow, but I generally don't care about the outline in such a large file anyway, so it seems OK to disable that feature. 

This PR adds a configuration option `largeFileThreshold`  which defaults to 1000000. At the moment, it just disables document symbols computation, but there might be other expensive operations we could disable with this option as well. 

I also noticed there was no logging for this LSP message, so I added it. 