### PR TITLE
avoid Component.defaultProps for icon components

### DIFF
--- a/.changeset/nervous-numbers-push.md
+++ b/.changeset/nervous-numbers-push.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Avoid using deprecated Component.defaultProps for icon titles

--- a/packages/graphiql-react/src/icons/index.tsx
+++ b/packages/graphiql-react/src/icons/index.tsx
@@ -74,6 +74,9 @@ function generateIcon(
     .trimStart()
     .toLowerCase() + ' icon',
 ): FC<ComponentProps<'svg'>> {
-  RawComponent.defaultProps = { title };
-  return RawComponent;
+  function IconComponent(props: ComponentProps<'svg'>) {
+    return <RawComponent title={title} {...props} />;
+  }
+  IconComponent.displayName = RawComponent.name;
+  return IconComponent;
 }


### PR DESCRIPTION
Setting `Component.defaultProps` issues some warnings in the console as the feature is considered deprecated. Replacing it with spreading component props with a default value instead.