### PR TITLE
fix: temporarily disable astro parsing again

### DIFF
--- a/.changeset/ten-mangos-judge.md
+++ b/.changeset/ten-mangos-judge.md
@@ -1,0 +1,7 @@
+---
+"graphql-language-service-server": patch
+"graphql-language-service-cli": patch
+"vscode-graphql": patch
+---
+
+Temporarily disable astro support again because of bundling issues

--- a/packages/graphql-language-service-server/src/__tests__/findGraphQLTags.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/findGraphQLTags.test.ts
@@ -559,7 +559,8 @@ export function Example(arg: string) {}`;
     const contents = findGraphQLTags(text, '.svelte');
     expect(contents.length).toEqual(1);
   });
-  it('handles full astro example', () => {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('handles full astro example', () => {
     const text = `
     ---
     const gql = String.raw;

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -58,6 +58,7 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.cts',
   '.mts',
 ] as const;
+
 export type SupportedExtensions = typeof DEFAULT_SUPPORTED_EXTENSIONS;
 export type SupportedExtensionsEnum =
   (typeof DEFAULT_SUPPORTED_EXTENSIONS)[number];

--- a/packages/graphql-language-service-server/src/constants.ts
+++ b/packages/graphql-language-service-server/src/constants.ts
@@ -54,7 +54,7 @@ export const DEFAULT_SUPPORTED_EXTENSIONS = [
   '.tsx',
   '.vue',
   '.svelte',
-  '.astro',
+  // '.astro',
   '.cts',
   '.mts',
 ] as const;

--- a/packages/graphql-language-service-server/src/findGraphQLTags.ts
+++ b/packages/graphql-language-service-server/src/findGraphQLTags.ts
@@ -18,7 +18,7 @@ import { Position, Range } from 'graphql-language-service';
 import { TAG_MAP } from './constants';
 import { ecmaParser, tsParser } from './parsers/babel';
 import { vueParser } from './parsers/vue';
-import { astroParser } from './parsers/astro';
+// import { astroParser } from './parsers/astro';
 import type { Logger, NoopLogger } from './Logger';
 import { RangeMapper } from './parsers/types';
 import { svelteParser } from './parsers/svelte';
@@ -43,7 +43,7 @@ const parserMap = {
   '.mts': tsParser,
   '.svelte': svelteParser,
   '.vue': vueParser,
-  '.astro': astroParser,
+  // '.astro': astroParser,
 };
 
 export function findGraphQLTags(

--- a/packages/graphql-language-service-server/src/parsers/astro.ts
+++ b/packages/graphql-language-service-server/src/parsers/astro.ts
@@ -1,72 +1,72 @@
-import { Position, Range } from 'graphql-language-service';
-import { RangeMapper, SourceParser } from './types';
-import { babelParser } from './babel';
-import { parse } from 'astrojs-compiler-sync';
+// import { Position, Range } from 'graphql-language-service';
+// import { RangeMapper, SourceParser } from './types';
+// import { babelParser } from './babel';
+// import { parse } from 'astrojs-compiler-sync';
 
-// import { teardown } from '@astrojs/compiler/dist/node';
+// // import { teardown } from '@astrojs/compiler/dist/node';
 
-type ParseAstroResult =
-  | { type: 'error'; errors: string[] }
-  | {
-      type: 'ok';
-      scriptOffset: number;
-      scriptAst: any[];
-    };
+// type ParseAstroResult =
+//   | { type: 'error'; errors: string[] }
+//   | {
+//       type: 'ok';
+//       scriptOffset: number;
+//       scriptAst: any[];
+//     };
 
-function parseAstro(source: string): ParseAstroResult {
-  // eslint-disable-next-line unicorn/no-useless-undefined
-  const { ast, diagnostics } = parse(source, undefined);
+// function parseAstro(source: string): ParseAstroResult {
+//   // eslint-disable-next-line unicorn/no-useless-undefined
+//   const { ast, diagnostics } = parse(source, undefined);
 
-  if (diagnostics.some(d => d.severity === /* Error */ 1)) {
-    return {
-      type: 'error',
-      errors: diagnostics.map(d => JSON.stringify(d)),
-    };
-  }
+//   if (diagnostics.some(d => d.severity === /* Error */ 1)) {
+//     return {
+//       type: 'error',
+//       errors: diagnostics.map(d => JSON.stringify(d)),
+//     };
+//   }
 
-  for (const node of ast.children) {
-    if (node.type === 'frontmatter') {
-      try {
-        return {
-          type: 'ok',
-          scriptOffset: (node.position?.start.line ?? 1) - 1,
-          scriptAst: [babelParser(node.value, ['typescript'])],
-        };
-      } catch (error) {
-        return {
-          type: 'error',
-          errors: [String(error)],
-        };
-      }
-    }
-  }
+//   for (const node of ast.children) {
+//     if (node.type === 'frontmatter') {
+//       try {
+//         return {
+//           type: 'ok',
+//           scriptOffset: (node.position?.start.line ?? 1) - 1,
+//           scriptAst: [babelParser(node.value, ['typescript'])],
+//         };
+//       } catch (error) {
+//         return {
+//           type: 'error',
+//           errors: [String(error)],
+//         };
+//       }
+//     }
+//   }
 
-  return { type: 'error', errors: ['Could not find frontmatter block'] };
-}
+//   return { type: 'error', errors: ['Could not find frontmatter block'] };
+// }
 
-export const astroParser: SourceParser = (text, uri, logger) => {
-  const parseAstroResult = parseAstro(text);
-  if (parseAstroResult.type === 'error') {
-    logger.info(
-      `Could not parse the astro file at ${uri} to extract the graphql tags:`,
-    );
-    for (const error of parseAstroResult.errors) {
-      logger.info(String(error));
-    }
-    return null;
-  }
+// export const astroParser: SourceParser = (text, uri, logger) => {
+//   const parseAstroResult = parseAstro(text);
+//   if (parseAstroResult.type === 'error') {
+//     logger.info(
+//       `Could not parse the astro file at ${uri} to extract the graphql tags:`,
+//     );
+//     for (const error of parseAstroResult.errors) {
+//       logger.info(String(error));
+//     }
+//     return null;
+//   }
 
-  const rangeMapper: RangeMapper = range => {
-    return new Range(
-      new Position(
-        range.start.line + parseAstroResult.scriptOffset,
-        range.start.character,
-      ),
-      new Position(
-        range.end.line + parseAstroResult.scriptOffset,
-        range.end.character,
-      ),
-    );
-  };
-  return { asts: parseAstroResult.scriptAst, rangeMapper };
-};
+//   const rangeMapper: RangeMapper = range => {
+//     return new Range(
+//       new Position(
+//         range.start.line + parseAstroResult.scriptOffset,
+//         range.start.character,
+//       ),
+//       new Position(
+//         range.end.line + parseAstroResult.scriptOffset,
+//         range.end.character,
+//       ),
+//     );
+//   };
+//   return { asts: parseAstroResult.scriptAst, rangeMapper };
+// };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16297,7 +16297,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16331,6 +16331,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -16435,7 +16444,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16462,6 +16471,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18457,7 +18473,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18487,6 +18503,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
the astro parsing is not causing the esbuild bundling process to fail, but the resultant `vscode-graphql` bundle does fail on server init

follow up to re-introduce astro support: we need to refactor parseDocument and it's children to be async, and to call this.parse() asynchronously throughout the language server to work around the node worker implementation of this which causes many issues

Note: you cannot re-create this by using the vscode debug runner, but by manually running `vsce:package` and installing the bundled vsix
