### PR TITLE
Remove changeset for astro removal

### DIFF
--- a/.changeset/ten-mangos-judge.md
+++ b/.changeset/ten-mangos-judge.md
@@ -1,7 +1,0 @@
----
-"graphql-language-service-server": patch
-"graphql-language-service-cli": patch
-"vscode-graphql": patch
----
-
-Temporarily disable astro support again because of bundling issues


### PR DESCRIPTION
Now that I've fixed the astro parsing and made the vsix bundle happy, we don't want to clutter the changelog with this confusion