### PR TITLE
Fix bug in Explorer plugin where characters are dropped when typing quickly

### DIFF
--- a/.changeset/fresh-rabbits-move.md
+++ b/.changeset/fresh-rabbits-move.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Fix bug in `@graphiql/plugin-explorer` whereby typing quickly into explorer sidebar would result in characters being dropped.

--- a/.changeset/fresh-rabbits-move.md
+++ b/.changeset/fresh-rabbits-move.md
@@ -1,5 +1,5 @@
 ---
-'graphiql': patch
+'@graphiql/plugin-explorer': patch
 ---
 
-Fix bug in `@graphiql/plugin-explorer` whereby typing quickly into explorer sidebar would result in characters being dropped.
+Fix bug whereby typing quickly into explorer sidebar would result in characters being dropped.

--- a/.changeset/silent-spoons-shout.md
+++ b/.changeset/silent-spoons-shout.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Add new `useOptimisticState` hook that can wrap a useState-like hook to perform optimistic caching of state changes, this helps to avoid losing characters when the user is typing rapidly. Example of usage: `const [state, setState] = useOptimisticState(useOperationsEditorState());`

--- a/packages/graphiql-plugin-explorer/src/index.tsx
+++ b/packages/graphiql-plugin-explorer/src/index.tsx
@@ -9,7 +9,13 @@ import {
   Explorer as GraphiQLExplorer,
   GraphiQLExplorerProps,
 } from 'graphiql-explorer';
-import React, { useCallback, useState, useEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+} from 'react';
 
 import './graphiql-explorer.d.ts';
 import './index.css';
@@ -207,21 +213,31 @@ function useOptimisticOperationsEditorState(): ReturnType<
         setOperationsText(upstreamOperationsString);
       }
     }
-  }, [upstreamOperationsString, operationsString]);
+  }, [
+    upstreamOperationsString,
+    operationsString,
+    upstreamHandleEditOperations,
+  ]);
 
-  const handleEditOperations = useCallback((operationsString: string) => {
-    setOperationsText(operationsString);
-    if (
-      lastStateRef.current.pending === null &&
-      lastStateRef.current.last !== operationsString
-    ) {
-      // No pending updates and change has occurred... send it upstream
-      lastStateRef.current.pending = operationsString;
-      upstreamHandleEditOperations(operationsString);
-    }
-  }, []);
+  const handleEditOperations = useCallback(
+    (newOperationsString: string) => {
+      setOperationsText(newOperationsString);
+      if (
+        lastStateRef.current.pending === null &&
+        lastStateRef.current.last !== newOperationsString
+      ) {
+        // No pending updates and change has occurred... send it upstream
+        lastStateRef.current.pending = newOperationsString;
+        upstreamHandleEditOperations(newOperationsString);
+      }
+    },
+    [upstreamHandleEditOperations],
+  );
 
-  return [operationsString, handleEditOperations];
+  return useMemo(
+    () => [operationsString, handleEditOperations],
+    [operationsString, handleEditOperations],
+  );
 }
 
 export function explorerPlugin(

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -396,7 +396,7 @@ export const useHeadersEditorState = (): [
  *
  * Use this as a wrapper around `useOperationsEditorState`,
  * `useVariablesEditorState`, or `useHeadersEditorState` if you anticipate
- * calling them with great frequency (due to, e.g., mouse, keyboard or
+ * calling them with great frequency (due to, for instance, mouse, keyboard, or
  * network events).
  *
  * Example:

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -396,8 +396,8 @@ export const useHeadersEditorState = (): [
  *
  * Use this as a wrapper around `useOperationsEditorState`,
  * `useVariablesEditorState`, or `useHeadersEditorState` if you anticipate
- * calling them with great frequency (e.g. due to mouse, keyboard or network
- * events).
+ * calling them with great frequency (due to, e.g., mouse, keyboard or
+ * network events).
  *
  * Example:
  *

--- a/packages/graphiql-react/src/editor/hooks.ts
+++ b/packages/graphiql-react/src/editor/hooks.ts
@@ -3,7 +3,7 @@ import type { EditorChange, EditorConfiguration } from 'codemirror';
 import type { SchemaReference } from 'codemirror-graphql/utils/SchemaReference';
 import copyToClipboard from 'copy-to-clipboard';
 import { parse, print } from 'graphql';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useExplorerContext } from '../explorer';
 import { usePluginContext } from '../plugin';
@@ -388,3 +388,76 @@ export const useHeadersEditorState = (): [
 ] => {
   return useEditorState('header');
 };
+
+/**
+ * Implements an optimistic caching strategy around a useState-like hook in
+ * order to prevent loss of updates when the hook has an internal delay and the
+ * update function is called again before the updated state is sent out.
+ *
+ * Use this as a wrapper around `useOperationsEditorState`,
+ * `useVariablesEditorState`, or `useHeadersEditorState` if you anticipate
+ * calling them with great frequency (e.g. due to mouse, keyboard or network
+ * events).
+ *
+ * Example:
+ *
+ * ```ts
+ * const [operationsString, handleEditOperations] =
+ *   useOptimisticState(useOperationsEditorState());
+ * ```
+ */
+export function useOptimisticState([
+  upstreamState,
+  upstreamSetState,
+]: ReturnType<typeof useEditorState>): ReturnType<typeof useEditorState> {
+  const lastStateRef = useRef({
+    /** The last thing that we sent upstream; we're expecting this back */
+    pending: null as string | null,
+    /** The last thing we received from upstream */
+    last: upstreamState,
+  });
+
+  const [state, setOperationsText] = useState(upstreamState);
+
+  useEffect(() => {
+    if (lastStateRef.current.last === upstreamState) {
+      // No change; ignore
+    } else {
+      lastStateRef.current.last = upstreamState;
+      if (lastStateRef.current.pending === null) {
+        // Gracefully accept update from upstream
+        setOperationsText(upstreamState);
+      } else if (lastStateRef.current.pending === upstreamState) {
+        // They received our update and sent it back to us - clear pending, and
+        // send next if appropriate
+        lastStateRef.current.pending = null;
+        if (upstreamState !== state) {
+          // Change has occurred; upstream it
+          lastStateRef.current.pending = state;
+          upstreamSetState(state);
+        }
+      } else {
+        // They got a different update; overwrite our local state (!!)
+        lastStateRef.current.pending = null;
+        setOperationsText(upstreamState);
+      }
+    }
+  }, [upstreamState, state, upstreamSetState]);
+
+  const setState = useCallback(
+    (newState: string) => {
+      setOperationsText(newState);
+      if (
+        lastStateRef.current.pending === null &&
+        lastStateRef.current.last !== newState
+      ) {
+        // No pending updates and change has occurred... send it upstream
+        lastStateRef.current.pending = newState;
+        upstreamSetState(newState);
+      }
+    },
+    [upstreamSetState],
+  );
+
+  return useMemo(() => [state, setState], [state, setState]);
+}

--- a/packages/graphiql-react/src/editor/index.ts
+++ b/packages/graphiql-react/src/editor/index.ts
@@ -18,6 +18,7 @@ export {
   usePrettifyEditors,
   useEditorState,
   useOperationsEditorState,
+  useOptimisticState,
   useVariablesEditorState,
   useHeadersEditorState,
 } from './hooks';

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -18,6 +18,7 @@ export {
   useVariableEditor,
   useEditorState,
   useOperationsEditorState,
+  useOptimisticState,
   useVariablesEditorState,
   useHeadersEditorState,
   VariableEditor,


### PR DESCRIPTION
To see a reproduction of this issue, check out: https://github.com/graphile/crystal/issues/1845

The issue stems from some delays interfering with the reactivity model of React - when you type a character into Explorer, that change gets transformed into a GraphQL document string which is sent upstream into GraphiQL, GraphiQL then updates everything and sends the result back down stream to GraphiQL Explorer, which renders the new data. The issue is that if the user has typed another character in the interrim, their keypress will be overwritten by this flow because there is (I think!) a delay somewhere, i.e. the state is not updated synchronously. If the user types faster than this update loop, characters will be lost.

To solve this, we could use the "throttle" or "debounce" patterns to only send updates every so often or when the user is paused typing, but this leads to a less-than-instant experience for the user. Instead, I've opted to send the update upstream and then not send any further updates upstream until we receive back what we sent. If we get back what we sent then we send the next update (skipping all the intermediary keypresses and just jumping right to the current state), giving the user near-instant feedback on their typing. If what we receive is not what we sent then something else must have happened, and thus we overwrite our local state (which is the status quo). Through intense and rapid typing into both the explorer plugin and the operations text I was not able to trigger this branch, but nonetheless it is present to handle this situation.

The interface now feels buttery smooth to me, so I think this issue is solved.

To make the solution nice and clean I've put it in its own hook.