### PR TITLE
temporarily revert svelte parsing until we can fix bundling issues

### DIFF
--- a/.changeset/beige-parrots-sleep.md
+++ b/.changeset/beige-parrots-sleep.md
@@ -1,0 +1,6 @@
+---
+'graphql-language-service-server': patch
+'vscode-graphql': patch
+---
+
+Temporarily revert svelte parsing until we can fix bundling issues with svelte2tsx. For now we return to using the vue parser to parse svelte files which will invariably cause some issues, such as being off by several characters

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -55,10 +55,8 @@
     "vscode-languageserver": "^8.0.1",
     "vscode-languageserver-types": "^3.17.2",
     "vscode-uri": "^3.0.2",
-    "svelte2tsx": "^0.6.27",
     "svelte": "^4.1.1",
-    "source-map-js": "1.0.2",
-    "typescript": "5.3.3"
+    "source-map-js": "1.0.2"
   },
   "devDependencies": {
     "@types/glob": "^8.1.0",

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags-test.ts
@@ -355,7 +355,8 @@ query {id}`);
 `);
 
     expect(JSON.stringify(contents[0].range)).toEqual(
-      JSON.stringify(new Range(new Position(2, 29), new Position(12, 0))),
+      // TODO: change back to 29 when we get svelte parser working again
+      JSON.stringify(new Range(new Position(2, 27), new Position(12, 0))),
     );
   });
 

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -17,7 +17,7 @@ import { Position, Range } from 'graphql-language-service';
 
 import { TAG_MAP } from './constants';
 import { ecmaParser, tsParser } from './parsers/babel';
-import { svelteParser } from './parsers/svelte';
+// import { svelteParser } from './parsers/svelte';
 import { vueParser } from './parsers/vue';
 import type { Logger, NoopLogger } from './Logger';
 import { RangeMapper } from './parsers/types';
@@ -40,7 +40,9 @@ const parserMap = {
   '.tsx': tsParser,
   '.cts': tsParser,
   '.mts': tsParser,
-  '.svelte': svelteParser,
+  // disabled for now, until we can figure out how to get svelte2tsx working in esbuild bundle
+  // '.svelte': svelteParser,
+  '.svelte': vueParser,
   '.vue': vueParser,
 };
 

--- a/packages/graphql-language-service-server/src/parsers/svelte.ts
+++ b/packages/graphql-language-service-server/src/parsers/svelte.ts
@@ -1,4 +1,6 @@
 import { babelParser } from './babel';
+// TODO: Remove this when we have a working svelte parsing implementation
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { svelte2tsx } from 'svelte2tsx';
 import { SourceMapConsumer } from 'source-map-js';
 import { Position, Range } from 'graphql-language-service';

--- a/packages/vscode-graphql/esbuild.js
+++ b/packages/vscode-graphql/esbuild.js
@@ -49,7 +49,6 @@ build({
     'atpl',
     'liquor',
     'twig',
-    'typescript',
   ],
 })
   .then(({ errors, warnings }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18401,14 +18401,6 @@ svelte2tsx@^0.6.16:
     dedent-js "^1.0.1"
     pascal-case "^3.1.1"
 
-svelte2tsx@^0.6.27:
-  version "0.6.27"
-  resolved "https://registry.yarnpkg.com/svelte2tsx/-/svelte2tsx-0.6.27.tgz#5b2c21f38608be51cd32de177722f123e57919e5"
-  integrity sha512-E1uPW1o6VsbRz+nUk3fznZ2lSmCITAJoNu8AYefWSvIwE2pSB01i5sId4RMbWNzfcwCQl1DcgGShCPcldl4rvg==
-  dependencies:
-    dedent-js "^1.0.1"
-    pascal-case "^3.1.1"
-
 svelte@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/svelte/-/svelte-4.1.1.tgz#468ed0377d3cae542b35df8a22a3ca188d93272a"
@@ -18981,11 +18973,6 @@ typedoc@^0.19.2:
     semver "^7.3.2"
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
-
-typescript@5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
-  integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 typescript@^4.2.3:
   version "4.7.4"


### PR DESCRIPTION
Temporarily revert svelte parsing until we can fix bundling issues with svelte2tsx. For now we return to using the vue parser to parse svelte files which will invariably cause some issues, such as being off by several characters