### PR TITLE
fix(language-service): improve types, nullable member access

### DIFF
--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -379,14 +379,12 @@ export class GraphQLLanguageService {
       }
 
       output.push({
-        // @ts-ignore
         name: tree.representativeName ?? 'Anonymous',
         kind: getKind(tree),
         location: {
           uri: filePath,
           range: {
             start: tree.startPosition,
-            // @ts-ignore
             end: tree.endPosition,
           },
         },

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -7,6 +7,7 @@
  *
  */
 
+import * as path from 'node:path';
 import {
   DocumentNode,
   FragmentSpreadNode,
@@ -22,6 +23,7 @@ import {
   isTypeDefinitionNode,
   ArgumentNode,
   typeFromAST,
+  Source as GraphQLSource,
 } from 'graphql';
 
 import {
@@ -47,6 +49,7 @@ import {
   getTypeInfo,
   DefinitionQueryResponse,
   getDefinitionQueryResultForArgument,
+  IRange,
 } from 'graphql-language-service';
 
 import type { GraphQLCache } from './GraphQLCache';
@@ -359,8 +362,13 @@ export class GraphQLLanguageService {
   public async getDocumentSymbols(
     document: string,
     filePath: Uri,
+    fileDocumentRange?: IRange | null,
   ): Promise<SymbolInformation[]> {
-    const outline = await this.getOutline(document);
+    const outline = await this.getOutline(
+      document,
+      path.basename(filePath),
+      fileDocumentRange?.start,
+    );
     if (!outline) {
       return [];
     }
@@ -537,7 +545,20 @@ export class GraphQLLanguageService {
     );
   }
 
-  async getOutline(documentText: string): Promise<Outline | null> {
-    return getOutline(documentText);
+  async getOutline(
+    documentText: string,
+    documentName: string,
+    documentOffset?: IPosition,
+  ): Promise<Outline | null> {
+    return getOutline(
+      new GraphQLSource(
+        documentText,
+        documentName,
+        documentOffset && {
+          column: documentOffset.character + 1,
+          line: documentOffset.line + 1,
+        },
+      ),
+    );
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -66,7 +66,12 @@ import {
   LoaderNoResultError,
   ProjectNotFoundError,
 } from 'graphql-config';
-import type { LoadConfigOptions, LocateCommand } from './types';
+import type {
+  LoadConfigOptions,
+  LocateCommand,
+  VSCodeGraphQLConfigLoadSettings,
+  VSCodeGraphQLSettings,
+} from './types';
 import {
   DEFAULT_SUPPORTED_EXTENSIONS,
   SupportedExtensionsEnum,
@@ -89,6 +94,13 @@ function toPosition(position: VscodePosition): IPosition {
   return new Position(position.line, position.character);
 }
 
+interface MessageProcessorSettings extends VSCodeGraphQLSettings {
+  load: VSCodeGraphQLConfigLoadSettings & {
+    fileName?: string;
+    [key: string]: unknown;
+  };
+}
+
 export class MessageProcessor {
   private _connection: Connection;
   private _graphQLCache!: GraphQLCache;
@@ -103,7 +115,7 @@ export class MessageProcessor {
   private _tmpDirBase: string;
   private _loadConfigOptions: LoadConfigOptions;
   private _rootPath: string = process.cwd();
-  private _settings: any;
+  private _settings: MessageProcessorSettings = { load: {} };
   private _providedConfig?: GraphQLConfig;
 
   constructor({
@@ -210,7 +222,7 @@ export class MessageProcessor {
     // TODO: eventually we will instantiate an instance of this per workspace,
     // so rootDir should become that workspace's rootDir
     this._settings = { ...settings, ...vscodeSettings };
-    const rootDir = this._settings?.load?.rootDir.length
+    const rootDir = this._settings?.load?.rootDir?.length
       ? this._settings?.load?.rootDir
       : this._rootPath;
     if (settings?.dotEnvPath) {

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -971,10 +971,16 @@ export class MessageProcessor {
       }),
     );
 
-    return this._languageService.getDocumentSymbols(
-      cachedDocument.contents[0].query,
-      textDocument.uri,
+    const results = await Promise.all(
+      cachedDocument.contents.map(content =>
+        this._languageService.getDocumentSymbols(
+          content.query,
+          textDocument.uri,
+          content.range,
+        ),
+      ),
     );
+    return results.flat();
   }
 
   // async handleReferencesRequest(params: ReferenceParams): Promise<Location[]> {
@@ -1021,11 +1027,16 @@ export class MessageProcessor {
           ) {
             return [];
           }
-          const docSymbols = await this._languageService.getDocumentSymbols(
-            cachedDocument.contents[0].query,
-            uri,
+          const docSymbols = await Promise.all(
+            cachedDocument.contents.map(content =>
+              this._languageService.getDocumentSymbols(
+                content.query,
+                uri,
+                content.range,
+              ),
+            ),
           );
-          symbols.push(...docSymbols);
+          symbols.push(...docSymbols.flat());
         }),
       );
       return symbols.filter(symbol => symbol?.name?.includes(params.query));

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -88,6 +88,7 @@ const configDocLink =
 type CachedDocumentType = {
   version: number;
   contents: CachedContent[];
+  size: number;
 };
 
 function toPosition(position: VscodePosition): IPosition {
@@ -498,17 +499,11 @@ export class MessageProcessor {
 
       // As `contentChanges` is an array, and we just want the
       // latest update to the text, grab the last entry from the array.
-
-      // If it's a .js file, try parsing the contents to see if GraphQL queries
-      // exist. If not found, delete from the cache.
       const { contents } = await this._parseAndCacheFile(
         uri,
         project,
         contentChanges.at(-1)!.text,
       );
-      // // If it's a .graphql file, proceed normally and invalidate the cache.
-      // await this._invalidateCache(textDocument, uri, contents);
-
       const diagnostics: Diagnostic[] = [];
 
       if (project?.extensions?.languageService?.enableValidation !== false) {
@@ -718,7 +713,10 @@ export class MessageProcessor {
       const contents = await this._parser(fileText, uri);
       const cachedDocument = this._textDocumentCache.get(uri);
       const version = cachedDocument ? cachedDocument.version++ : 0;
-      await this._invalidateCache({ uri, version }, uri, contents);
+      await this._invalidateCache(
+        { uri, version },
+        { contents, size: fileText.length },
+      );
       await this._updateFragmentDefinition(uri, contents);
       await this._updateObjectTypeDefinition(uri, contents, project);
       await this._updateSchemaIfChanged(project, uri);
@@ -954,14 +952,13 @@ export class MessageProcessor {
 
     const { textDocument } = params;
     const cachedDocument = this._getCachedDocument(textDocument.uri);
-    if (!cachedDocument?.contents[0]) {
+    if (!cachedDocument?.contents?.length) {
       return [];
     }
 
     if (
       this._settings.largeFileThreshold !== undefined &&
-      this._settings.largeFileThreshold <
-        cachedDocument.contents[0].query.length
+      this._settings.largeFileThreshold < cachedDocument.size
     ) {
       return [];
     }
@@ -1015,7 +1012,13 @@ export class MessageProcessor {
         documents.map(async ([uri]) => {
           const cachedDocument = this._getCachedDocument(uri);
 
-          if (!cachedDocument) {
+          if (!cachedDocument?.contents?.length) {
+            return [];
+          }
+          if (
+            this._settings.largeFileThreshold !== undefined &&
+            this._settings.largeFileThreshold < cachedDocument.size
+          ) {
             return [];
           }
           const docSymbols = await this._languageService.getDocumentSymbols(
@@ -1044,7 +1047,10 @@ export class MessageProcessor {
     try {
       const contents = await this._parser(text, uri);
       if (contents.length > 0) {
-        await this._invalidateCache({ version, uri }, uri, contents);
+        await this._invalidateCache(
+          { version, uri },
+          { contents, size: text.length },
+        );
         await this._updateObjectTypeDefinition(uri, contents, project);
       }
     } catch (err) {
@@ -1256,7 +1262,10 @@ export class MessageProcessor {
           }
           await this._updateObjectTypeDefinition(uri, contents);
           await this._updateFragmentDefinition(uri, contents);
-          await this._invalidateCache({ version: 1, uri }, uri, contents);
+          await this._invalidateCache(
+            { version: 1, uri },
+            { contents, size: document.rawSDL.length },
+          );
         }),
       );
     } catch (err) {
@@ -1365,27 +1374,20 @@ export class MessageProcessor {
   }
   private async _invalidateCache(
     textDocument: VersionedTextDocumentIdentifier,
-    uri: Uri,
-    contents: CachedContent[],
+    meta: Omit<CachedDocumentType, 'version'>,
   ): Promise<Map<string, CachedDocumentType> | null> {
+    const { uri, version } = textDocument;
     if (this._textDocumentCache.has(uri)) {
       const cachedDocument = this._textDocumentCache.get(uri);
-      if (
-        cachedDocument &&
-        textDocument?.version &&
-        cachedDocument.version < textDocument.version
-      ) {
+      if (cachedDocument && version && cachedDocument.version < version) {
         // Current server capabilities specify the full sync of the contents.
         // Therefore always overwrite the entire content.
-        return this._textDocumentCache.set(uri, {
-          version: textDocument.version,
-          contents,
-        });
+        return this._textDocumentCache.set(uri, { ...meta, version });
       }
     }
     return this._textDocumentCache.set(uri, {
-      version: textDocument.version ?? 0,
-      contents,
+      ...meta,
+      version: version ?? 0,
     });
   }
 }

--- a/packages/graphql-language-service-server/src/parseDocument.ts
+++ b/packages/graphql-language-service-server/src/parseDocument.ts
@@ -34,10 +34,12 @@ export async function parseDocument(
     return [];
   }
 
+  // If it's a .js file, parse the contents to see if GraphQL queries exist.
   if (fileExtensions.includes(ext)) {
     const templates = await findGraphQLTags(text, ext, uri, logger);
     return templates.map(({ template, range }) => ({ query: template, range }));
   }
+  // If it's a .graphql file, use the entire file
   if (graphQLFileExtensions.includes(ext)) {
     const query = text;
     const lines = query.split('\n');

--- a/packages/graphql-language-service-server/src/types.ts
+++ b/packages/graphql-language-service-server/src/types.ts
@@ -115,3 +115,45 @@ export interface ServerOptions {
    */
   debug?: true;
 }
+
+export interface VSCodeGraphQLSettings {
+  /**
+   * Enable debug logs and node debugger for client
+   */
+  debug?: boolean | null;
+  /**
+   * Use a cached file output of your graphql-config schema result for definition lookups, symbols, outline, etc. Enabled by default when one or more schema entry is not a local file with SDL in it. Disable if you want to use SDL with a generated schema.
+   */
+  cacheSchemaFileForLookup?: boolean;
+  /**
+   * Disables outlining and other expensive operations for files larger than this threshold (in bytes). Defaults to 1000000 (one million).
+   */
+  largeFileThreshold?: number;
+  /**
+   * Fail the request on invalid certificate
+   */
+  rejectUnauthorized?: boolean;
+  /**
+   * Schema cache ttl in milliseconds - the interval before requesting a fresh schema when caching the local schema file is enabled. Defaults to 30000 (30 seconds).
+   */
+  schemaCacheTTL?: number;
+}
+
+export interface VSCodeGraphQLConfigLoadSettings {
+  /**
+   * Base dir for graphql config loadConfig(), to look for config files or package.json
+   */
+  rootDir?: string;
+  /**
+   * exact filePath for a `graphql-config` file `loadConfig()`
+   */
+  filePath?: string;
+  /**
+   * optional <configName>.config.{js,ts,toml,yaml,json} & <configName>rc* instead of default `graphql`
+   */
+  configName?: string;
+  /**
+   * legacy mode for graphql config v2 config
+   */
+  legacy?: boolean;
+}

--- a/packages/graphql-language-service/src/interface/getDefinition.ts
+++ b/packages/graphql-language-service/src/interface/getDefinition.ts
@@ -25,7 +25,7 @@ import {
 
 import { Definition, FragmentInfo, Uri, ObjectTypeInfo } from '../types';
 
-import { locToRange, offsetToPosition, Range, Position } from '../utils';
+import { locToRange, locStartToPosition, Range, Position } from '../utils';
 // import { getTypeInfo } from './getAutocompleteSuggestions';
 
 export type DefinitionQueryResult = {
@@ -56,7 +56,7 @@ function getRange(text: string, node: ASTNode): Range {
 function getPosition(text: string, node: ASTNode): Position {
   const location = node.loc!;
   assert(location, 'Expected ASTNode to have a location.');
-  return offsetToPosition(text, location.start);
+  return locStartToPosition(text, location);
 }
 
 export async function getDefinitionQueryResultForNamedType(

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -41,7 +41,7 @@ import {
 } from 'graphql';
 import type { ASTReducer } from 'graphql/language/visitor';
 
-import { offsetToPosition } from '../utils';
+import { locToRange } from '../utils';
 
 const { INLINE_FRAGMENT } = Kind;
 
@@ -133,10 +133,11 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
     DocumentNode | SelectionSetNode | NameNode | InlineFragmentNode
   >;
   const meta = (node: ExclusiveUnion<MetaNode>): OutlineTreeResultMeta => {
+    const range = locToRange(docText, node.loc!);
     return {
       representativeName: node.name,
-      startPosition: offsetToPosition(docText, node.loc!.start),
-      endPosition: offsetToPosition(docText, node.loc!.end),
+      startPosition: range.start,
+      endPosition: range.end,
       kind: node.kind,
       children:
         node.selectionSet || node.fields || node.values || node.arguments || [],

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -19,7 +19,9 @@ import {
   Kind,
   parse,
   visit,
+  ASTNode,
   FieldNode,
+  ArgumentNode,
   InlineFragmentNode,
   DocumentNode,
   FragmentSpreadNode,
@@ -35,7 +37,9 @@ import {
   InputValueDefinitionNode,
   FieldDefinitionNode,
   EnumValueDefinitionNode,
+  InputObjectTypeDefinitionNode,
 } from 'graphql';
+import type { ASTReducer } from 'graphql/language/visitor';
 
 import { offsetToPosition } from '../utils';
 
@@ -59,27 +63,47 @@ const OUTLINEABLE_KINDS = {
   FieldDefinition: true,
 };
 
-export type OutlineableKinds = keyof typeof OUTLINEABLE_KINDS;
+type LiteralToEnum<Literal, Enum> = Enum extends never
+  ? never
+  : { 0: Enum }[Enum extends Literal ? 0 : never];
 
-// type OutlineableNodes = FieldNode | OperationDefinitionNode | DocumentNode | SelectionSetNode | NameNode | FragmentDefinitionNode | FragmentSpreadNode |InlineFragmentNode | ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode
+export type OutlineableKinds = LiteralToEnum<
+  keyof typeof OUTLINEABLE_KINDS,
+  Kind
+>;
+
+type OutlineableNode = Extract<ASTNode, { kind: OutlineableKinds }>;
+type AllKeys<T> = T extends unknown ? keyof T : never;
+type ExclusiveUnion<T, K extends PropertyKey = AllKeys<T>> = T extends never
+  ? never
+  : T & Partial<Record<Exclude<K, keyof T>, never>>;
+
+type OutlineTreeResultMeta = {
+  representativeName?: string | NameNode;
+  startPosition: IPosition;
+  endPosition: IPosition;
+  kind: OutlineableKinds;
+  children:
+    | SelectionSetNode
+    | readonly ArgumentNode[]
+    | readonly FieldDefinitionNode[]
+    | readonly EnumValueDefinitionNode[]
+    | readonly InputValueDefinitionNode[];
+};
 
 type OutlineTreeResult =
-  | {
-      representativeName: string;
-      startPosition: IPosition;
-      endPosition: IPosition;
-      children: SelectionSetNode[] | [];
-      tokenizedText: TextToken[];
-    }
+  | (OutlineTreeResultMeta & { tokenizedText: TextToken[] })
   | string
   | readonly DefinitionNode[]
   | readonly SelectionNode[]
   | FieldNode[]
   | SelectionSetNode;
 
-type OutlineTreeConverterType = Partial<{
-  [key in OutlineableKinds]: (node: any) => OutlineTreeResult;
-}>;
+type OutlineTreeConverterType = {
+  [key in OutlineableKinds]: (
+    node: Extract<OutlineableNode, { kind: key }>,
+  ) => OutlineTreeResult;
+};
 
 export function getOutline(documentText: string): Outline | null {
   let ast;
@@ -89,28 +113,30 @@ export function getOutline(documentText: string): Outline | null {
     return null;
   }
 
-  const visitorFns = outlineTreeConverter(documentText);
+  type VisitorFns = Record<Kind, (node: ASTNode) => OutlineTreeResult>;
+  const visitorFns = outlineTreeConverter(documentText) as VisitorFns;
   const outlineTrees = visit(ast, {
-    leave(node) {
-      if (visitorFns !== undefined && node.kind in visitorFns) {
-        // @ts-ignore
+    leave(node: ASTNode) {
+      if (node.kind in visitorFns) {
         return visitorFns[node.kind](node);
       }
       return null;
     },
-  }) as unknown as OutlineTree[];
+  } as ASTReducer<OutlineTreeResult>) as OutlineTree[];
 
   return { outlineTrees };
 }
 
 function outlineTreeConverter(docText: string): OutlineTreeConverterType {
-  // TODO: couldn't find a type that would work for all cases here,
-  // however the inference is not broken by this at least
-  const meta = (node: any) => {
+  type MetaNode = Exclude<
+    OutlineableNode,
+    DocumentNode | SelectionSetNode | NameNode | InlineFragmentNode
+  >;
+  const meta = (node: ExclusiveUnion<MetaNode>): OutlineTreeResultMeta => {
     return {
       representativeName: node.name,
-      startPosition: offsetToPosition(docText, node.loc.start),
-      endPosition: offsetToPosition(docText, node.loc.end),
+      startPosition: offsetToPosition(docText, node.loc!.start),
+      endPosition: offsetToPosition(docText, node.loc!.end),
       kind: node.kind,
       children:
         node.selectionSet || node.fields || node.values || node.arguments || [],
@@ -176,7 +202,7 @@ function outlineTreeConverter(docText: string): OutlineTreeConverterType {
       ],
       ...meta(node),
     }),
-    InputObjectTypeDefinition: (node: ObjectTypeDefinitionNode) => ({
+    InputObjectTypeDefinition: (node: InputObjectTypeDefinitionNode) => ({
       tokenizedText: [
         buildToken('keyword', 'input'),
         buildToken('whitespace', ' '),

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -13,6 +13,7 @@ import {
   TokenKind,
   IPosition,
   OutlineTree,
+  IRange,
 } from '../types';
 
 import {
@@ -38,6 +39,7 @@ import {
   FieldDefinitionNode,
   EnumValueDefinitionNode,
   InputObjectTypeDefinitionNode,
+  Source as GraphQLSource,
 } from 'graphql';
 import type { ASTReducer } from 'graphql/language/visitor';
 
@@ -105,16 +107,16 @@ type OutlineTreeConverterType = {
   ) => OutlineTreeResult;
 };
 
-export function getOutline(documentText: string): Outline | null {
+export function getOutline(document: string | GraphQLSource): Outline | null {
   let ast;
   try {
-    ast = parse(documentText);
+    ast = parse(document);
   } catch {
     return null;
   }
 
   type VisitorFns = Record<Kind, (node: ASTNode) => OutlineTreeResult>;
-  const visitorFns = outlineTreeConverter(documentText) as VisitorFns;
+  const visitorFns = outlineTreeConverter(document) as VisitorFns;
   const outlineTrees = visit(ast, {
     leave(node: ASTNode) {
       if (node.kind in visitorFns) {
@@ -127,13 +129,19 @@ export function getOutline(documentText: string): Outline | null {
   return { outlineTrees };
 }
 
-function outlineTreeConverter(docText: string): OutlineTreeConverterType {
+function outlineTreeConverter(
+  document: string | GraphQLSource,
+): OutlineTreeConverterType {
+  const docText = typeof document === 'string' ? document : document.body;
+  const { locationOffset }: Partial<GraphQLSource> =
+    typeof document === 'string' ? {} : document;
   type MetaNode = Exclude<
     OutlineableNode,
     DocumentNode | SelectionSetNode | NameNode | InlineFragmentNode
   >;
   const meta = (node: ExclusiveUnion<MetaNode>): OutlineTreeResultMeta => {
     const range = locToRange(docText, node.loc!);
+    applyOffsetToRange(range, locationOffset);
     return {
       representativeName: node.name,
       startPosition: range.start,
@@ -249,4 +257,25 @@ function concatMap<V>(arr: Readonly<V[]>, fn: Function): Readonly<V[]> {
     }
   }
   return res;
+}
+
+function applyOffsetToRange(
+  range: IRange,
+  locationOffset?: GraphQLSource['locationOffset'],
+) {
+  if (!locationOffset) {
+    return;
+  }
+  applyOffsetToPosition(range.start, locationOffset);
+  applyOffsetToPosition(range.end, locationOffset);
+}
+
+function applyOffsetToPosition(
+  position: IPosition,
+  locationOffset: GraphQLSource['locationOffset'],
+) {
+  if (position.line === 1) {
+    position.character += locationOffset.column - 1;
+  }
+  position.line += locationOffset.line - 1;
 }

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -217,7 +217,7 @@ export type OutlineTree = {
   representativeName?: string;
   kind: string;
   startPosition: IPosition;
-  endPosition?: IPosition;
+  endPosition: IPosition;
   children: OutlineTree[];
 };
 

--- a/packages/graphql-language-service/src/utils/index.ts
+++ b/packages/graphql-language-service/src/utils/index.ts
@@ -21,7 +21,13 @@ export {
 
 export { getASTNodeAtPosition, pointToOffset } from './getASTNodeAtPosition';
 
-export { Position, Range, locToRange, offsetToPosition } from './Range';
+export {
+  Position,
+  Range,
+  locStartToPosition,
+  locToRange,
+  offsetToPosition,
+} from './Range';
 
 export { validateWithCustomRules } from './validateWithCustomRules';
 


### PR DESCRIPTION
In VSCode, I noticed that the editor sticky scroll headers were showing the wrong headers, and I tracked it down to the GraphQL language support. This also fixes the locations when you navigate to graphql sections using breadcrumbs or the outline panel.

I also emit outlines for all embedded graphql documents, rather than just the first one. This only works properly when the location data is correct (i tried this first, and it lead to some interesting results)

This PR also includes some additional typing and performance improvements, but I saw some mentions of an ongoing refactoring in the commit history, so I have just the targeted changes in a branch: https://github.com/graphql/graphiql/compare/main...forivall:graphiql:outline-embedded-offset-simple

I only added tests for my performance improvement, but let me know if you need more tests! 