### PR TITLE
[v4] polish `tabs.cy` tests, remove `.graphiql-session` class

### DIFF
--- a/.changeset/old-zebras-knock.md
+++ b/.changeset/old-zebras-knock.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+remove `.graphiql-session` class

--- a/.changeset/shaggy-rice-doubt.md
+++ b/.changeset/shaggy-rice-doubt.md
@@ -1,5 +1,0 @@
----
-'graphiql': minor
----
-
-remove `id="graphiql-session"` html attribute

--- a/.changeset/shaggy-rice-doubt.md
+++ b/.changeset/shaggy-rice-doubt.md
@@ -2,4 +2,4 @@
 'graphiql': minor
 ---
 
-remove `id="graphiql-session-tab-{index}"` and `id="graphiql-session"` html attributes
+remove `id="graphiql-session"` html attribute

--- a/.changeset/shaggy-rice-doubt.md
+++ b/.changeset/shaggy-rice-doubt.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+remove `id="graphiql-session-tab-{index}"` and `id="graphiql-session"` html attributes

--- a/packages/graphiql/cypress/e2e/tabs.cy.ts
+++ b/packages/graphiql/cypress/e2e/tabs.cy.ts
@@ -2,8 +2,8 @@ describe('Tabs', () => {
   it('Should store editor contents when switching between tabs', () => {
     cy.visit('/?query=');
 
-    // Assert that no tab visible when there's only one session
-    cy.get('#graphiql-session-tab-0').should('not.exist');
+    // Assert that tab visible when there's only one session
+    cy.get('.graphiql-tab-button').eq(0).should('exist');
 
     // Enter a query without operation name
     cy.get('.graphiql-query-editor textarea').type('{id', { force: true });
@@ -18,7 +18,7 @@ describe('Tabs', () => {
     cy.get('.graphiql-query-editor textarea').type('query Foo {image', {
       force: true,
     });
-    cy.get('#graphiql-session-tab-1').should('have.text', 'Foo');
+    cy.get('.graphiql-tab-button').eq(1).should('have.text', 'Foo');
 
     // Enter variables
     cy.get('.graphiql-editor-tool textarea')
@@ -35,11 +35,11 @@ describe('Tabs', () => {
     cy.clickExecuteQuery();
 
     // Switch back to the first tab
-    cy.get('#graphiql-session-tab-0').click();
+    cy.get('.graphiql-tab-button').eq(0).click();
 
     // Assert tab titles
-    cy.get('#graphiql-session-tab-0').should('have.text', '<untitled>');
-    cy.get('#graphiql-session-tab-1').should('have.text', 'Foo');
+    cy.get('.graphiql-tab-button').eq(0).should('have.text', '<untitled>');
+    cy.get('.graphiql-tab-button').eq(1).should('have.text', 'Foo');
 
     // Assert editor values
     cy.assertHasValues({
@@ -50,11 +50,11 @@ describe('Tabs', () => {
     });
 
     // Switch back to the second tab
-    cy.get('#graphiql-session-tab-1').click();
+    cy.get('.graphiql-tab-button').eq(1).click();
 
     // Assert tab titles
-    cy.get('#graphiql-session-tab-0').should('have.text', '<untitled>');
-    cy.get('#graphiql-session-tab-1').should('have.text', 'Foo');
+    cy.get('.graphiql-tab-button').eq(0).should('have.text', '<untitled>');
+    cy.get('.graphiql-tab-button').eq(1).should('have.text', 'Foo');
 
     // Assert editor values
     cy.assertHasValues({
@@ -65,10 +65,10 @@ describe('Tabs', () => {
     });
 
     // Close tab
-    cy.get('#graphiql-session-tab-1 + .graphiql-tab-close').click();
+    cy.get('.graphiql-tab-button + .graphiql-tab-close').eq(1).click();
 
     // Assert that tab close button not visible when there is only 1 tab
-    cy.get('#graphiql-session-tab-0 + .graphiql-tab-close').should('not.exist');
+    cy.get('.graphiql-tab-button + .graphiql-tab-close').should('not.exist');
 
     // Assert editor values
     cy.assertHasValues({

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -569,8 +569,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             </div>
             <div
               role="tabpanel"
-              id="graphiql-session"
-              className="graphiql-session"
+              id="graphiql-session" // used by aria-controls="graphiql-session"
               aria-labelledby={`graphiql-session-tab-${editorContext.activeTabIndex}`}
             >
               <div ref={editorResize.firstRef}>

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -569,6 +569,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             </div>
             <div
               role="tabpanel"
+              id="graphiql-session"
               className="graphiql-session"
               aria-labelledby={`graphiql-session-tab-${editorContext.activeTabIndex}`}
             >

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -533,6 +533,7 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   >
                     <Tab.Button
                       aria-controls="graphiql-session"
+                      id={`graphiql-session-tab-${index}`}
                       title={tab.title}
                       onClick={() => {
                         executionContext.stop();

--- a/packages/graphiql/src/components/GraphiQL.tsx
+++ b/packages/graphiql/src/components/GraphiQL.tsx
@@ -533,7 +533,6 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
                   >
                     <Tab.Button
                       aria-controls="graphiql-session"
-                      id={`graphiql-session-tab-${index}`}
                       title={tab.title}
                       onClick={() => {
                         executionContext.stop();
@@ -569,7 +568,6 @@ export function GraphiQLInterface(props: GraphiQLInterfaceProps) {
             </div>
             <div
               role="tabpanel"
-              id="graphiql-session"
               className="graphiql-session"
               aria-labelledby={`graphiql-session-tab-${editorContext.activeTabIndex}`}
             >

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -103,7 +103,7 @@ button.graphiql-tab-add {
 }
 
 /* The editor of the session */
-.graphiql-container .graphiql-session {
+.graphiql-container #graphiql-session {
   display: flex;
   flex: 1;
   padding: 0 var(--px-8) var(--px-8);


### PR DESCRIPTION
<s>I firstly did mistake and remove `#graphiql-session` id, I was thinking it nowhere used</s> but it was used by `aria-controls="graphiql-session"`