### PR TITLE
feat(graphql-language-service): Support for experimental fragment arguments

### DIFF
--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions-test.ts
@@ -397,6 +397,7 @@ describe('getAutocompleteSuggestions', () => {
         },
       ]);
     });
+
     const metaArgs = [
       {
         label: '__DirectiveLocation',
@@ -409,6 +410,7 @@ describe('getAutocompleteSuggestions', () => {
           'An enum describing what kind of type a given `__Type` is.',
       },
     ];
+
     it('provides correct input type suggestions', () => {
       const result = testSuggestions(
         'query($exampleVariable: ) { ',
@@ -421,6 +423,45 @@ describe('getAutocompleteSuggestions', () => {
         { label: 'InputType' },
         { label: 'Int', documentation: GraphQLInt.description },
         { label: 'String', documentation: GraphQLString.description },
+      ]);
+    });
+    
+    it('provides correct input type suggestions for fragments', () => {
+      const result = testSuggestions(
+        'fragment someFragment($exampleVariable: ) on Type { ',
+        new Position(0, 41),
+      );
+      expect(result).toEqual([
+        ...metaArgs,
+        { label: 'Boolean', documentation: GraphQLBoolean.description },
+        { label: 'Episode' },
+        { label: 'InputType' },
+        { label: 'Int', documentation: GraphQLInt.description },
+        { label: 'String', documentation: GraphQLString.description },
+      ]);
+    });
+    
+    it.skip('provides correct argument suggestions for fragment-spreads', () => {
+      const externalFragments = parse(`
+        fragment CharacterDetails($someVariable: Int) on Human {
+          name
+        }
+      `, {experimentalFragmentVariables:true}).definitions as FragmentDefinitionNode[];
+
+      const result = testSuggestions(
+        'query { human(id: "1") { ...CharacterDetails() }}',
+        new Position(0, 46),
+        externalFragments,
+      );
+
+      expect(result).toEqual([
+        {
+          label: 'someVariable',
+          insertText: 'someVariable: ',
+          command: suggestionCommand,
+          insertTextFormat: 2,
+          labelDetails: { detail: ' Int' },
+        },
       ]);
     });
 

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -422,6 +422,7 @@ export function getAutocompleteSuggestions(
   if (
     (kind === RuleKinds.VARIABLE_DEFINITION && step === 2) ||
     (kind === RuleKinds.LIST_TYPE && step === 1) ||
+    (kind === RuleKinds.FRAGMENT_DEFINITION && step === 3) ||
     (kind === RuleKinds.NAMED_TYPE &&
       prevState &&
       (prevState.kind === RuleKinds.VARIABLE_DEFINITION ||

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -143,7 +143,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
 
   Arguments: [p('('), list('Argument'), p(')')],
   Argument: [name('attribute'), p(':'), 'Value'],
-  FragmentSpread: [p('...'), name('def'), list('Directive')],
+  FragmentSpread: [p('...'), name('def'), opt('Arguments'), list('Directive')],
   InlineFragment: [
     p('...'),
     opt('TypeCondition'),
@@ -154,6 +154,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
   FragmentDefinition: [
     word('fragment'),
     opt(butNot(name('def'), [word('on')])),
+    opt('VariableDefinitions'),
     'TypeCondition',
     list('Directive'),
     'SelectionSet',

--- a/packages/graphql-language-service/src/parser/getTypeInfo.ts
+++ b/packages/graphql-language-service/src/parser/getTypeInfo.ts
@@ -178,6 +178,9 @@ export function getTypeInfo(
               argDefs =
                 directiveDef && (directiveDef.args as GraphQLArgument[]);
               break;
+            case RuleKinds.FRAGMENT_SPREAD:
+              // TODO: lookup fragment and return variable definitions (?)
+              break;
             // TODO: needs more tests
             case RuleKinds.ALIASED_FIELD: {
               const name = state.prevState?.name;

--- a/packages/graphql-language-service/src/utils/validateWithCustomRules.ts
+++ b/packages/graphql-language-service/src/utils/validateWithCustomRules.ts
@@ -10,6 +10,7 @@
 import {
   ValidationRule,
   DocumentNode,
+  // TODO: this should contain fragment-arguments rules
   specifiedRules,
   validate,
   GraphQLError,


### PR DESCRIPTION
This is a work in progress branch for:

- Spec: https://github.com/graphql/graphql-spec/pull/1081
- Reference implementation: https://github.com/graphql/graphql-js/pull/4015

Being able to finish auto-complete and validation will depend on getting an alpha published as we need `parse` to behave well. The steps included in finishing this would be to add an auto-complete step for fragment arguments where we look up all fragments and check the available arguments so we can auto-complete.