### PR TITLE
fix: Fix vscode-graphql-syntax’s grammar to support string literals on separate lines

### DIFF
--- a/.changeset/famous-games-begin.md
+++ b/.changeset/famous-games-begin.md
@@ -2,4 +2,4 @@
 'vscode-graphql-syntax': patch
 ---
 
-Fix Textmate grammar to support string literals that don’t immediately follow a function call paranthesis (`(`).
+Fix TextMate grammar to support string literals that don’t immediately follow a function call's left-parenthesis (`(`).

--- a/.changeset/famous-games-begin.md
+++ b/.changeset/famous-games-begin.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Fix Textmate grammar to support string literals that don’t immediately follow a function call paranthesis (`(`).

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*\\(?\\s*(`|'|\")",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*(\\(\\s*[\\n\\s]*)?(`|'|\")",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -36,7 +36,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*(?:<.*>)\\s*\\(?\\s*(`|'|\")",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*(?:<.*>)\\s*(\\(\\s*[\\n\\s]*)?(`|'|\")",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -15,6 +15,11 @@
               "name": "punctuation.definition.string.template.begin.js"
             }
           },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.template.end.js"
+            }
+          },
           "patterns": [
             {
               "include": "source.graphql"

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -36,7 +36,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*\\(?\\s*(?:<.*>)(`|'|\")",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*(?:<.*>)\\s*\\(?\\s*(`|'|\")",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -4,7 +4,28 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*(\\(\\s*[\\n\\s]*)?(`|'|\")",
+      "begin": "(?<=(?:(?:Relay\\??\\.)QL|gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "(`|'|\")",
+          "end": "(`|'|\")",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.template.begin.js"
+            }
+          },
+          "patterns": [
+            {
+              "include": "source.graphql"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|'|\")",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -19,35 +40,6 @@
           "name": "comment.graphql.js"
         },
         "5": {
-          "name": "punctuation.definition.string.template.begin.js"
-        }
-      },
-      "end": "(`|'|\")",
-      "endCaptures": {
-        "0": {
-          "name": "punctuation.definition.string.template.end.js"
-        }
-      },
-      "patterns": [
-        {
-          "include": "source.graphql"
-        }
-      ]
-    },
-    {
-      "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*(?:<.*>)\\s*(\\(\\s*[\\n\\s]*)?(`|'|\")",
-      "beginCaptures": {
-        "1": {
-          "name": "variable.other.class.js"
-        },
-        "2": {
-          "name": "entity.name.function.tagged-template.js"
-        },
-        "3": {
-          "name": "entity.name.function.tagged-template.js"
-        },
-        "4": {
           "name": "punctuation.definition.string.template.begin.js"
         }
       },

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -8,8 +8,8 @@
       "end": "\\)",
       "patterns": [
         {
-          "begin": "[`']",
-          "end": "[`']",
+          "begin": "(`|')",
+          "end": "(`|')",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.string.template.begin.js"
@@ -30,7 +30,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)|(/\\* GraphQL \\*/))\\s*[`']",
+      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -48,7 +48,7 @@
           "name": "punctuation.definition.string.template.begin.js"
         }
       },
-      "end": "[`']",
+      "end": "(`|')",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.template.end.js"
@@ -63,7 +63,7 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.graphql",
-      "begin": "[`'](#graphql)",
+      "begin": "(`|')(#graphql)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.template.begin.js"
@@ -72,7 +72,7 @@
           "name": "comment.line.graphql.js"
         }
       },
-      "end": "[`']",
+      "end": "(`|')",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.template.end.js"

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test-js.md
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test-js.md
@@ -26,6 +26,50 @@ const Component = () => {
 };
 ```
 
+```js
+const variable = 1;
+
+const queryA = graphql(`
+  query {
+    something(arg: ${variable})
+  }
+`);
+
+const queryB = graphql(
+  `
+    query {
+      something(arg: ${variable})
+    }
+  `
+);
+
+const queryC = graphql(
+  'query { something(arg: ${variable}) }'
+);
+```
+
+```ts
+const variable: number = 1;
+
+const queryA = graphql(`
+  query {
+    something(arg: ${variable})
+  }
+`);
+
+const queryB = graphql(
+  `
+    query {
+      something(arg: ${variable})
+    }
+  `
+);
+
+const queryC = graphql(
+  'query { something(arg: ${variable}) }'
+);
+```
+
 ### svelte
 
 ```svelte

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -36,6 +36,13 @@ const graphql = graphql(`
   }
 `);
 
+const graphql = graphql(
+  `
+    query { test }
+  `,
+  [var1, var2]
+);
+
 const query = /* GraphQL */ 'query { id } ';
 const query = graphql('query { id } ');
 const query = graphql(

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -39,15 +39,15 @@ const graphql = graphql(`
 
 const graphql = graphql(
   `
-    query { test }
+    query($id: ID!) { test }
   `,
   [var1, var2]
 );
 
 const query = /* GraphQL */ 'query { id } ';
-const query = graphql('query { id } ');
+const query = graphql('query($id: ID!) { id } ');
 const query = graphql(
-  'query { id } '
+  'query($id: ID!) { test }'
 );
 
 const queryWithInlineComment = `#graphql

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -38,6 +38,9 @@ const graphql = graphql(`
 
 const query = /* GraphQL */ 'query { id } ';
 const query = graphql('query { id } ');
+const query = graphql(
+  'query { id } '
+);
 
 const queryWithInlineComment = `#graphql
  query {
@@ -58,7 +61,6 @@ const queryWithInlineComment = `#graphql
         }
     }
 `;
-// TODO: fix this
 const queryWithInlineComment = `
 #graphql
  query {

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -25,8 +25,15 @@ const query = graphql<SomeGeneric>`
   }
 `;
 
-// TODO: Fix this
 const query = graphql<Generic>('query { id }');
+
+const query = graphql(
+  'query { id }'
+);
+
+const query = graphql<Generic>(
+  'query { id }'
+);
 
 const queryWithInlineComment = `#graphql
  query {

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -35,6 +35,17 @@ const query = graphql<Generic>(
   'query { id }'
 );
 
+const query = graphql(`
+  query { id }
+`);
+
+const query = graphql(
+  `
+    query { id }
+  `,
+  [var1, var2]
+);
+
 const queryWithInlineComment = `#graphql
  query {
         user(id: "5", name: boolean) {

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -145,6 +145,25 @@ something                              | meta.embedded.block.graphql meta.select
 )                                      | 
 ;                                      | 
                                        | 
+const graphql = graphql                | 
+(                                      | 
+                                       | meta.embedded.block.graphql
+\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+                                       | meta.embedded.block.graphql
+query                                  | meta.embedded.block.graphql keyword.operation.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                       | meta.embedded.block.graphql
+\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
+,                                      | meta.embedded.block.graphql
+  [var1, var2]                         | meta.embedded.block.graphql
+)                                      | 
+;                                      | 
+                                       | 
 const query =                          | 
                                        | 
 /* GraphQL */                          | comment.graphql.js
@@ -512,6 +531,40 @@ id                              | meta.embedded.block.graphql meta.selectionset.
                                 | meta.embedded.block.graphql meta.selectionset.graphql
 }                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
 '                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
+)                               | 
+;                               | 
+                                | 
+const query = graphql           | 
+(                               | 
+\`                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
+)                               | 
+;                               | 
+                                | 
+const query = graphql           | 
+(                               | 
+                                | meta.embedded.block.graphql
+\`                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql
+\`                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
+,                               | meta.embedded.block.graphql
+  [var1, var2]                  | meta.embedded.block.graphql
 )                               | 
 ;                               | 
                                 | 

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -155,6 +155,13 @@ const graphql = graphql                |
 \`                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
                                        | meta.embedded.block.graphql
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
+(                                      | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                       | meta.embedded.block.graphql meta.variables.graphql
+ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                      | meta.embedded.block.graphql meta.brace.round.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
@@ -187,6 +194,13 @@ const query = graphql                  |
 (                                      | 
 '                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
+(                                      | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                       | meta.embedded.block.graphql meta.variables.graphql
+ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                      | meta.embedded.block.graphql meta.brace.round.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
@@ -202,13 +216,19 @@ const query = graphql                  |
                                        | meta.embedded.block.graphql
 '                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
+(                                      | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                       | meta.embedded.block.graphql meta.variables.graphql
+ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                      | meta.embedded.block.graphql meta.brace.round.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
 '                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                                      | 
 ;                                      | 

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -141,7 +141,7 @@ something                              | meta.embedded.block.graphql meta.select
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | meta.embedded.block.graphql
+\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                                      | 
 ;                                      | 
                                        | 
@@ -171,7 +171,7 @@ id                                     | meta.embedded.block.graphql meta.select
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql
-'                                      | meta.embedded.block.graphql
+'                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                                      | 
 ;                                      | 
                                        | 
@@ -467,7 +467,7 @@ query                           | meta.embedded.block.graphql keyword.operation.
 id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
                                 | meta.embedded.block.graphql meta.selectionset.graphql
 }                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                               | 
 ;                               | 
                                 | 
@@ -482,7 +482,7 @@ query                           | meta.embedded.block.graphql keyword.operation.
 id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
                                 | meta.embedded.block.graphql meta.selectionset.graphql
 }                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                               | 
 ;                               | 
                                 | 
@@ -497,7 +497,7 @@ query                           | meta.embedded.block.graphql keyword.operation.
 id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
                                 | meta.embedded.block.graphql meta.selectionset.graphql
 }                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                               | 
 ;                               | 
                                 | 

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -457,9 +457,38 @@ something                       | meta.embedded.block.graphql meta.selectionset.
 \`                               | punctuation.definition.string.template.end.js
 ;                               | 
                                 | 
-// TODO: Fix this               | 
 const query = graphql<Generic>  | 
 (                               | 
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                               | meta.embedded.block.graphql
+)                               | 
+;                               | 
+                                | 
+const query = graphql           | 
+(                               | 
+                                | meta.embedded.block.graphql
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                               | meta.embedded.block.graphql
+)                               | 
+;                               | 
+                                | 
+const query = graphql<Generic>  | 
+(                               | 
+                                | meta.embedded.block.graphql
 '                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
 query                           | meta.embedded.block.graphql keyword.operation.graphql
                                 | meta.embedded.block.graphql meta.selectionset.graphql

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -174,6 +174,21 @@ id                                     | meta.embedded.block.graphql meta.select
 '                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
 )                                      | 
 ;                                      | 
+const query = graphql                  | 
+(                                      | 
+                                       | meta.embedded.block.graphql
+'                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+query                                  | meta.embedded.block.graphql keyword.operation.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                       | meta.embedded.block.graphql
+'                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
+)                                      | 
+;                                      | 
                                        | 
 const queryWithInlineComment =         | 
 \`                                      | taggedTemplates punctuation.definition.string.template.begin.js
@@ -270,7 +285,6 @@ something                              | taggedTemplates meta.embedded.block.gra
 }                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
 \`                                      | taggedTemplates punctuation.definition.string.template.end.js
 ;                                      | 
-// TODO: fix this                      | 
 const queryWithInlineComment = \`       | 
 #graphql                               | 
  query {                               | 

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -108,11 +108,9 @@ something                              | meta.embedded.block.graphql meta.select
 \`                                      | punctuation.definition.string.template.end.js
 ;                                      | 
                                        | 
-const graphql =                        | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
+const graphql = graphql                | 
 (                                      | 
-\`                                      | punctuation.definition.string.template.begin.js
+\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
                                        | meta.embedded.block.graphql
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
@@ -143,8 +141,9 @@ something                              | meta.embedded.block.graphql meta.select
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-);                                     | 
+\`                                      | meta.embedded.block.graphql
+)                                      | 
+;                                      | 
                                        | 
 const query =                          | 
                                        | 
@@ -161,11 +160,9 @@ id                                     | meta.embedded.block.graphql meta.select
                                        | meta.embedded.block.graphql
 '                                      | punctuation.definition.string.template.end.js
 ;                                      | 
-const query =                          | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
+const query = graphql                  | 
 (                                      | 
-'                                      | punctuation.definition.string.template.begin.js
+'                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
@@ -174,8 +171,9 @@ id                                     | meta.embedded.block.graphql meta.select
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql
-'                                      | punctuation.definition.string.template.end.js
-);                                     | 
+'                                      | meta.embedded.block.graphql
+)                                      | 
+;                                      | 
                                        | 
 const queryWithInlineComment =         | 
 \`                                      | taggedTemplates punctuation.definition.string.template.begin.js
@@ -356,180 +354,192 @@ hello                  | meta.embedded.block.graphql meta.selectionset.graphql v
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple typescript file 1`] = `
-/* eslint-disable */                            | 
-// @ts-nocheck                                  | 
-                                                | 
-gql                                             | entity.name.function.tagged-template.js
-\`                                               | punctuation.definition.string.template.begin.js
-                                                | meta.embedded.block.graphql
-query                                           | meta.embedded.block.graphql keyword.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                               | punctuation.definition.string.template.end.js
-;                                               | 
-                                                | 
-graphql                                         | entity.name.function.tagged-template.js
-<SomeGeneric>                                   | 
-\`                                               | punctuation.definition.string.template.begin.js
-                                                | meta.embedded.block.graphql
-query                                           | meta.embedded.block.graphql keyword.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                               | punctuation.definition.string.template.end.js
-;                                               | 
-                                                | 
-const query =                                   | 
-                                                | 
-graphql                                         | entity.name.function.tagged-template.js
-<SomeGeneric>                                   | 
-\`                                               | punctuation.definition.string.template.begin.js
-                                                | meta.embedded.block.graphql
-query                                           | meta.embedded.block.graphql keyword.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                               | punctuation.definition.string.template.end.js
-;                                               | 
-                                                | 
-// TODO: Fix this                               | 
-const query = graphql<Generic>('query { id }'); | 
-                                                | 
-const queryWithInlineComment =                  | 
-\`                                               | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                                        | taggedTemplates comment.line.graphql.js
-                                                | taggedTemplates meta.embedded.block.graphql
-query                                           | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                               | taggedTemplates punctuation.definition.string.template.end.js
-;                                               | 
-                                                | 
-const queryWithLeadingComment =                 | 
-                                                | 
-/* GraphQL */                                   | comment.graphql.js
-                                                | 
-\`                                               | punctuation.definition.string.template.begin.js
-                                                | meta.embedded.block.graphql
-query                                           | meta.embedded.block.graphql keyword.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                               | punctuation.definition.string.template.end.js
-;                                               | 
-                                                | 
+/* eslint-disable */            | 
+// @ts-nocheck                  | 
+                                | 
+gql                             | entity.name.function.tagged-template.js
+\`                               | punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | punctuation.definition.string.template.end.js
+;                               | 
+                                | 
+graphql                         | entity.name.function.tagged-template.js
+<SomeGeneric>                   | 
+\`                               | punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | punctuation.definition.string.template.end.js
+;                               | 
+                                | 
+const query =                   | 
+                                | 
+graphql                         | entity.name.function.tagged-template.js
+<SomeGeneric>                   | 
+\`                               | punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | punctuation.definition.string.template.end.js
+;                               | 
+                                | 
+// TODO: Fix this               | 
+const query = graphql<Generic>  | 
+(                               | 
+'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                               | meta.embedded.block.graphql
+)                               | 
+;                               | 
+                                | 
+const queryWithInlineComment =  | 
+\`                               | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                        | taggedTemplates comment.line.graphql.js
+                                | taggedTemplates meta.embedded.block.graphql
+query                           | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | taggedTemplates punctuation.definition.string.template.end.js
+;                               | 
+                                | 
+const queryWithLeadingComment = | 
+                                | 
+/* GraphQL */                   | comment.graphql.js
+                                | 
+\`                               | punctuation.definition.string.template.begin.js
+                                | meta.embedded.block.graphql
+query                           | meta.embedded.block.graphql keyword.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                               | punctuation.definition.string.template.end.js
+;                               | 
+                                | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple vue sfc comp file 1`] = `

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/markdown-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/markdown-grammar.spec.ts.snap
@@ -109,6 +109,50 @@ const Component = () => {                            |
 };                                                   | 
 \`\`\`                                                  | 
                                                      | 
+\`\`\`js                                                | 
+const variable = 1;                                  | 
+                                                     | 
+const queryA = graphql(\`                             | 
+  query {                                            | 
+    something(arg: \${variable})                      | 
+  }                                                  | 
+\`);                                                  | 
+                                                     | 
+const queryB = graphql(                              | 
+  \`                                                  | 
+    query {                                          | 
+      something(arg: \${variable})                    | 
+    }                                                | 
+  \`                                                  | 
+);                                                   | 
+                                                     | 
+const queryC = graphql(                              | 
+  'query { something(arg: \${variable}) }'            | 
+);                                                   | 
+\`\`\`                                                  | 
+                                                     | 
+\`\`\`ts                                                | 
+const variable: number = 1;                          | 
+                                                     | 
+const queryA = graphql(\`                             | 
+  query {                                            | 
+    something(arg: \${variable})                      | 
+  }                                                  | 
+\`);                                                  | 
+                                                     | 
+const queryB = graphql(                              | 
+  \`                                                  | 
+    query {                                          | 
+      something(arg: \${variable})                    | 
+    }                                                | 
+  \`                                                  | 
+);                                                   | 
+                                                     | 
+const queryC = graphql(                              | 
+  'query { something(arg: \${variable}) }'            | 
+);                                                   | 
+\`\`\`                                                  | 
+                                                     | 
 ### svelte                                           | 
                                                      | 
 \`\`\`svelte                                            | 


### PR DESCRIPTION
## Summary

We're currently working on [`gql.tada`](https://github.com/0no-co/gql.tada), which is _mostly_ compatible with the expected syntax of `graphql` calls.
However, while getting this in users hands we noticed that a specific grammar that Prettier formats `graphql()` calls into fails to be matched by the Textmate grammar in `vscode-graphql-syntax`.

Specifically, when a GraphQL string literal is placed on a new line, the `begin` pattern of the rules can't match. This is a limitation in Textmate grammars, as it turns out, and we can't even manually match `\n` patterns.

I'm not an expert at Textmate grammars, but, in theory, a grammar rule that matches GraphQL calls as a lookbehind, then matches the inner string literal separately, should do the trick.

<table>
<thead><tr>
<td><strong>Before</strong></td>
<td><strong>After</strong></td>
</tr></thead>
<tr>
<td><img width="342" alt="Before" src="https://github.com/graphql/graphiql/assets/2041385/42549976-0f46-4e6d-b688-22875da7142d"></td>
<td><img width="363" alt="After" src="https://github.com/graphql/graphiql/assets/2041385/15854c1d-d937-449e-a091-92444900d72f"></td>
</tr>
</table>

## Follow-up questions

- Is there a test suite / sample files for this we can check for regressions?
- Does anyone here know more about Textmate grammars to proof read this change?

## Set of changes

- Try out newline matches in `begin` rule (**DELETED CHANGE**)
- Add separate rule for matching `graphql(...)` calls then matching string literals inside
- Combining redundant rules into one (move generic over)
- Update snapshots (remove `TODO: fix this`) and add more grammar checks for JS