### PR TITLE
fix doc explorer search input is cut off while clicking on autocomplete results

### DIFF
--- a/.changeset/blue-points-taste.md
+++ b/.changeset/blue-points-taste.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+fix doc explorer search input is cut off while clicking on autocomplete results

--- a/packages/graphiql-react/src/explorer/components/doc-explorer.css
+++ b/packages/graphiql-react/src/explorer/components/doc-explorer.css
@@ -36,7 +36,7 @@
     left: 0;
   }
 
-  & [role='combobox'] {
+  &:not(:focus-within) [role='combobox'] {
     height: 24px;
     width: 4ch;
   }


### PR DESCRIPTION
## before
https://github.com/graphql/graphiql/assets/7361780/2671e217-bfa7-4619-a8b7-6dee9bf97267

## after
https://github.com/graphql/graphiql/assets/7361780/09464327-d2fc-42fa-b52a-e8d8050a4d82

