### PR TITLE
fix: Race condition in the workerManager

### DIFF
--- a/.changeset/nice-cars-rush.md
+++ b/.changeset/nice-cars-rush.md
@@ -1,0 +1,5 @@
+---
+'monaco-graphql': minor
+---
+
+Fix race condition in the worker Manager

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -18,7 +18,7 @@ export class WorkerManager {
   private _lastUsedTime = 0;
   private _configChangeListener: IDisposable;
   private _worker: editor.MonacoWebWorker<GraphQLWorker> | null = null;
-  private _client: GraphQLWorker | null = null;
+  private _client: Promise<GraphQLWorker> | null = null;
 
   constructor(defaults: MonacoGraphQLAPI) {
     this._defaults = defaults;
@@ -83,13 +83,13 @@ export class WorkerManager {
             },
           } as ICreateData,
         });
-        this._client = await this._worker.getProxy();
+        this._client = this._worker.getProxy();
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('error loading worker', error);
       }
     }
-    return this._client!;
+    return await this._client!;
   }
 
   async getLanguageServiceWorker(...resources: Uri[]): Promise<GraphQLWorker> {

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -89,7 +89,7 @@ export class WorkerManager {
         console.error('error loading worker', error);
       }
     }
-    return await this._client!;
+    return this._client!;
   }
 
   async getLanguageServiceWorker(...resources: Uri[]): Promise<GraphQLWorker> {


### PR DESCRIPTION
There was a race condition in the workerManager. 

Which caused `worker` to be null [here](https://github.com/graphql/graphiql/blob/main/packages/monaco-graphql/src/languageFeatures.ts#L120).

This happened when several GraphQL editors on different models were present. `getLanguageServiceWorker()` called very quickly several times.

The root cause was that [here](https://github.com/graphql/graphiql/blob/main/packages/monaco-graphql/src/workerManager.ts#L61), `this._client` was still resolving (and therefore was null), but `this._worker` was present.
