### PR TITLE
[lsp] Fix parsing of relay style locations in locateCommand results

### DIFF
--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -180,7 +180,7 @@ module.exports = {
         );
         return { uri: path, range }; // range.start.line/range.end.character/etc, base 1
         // you can also return relay LSP style
-        // return '/path/to/file.py:20:23'; // (range: 20:1 )
+        // return '/path/to/file.py:20:1'; // (range: 20:1 20:1 )
         // return '/path/to/file.py'; // (range: 1:1 1:1)
       },
     },

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -910,12 +910,14 @@ export class MessageProcessor {
         project,
       });
       if (typeof locateResult === 'string') {
-        const [uri, startLine = '1', endLine = '1'] = locateResult.split(':');
+        const [uri, line = '1', character = '1'] = locateResult.split(':');
+        const startLine = Math.max(parseInt(line, 10) - 1, 0);
+        const startCharacter = Math.max(parseInt(character, 10) - 1, 0);
         return {
           uri,
           range: new Range(
-            new Position(parseInt(startLine, 10), 0),
-            new Position(parseInt(endLine, 10), 0),
+            new Position(startLine, startCharacter),
+            new Position(startLine, startCharacter),
           ),
         };
       }

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
@@ -465,10 +465,10 @@ describe('MessageProcessor', () => {
       () => 'hello:2:4',
     );
     expect(customResult2.uri).toEqual('hello');
-    expect(customResult2.range.start.line).toEqual(2);
-    expect(customResult2.range.start.character).toEqual(0);
-    expect(customResult2.range.end.line).toEqual(4);
-
+    expect(customResult2.range.start.line).toEqual(1);
+    expect(customResult2.range.start.character).toEqual(3);
+    expect(customResult2.range.end.line).toEqual(1);
+    expect(customResult2.range.end.character).toEqual(3);
     const customResult3 = messageProcessor._getCustomLocateResult(
       project,
       { definitions: result, printedName: 'example' },
@@ -496,9 +496,10 @@ describe('MessageProcessor', () => {
       },
     }));
     const result2 = await messageProcessor.handleDefinitionRequest(test);
-    expect(result2[0].range.start.line).toBe(3);
-    expect(result2[0].range.end.line).toBe(4);
-    expect(result2[0].range.end.character).toBe(0);
+    expect(result2[0].range.start.line).toBe(2);
+    expect(result2[0].range.start.character).toBe(3);
+    expect(result2[0].range.end.line).toBe(2);
+    expect(result2[0].range.end.character).toBe(3);
     messageProcessor._graphQLCache.getProjectForFile = oldGetProject;
   });
   it('runs hover requests', async () => {

--- a/packages/graphql-language-service-server/src/types.ts
+++ b/packages/graphql-language-service-server/src/types.ts
@@ -27,12 +27,17 @@ type AdditionalLocateInfo = {
   project: GraphQLProjectConfig;
 };
 
+type LineNumber = string;
+type CharacterNumber = string;
 type RelayLSPLocateCommand = (
   // either Type, Type.field or Type.field(argument)
   projectName: string,
   typeName: string,
   info: AdditionalLocateInfo,
-) => `${string}:${string}:${string}` | `${string}:${string}` | string;
+) =>
+  | `${string}:${LineNumber}:${CharacterNumber}`
+  | `${string}:${LineNumber}`
+  | string;
 
 type GraphQLLocateCommand = (
   projectName: string,


### PR DESCRIPTION
Currently `locateCommand` is described as accepting "relay style" locations, which are interpreted as `uri:startLine:endLine`.

Relay actually uses `uri:line:column` which aligns with with how locations are represented in stack traces. 

The values are also being interpreted as 0 indexed, when I believe they are actually 1 index in relay and stack traces