### PR TITLE
add ts dependency

### DIFF
--- a/.changeset/wet-bikes-complain.md
+++ b/.changeset/wet-bikes-complain.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+Add typescript as a dependency for `svelte2tsx`

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0"
   },
+  "COMMENT": "please do not remove depenencies without thorough testing. many dependencies are not imported directly, as they are peer dependencies",
   "dependencies": {
     "@babel/parser": "^7.23.6",
     "@babel/types": "^7.23.5",
@@ -56,7 +57,8 @@
     "vscode-uri": "^3.0.2",
     "svelte2tsx": "^0.6.27",
     "svelte": "^4.1.1",
-    "source-map-js": "1.0.2"
+    "source-map-js": "1.0.2",
+    "typescript": "4.3.5"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/packages/vscode-graphql/esbuild.js
+++ b/packages/vscode-graphql/esbuild.js
@@ -49,6 +49,7 @@ build({
     'atpl',
     'liquor',
     'twig',
+    'typescript',
   ],
 })
   .then(({ errors, warnings }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18982,6 +18982,16 @@ typedoc@^0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+
+typescript@4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
 typescript@^4.2.3:
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"


### PR DESCRIPTION
re-add typescript as a direct dependency of `graphql-language-service-server`, at a fixed version, because of svelte2tsx

this should resolve #3496 #3497