### PR TITLE
fix failed tests from `MessageProcessor.spec.ts` on MacOS

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
@@ -1,11 +1,11 @@
+import { readFile, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import mockfs from 'mock-fs';
-import { join } from 'node:path';
 import { MockFile, MockProject } from './__utils__/MockProject';
-// import { readFileSync } from 'node:fs';
 import { FileChangeType } from 'vscode-languageserver';
 import { serializeRange } from './__utils__/utils';
-import { readFile } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { URI } from 'vscode-uri';
 import {
   GraphQLSchema,
@@ -64,8 +64,14 @@ const fooInlineTypePosition = {
   end: { line: 5, character: 24 },
 };
 
-const genSchemaPath =
-  '/tmp/graphql-language-service/test/projects/default/generated-schema.graphql';
+const genSchemaPath = path.join(
+  tmpdir(),
+  'graphql-language-service',
+  'test',
+  'projects',
+  'default',
+  'generated-schema.graphql',
+);
 
 // TODO:
 // - reorganize into multiple files
@@ -76,10 +82,18 @@ const genSchemaPath =
 // - fix TODO comments where bugs were found that couldn't be resolved quickly (2-4hr time box)
 
 describe('MessageProcessor with no config', () => {
+  beforeAll(async () => {
+    await rm(path.join(tmpdir(), 'graphql-language-service'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
   afterEach(() => {
     mockfs.restore();
     fetchMock.restore();
   });
+
   it('fails to initialize with empty config file', async () => {
     const project = new MockProject({
       files: [...defaultFiles, ['graphql.config.json', '']],
@@ -97,6 +111,7 @@ describe('MessageProcessor with no config', () => {
     expect(project.lsp._isGraphQLConfigMissing).toEqual(true);
     project.lsp.handleShutdownRequest();
   });
+
   it('fails to initialize with no config file present', async () => {
     const project = new MockProject({
       files: [...defaultFiles],
@@ -113,6 +128,7 @@ describe('MessageProcessor with no config', () => {
     expect(project.lsp._isGraphQLConfigMissing).toEqual(true);
     project.lsp.handleShutdownRequest();
   });
+
   it('initializes when presented with a valid config later', async () => {
     const project = new MockProject({
       files: [...defaultFiles],
@@ -144,13 +160,7 @@ describe('MessageProcessor with config', () => {
     mockfs.restore();
     fetchMock.restore();
   });
-  // beforeAll(async () => {
-  //   app = await import('../../../graphiql/test/e2e-server');
-  // });
-  // afterAll(() => {
-  //   app.server.close();
-  //   app.wsServer.close();
-  // });
+
   it('caches files and schema with .graphql file config, and the schema updates with watched file changes', async () => {
     const project = new MockProject({
       files: [
@@ -250,14 +260,7 @@ describe('MessageProcessor with config', () => {
       // now Foo has a bad field, the fragment should be invalid
       'type Query { foo: Foo, test: Test }\n\n type Test { test: String }\n\n\n\n\n\ntype Foo { bad: Int }',
     );
-    // await project.lsp.handleWatchedFilesChangedNotification({
-    //   changes: [
-    //     {
-    //       type: FileChangeType.Changed,
-    //       uri: project.uri('schema.graphql'),
-    //     },
-    //   ],
-    // });
+
     await project.lsp.handleDidChangeNotification({
       contentChanges: [
         {
@@ -290,7 +293,7 @@ describe('MessageProcessor with config', () => {
     expect(result.diagnostics[0].message).toEqual(
       'Cannot query field "bar" on type "Foo". Did you mean "bad"?',
     );
-    const generatedFile = existsSync(join(genSchemaPath));
+    const generatedFile = existsSync(genSchemaPath);
     // this generated file should not exist because the schema is local!
     expect(generatedFile).toEqual(false);
     // simulating codegen
@@ -376,7 +379,6 @@ describe('MessageProcessor with config', () => {
         ],
       ],
     });
-
     const initParams = await project.init('query.graphql');
     expect(project.lsp._logger.error).not.toHaveBeenCalled();
 
@@ -392,7 +394,7 @@ describe('MessageProcessor with config', () => {
     expect(await project.lsp._graphQLCache.getSchema('default')).toBeDefined();
 
     // schema file is present and contains schema
-    const file = await readFile(join(genSchemaPath), { encoding: 'utf-8' });
+    const file = await readFile(genSchemaPath, 'utf8');
     expect(file.split('\n').length).toBeGreaterThan(10);
 
     // hover works
@@ -426,7 +428,6 @@ describe('MessageProcessor with config', () => {
       textDocument: { uri: project.uri('fragments.graphql') },
       position: { character: 15, line: 0 },
     });
-
     expect(typeDefinitions[0].uri).toEqual(URI.parse(genSchemaPath).toString());
 
     expect(serializeRange(typeDefinitions[0].range)).toEqual({
@@ -560,9 +561,7 @@ describe('MessageProcessor with config', () => {
       (await project.lsp._graphQLCache.getSchema('a')).getType('example100'),
     ).toBeTruthy();
     await sleep(1000);
-    const file = await readFile(join(genSchemaPath.replace('default', 'a')), {
-      encoding: 'utf-8',
-    });
+    const file = await readFile(genSchemaPath.replace('default', 'a'), 'utf8');
     expect(file).toContain('example100');
     // add a new typescript file with empty query to the b project
     // and expect autocomplete to only show options for project b


### PR DESCRIPTION
I had always failed tests on my machine

![image](https://github.com/user-attachments/assets/d4edf26b-c101-4649-a20c-3f9a82756fe4)

after investigation, I found that `genSchemaPath` doesn't include `os.tempdir()` but on CI it pass

https://github.com/graphql/graphiql/blob/7404e8e6c62b06107f452142493297ec70f1649c/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts#L67-L68

![image](https://github.com/user-attachments/assets/85f2fba9-03e9-4b54-9f88-4c6de035386f)

сс @acao 