### PR TITLE
fix: improve handling of tabs scrolling

### DIFF
--- a/.changeset/tabs-enhancements.md
+++ b/.changeset/tabs-enhancements.md
@@ -1,0 +1,7 @@
+---
+"@graphiql/react": patch
+"graphiql": patch
+---
+
+fix: improve tabs scrolling style and usability
+

--- a/packages/graphiql-react/src/ui/tabs.css
+++ b/packages/graphiql-react/src/ui/tabs.css
@@ -2,11 +2,26 @@
   display: flex;
   align-items: center;
   overflow-x: auto;
-  padding: var(--px-12);
+  scrollbar-color: #88888888 transparent;
+  padding: 0 var(--px-12);
+  margin: 0;
 
   & > :not(:first-child) {
     margin-left: var(--px-12);
   }
+}
+
+/* Safari scrollbars */
+.graphiql-tabs::-webkit-scrollbar-track,
+.graphiql-tabs::-webkit-scrollbar {
+  background-color: transparent;
+}
+
+.graphiql-tabs::-webkit-scrollbar-thumb {
+  border-radius: 99px;
+  padding: 3px;
+  box-shadow: inset 0 0 99px 99px #88888888;
+  border: solid 3px transparent;
 }
 
 .graphiql-tab {

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -64,6 +64,7 @@
   margin: var(--px-16);
   margin-left: 0;
   min-width: 0;
+  overflow: hidden;
 }
 
 /* The session header containing tabs and the logo */


### PR DESCRIPTION
The scrollbar for tabs would usually end up being shown behind other UI elements. This change brings the following enhancements:
* reduce tabs height when the scrollbar is shown to fit the scrollbar
* use a transparent scrollbar to look nicer, especially when using dark mode