### PR TITLE
deprecate graphql@15 support

### DIFF
--- a/.changeset/neat-houses-explode.md
+++ b/.changeset/neat-houses-explode.md
@@ -1,0 +1,16 @@
+---
+'graphql-language-service-server': minor
+'@graphiql/plugin-code-exporter': minor
+'graphql-language-service-cli': minor
+'@graphiql/plugin-explorer': minor
+'graphql-language-service': minor
+'codemirror-graphql': minor
+'@graphiql/toolkit': minor
+'@graphiql/react': minor
+'monaco-graphql': minor
+'cm6-graphql': minor
+'graphiql': minor
+---
+
+officially deprecate graphql@15 support, as our types and other runtime capabilities ceased to be compatible in 2022 or 2023, but the regression tests were disabled
+`graphql-language-service` is where the bug is, which is used by all of the libraries and applications in `graphiql` monorepo.

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -23,7 +23,13 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        release: ['^16', '17.0.0-alpha.7']
+        release:
+          # test against the latest 16.x version, which might be newer than what we have
+          - '^16'
+          # test against the oldest version we support
+          - '^16.0.0'
+          # test against the latest alpha
+          - '^17.0.0-alpha'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -23,8 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        release:
-          ['15.5.3', '^15.8.0', '16.1.0', '16.2.0', '16.3.0', '17.0.0-alpha.7']
+        release: ['^16', '17.0.0-alpha.7']
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/packages/cm6-graphql/package.json
+++ b/packages/cm6-graphql/package.json
@@ -44,7 +44,7 @@
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "@lezer/highlight": "^1.0.0",
-    "graphql": "^16.5.0 || ^17.0.0-alpha.2"
+    "graphql": "^16.5.0"
   },
   "license": "MIT"
 }

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@codemirror/language": "6.0.0",
     "codemirror": "^5.65.3",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2"
+    "graphql": "^16.0.0"
   },
   "// TEMPORARILY PINNED until we fix graphql 15 support": "",
   "dependencies": {

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "@graphiql/react": "^0.26.0",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "react": "^16.8.0 || ^17 || ^18",
     "react-dom": "^16.8.0 || ^17 || ^18"
   },

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@graphiql/react": "^0.26.0",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "react": "^16.8.0 || ^17 || ^18",
     "react-dom": "^16.8.0 || ^17 || ^18"
   },

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -43,7 +43,7 @@
     "build": "tsc --emitDeclarationOnly && vite build"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "react": "^16.8.0 || ^17 || ^18",
     "react-dom": "^16.8.0 || ^17 || ^18"
   },

--- a/packages/graphiql-toolkit/package.json
+++ b/packages/graphiql-toolkit/package.json
@@ -37,7 +37,7 @@
     "tsup": "^8.2.4"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "graphql-ws": ">= 4.5.0"
   },
   "peerDependenciesMeta": {

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -50,7 +50,7 @@
     "@graphiql/react": "^0.26.2"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "react": "^16.8.0 || ^17 || ^18",
     "react-dom": "^16.8.0 || ^17 || ^18"
   },

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -32,7 +32,7 @@
     "LSP"
   ],
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2"
+    "graphql": "^16.0.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -34,7 +34,7 @@
   "module": "esm/index.js",
   "typings": "esm/index.d.ts",
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2"
+    "graphql": "^16.0.0"
   },
   "COMMENT": "please do not remove dependencies without thorough testing. many dependencies are not imported directly, as they are peer dependencies",
   "dependencies": {

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -32,7 +32,7 @@
     "graphql": "./dist/temp-bin.js"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2"
+    "graphql": "^16.0.0"
   },
   "dependencies": {
     "debounce-promise": "^3.1.2",

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -77,7 +77,7 @@
     "vscode-languageserver-types": "^3.17.1"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.0.0",
     "monaco-editor": ">= 0.20.0 < 1",
     "prettier": "^2.8.0 || ^3.0.0"
   }


### PR DESCRIPTION
after re-enabling the regression tests, we can see that we are no longer compatible with even the last major 15.x version of graphql, so we must remove it from `peerDependencies`