### PR TITLE
Update esbuild.js

### DIFF
--- a/.changeset/smooth-clocks-try.md
+++ b/.changeset/smooth-clocks-try.md
@@ -1,0 +1,6 @@
+---
+"vscode-graphql-execution": patch
+"vscode-graphql": patch
+---
+
+Fix execution extension esbuild bundling

--- a/packages/vscode-graphql-execution/esbuild.js
+++ b/packages/vscode-graphql-execution/esbuild.js
@@ -46,10 +46,13 @@ build({
     'atpl',
     'liquor',
     'twig',
-    'graphql-config',
   ],
   format: 'cjs',
   sourcemap: true,
+  define: { 'import.meta.url': '_importMetaUrl' },
+  banner: {
+    js: "const _importMetaUrl=require('url').pathToFileURL(__filename)",
+  },
 })
   .then(({ errors, warnings }) => {
     if (warnings.length) {

--- a/packages/vscode-graphql-execution/esbuild.js
+++ b/packages/vscode-graphql-execution/esbuild.js
@@ -46,6 +46,7 @@ build({
     'atpl',
     'liquor',
     'twig',
+    'graphql-config',
   ],
   format: 'cjs',
   sourcemap: true,


### PR DESCRIPTION
This is probably a naive fix, but it does make the extension work again in my copy of VSCode.  

Fixes #3171 