### PR TITLE
Revert "fix: Fix vscode-graphql-syntax’s grammar to support string literals on separate lines"

### DIFF
--- a/.changeset/famous-ads-jam.md
+++ b/.changeset/famous-ads-jam.md
@@ -1,0 +1,6 @@
+---
+"vscode-graphql-syntax": patch
+"vscode-graphql": patch
+---
+
+Temporarily revert a syntax highlighting bugfix that caused more bugs

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -4,33 +4,7 @@
   "patterns": [
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "(?<=(?:(?:Relay\\??\\.)QL|gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)\\(",
-      "end": "\\)",
-      "patterns": [
-        {
-          "begin": "(`|')",
-          "end": "(`|')",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.template.begin.js"
-            }
-          },
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.string.template.end.js"
-            }
-          },
-          "patterns": [
-            {
-              "include": "source.graphql"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)|(/\\* GraphQL \\*/))\\s*\\(?\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -45,6 +19,35 @@
           "name": "comment.graphql.js"
         },
         "5": {
+          "name": "punctuation.definition.string.template.begin.js"
+        }
+      },
+      "end": "(`|')",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.graphql"
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.graphql",
+      "begin": "\\s*+(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental))\\s*\\(?\\s*(?:<.*>)(`|')",
+      "beginCaptures": {
+        "1": {
+          "name": "variable.other.class.js"
+        },
+        "2": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "3": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "4": {
           "name": "punctuation.definition.string.template.begin.js"
         }
       },

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test-js.md
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test-js.md
@@ -26,50 +26,6 @@ const Component = () => {
 };
 ```
 
-```js
-const variable = 1;
-
-const queryA = graphql(`
-  query {
-    something(arg: ${variable})
-  }
-`);
-
-const queryB = graphql(
-  `
-    query {
-      something(arg: ${variable})
-    }
-  `
-);
-
-const queryC = graphql(
-  'query { something(arg: ${variable}) }'
-);
-```
-
-```ts
-const variable: number = 1;
-
-const queryA = graphql(`
-  query {
-    something(arg: ${variable})
-  }
-`);
-
-const queryB = graphql(
-  `
-    query {
-      something(arg: ${variable})
-    }
-  `
-);
-
-const queryC = graphql(
-  'query { something(arg: ${variable}) }'
-);
-```
-
 ### svelte
 
 ```svelte

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -37,18 +37,8 @@ const graphql = graphql(`
   }
 `);
 
-const graphql = graphql(
-  `
-    query($id: ID!) { test }
-  `,
-  [var1, var2]
-);
-
 const query = /* GraphQL */ 'query { id } ';
-const query = graphql('query($id: ID!) { id } ');
-const query = graphql(
-  'query($id: ID!) { test }'
-);
+const query = graphql('query { id } ');
 
 const queryWithInlineComment = `#graphql
  query {
@@ -69,6 +59,7 @@ const queryWithInlineComment = `#graphql
         }
     }
 `;
+// TODO: fix this
 const queryWithInlineComment = `
 #graphql
  query {

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -25,26 +25,8 @@ const query = graphql<SomeGeneric>`
   }
 `;
 
+// TODO: Fix this
 const query = graphql<Generic>('query { id }');
-
-const query = graphql(
-  'query { id }'
-);
-
-const query = graphql<Generic>(
-  'query { id }'
-);
-
-const query = graphql(`
-  query { id }
-`);
-
-const query = graphql(
-  `
-    query { id }
-  `,
-  [var1, var2]
-);
 
 const queryWithInlineComment = `#graphql
  query {

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -108,9 +108,11 @@ something                              | meta.embedded.block.graphql meta.select
 \`                                      | punctuation.definition.string.template.end.js
 ;                                      | 
                                        | 
-const graphql = graphql                | 
+const graphql =                        | 
+                                       | 
+graphql                                | entity.name.function.tagged-template.js
 (                                      | 
-\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+\`                                      | punctuation.definition.string.template.begin.js
                                        | meta.embedded.block.graphql
 """                                    | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
  this is a comment                     | meta.embedded.block.graphql comment.line.graphql.js
@@ -145,35 +147,8 @@ something                              | meta.embedded.block.graphql meta.select
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-                                       | 
-const graphql = graphql                | 
-(                                      | 
-                                       | meta.embedded.block.graphql
-\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-\`                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-,                                      | meta.embedded.block.graphql
-  [var1, var2]                         | meta.embedded.block.graphql
-)                                      | 
-;                                      | 
+\`                                      | punctuation.definition.string.template.end.js
+);                                     | 
                                        | 
 const query =                          | 
                                        | 
@@ -190,17 +165,12 @@ id                                     | meta.embedded.block.graphql meta.select
                                        | meta.embedded.block.graphql
 '                                      | punctuation.definition.string.template.end.js
 ;                                      | 
-const query = graphql                  | 
+const query =                          | 
+                                       | 
+graphql                                | entity.name.function.tagged-template.js
 (                                      | 
-'                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
+'                                      | punctuation.definition.string.template.begin.js
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
@@ -208,30 +178,8 @@ id                                     | meta.embedded.block.graphql meta.select
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 }                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
                                        | meta.embedded.block.graphql
-'                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-const query = graphql                  | 
-(                                      | 
-                                       | meta.embedded.block.graphql
-'                                      | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                                      | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
+'                                      | punctuation.definition.string.template.end.js
+);                                     | 
                                        | 
 const queryWithInlineComment =         | 
 \`                                      | taggedTemplates punctuation.definition.string.template.begin.js
@@ -328,6 +276,7 @@ something                              | taggedTemplates meta.embedded.block.gra
 }                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
 \`                                      | taggedTemplates punctuation.definition.string.template.end.js
 ;                                      | 
+// TODO: fix this                      | 
 const queryWithInlineComment = \`       | 
 #graphql                               | 
  query {                               | 
@@ -415,255 +364,180 @@ hello                  | meta.embedded.block.graphql meta.selectionset.graphql v
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple typescript file 1`] = `
-/* eslint-disable */            | 
-// @ts-nocheck                  | 
-                                | 
-gql                             | entity.name.function.tagged-template.js
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-graphql                         | entity.name.function.tagged-template.js
-<SomeGeneric>                   | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const query =                   | 
-                                | 
-graphql                         | entity.name.function.tagged-template.js
-<SomeGeneric>                   | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const query = graphql<Generic>  | 
-(                               | 
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query = graphql           | 
-(                               | 
-                                | meta.embedded.block.graphql
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query = graphql<Generic>  | 
-(                               | 
-                                | meta.embedded.block.graphql
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query = graphql           | 
-(                               | 
-\`                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query = graphql           | 
-(                               | 
-                                | meta.embedded.block.graphql
-\`                               | meta.embedded.block.graphql punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql
-\`                               | meta.embedded.block.graphql punctuation.definition.string.template.end.js
-,                               | meta.embedded.block.graphql
-  [var1, var2]                  | meta.embedded.block.graphql
-)                               | 
-;                               | 
-                                | 
-const queryWithInlineComment =  | 
-\`                               | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                        | taggedTemplates comment.line.graphql.js
-                                | taggedTemplates meta.embedded.block.graphql
-query                           | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | taggedTemplates punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const queryWithLeadingComment = | 
-                                | 
-/* GraphQL */                   | comment.graphql.js
-                                | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
+/* eslint-disable */                            | 
+// @ts-nocheck                                  | 
+                                                | 
+gql                                             | entity.name.function.tagged-template.js
+\`                                               | punctuation.definition.string.template.begin.js
+                                                | meta.embedded.block.graphql
+query                                           | meta.embedded.block.graphql keyword.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                               | punctuation.definition.string.template.end.js
+;                                               | 
+                                                | 
+graphql                                         | entity.name.function.tagged-template.js
+<SomeGeneric>                                   | 
+\`                                               | punctuation.definition.string.template.begin.js
+                                                | meta.embedded.block.graphql
+query                                           | meta.embedded.block.graphql keyword.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                               | punctuation.definition.string.template.end.js
+;                                               | 
+                                                | 
+const query =                                   | 
+                                                | 
+graphql                                         | entity.name.function.tagged-template.js
+<SomeGeneric>                                   | 
+\`                                               | punctuation.definition.string.template.begin.js
+                                                | meta.embedded.block.graphql
+query                                           | meta.embedded.block.graphql keyword.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                               | punctuation.definition.string.template.end.js
+;                                               | 
+                                                | 
+// TODO: Fix this                               | 
+const query = graphql<Generic>('query { id }'); | 
+                                                | 
+const queryWithInlineComment =                  | 
+\`                                               | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                        | taggedTemplates comment.line.graphql.js
+                                                | taggedTemplates meta.embedded.block.graphql
+query                                           | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                               | taggedTemplates punctuation.definition.string.template.end.js
+;                                               | 
+                                                | 
+const queryWithLeadingComment =                 | 
+                                                | 
+/* GraphQL */                                   | comment.graphql.js
+                                                | 
+\`                                               | punctuation.definition.string.template.begin.js
+                                                | meta.embedded.block.graphql
+query                                           | meta.embedded.block.graphql keyword.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+user                                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                | meta.embedded.block.graphql meta.selectionset.graphql
+}                                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                               | punctuation.definition.string.template.end.js
+;                                               | 
+                                                | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple vue sfc comp file 1`] = `

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/markdown-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/markdown-grammar.spec.ts.snap
@@ -109,50 +109,6 @@ const Component = () => {                            |
 };                                                   | 
 \`\`\`                                                  | 
                                                      | 
-\`\`\`js                                                | 
-const variable = 1;                                  | 
-                                                     | 
-const queryA = graphql(\`                             | 
-  query {                                            | 
-    something(arg: \${variable})                      | 
-  }                                                  | 
-\`);                                                  | 
-                                                     | 
-const queryB = graphql(                              | 
-  \`                                                  | 
-    query {                                          | 
-      something(arg: \${variable})                    | 
-    }                                                | 
-  \`                                                  | 
-);                                                   | 
-                                                     | 
-const queryC = graphql(                              | 
-  'query { something(arg: \${variable}) }'            | 
-);                                                   | 
-\`\`\`                                                  | 
-                                                     | 
-\`\`\`ts                                                | 
-const variable: number = 1;                          | 
-                                                     | 
-const queryA = graphql(\`                             | 
-  query {                                            | 
-    something(arg: \${variable})                      | 
-  }                                                  | 
-\`);                                                  | 
-                                                     | 
-const queryB = graphql(                              | 
-  \`                                                  | 
-    query {                                          | 
-      something(arg: \${variable})                    | 
-    }                                                | 
-  \`                                                  | 
-);                                                   | 
-                                                     | 
-const queryC = graphql(                              | 
-  'query { something(arg: \${variable}) }'            | 
-);                                                   | 
-\`\`\`                                                  | 
-                                                     | 
 ### svelte                                           | 
                                                      | 
 \`\`\`svelte                                            | 


### PR DESCRIPTION
Reverts graphql/graphiql#3518 which caused a new bug #3542 