### PR TITLE
multiple argument syntax highlighting

### DIFF
--- a/.changeset/green-houses-raise.md
+++ b/.changeset/green-houses-raise.md
@@ -1,0 +1,5 @@
+---
+'cm6-graphql': patch
+---
+
+fix: multiple argument syntax highlighting

--- a/packages/cm6-graphql/__tests__/cases.txt
+++ b/packages/cm6-graphql/__tests__/cases.txt
@@ -145,3 +145,13 @@ Document(
     )
   )
 )
+
+# multiple arguments separated by a commas
+
+{
+  picture(width: 200, height: 100)
+}
+
+==>
+
+Document(OperationDefinition(SelectionSet("{",Selection(Field(FieldName,Arguments("(",Argument(ArgumentAttributeName,IntValue),Argument(ArgumentAttributeName,IntValue),")"))),"}")))

--- a/packages/cm6-graphql/src/syntax.grammar
+++ b/packages/cm6-graphql/src/syntax.grammar
@@ -291,7 +291,7 @@ Directive { DirectiveName Arguments? }
 Arguments { "(" Argument+ ")"}
 
 // https://spec.graphql.org/October2021/#Argument
-Argument { ArgumentAttributeName ":" value }
+Argument { ArgumentAttributeName ":" value comma? }
 
 ArgumentAttributeName { name }
 


### PR DESCRIPTION
## Issue

arguments separated by commas we not being parsed by the grammar leading to incorrect syntax highlighting in cm6-graphql package. 

## Solution

Add an optional comma to Arguments in the grammar. This allows comma separated arguments as seen in the spec: https://spec.graphql.org/October2021/#sec-Language.Arguments.Arguments-are-unordered