### PR TITLE
fix: remove deprecated Function.prototype.caller reference

### DIFF
--- a/.changeset/four-dogs-swim.md
+++ b/.changeset/four-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Fix: removed deprecated usage of Fn.prototype.caller

--- a/packages/graphiql-react/src/utility/context.ts
+++ b/packages/graphiql-react/src/utility/context.ts
@@ -21,7 +21,7 @@ export function createContextHook<T>(context: Context<T | null>) {
     if (value === null && options?.nonNull) {
       throw new Error(
         `Tried to use \`${
-          options.caller?.name || useGivenContext.caller.name
+          options.caller?.name || 'a component'
         }\` without the necessary context. Make sure to render the \`${
           context.displayName
         }Provider\` component higher up the tree.`,


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_caller_or_arguments_usage

![Screenshot 2024-11-05 at 3 08 01 PM](https://github.com/user-attachments/assets/955d5963-6e77-498d-ac57-05e386d4c4b9)

While it's helpful during development to have as much information as possible about which component doesn't have the necessary context, it's very not helpful to have the error message itself throw a blocking error due to this deprecated usage 😅 

In a future PR, it might be nice to rename the `caller` argument found throughout GraphiQL packages to something like `callerFn` for clarity, making it clear at a glance that it's a custom arg and not an attempt to access `Function.prototype.caller`.