### PR TITLE
[1/3] [v3] Exclude `codemirror/...` and `codemirror-graphql/...` imports from bundle

### DIFF
--- a/.changeset/silly-nails-double.md
+++ b/.changeset/silly-nails-double.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Exclude `codemirror/...` and `codemirror-graphql/...` imports from bundle

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -24,7 +24,7 @@ module.exports = (dir, env = 'jsdom') => {
       '^graphql-language-([^/]+)': `${__dirname}/packages/graphql-language-$1/src`,
       '^@graphiql\\/([^/]+)': `${__dirname}/packages/graphiql-$1/src`,
       '^@graphiql-plugins\\/([^/]+)': `${__dirname}/plugins/$1/src`,
-      '^codemirror-graphql\\/esm([^]+)': `${__dirname}/packages/codemirror-graphql/src/$1`,
+      '^codemirror-graphql\\/esm([^]+)\\.js': `${__dirname}/packages/codemirror-graphql/src/$1`,
       '^codemirror-graphql\\/cjs([^]+)': `${__dirname}/packages/codemirror-graphql/src/$1`,
       // relies on compilation
       '^cm6-graphql\\/src\\/([^]+)': `${__dirname}/packages/cm6-graphql/dist/$1`,

--- a/packages/graphiql-react/src/editor/common.ts
+++ b/packages/graphiql-react/src/editor/common.ts
@@ -34,17 +34,17 @@ export async function importCodeMirror(
     options?.useCommonAddons === false
       ? addons
       : [
-          import('codemirror/addon/hint/show-hint'),
-          import('codemirror/addon/edit/matchbrackets'),
-          import('codemirror/addon/edit/closebrackets'),
-          import('codemirror/addon/fold/brace-fold'),
-          import('codemirror/addon/fold/foldgutter'),
-          import('codemirror/addon/lint/lint'),
-          import('codemirror/addon/search/searchcursor'),
-          import('codemirror/addon/search/jump-to-line'),
-          import('codemirror/addon/dialog/dialog'),
+          import('codemirror/addon/hint/show-hint.js'),
+          import('codemirror/addon/edit/matchbrackets.js'),
+          import('codemirror/addon/edit/closebrackets.js'),
+          import('codemirror/addon/fold/brace-fold.js'),
+          import('codemirror/addon/fold/foldgutter.js'),
+          import('codemirror/addon/lint/lint.js'),
+          import('codemirror/addon/search/searchcursor.js'),
+          import('codemirror/addon/search/jump-to-line.js'),
+          import('codemirror/addon/dialog/dialog.js'),
           // @ts-expect-error
-          import('codemirror/keymap/sublime'),
+          import('codemirror/keymap/sublime.js'),
           ...addons,
         ],
   );

--- a/packages/graphiql-react/src/editor/header-editor.ts
+++ b/packages/graphiql-react/src/editor/header-editor.ts
@@ -53,7 +53,7 @@ export function useHeaderEditor(
 
     void importCodeMirror([
       // @ts-expect-error
-      import('codemirror/mode/javascript/javascript'),
+      import('codemirror/mode/javascript/javascript.js'),
     ]).then(CodeMirror => {
       // Don't continue if the effect has already been cleaned up
       if (!isActive) {

--- a/packages/graphiql-react/src/editor/query-editor.ts
+++ b/packages/graphiql-react/src/editor/query-editor.ts
@@ -144,8 +144,8 @@ export function useQueryEditor(
     let isActive = true;
 
     void importCodeMirror([
-      import('codemirror/addon/comment/comment'),
-      import('codemirror/addon/search/search'),
+      import('codemirror/addon/comment/comment.js'),
+      import('codemirror/addon/search/search.js'),
       import('codemirror-graphql/esm/hint'),
       import('codemirror-graphql/esm/lint'),
       import('codemirror-graphql/esm/info'),

--- a/packages/graphiql-react/src/editor/query-editor.ts
+++ b/packages/graphiql-react/src/editor/query-editor.ts
@@ -146,11 +146,11 @@ export function useQueryEditor(
     void importCodeMirror([
       import('codemirror/addon/comment/comment.js'),
       import('codemirror/addon/search/search.js'),
-      import('codemirror-graphql/esm/hint'),
-      import('codemirror-graphql/esm/lint'),
-      import('codemirror-graphql/esm/info'),
-      import('codemirror-graphql/esm/jump'),
-      import('codemirror-graphql/esm/mode'),
+      import('codemirror-graphql/esm/hint.js'),
+      import('codemirror-graphql/esm/lint.js'),
+      import('codemirror-graphql/esm/info.js'),
+      import('codemirror-graphql/esm/jump.js'),
+      import('codemirror-graphql/esm/mode.js'),
     ]).then(CodeMirror => {
       // Don't continue if the effect has already been cleaned up
       if (!isActive) {

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -72,8 +72,8 @@ export function useResponseEditor(
         import('codemirror/addon/search/jump-to-line.js'),
         // @ts-expect-error
         import('codemirror/keymap/sublime.js'),
-        import('codemirror-graphql/esm/results/mode'),
-        import('codemirror-graphql/esm/utils/info-addon'),
+        import('codemirror-graphql/esm/results/mode.js'),
+        import('codemirror-graphql/esm/utils/info-addon.js'),
       ],
       { useCommonAddons: false },
     ).then(CodeMirror => {

--- a/packages/graphiql-react/src/editor/response-editor.tsx
+++ b/packages/graphiql-react/src/editor/response-editor.tsx
@@ -64,14 +64,14 @@ export function useResponseEditor(
     let isActive = true;
     void importCodeMirror(
       [
-        import('codemirror/addon/fold/foldgutter'),
-        import('codemirror/addon/fold/brace-fold'),
-        import('codemirror/addon/dialog/dialog'),
-        import('codemirror/addon/search/search'),
-        import('codemirror/addon/search/searchcursor'),
-        import('codemirror/addon/search/jump-to-line'),
+        import('codemirror/addon/fold/foldgutter.js'),
+        import('codemirror/addon/fold/brace-fold.js'),
+        import('codemirror/addon/dialog/dialog.js'),
+        import('codemirror/addon/search/search.js'),
+        import('codemirror/addon/search/searchcursor.js'),
+        import('codemirror/addon/search/jump-to-line.js'),
         // @ts-expect-error
-        import('codemirror/keymap/sublime'),
+        import('codemirror/keymap/sublime.js'),
         import('codemirror-graphql/esm/results/mode'),
         import('codemirror-graphql/esm/utils/info-addon'),
       ],

--- a/packages/graphiql-react/src/editor/variable-editor.ts
+++ b/packages/graphiql-react/src/editor/variable-editor.ts
@@ -58,9 +58,9 @@ export function useVariableEditor(
     let isActive = true;
 
     void importCodeMirror([
-      import('codemirror-graphql/esm/variables/hint'),
-      import('codemirror-graphql/esm/variables/lint'),
-      import('codemirror-graphql/esm/variables/mode'),
+      import('codemirror-graphql/esm/variables/hint.js'),
+      import('codemirror-graphql/esm/variables/lint.js'),
+      import('codemirror-graphql/esm/variables/mode.js'),
     ]).then(CodeMirror => {
       // Don't continue if the effect has already been cleaned up
       if (!isActive) {

--- a/packages/graphiql-react/vite.config.mts
+++ b/packages/graphiql-react/vite.config.mts
@@ -32,9 +32,9 @@ export default defineConfig({
         'react/jsx-runtime',
         // Exclude peer dependencies and dependencies from bundle
         ...Object.keys(packageJSON.peerDependencies),
-        ...Object.keys(packageJSON.dependencies).filter(
-          dependency => dependency !== 'codemirror',
-        ),
+        ...Object.keys(packageJSON.dependencies),
+        // Exclude `codemirror/...` and `codemirror-graphql/...` but not `../style/codemirror.css`
+        /codemirror[/-]/,
       ],
       output: {
         chunkFileNames: '[name].[format].js',


### PR DESCRIPTION
These files absolutely shouldn't be included in `dist`, they should rely on an installed version from `node_modules`

## before

```
 dmytro@MacBook-Pro-9  ~/Desktop/GUILD/graphiql   do-not-bundle-codemirror  yarn workspace @graphiql/react build
yarn workspace v1.22.22
yarn run v1.22.22
$ rimraf dist types
$ tsc --emitDeclarationOnly && vite build
vite v5.3.6 building for production...
✓ 178 modules transformed.
dist/style.css                53.95 kB │ gzip: 10.24 kB
dist/forEachState.cjs.js       0.42 kB │ gzip:  0.25 kB │ map:   0.82 kB
dist/mode-indent.cjs.js        0.45 kB │ gzip:  0.28 kB │ map:   0.88 kB
dist/mode.cjs.js               0.89 kB │ gzip:  0.44 kB │ map:   1.66 kB
dist/codemirror.cjs.js         1.01 kB │ gzip:  0.50 kB │ map:   0.13 kB
dist/lint.cjs2.js              1.03 kB │ gzip:  0.49 kB │ map:   1.75 kB
dist/matchbrackets.cjs.js      1.07 kB │ gzip:  0.51 kB │ map:   0.13 kB
dist/hint.cjs.js               1.64 kB │ gzip:  0.67 kB │ map:   2.90 kB
dist/mode.cjs3.js              2.46 kB │ gzip:  0.86 kB │ map:   3.96 kB
dist/mode.cjs2.js              2.69 kB │ gzip:  0.95 kB │ map:   4.40 kB
dist/jump-to-line.cjs.js       2.79 kB │ gzip:  1.16 kB │ map:   3.74 kB
dist/info-addon.cjs.js         4.48 kB │ gzip:  1.26 kB │ map:   8.13 kB
dist/jump.cjs.js               4.78 kB │ gzip:  1.35 kB │ map:   9.03 kB
dist/SchemaReference.cjs.js    5.52 kB │ gzip:  1.28 kB │ map:  10.55 kB
dist/brace-fold.cjs.js         5.59 kB │ gzip:  1.70 kB │ map:   8.37 kB
dist/dialog.cjs.js             5.88 kB │ gzip:  1.63 kB │ map:   8.82 kB
dist/hint.cjs2.js              5.96 kB │ gzip:  1.80 kB │ map:  11.72 kB
dist/matchbrackets.cjs2.js     6.51 kB │ gzip:  1.86 kB │ map:  11.50 kB
dist/info.cjs.js               6.75 kB │ gzip:  1.33 kB │ map:  12.02 kB
dist/closebrackets.cjs.js      8.18 kB │ gzip:  2.29 kB │ map:  13.18 kB
dist/lint.cjs3.js              8.96 kB │ gzip:  2.53 kB │ map:  17.83 kB
dist/comment.cjs.js            9.81 kB │ gzip:  2.53 kB │ map:  16.04 kB
dist/lint.cjs.js              10.96 kB │ gzip:  3.08 kB │ map:  17.47 kB
dist/foldgutter.cjs.js        11.45 kB │ gzip:  2.92 kB │ map:  18.38 kB
dist/search.cjs.js            12.92 kB │ gzip:  3.25 kB │ map:  20.80 kB
dist/searchcursor.cjs.js      13.14 kB │ gzip:  3.00 kB │ map:  21.71 kB
dist/show-hint.cjs.js         21.30 kB │ gzip:  5.41 kB │ map:  34.36 kB
dist/sublime.cjs.js           28.64 kB │ gzip:  6.18 kB │ map:  47.82 kB
dist/javascript.cjs.js        43.37 kB │ gzip:  8.38 kB │ map:  69.48 kB
dist/index.js                174.59 kB │ gzip: 35.13 kB │ map: 339.97 kB
dist/codemirror.cjs2.js      404.00 kB │ gzip: 84.15 kB │ map: 682.18 kB
dist/style.css               53.95 kB │ gzip: 10.24 kB
dist/forEachState.es.js       0.40 kB │ gzip:  0.24 kB │ map:   0.81 kB
dist/mode-indent.es.js        0.44 kB │ gzip:  0.28 kB │ map:   0.88 kB
dist/mode.es.js               0.77 kB │ gzip:  0.43 kB │ map:   1.54 kB
dist/lint.es2.js              0.95 kB │ gzip:  0.47 kB │ map:   1.70 kB
dist/codemirror.es.js         0.99 kB │ gzip:  0.50 kB │ map:   0.12 kB
dist/matchbrackets.es.js      1.04 kB │ gzip:  0.51 kB │ map:   0.13 kB
dist/hint.es.js               1.55 kB │ gzip:  0.66 kB │ map:   2.81 kB
dist/mode.es3.js              1.94 kB │ gzip:  0.83 kB │ map:   3.74 kB
dist/mode.es2.js              2.15 kB │ gzip:  0.92 kB │ map:   4.17 kB
dist/jump-to-line.es.js       2.79 kB │ gzip:  1.17 kB │ map:   3.71 kB
dist/info-addon.es.js         4.29 kB │ gzip:  1.25 kB │ map:   8.01 kB
dist/jump.es.js               4.66 kB │ gzip:  1.38 kB │ map:   8.77 kB
dist/SchemaReference.es.js    5.40 kB │ gzip:  1.30 kB │ map:  10.29 kB
dist/brace-fold.es.js         5.59 kB │ gzip:  1.70 kB │ map:   8.37 kB
dist/dialog.es.js             5.86 kB │ gzip:  1.63 kB │ map:   8.81 kB
dist/hint.es2.js              5.90 kB │ gzip:  1.81 kB │ map:  11.50 kB
dist/matchbrackets.es2.js     6.48 kB │ gzip:  1.85 kB │ map:  11.49 kB
dist/info.es.js               6.72 kB │ gzip:  1.36 kB │ map:  11.76 kB
dist/closebrackets.es.js      8.18 kB │ gzip:  2.29 kB │ map:  13.17 kB
dist/lint.es3.js              8.97 kB │ gzip:  2.54 kB │ map:  17.68 kB
dist/comment.es.js            9.81 kB │ gzip:  2.53 kB │ map:  16.03 kB
dist/lint.es.js              10.97 kB │ gzip:  3.08 kB │ map:  17.46 kB
dist/foldgutter.es.js        11.43 kB │ gzip:  2.92 kB │ map:  18.37 kB
dist/search.es.js            12.92 kB │ gzip:  3.24 kB │ map:  20.77 kB
dist/searchcursor.es.js      13.12 kB │ gzip:  3.01 kB │ map:  21.71 kB
dist/show-hint.es.js         21.30 kB │ gzip:  5.41 kB │ map:  34.35 kB
dist/sublime.es.js           28.64 kB │ gzip:  6.18 kB │ map:  47.81 kB
dist/javascript.es.js        43.36 kB │ gzip:  8.38 kB │ map:  69.47 kB
dist/index.mjs              164.98 kB │ gzip: 34.41 kB │ map: 335.28 kB
dist/codemirror.es2.js      403.94 kB │ gzip: 84.14 kB │ map: 682.16 kB
✓ built in 1.86s
✨  Done in 6.31s.
✨  Done in 6.58s.
```

## now

```
 dmytro@MacBook-Pro-9  ~/Desktop/GUILD/graphiql   do-not-bundle-codemirror ±✚  yarn workspace @graphiql/react build
yarn workspace v1.22.22
yarn run v1.22.22
$ rimraf dist types
$ tsc --emitDeclarationOnly && vite build
vite v5.3.6 building for production...
✓ 125 modules transformed.
dist/style.css   53.95 kB │ gzip: 10.24 kB
dist/index.js   174.72 kB │ gzip: 35.47 kB │ map: 338.57 kB
dist/style.css   53.95 kB │ gzip: 10.24 kB
dist/index.mjs  165.10 kB │ gzip: 34.43 kB │ map: 334.76 kB
✓ built in 931ms
✨  Done in 4.81s.
✨  Done in 5.06s.
```