### PR TITLE
[v4] show tabs even there is only 1 tab

### DIFF
--- a/.changeset/few-steaks-clap.md
+++ b/.changeset/few-steaks-clap.md
@@ -1,0 +1,5 @@
+---
+'graphiql': major
+---
+
+show tabs even there is only 1 tab

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -68,7 +68,6 @@
   /* Layout */
   --sidebar-width: 60px;
   --toolbar-width: 40px;
-  --session-header-height: 38.5px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/graphiql/cypress/e2e/tabs.cy.ts
+++ b/packages/graphiql/cypress/e2e/tabs.cy.ts
@@ -67,8 +67,8 @@ describe('Tabs', () => {
     // Close tab
     cy.get('#graphiql-session-tab-1 + .graphiql-tab-close').click();
 
-    // Assert that no tab visible when there's only one session
-    cy.get('#graphiql-session-tab-0').should('not.exist');
+    // Assert that tab close button not visible when there is only 1 tab
+    cy.get('#graphiql-session-tab-0 + .graphiql-tab-close').should('not.exist');
 
     // Assert editor values
     cy.assertHasValues({

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -538,7 +538,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                 onReorder={handleReorder}
                 aria-label="Select active operation"
               >
-                {editorContext.tabs.map((tab, index) => (
+                {editorContext.tabs.map((tab, index, tabs) => (
                   <Tab
                     key={tab.id}
                     value={tab}
@@ -556,14 +556,16 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                         {tab.title}
                       </Tab.Button>
                     </Tooltip>
-                    <Tab.Close
-                      onClick={() => {
-                        if (editorContext.activeTabIndex === index) {
-                          executionContext.stop();
-                        }
-                        editorContext.closeTab(index);
-                      }}
-                    />
+                    {tabs.length > 1 && (
+                      <Tab.Close
+                        onClick={() => {
+                          if (editorContext.activeTabIndex === index) {
+                            executionContext.stop();
+                          }
+                          editorContext.closeTab(index);
+                        }}
+                      />
+                    )}
                   </Tab>
                 ))}
               </Tabs>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -454,69 +454,63 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
     }
   }, []);
 
-  const hasMultipleTabs = editorContext.tabs.length > 1;
-
   const className = props.className ? ` ${props.className}` : '';
 
   return (
     <Tooltip.Provider>
       <div className={`graphiql-container${className}`}>
         <div className="graphiql-sidebar">
-          <div className="graphiql-sidebar-section">
-            {pluginContext?.plugins.map((plugin, index) => {
-              const isVisible = plugin === pluginContext.visiblePlugin;
-              const label = `${isVisible ? 'Hide' : 'Show'} ${plugin.title}`;
-              const Icon = plugin.icon;
-              return (
-                <Tooltip key={plugin.title} label={label}>
-                  <UnStyledButton
-                    type="button"
-                    className={isVisible ? 'active' : ''}
-                    onClick={handlePluginClick}
-                    data-index={index}
-                    aria-label={label}
-                  >
-                    <Icon aria-hidden="true" />
-                  </UnStyledButton>
-                </Tooltip>
-              );
-            })}
-          </div>
-          <div className="graphiql-sidebar-section">
-            <Tooltip label="Re-fetch GraphQL schema">
-              <UnStyledButton
-                type="button"
-                disabled={schemaContext.isFetching}
-                onClick={handleRefetchSchema}
-                aria-label="Re-fetch GraphQL schema"
-              >
-                <ReloadIcon
-                  className={schemaContext.isFetching ? 'graphiql-spin' : ''}
-                  aria-hidden="true"
-                />
-              </UnStyledButton>
-            </Tooltip>
-            <Tooltip label="Open short keys dialog">
-              <UnStyledButton
-                type="button"
-                data-value="short-keys"
-                onClick={handleShowDialog}
-                aria-label="Open short keys dialog"
-              >
-                <KeyboardShortcutIcon aria-hidden="true" />
-              </UnStyledButton>
-            </Tooltip>
-            <Tooltip label="Open settings dialog">
-              <UnStyledButton
-                type="button"
-                data-value="settings"
-                onClick={handleShowDialog}
-                aria-label="Open settings dialog"
-              >
-                <SettingsIcon aria-hidden="true" />
-              </UnStyledButton>
-            </Tooltip>
-          </div>
+          {pluginContext?.plugins.map((plugin, index) => {
+            const isVisible = plugin === pluginContext.visiblePlugin;
+            const label = `${isVisible ? 'Hide' : 'Show'} ${plugin.title}`;
+            return (
+              <Tooltip key={plugin.title} label={label}>
+                <UnStyledButton
+                  type="button"
+                  className={isVisible ? 'active' : ''}
+                  onClick={handlePluginClick}
+                  data-index={index}
+                  aria-label={label}
+                >
+                  <plugin.icon aria-hidden="true" />
+                </UnStyledButton>
+              </Tooltip>
+            );
+          })}
+          <Tooltip label="Re-fetch GraphQL schema">
+            <UnStyledButton
+              type="button"
+              disabled={schemaContext.isFetching}
+              onClick={handleRefetchSchema}
+              aria-label="Re-fetch GraphQL schema"
+              style={{ marginTop: 'auto' }}
+            >
+              <ReloadIcon
+                className={schemaContext.isFetching ? 'graphiql-spin' : ''}
+                aria-hidden="true"
+              />
+            </UnStyledButton>
+          </Tooltip>
+          <Tooltip label="Open short keys dialog">
+            <UnStyledButton
+              type="button"
+              data-value="short-keys"
+              onClick={handleShowDialog}
+              aria-label="Open short keys dialog"
+            >
+              <KeyboardShortcutIcon aria-hidden="true" />
+            </UnStyledButton>
+          </Tooltip>
+          <Tooltip label="Open settings dialog">
+            <UnStyledButton
+              type="button"
+              data-value="settings"
+              onClick={handleShowDialog}
+              aria-label="Open settings dialog"
+            >
+              <SettingsIcon aria-hidden="true" />
+            </UnStyledButton>
+          </Tooltip>
         </div>
         <div className="graphiql-main">
           <div
@@ -539,41 +533,40 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
           )}
           <div ref={pluginResize.secondRef} className="graphiql-sessions">
             <div className="graphiql-session-header">
-              {hasMultipleTabs && (
-                <Tabs
-                  values={editorContext.tabs}
-                  onReorder={handleReorder}
-                  aria-label="Select active operation"
-                >
-                  {editorContext.tabs.map((tab, index) => (
-                    <Tooltip key={tab.id} label={tab.title}>
-                      <Tab
-                        value={tab}
-                        isActive={index === editorContext.activeTabIndex}
+              <Tabs
+                values={editorContext.tabs}
+                onReorder={handleReorder}
+                aria-label="Select active operation"
+              >
+                {editorContext.tabs.map((tab, index) => (
+                  <Tab
+                    key={tab.id}
+                    value={tab}
+                    isActive={index === editorContext.activeTabIndex}
+                  >
+                    <Tooltip label={tab.title}>
+                      <Tab.Button
+                        aria-controls="graphiql-session"
+                        id={`graphiql-session-tab-${index}`}
+                        onClick={() => {
+                          executionContext.stop();
+                          editorContext.changeTab(index);
+                        }}
                       >
-                        <Tab.Button
-                          aria-controls="graphiql-session"
-                          id={`graphiql-session-tab-${index}`}
-                          onClick={() => {
-                            executionContext.stop();
-                            editorContext.changeTab(index);
-                          }}
-                        >
-                          {tab.title}
-                        </Tab.Button>
-                        <Tab.Close
-                          onClick={() => {
-                            if (editorContext.activeTabIndex === index) {
-                              executionContext.stop();
-                            }
-                            editorContext.closeTab(index);
-                          }}
-                        />
-                      </Tab>
+                        {tab.title}
+                      </Tab.Button>
                     </Tooltip>
-                  ))}
-                </Tabs>
-              )}
+                    <Tab.Close
+                      onClick={() => {
+                        if (editorContext.activeTabIndex === index) {
+                          executionContext.stop();
+                        }
+                        editorContext.closeTab(index);
+                      }}
+                    />
+                  </Tab>
+                ))}
+              </Tabs>
               <Tooltip label="New tab">
                 <UnStyledButton
                   type="button"
@@ -593,17 +586,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
               aria-labelledby={`graphiql-session-tab-${editorContext.activeTabIndex}`}
             >
               <div ref={editorResize.firstRef}>
-                <div
-                  className="graphiql-editors"
-                  style={
-                    hasMultipleTabs
-                      ? { borderTopLeftRadius: 0, borderTopRightRadius: 0 }
-                      : {
-                          marginTop:
-                            'calc(var(--px-8) - var(--session-header-height))',
-                        }
-                  }
-                >
+                <div className="graphiql-editors">
                   <div ref={editorToolsResize.firstRef}>
                     <section
                       className="graphiql-query-editor"

--- a/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/components/__tests__/GraphiQL.spec.tsx
@@ -410,13 +410,13 @@ describe('GraphiQL', () => {
   });
 
   describe('Tabs', () => {
-    it('show tabs if there are more than one', async () => {
+    it('show tabs', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-        ).toHaveLength(0);
+        ).toHaveLength(1);
       });
 
       act(() => {
@@ -492,7 +492,7 @@ describe('GraphiQL', () => {
       await waitFor(() => {
         expect(
           container.querySelectorAll('.graphiql-tabs .graphiql-tab'),
-        ).toHaveLength(0);
+        ).toHaveLength(1);
         expect(
           container.querySelectorAll('.graphiql-tab .graphiql-tab-close'),
         ).toHaveLength(0);

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -16,32 +16,24 @@
 .graphiql-container .graphiql-sidebar {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   padding: var(--px-8);
   width: var(--sidebar-width);
-}
-
-.graphiql-container .graphiql-sidebar .graphiql-sidebar-section {
-  display: flex;
-  flex-direction: column;
   gap: var(--px-8);
+  overflow-y: scroll;
 }
 
-.graphiql-container .graphiql-sidebar button {
+.graphiql-container .graphiql-sidebar > button {
   display: flex;
   align-items: center;
   justify-content: center;
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   height: calc(var(--sidebar-width) - (2 * var(--px-8)));
   width: calc(var(--sidebar-width) - (2 * var(--px-8)));
+  flex-shrink: 0;
 }
 
 .graphiql-container .graphiql-sidebar button.active {
   color: hsl(var(--color-neutral));
-}
-
-.graphiql-container .graphiql-sidebar button:not(:first-child) {
-  margin-top: var(--px-4);
 }
 
 .graphiql-container .graphiql-sidebar button > svg {
@@ -75,7 +67,6 @@
   align-items: center;
   display: flex;
   justify-content: flex-end;
-  height: var(--session-header-height);
   padding: var(--px-8) var(--px-8) 0;
   gap: var(--px-8);
 
@@ -121,7 +112,7 @@ button.graphiql-tab-add {
 /* All editors (query, variable, headers) */
 .graphiql-container .graphiql-editors {
   background-color: hsl(var(--color-base));
-  border-radius: var(--border-radius-12);
+  border-radius: 0 0 var(--border-radius-12) var(--border-radius-12);
   box-shadow: var(--popover-box-shadow);
   display: flex;
   flex: 1;
@@ -141,10 +132,13 @@ button.graphiql-tab-add {
 /* The vertical toolbar next to the query editor */
 .graphiql-container .graphiql-toolbar {
   width: var(--toolbar-width);
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-8);
 }
 
-.graphiql-container .graphiql-toolbar > * + * {
-  margin-top: var(--px-8);
+.graphiql-container .graphiql-toolbar > button {
+  flex-shrink: 0;
 }
 
 /* The toolbar icons */

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -66,13 +66,8 @@
 .graphiql-container .graphiql-session-header {
   align-items: center;
   display: flex;
-  justify-content: flex-end;
   padding: var(--px-8) var(--px-8) 0;
   gap: var(--px-8);
-
-  .graphiql-tabs + .graphiql-tab-add {
-    margin-right: auto;
-  }
 }
 
 /* The button to add a new tab */
@@ -88,6 +83,7 @@ button.graphiql-tab-add {
 
 /* The GraphiQL logo */
 .graphiql-container .graphiql-logo {
+  margin-left: auto;
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   font-size: var(--font-size-h4);
   font-weight: var(--font-weight-medium);


### PR DESCRIPTION
it's hard to find `Add tab` when there is only 1 tab

![deploy-preview-3685--graphiql-test netlify app__query=%23%20Welcome%20to%20GraphiQL%0A%23%0A%23%20GraphiQL%20is%20an%20in-browser%20tool%20for%20writing%2C%20validating%2C%20and%0A%23%20testing%20GraphQL%20queries %0A%23%0A%23%20Type%20quer](https://github.com/user-attachments/assets/6410dc8d-77bf-41bf-886c-c24eaab14c03)

I think we should follow Chrome UX and show tabs even when there is 1 tab

![deploy-preview-3713--graphiql-test netlify app__query=%23%20Welcome%20to%20GraphiQL%0A%23%0A%23%20GraphiQL%20is%20an%20in-browser%20tool%20for%20writing%2C%20validating%2C%20and%0A%23%20testing%20GraphQL%20queries %0A%23%0A%23%20Type%20quer](https://github.com/user-attachments/assets/3a82a7b9-4fba-4a9d-aebd-fd65bd5a2ffd)