### PR TITLE
feature: Add syntax highlighting support for the repeatable keyword on a directive definition.

### DIFF
--- a/.changeset/three-lions-yawn.md
+++ b/.changeset/three-lions-yawn.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Add syntax highlighting support for the repeatable keyword on a directive definition.

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -390,22 +390,32 @@
         "2": {
           "name": "entity.name.function.directive.graphql"
         },
-        "3": { "name": "keyword.on.graphql" },
-        "4": { "name": "support.type.graphql" }
+        "3": {
+          "name": "keyword.repeatable.graphql"
+        },
+        "4": {
+          "name": "keyword.on.graphql"
+        },
+        "5": {
+          "name": "support.type.graphql"
+        }
       },
       "patterns": [
         {
           "include": "#graphql-variable-definitions"
         },
         {
-          "begin": "\\s*(\\bon\\b)\\s*([_A-Za-z]*)",
+          "begin": "\\s*(\\brepeatable\\b)?\\s*(\\bon\\b)\\s*([_A-Za-z]*)",
           "end": "(?=.)",
           "applyEndPatternLast": 1,
           "beginCaptures": {
             "1": {
-              "name": "keyword.on.graphql"
+              "name": "keyword.repeatable.graphql"
             },
             "2": {
+              "name": "keyword.on.graphql"
+            },
+            "3": {
               "name": "support.type.location.graphql"
             }
           },

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/StarWarsSchema.graphql
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/StarWarsSchema.graphql
@@ -5,6 +5,7 @@ schema {
 directive @test(testArg: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @onArg on ARGUMENT_DEFINITION
 directive @onAllDefs on SCHEMA | SCALAR | OBJECT | FIELD_DEFINITION | INTERFACE | UNION | ENUM_VALUE | INPUT_OBJECT | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
+directive @onRepeatable repeatable on FIELD_DEFINITION
 
 enum Episode {
   NEWHOPE

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
@@ -329,6 +329,15 @@ INPUT_OBJECT           | support.type.location.graphql
 ARGUMENT_DEFINITION    | support.type.location.graphql
  |                     | 
 INPUT_FIELD_DEFINITION | support.type.location.graphql
+directive              | keyword.directive.graphql
+                       | 
+@onRepeatable          | entity.name.function.directive.graphql
+                       | 
+repeatable             | keyword.repeatable.graphql
+                       | 
+on                     | keyword.on.graphql
+                       | 
+FIELD_DEFINITION       | support.type.location.graphql
                        | 
 enum                   | meta.enum.graphql keyword.enum.graphql
                        | meta.enum.graphql


### PR DESCRIPTION
See https://spec.graphql.org/October2021/#sec-Type-System.Directives