### PR TITLE
Allow GraphiQL apps control over closing tabs

### DIFF
--- a/packages/graphiql-react/src/editor/context.tsx
+++ b/packages/graphiql-react/src/editor/context.tsx
@@ -56,6 +56,14 @@ export type EditorContextType = TabsState & {
    */
   changeTab(index: number): void;
   /**
+   * When the user clicks a close tab button, this function is invoked with
+   * the index of the tab that is about to be closed. It returns a promise
+   * that should resolve to `true` (meaning the tab may be closed) or `false`
+   * (meaning the tab may not be closed).
+   * @param index The index of the tab that should be closed.
+   */
+  closeTabConfirmation(index: number): Promise<boolean>;
+  /**
    * Move a tab to a new spot.
    * @param newOrder The new order for the tabs.
    */
@@ -212,6 +220,14 @@ export type EditorContextProviderProps = {
    * @param operationName The operation name after it has been changed.
    */
   onEditOperationName?(operationName: string): void;
+  /**
+   * When the user clicks a close tab button, this function is invoked with
+   * the index of the tab that is about to be closed. It returns a promise
+   * that should resolve to `true` (meaning the tab may be closed) or `false`
+   * (meaning the tab may not be closed).
+   * @param index The index of the tab that should be closed.
+   */
+  confirmCloseTab?(index: number): Promise<boolean>;
   /**
    * Invoked when the state of the tabs changes. Possible triggers are:
    * - Updating any editor contents inside the currently active tab
@@ -422,6 +438,19 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
     [onTabChange, setEditorValues, storeTabs],
   );
 
+  const closeTabConfirmation = useCallback<
+    EditorContextType['closeTabConfirmation']
+  >(
+    async index => {
+      if (props.confirmCloseTab) {
+        const confirmation = await props.confirmCloseTab(index);
+        return confirmation;
+      }
+      return true;
+    },
+    [props.confirmCloseTab],
+  );
+
   const closeTab = useCallback<EditorContextType['closeTab']>(
     index => {
       setTabState(current => {
@@ -497,6 +526,7 @@ export function EditorContextProvider(props: EditorContextProviderProps) {
       addTab,
       changeTab,
       moveTab,
+      closeTabConfirmation,
       closeTab,
       updateActiveTabValues,
 

--- a/packages/graphiql-react/src/provider.tsx
+++ b/packages/graphiql-react/src/provider.tsx
@@ -22,6 +22,7 @@ export type GraphiQLProviderProps = EditorContextProviderProps &
 
 export function GraphiQLProvider({
   children,
+  confirmCloseTab,
   dangerouslyAssumeSchemaIsValid,
   defaultQuery,
   defaultHeaders,
@@ -53,6 +54,7 @@ export function GraphiQLProvider({
     <StorageContextProvider storage={storage}>
       <HistoryContextProvider maxHistoryLength={maxHistoryLength}>
         <EditorContextProvider
+          confirmCloseTab={confirmCloseTab}
           defaultQuery={defaultQuery}
           defaultHeaders={defaultHeaders}
           defaultTabs={defaultTabs}

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -102,6 +102,7 @@ export type GraphiQLProps = Omit<GraphiQLProviderProps, 'children'> &
 
 export function GraphiQL({
   dangerouslyAssumeSchemaIsValid,
+  confirmCloseTab,
   defaultQuery,
   defaultTabs,
   externalFragments,
@@ -138,6 +139,7 @@ export function GraphiQL({
 
   return (
     <GraphiQLProvider
+      confirmCloseTab={confirmCloseTab}
       getDefaultFieldNames={getDefaultFieldNames}
       dangerouslyAssumeSchemaIsValid={dangerouslyAssumeSchemaIsValid}
       defaultQuery={defaultQuery}
@@ -545,11 +547,15 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                             {tab.title}
                           </Tab.Button>
                           <Tab.Close
-                            onClick={() => {
-                              if (editorContext.activeTabIndex === index) {
-                                executionContext.stop();
+                            onClick={async () => {
+                              if (
+                                await editorContext.closeTabConfirmation(index)
+                              ) {
+                                if (editorContext.activeTabIndex === index) {
+                                  executionContext.stop();
+                                }
+                                editorContext.closeTab(index);
                               }
-                              editorContext.closeTab(index);
                             }}
                           />
                         </Tab>


### PR DESCRIPTION
### Allow GraphiQL apps control over closing tabs

This feature is about closing tabs.

Current functionality:
- When closing a tab, it just happens, the tab is removed and all state is gone

Requested functionality
- Have a possibility to at give control back to the user (i.e. the app that mounts the GraphiQL component) if they are OK with closing a particular tab
- This could for instance be an dialogue "Are you sure you want to close the tab?"

In our case, we are working on a Collection plugin that you can click to read saved queries / variables / headers from a DB, and this opens it in a new tab. So we need to sync tabState with the list of Collection items. And if a user starts to change a Collection item, we want to warn the user that changes will be lost.

It is the same as if the user selected a file in a code editor, started to change it, and then tries to close the tab. 

#### Mock screenshots

![Screenshot 2024-03-19 at 16 32 30](https://github.com/graphql/graphiql/assets/2785359/f14781ec-d10e-4670-90b1-3a278df678ed)

![Screenshot 2024-03-19 at 16 32 41](https://github.com/graphql/graphiql/assets/2785359/4a363f72-d6b2-487c-8755-b3482adbcf8c)