### PR TITLE
fix: remove schema cache invalidation

### DIFF
--- a/.changeset/spotty-cameras-unite.md
+++ b/.changeset/spotty-cameras-unite.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Fix schema cache invalidation for network schemas

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -706,7 +706,6 @@ export class MessageProcessor {
       await this._invalidateCache({ uri, version }, uri, contents);
       await this._updateFragmentDefinition(uri, contents);
       await this._updateObjectTypeDefinition(uri, contents, project);
-      await this._updateSchemaIfChanged(project, uri);
       return { contents, version };
     } catch {
       return { contents: [], version: 0 };
@@ -1299,27 +1298,6 @@ export class MessageProcessor {
         contents,
       );
     }
-  }
-
-  private async _updateSchemaIfChanged(
-    project: GraphQLProjectConfig,
-    uri: Uri,
-  ): Promise<void> {
-    await Promise.all(
-      unwrapProjectSchema(project).map(async schema => {
-        const schemaFilePath = path.resolve(project.dirpath, schema);
-        const uriFilePath = URI.parse(uri).fsPath;
-        if (uriFilePath === schemaFilePath) {
-          try {
-            const file = await readFile(schemaFilePath, 'utf-8');
-            // only invalidate the schema cache if we can actually parse the file
-            // otherwise, leave the last valid one in place
-            parse(file, { noLocation: true });
-            this._graphQLCache.invalidateSchemaCacheForProject(project);
-          } catch {}
-        }
-      }),
-    );
   }
 
   private async _updateObjectTypeDefinition(


### PR DESCRIPTION
the intention is to ensure that type definitions update, and that the schema cache is not completely invalidated when handling every (watched) file change. the schema cache should now only be invalidated by the lru-cache ttl itself

this should fix #3622 but requires further testing, as there could be other problems with my lru cache implementation here