### PR TITLE
fix: graphql-ws type import

### DIFF
--- a/.changeset/two-owls-approve.md
+++ b/.changeset/two-owls-approve.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': patch
+---
+
+Fix type export to prevent build time bugs

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -1,11 +1,12 @@
 import { DocumentNode, visit } from 'graphql';
 import { meros } from 'meros';
-import {
+import type {
   Client,
   ClientOptions,
   ExecutionResult,
   createClient as createClientType,
 } from 'graphql-ws';
+
 import {
   isAsyncIterable,
   makeAsyncIterableIteratorFromSink,


### PR DESCRIPTION
fixes #2405 

switching to a type import will prevent bundling issues with legacy bundlers, as the older babel/ts transforms will know to strip type only imports before build time