### PR TITLE
docs: remove path(/dev.html) from local development GraphiQL URL

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ Then, you can run these commands:
 - `yarn dev-graphiql` — which will launch `webpack` dev server for graphiql
   from the root
 
-> The GraphiQL UI is available at http://localhost:8080/dev.html
+> The GraphiQL UI is available at http://localhost:8080
 
 ### Developing Monaco GraphQL
 


### PR DESCRIPTION
When I first tried to set up the development environment for GraphiQL, I noticed that the documentation in DEVELOPMENT.md mentioned that GraphiQL is hosted at `http://localhost:8080/dev.html`
However, it was actually hosted at `http://localhost:8080`, so I updated the documentation to reflect this.