### PR TITLE
feat(graphiql-toolkit): accept HeadersInit

### DIFF
--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -31,7 +31,7 @@ export type FetcherParams = {
 };
 
 export type FetcherOpts = {
-  headers?: { [key: string]: any };
+  headers?: HeadersInit;
   documentAST?: DocumentNode;
 };
 
@@ -104,7 +104,7 @@ export interface CreateFetcherOptions {
    * If you enable the headers editor and the user provides
    * A header you set statically here, it will be overridden by their value.
    */
-  headers?: Record<string, string>;
+  headers?: HeadersInit;
   /**
    * Websockets connection params used when you provide subscriptionUrl. graphql-ws `ClientOptions.connectionParams`
    */


### PR DESCRIPTION
This PR enhances `graphiql-toolkit` package fetcher utility to accept `HeadersInit` type instead of `Record<string, string>` in places where headers are accepted.

This is a backwards compatible change because `Record<string, string>` is a sub-type of `HeadersInit`. As well, care in this PR has been taken to preserve the way in which same-name headers from different sources would overwrite, not merge, together.

The benefit of this change is that consumers can now pass values of `Headers` or `[string,string][]` type which permits the possibility of a header repeated multiple, which HTTP supports.

In practice a place this issue became relevant was in my work on Hive Console's Laboratory Preflight Script feature:

https://github.com/graphql-hive/console/pull/6378#discussion_r1919125548