### PR TITLE
[v4] remove `GraphiQLLogo.displayName`, `GraphiQLToolbar.displayName` and `GraphiQLFooter.displayName`

### DIFF
--- a/.changeset/popular-llamas-think.md
+++ b/.changeset/popular-llamas-think.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+remove `GraphiQLLogo.displayName`, `GraphiQLToolbar.displayName` and `GraphiQLFooter.displayName`

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -946,22 +946,16 @@ function GraphiQLLogo<TProps>(props: PropsWithChildren<TProps>) {
   );
 }
 
-GraphiQLLogo.displayName = 'GraphiQLLogo';
-
 // Configure the UI by providing this Component as a child of GraphiQL.
 function GraphiQLToolbar<TProps>(props: PropsWithChildren<TProps>) {
   // eslint-disable-next-line react/jsx-no-useless-fragment
   return <>{props.children}</>;
 }
 
-GraphiQLToolbar.displayName = 'GraphiQLToolbar';
-
 // Configure the UI by providing this Component as a child of GraphiQL.
 function GraphiQLFooter<TProps>(props: PropsWithChildren<TProps>) {
   return <div className="graphiql-footer">{props.children}</div>;
 }
-
-GraphiQLFooter.displayName = 'GraphiQLFooter';
 
 // Determines if the React child is of the same type of the provided React component
 function isChildComponentType<T extends ComponentType>(


### PR DESCRIPTION
they don't use `forwardRef`, so this is not needed