### PR TITLE
add `packageManager` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
       "pre-commit": "lint-staged"
     }
   },
-  "engines": {
-    "npm": "please_use_yarn_instead"
-  },
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "build": "yarn build-clean && yarn tsc && yarn build:nontsc",
     "build-bundles": "yarn prebuild-bundles && yarn wsrun:noexamples --stages build-bundles",


### PR DESCRIPTION
corepack report error while installing dependencies

```text
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager

yarn install v1.22.22
```

