### PR TITLE
fix: Do not override existing json diagnostic schemas

### DIFF
--- a/.changeset/healthy-toes-grab.md
+++ b/.changeset/healthy-toes-grab.md
@@ -1,0 +1,5 @@
+---
+'monaco-graphql': patch
+---
+
+Fix JSON diagnostics

--- a/.changeset/healthy-toes-grab.md
+++ b/.changeset/healthy-toes-grab.md
@@ -2,4 +2,4 @@
 'monaco-graphql': patch
 ---
 
-Fix JSON diagnostics
+Fix JSON diagnostics for multiple editors

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -150,12 +150,17 @@ export class DiagnosticsAdapter {
         schema: jsonSchema,
         fileMatch: variablesUris,
       };
+      const currentSchemas =
+        languages.json.jsonDefaults.diagnosticsOptions.schemas?.filter(
+          s => s.uri !== schemaUri,
+        ) || [];
+
       // TODO: export from api somehow?
       languages.json.jsonDefaults.setDiagnosticsOptions({
         schemaValidation: 'error',
         validate: true,
         ...this.defaults?.diagnosticSettings?.jsonDiagnosticSettings,
-        schemas: [configResult],
+        schemas: [...currentSchemas, configResult],
         enableSchemaRequest: false,
       });
     }


### PR DESCRIPTION
When working with different editors, the JSON schemas are always overridden by new ones