### PR TITLE
implement correct merging of incremental respones (@defer/@stream)

### DIFF
--- a/.changeset/clean-pets-dance.md
+++ b/.changeset/clean-pets-dance.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Implement correct merging of incremental responses (@defer/@stream)

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -1,13 +1,17 @@
 import {
   Fetcher,
-  FetcherResultPayload,
   formatError,
   formatResult,
   isAsyncIterable,
   isObservable,
   Unsubscribable,
 } from '@graphiql/toolkit';
-import { ExecutionResult, FragmentDefinitionNode, print } from 'graphql';
+import {
+  ExecutionResult,
+  FragmentDefinitionNode,
+  GraphQLError,
+  print,
+} from 'graphql';
 import { getFragmentDependenciesForAST } from 'graphql-language-service';
 import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import setValue from 'set-value';
@@ -183,7 +187,7 @@ export function ExecutionContextProvider({
     });
 
     try {
-      let fullResponse: FetcherResultPayload = { data: {} };
+      const fullResponse: ExecutionResult = {};
       const handleResponse = (result: ExecutionResult) => {
         // A different query was dispatched in the meantime, so don't
         // show the results of this one.
@@ -202,40 +206,8 @@ export function ExecutionContextProvider({
         }
 
         if (maybeMultipart) {
-          const payload: FetcherResultPayload = {
-            data: fullResponse.data,
-          };
-          const maybeErrors = [
-            ...(fullResponse?.errors || []),
-            ...maybeMultipart.flatMap(i => i.errors).filter(Boolean),
-          ];
-
-          if (maybeErrors.length) {
-            payload.errors = maybeErrors;
-          }
-
           for (const part of maybeMultipart) {
-            // We pull out errors here, so we dont include it later
-            const { path, data, errors, ...rest } = part;
-            if (path) {
-              if (!data) {
-                throw new Error(
-                  `Expected part to contain a data property, but got ${part}`,
-                );
-              }
-
-              setValue(payload.data, path, data, { merge: true });
-            } else if (data) {
-              // If there is no path, we don't know what to do with the payload,
-              // so we just set it.
-              payload.data = data;
-            }
-
-            // Ensures we also bring extensions and alike along for the ride
-            fullResponse = {
-              ...payload,
-              ...rest,
-            };
+            mergeIncrementalResult(fullResponse, part);
           }
 
           setIsFetching(false);
@@ -360,4 +332,61 @@ function tryParseJsonObject({
     throw new Error(errorMessageType);
   }
   return parsed;
+}
+
+type IncrementalResult = {
+  data?: Record<string, unknown> | null;
+  errors?: ReadonlyArray<GraphQLError>;
+  extensions?: Record<string, unknown>;
+  hasNext?: boolean;
+  path?: ReadonlyArray<string | number>;
+  incremental?: ReadonlyArray<IncrementalResult>;
+  label?: string;
+  items?: ReadonlyArray<Record<string, unknown>> | null;
+};
+
+/**
+ * @param executionResult The complete execution result object which will be
+ * mutated by merging the contents of the incremental result.
+ * @param incrementalResult The incremental result that will be merged into the
+ * complete execution result.
+ */
+function mergeIncrementalResult(
+  executionResult: ExecutionResult,
+  incrementalResult: IncrementalResult,
+): void {
+  const path = ['data', ...(incrementalResult.path ?? [])];
+
+  if (incrementalResult.items) {
+    for (const item of incrementalResult.items) {
+      setValue(executionResult, path.join('.'), item);
+      // Increment the last path segment (the array index) to merge the next item at the next index
+      (path.at(-1) as number)++;
+    }
+  }
+
+  if (incrementalResult.data) {
+    setValue(executionResult, path.join('.'), incrementalResult.data, {
+      merge: true,
+    });
+  }
+
+  if (incrementalResult.errors) {
+    executionResult.errors ||= [];
+    (executionResult.errors as GraphQLError[]).push(
+      ...incrementalResult.errors,
+    );
+  }
+
+  if (incrementalResult.extensions) {
+    setValue(executionResult, 'extensions', incrementalResult.extensions, {
+      merge: true,
+    });
+  }
+
+  if (incrementalResult.incremental) {
+    for (const incrementalSubResult of incrementalResult.incremental) {
+      mergeIncrementalResult(executionResult, incrementalSubResult);
+    }
+  }
 }

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -361,7 +361,7 @@ function mergeIncrementalResult(
     for (const item of incrementalResult.items) {
       setValue(executionResult, path.join('.'), item);
       // Increment the last path segment (the array index) to merge the next item at the next index
-      (path.at(-1) as number)++;
+      (path[path.length - 1] as number)++;
     }
   }
 

--- a/packages/graphiql-react/src/execution.tsx
+++ b/packages/graphiql-react/src/execution.tsx
@@ -361,6 +361,7 @@ function mergeIncrementalResult(
     for (const item of incrementalResult.items) {
       setValue(executionResult, path.join('.'), item);
       // Increment the last path segment (the array index) to merge the next item at the next index
+      // eslint-disable-next-line unicorn/prefer-at -- cannot mutate the array using Array.at()
       (path[path.length - 1] as number)++;
     }
   }


### PR DESCRIPTION
Hello fellow GraphiQL friends 👋 

We recently stumbled over the fact that GraphiQL does not yet implement the latest incremental response format for defer/stream, concretely the `incremental` payload property is not handled.

This PR cleans up the merge logic and makes it work for any incremental response payload. (Big inspiration taken from `graphql-tools/utils`, but if felt overkill to add the whole package just for this one utility, and since this is the official reference implementation for a GraphQL IDE it felt appropriate to have that utility as first-class citizen in our code.)

Some before-after illustrations:

| Feature | Before | After |
| --- | --- | --- |
| Defer | ![CleanShot 2024-04-10 at 11 16 14](https://github.com/graphql/graphiql/assets/22288634/086aee26-9fa8-4a2b-955f-7041bf19763f) | ![CleanShot 2024-04-10 at 11 16 55](https://github.com/graphql/graphiql/assets/22288634/bb83dabe-d66b-47b9-8a82-e7736800d9ff) |
| Stream | ![CleanShot 2024-04-10 at 11 16 30](https://github.com/graphql/graphiql/assets/22288634/bac1a4b9-8374-428e-bff9-2ba26a1a5ab0) | ![CleanShot 2024-04-10 at 11 17 13](https://github.com/graphql/graphiql/assets/22288634/0d6b642e-9443-47a8-a52b-d01202fa862b) |
