### PR TITLE
Remove cancellation of regression tests

### DIFF
--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -26,10 +26,6 @@ jobs:
         release:
           ['15.5.3', '^15.8.0', '16.1.0', '16.2.0', '16.3.0', '17.0.0-alpha.7']
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout Code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
The matrix regression test is designed to show us _which_ versions have regressions, so cancelling them when one fails does not make sense. Let's try to make sure we peer review changes to these workflows!