### PR TITLE
Add Benjie and archiving Playground to next meeting

### DIFF
--- a/working-group/agendas/2025/03-Mar/11-graphiql-wg-march-2025.md
+++ b/working-group/agendas/2025/03-Mar/11-graphiql-wg-march-2025.md
@@ -25,6 +25,7 @@ To read about the purpose of this subcommittee, please see [the README](../../RE
 <!-- prettier-ignore -->
 | Name                       | GitHub               | Organization       | Location                 |
 | :------------------------- | :------------------- | :----------------- | :----------------------- |
+| Benjie Gillam              | @benjie              | Graphile           | Chandler's Ford, UK      |
 
 
 ## Agenda
@@ -40,3 +41,4 @@ To read about the purpose of this subcommittee, please see [the README](../../RE
 1. Review previous meeting's action items (5m, Host)
    - [Ready for review](https://github.com/graphql/graphiql/issues?q=is%3Aissue+is%3Aopen+label%3A%22Ready+for+review+%F0%9F%99%8C%22+sort%3Aupdated-desc)
    - [All open action items (by last update)](https://github.com/graphql/graphiql/issues?q=is%3Aissue+is%3Aopen+label%3A%22Action+item+%3Aclapper%3A%22+sort%3Aupdated-desc)
+1. Archiving GraphQL Playground (15m, Benjie)


### PR DESCRIPTION
We may not actually need a meeting for this, but I'd like to discuss archiving GraphQL Playground. If we agree to do so, I think we ideally need a document that details how to move from Playground to GraphiQL - does such a document already exist? Then we'll update the playground README to point to it, and mark the repo as archived.

Main reason for archiving: it seems unmaintained, and most of the functionality is now available in GraphiQL?

cc @acao @dimaMachina @thomasheyenbrock @yaacovCR 