### PR TITLE
fix triple quote comment syntax

### DIFF
--- a/.changeset/angry-pots-return.md
+++ b/.changeset/angry-pots-return.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+fix triple double quote comment syntax by disabling inline double quote js strings for now

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -4,7 +4,7 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*\\(?\\s*(`|'|\")",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*\\(?\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -22,7 +22,7 @@
           "name": "punctuation.definition.string.template.begin.js"
         }
       },
-      "end": "(`|'|\")",
+      "end": "(`|')",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.template.end.js"
@@ -36,7 +36,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*\\(?\\s*(?:<.*>)(`|'|\")",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*\\(?\\s*(?:<.*>)(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -51,7 +51,7 @@
           "name": "punctuation.definition.string.template.begin.js"
         }
       },
-      "end": "(`|'|\")",
+      "end": "(`|')",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.template.end.js"
@@ -66,7 +66,7 @@
     {
       "name": "taggedTemplates",
       "contentName": "meta.embedded.block.graphql",
-      "begin": "(`|'|\")(#graphql)",
+      "begin": "(`|')(#graphql)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.template.begin.js"
@@ -75,7 +75,7 @@
           "name": "comment.line.graphql.js"
         }
       },
-      "end": "(`|'|\")",
+      "end": "(`|')",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.template.end.js"

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -29,6 +29,7 @@ const graphql = graphql`
 `;
 
 const graphql = graphql(`
+  """ this is a comment """
   query {
     user(id: "5", name: ${variable}) {
       something
@@ -70,6 +71,7 @@ const queryWithInlineComment = `
 
 const queryWithLeadingComment = /* GraphQL */ `
   query {
+    """ this is a comment """
     user(id: "5", name: boolean) {
       something
     }

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -114,6 +114,10 @@ graphql                                | entity.name.function.tagged-template.js
 (                                      | 
 \`                                      | punctuation.definition.string.template.begin.js
                                        | meta.embedded.block.graphql
+"""                                    | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                     | meta.embedded.block.graphql comment.line.graphql.js
+"""                                    | meta.embedded.block.graphql comment.line.graphql.js
+                                       | meta.embedded.block.graphql
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
@@ -291,6 +295,10 @@ const queryWithLeadingComment =        |
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                       | meta.embedded.block.graphql meta.selectionset.graphql
+"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                     | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
 (                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql


### PR DESCRIPTION
 fixes #3515
 
i broke this by introducing support for double quote graphql strings, which are much less common that these important doc annotations

adds test cases to confirm this still works