### PR TITLE
Wrap cm6-graphql lint logic in try..catch

### DIFF
--- a/.changeset/silver-lions-build.md
+++ b/.changeset/silver-lions-build.md
@@ -1,0 +1,5 @@
+---
+"cm6-graphql": patch
+---
+
+Wrap cm6-graphql lint logic in try..catch

--- a/packages/cm6-graphql/src/lint.ts
+++ b/packages/cm6-graphql/src/lint.ts
@@ -8,44 +8,48 @@ const SEVERITY = ['error', 'warning', 'info'] as const;
 
 export const lint: Extension = linter(
   view => {
-    const schema = getSchema(view.state);
-    if (!schema) {
+    try {
+      const schema = getSchema(view.state);
+      if (!schema) {
+        return [];
+      }
+      const results = getDiagnostics(view.state.doc.toString(), schema);
+
+      return results
+        .map((item): Diagnostic | null => {
+          if (!item.severity || !item.source) {
+            return null;
+          }
+
+          const calculatedFrom = posToOffset(
+            view.state.doc,
+            new Position(item.range.start.line, item.range.start.character),
+          );
+          const from = Math.max(
+            0,
+            Math.min(calculatedFrom, view.state.doc.length),
+          );
+          const calculatedRo = posToOffset(
+            view.state.doc,
+            new Position(item.range.end.line, item.range.end.character - 1),
+          );
+          const to = Math.min(
+            Math.max(from + 1, calculatedRo),
+            view.state.doc.length,
+          );
+          return {
+            from,
+            to: from === to ? to + 1 : to,
+            severity: SEVERITY[item.severity - 1],
+            // source: item.source, // TODO:
+            message: item.message,
+            actions: [], // TODO:
+          };
+        })
+        .filter((_): _ is Diagnostic => Boolean(_));
+    } catch {
       return [];
     }
-    const results = getDiagnostics(view.state.doc.toString(), schema);
-
-    return results
-      .map((item): Diagnostic | null => {
-        if (!item.severity || !item.source) {
-          return null;
-        }
-
-        const calculatedFrom = posToOffset(
-          view.state.doc,
-          new Position(item.range.start.line, item.range.start.character),
-        );
-        const from = Math.max(
-          0,
-          Math.min(calculatedFrom, view.state.doc.length),
-        );
-        const calculatedRo = posToOffset(
-          view.state.doc,
-          new Position(item.range.end.line, item.range.end.character - 1),
-        );
-        const to = Math.min(
-          Math.max(from + 1, calculatedRo),
-          view.state.doc.length,
-        );
-        return {
-          from,
-          to: from === to ? to + 1 : to,
-          severity: SEVERITY[item.severity - 1],
-          // source: item.source, // TODO:
-          message: item.message,
-          actions: [], // TODO:
-        };
-      })
-      .filter((_): _ is Diagnostic => Boolean(_));
   },
   {
     needsRefresh(vu) {


### PR DESCRIPTION
It turns out that `getDiagnostics` may throw errors which codemirror 6 doesn't handle in the lint. Wrapping the logic in try..catch to handle errors and just return an empty array instead.