### PR TITLE
add failing tests for triple-double-quote comments for js

### DIFF
--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -86,3 +86,50 @@ const queryWithLeadingAboveComment =
       }
     }
   `;
+
+// TODO: fix this
+const queryWithDocString = `
+  """
+  GraphQL
+  """
+  query {
+    user(id: "5", name: boolean) {
+      something
+    }
+  }
+`;
+
+// TODO: fix this
+const queryFieldWithDocString = `
+  query {
+    """
+    GraphQL
+    """
+    user(id: "5", name: boolean) {
+      something
+    }
+  }
+`;
+
+// TODO: fix this
+const queryArgWithDocString = `
+  query {
+    user(
+      """
+      GraphQL
+      """
+      id: "5"
+      name: boolean
+    ) {
+      something
+    }
+  }
+`;
+
+// TODO: fix this
+const scalarWithDocString = `
+  """
+  GraphQL
+  """
+  scalar Date
+`;

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -328,6 +328,53 @@ const queryWithLeadingAboveComment =   |
     }                                  | 
   \`;                                   | 
                                        | 
+// TODO: fix this                      | 
+const queryWithDocString = \`           | 
+  """                                  | 
+  GraphQL                              | 
+  """                                  | 
+  query {                              | 
+    user(id: "5", name: boolean) {     | 
+      something                        | 
+    }                                  | 
+  }                                    | 
+\`;                                     | 
+                                       | 
+// TODO: fix this                      | 
+const queryFieldWithDocString = \`      | 
+  query {                              | 
+    """                                | 
+    GraphQL                            | 
+    """                                | 
+    user(id: "5", name: boolean) {     | 
+      something                        | 
+    }                                  | 
+  }                                    | 
+\`;                                     | 
+                                       | 
+// TODO: fix this                      | 
+const queryArgWithDocString = \`        | 
+  query {                              | 
+    user(                              | 
+      """                              | 
+      GraphQL                          | 
+      """                              | 
+      id: "5"                          | 
+      name: boolean                    | 
+    ) {                                | 
+      something                        | 
+    }                                  | 
+  }                                    | 
+\`;                                     | 
+                                       | 
+// TODO: fix this                      | 
+const scalarWithDocString = \`          | 
+  """                                  | 
+  GraphQL                              | 
+  """                                  | 
+  scalar Date                          | 
+\`;                                     | 
+                                       | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple svelte file 1`] = `


### PR DESCRIPTION
This PR is not intended to be merged, but rather to provide tests to work with in fixing my reported bug in #3515 - for @acao and [their comment](https://github.com/graphql/graphiql/issues/3515#issuecomment-1909438594).

I'm new to this project so this is simply my educated guess as to what they need.

I can imagine these tests can be reduced, but given that the error affected these multi-line doc comments differently if they were outside or inside a block, I wanted to cover my bases by placing these test comments in various locations. 

_I can imagine the last one for scalar is not necessary but hey, it's there in case it's needed._