### PR TITLE
fix: Stop a tag with href of 'javascript:void 0' from navigating

### DIFF
--- a/.changeset/sharp-rules-hide.md
+++ b/.changeset/sharp-rules-hide.md
@@ -1,0 +1,5 @@
+---
+'codemirror-graphql': patch
+---
+
+tooltip a tag's click listener calls event.preventDefault() to stop navigating away from page

--- a/packages/codemirror-graphql/src/info.ts
+++ b/packages/codemirror-graphql/src/info.ts
@@ -299,6 +299,9 @@ function text(
       // want clicking the node to navigate anywhere.
       node.href = 'javascript:void 0'; // eslint-disable-line no-script-url
       node.addEventListener('click', (e: MouseEvent) => {
+        // Although an href of 'javascript:void 0' should never navigate away from the page,
+        //   that is not always the case: https://github.com/graphql/graphiql/issues/3565
+        e.preventDefault();
         onClick(ref, e);
       });
     } else {


### PR DESCRIPTION
I created #3565 to document a bug that I was only able to reproduce with GraphiQL embedded inside of Grafana. Some behavior or bug in Grafana was causing clicking on an `a` tag with an href of 'javascript:void 0' to navigate away from the page. Although this isn't supposed to happen when the href is 'javascript:void 0', this PR is a one-liner fix to this issue by calling `event.preventDefault()`, which prevents the default behavior of trying to navigate to `javascript:void 0`.

Closes #3565 