### PR TITLE
[graphiql] move `@graphiql/toolkit` to `devDependecies` because umd build is bundled with all dependencies in one file

### DIFF
--- a/.changeset/loud-cherries-crash.md
+++ b/.changeset/loud-cherries-crash.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+move `@graphiql/toolkit` to `devDependecies` because cdn bundled with all dependencies in one file

--- a/.changeset/loud-cherries-crash.md
+++ b/.changeset/loud-cherries-crash.md
@@ -2,4 +2,4 @@
 'graphiql': patch
 ---
 
-move `@graphiql/toolkit` to `devDependecies` because cdn bundled with all dependencies in one file
+move `@graphiql/toolkit` to `devDependecies` because umd build is bundled with all dependencies in one file

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -47,8 +47,7 @@
     "webpack": "webpack-cli --config resources/webpack.config.js"
   },
   "dependencies": {
-    "@graphiql/react": "^0.23.0",
-    "@graphiql/toolkit": "^0.9.2"
+    "@graphiql/react": "^0.23.0"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0",
@@ -56,6 +55,7 @@
     "react-dom": "^16.8.0 || ^17 || ^18"
   },
   "devDependencies": {
+    "@graphiql/toolkit": "^0.9.2",
     "@cypress/webpack-preprocessor": "^5.5.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",


### PR DESCRIPTION
after https://github.com/graphql/graphiql/pull/3655#issuecomment-2262788115 I realized that there is no need to have `@graphiql/toolkit` in `dependencies` too