### PR TITLE
switch back to graphql-http

### DIFF
--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -98,7 +98,6 @@ describe('GraphQL DocExplorer - deprecated fields', () => {
 
 let describeOrSkip = describe.skip;
 
-// TODO: disable when defer/stream is merged to graphql
 if (!version.includes('15.5')) {
   describeOrSkip = describe;
 }

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -68,7 +68,7 @@
     "express": "^4.19.2",
     "fork-ts-checker-webpack-plugin": "7.3.0",
     "graphql": "^16.9.0",
-    "graphql-helix": "^1.13.0",
+    "graphql-http": "^1.22.1",
     "graphql-subscriptions": "^2.0.0",
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",

--- a/packages/graphiql/test/beforeDevServer.js
+++ b/packages/graphiql/test/beforeDevServer.js
@@ -7,7 +7,6 @@
 
 const express = require('express');
 const path = require('node:path');
-// eslint-disable-next-line import-x/no-extraneous-dependencies
 const { createHandler } = require('graphql-http/lib/use/express');
 const schema = require('./schema');
 const { customExecute } = require('./execute');

--- a/packages/graphiql/test/e2e-server.js
+++ b/packages/graphiql/test/e2e-server.js
@@ -9,38 +9,14 @@
 const { createServer } = require('node:http');
 const express = require('express');
 const path = require('node:path');
-const {
-  getGraphQLParameters,
-  processRequest,
-  sendResult,
-} = require('graphql-helix'); // update when `graphql-http` is upgraded to support multipart requests for incremental delivery https://github.com/graphql/graphiql/pull/3682#discussion_r1715545279
+const { createHandler } = require('graphql-http/lib/use/express');
 const WebSocketsServer = require('./afterDevServer');
 const schema = require('./schema');
 const { customExecute } = require('./execute');
 
 const app = express();
 
-async function handler(req, res) {
-  const request = {
-    body: req.body,
-    headers: req.headers,
-    method: req.method,
-    query: req.query,
-  };
-
-  const { operationName, query, variables } = getGraphQLParameters(request);
-
-  const result = await processRequest({
-    operationName,
-    query,
-    variables,
-    request,
-    schema,
-    execute: customExecute,
-  });
-
-  sendResult(result, res);
-}
+const handler = createHandler({ schema, execute: customExecute });
 
 // Server
 app.use(express.json());

--- a/yarn.lock
+++ b/yarn.lock
@@ -10509,11 +10509,6 @@ graphql-config@5.0.3:
     string-env-interpolation "^1.0.1"
     tslib "^2.4.0"
 
-graphql-helix@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/graphql-helix/-/graphql-helix-1.13.0.tgz#e64dad5ef5f622ef38c97fa033f56f3d953c0104"
-  integrity sha512-cqDKMoRywKjnL0ZWCTB0GOiBgsH6d3nU4JGDF6RuzAyd35tmalzKpSxkx3NNp4H5RvnKWnrukWzR51wUq277ng==
-
 graphql-http@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/graphql-http/-/graphql-http-1.22.1.tgz#3857ac75366e55db189cfe09ade9cc4c4f2cfd09"


### PR DESCRIPTION
since we have rolled back to graphql@16 we are no longer testing incremental delivery and do not need to use graphql-helix for incremental delivery.