### PR TITLE
fix: block strings syntax highlighting in cm6-graphql

### DIFF
--- a/.changeset/new-tools-unite.md
+++ b/.changeset/new-tools-unite.md
@@ -1,0 +1,5 @@
+---
+'cm6-graphql': patch
+---
+
+fix: block strings syntax highlighting

--- a/packages/cm6-graphql/__tests__/cases.txt
+++ b/packages/cm6-graphql/__tests__/cases.txt
@@ -113,3 +113,35 @@ Document(
 Document(
   OperationDefinition(SelectionSet("{",Selection(Field(FieldName)),Selection(Field(FieldName,SelectionSet("{",Selection(Field(FieldName)),"}"))),"}"))
 )
+
+
+
+# Test case for blockStringCharacter in a Description
+
+"""
+This is a block string description
+with multiple lines.
+It can contain any character except for \""".
+"""
+type Example {
+  id: ID
+}
+
+==>
+
+Document(
+  TypeSystemDefinition(
+    TypeDefinition(
+      ObjectTypeDefinition(
+        Description(StringValue),
+        TypeKeyword(type),
+        Name,
+        FieldsDefinition(
+          "{",
+          FieldDefinition(Name, NamedType(Name)),
+          "}"
+        )
+      )
+    )
+  )
+)

--- a/packages/cm6-graphql/src/language.ts
+++ b/packages/cm6-graphql/src/language.ts
@@ -20,7 +20,7 @@ export const graphqlLanguage = LRLanguage.define({
       styleTags({
         Variable: t.variableName,
         BooleanValue: t.bool,
-        Description: t.docComment,
+        Description: t.string,
         StringValue: t.string,
         Comment: t.lineComment,
         IntValue: t.integer,

--- a/packages/cm6-graphql/src/language.ts
+++ b/packages/cm6-graphql/src/language.ts
@@ -20,6 +20,7 @@ export const graphqlLanguage = LRLanguage.define({
       styleTags({
         Variable: t.variableName,
         BooleanValue: t.bool,
+        Description: t.docComment,
         StringValue: t.string,
         Comment: t.lineComment,
         IntValue: t.integer,

--- a/packages/cm6-graphql/src/syntax.grammar
+++ b/packages/cm6-graphql/src/syntax.grammar
@@ -393,7 +393,10 @@ Name { name }
   // https://spec.graphql.org/October2021/#BlockStringCharacter
   blockStringCharacter {
     '\\"""' |
-    '"' '"'? !["]
+    '"' '"'? !["] |
+    stringCharacter |
+    '\n' |
+    '\r\n'
   }
   
   // https://spec.graphql.org/October2021/#EscapedUnicode


### PR DESCRIPTION
This PR fixes and issue where block strings aren't properly highlighted when they containe a new due to how their ANTLR grammar is defined in `cm6-graphql`

before:


https://github.com/graphql/graphiql/assets/105317851/67dcdc08-cf6c-4b68-905f-141b3a385642


after:


https://github.com/graphql/graphiql/assets/105317851/82d013fb-6bea-4c8b-9ec1-5b5bc163e6e8

