### PR TITLE
fix TS type of Tooltip.label prop

### DIFF
--- a/.changeset/twenty-chicken-shout.md
+++ b/.changeset/twenty-chicken-shout.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix TypeScript type of the `label` prop of the `Tooltip` component

--- a/packages/graphiql-react/src/ui/tooltip.tsx
+++ b/packages/graphiql-react/src/ui/tooltip.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import * as T from '@radix-ui/react-tooltip';
 import { createComponentGroup } from '../utility/component-group';
 import './tooltip.css';
@@ -9,7 +9,7 @@ export function TooltipRoot({
   side = 'bottom',
   sideOffset = 5,
   label,
-}: T.TooltipContentProps & { label: string }): ReactElement {
+}: T.TooltipContentProps & { label: ReactNode }): ReactElement {
   return (
     <T.Root>
       <T.Trigger asChild>{children}</T.Trigger>


### PR DESCRIPTION
The tooltip can accept any React Node as prop, no need to limit it to only `string`.