### PR TITLE
fix OpenVSX dependency bug by tweaking openvsx publish

### DIFF
--- a/.changeset/warm-cups-explain.md
+++ b/.changeset/warm-cups-explain.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql': patch
+---
+
+Fix OpenVSX build by re-using the vsce build (astro compiler bug)

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -161,7 +161,7 @@
     "vsce:package": "vsce package --yarn",
     "env:source": "export $(cat .envrc | xargs)",
     "vsce:publish": "vsce publish --yarn",
-    "open-vsx:publish": "ovsx publish --yarn -i . --pat $OVSX_PAT",
+    "open-vsx:publish": "ovsx publish --extensionFile $(ls -1 *.vsix | tail -n 1) --pat $OVSX_PAT",
     "release": "npm run vsce:publish && npm run open-vsx:publish"
   },
   "devDependencies": {


### PR DESCRIPTION
I think this will fix the open VSX issue, because as it turns out, `ovsx` cli just uses `vsce` to re-build your project if you don't pass `extensionFile` on `publish`! oops!