### PR TITLE
[RFC] Treat locate command response as path:line:column

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -910,13 +910,11 @@ export class MessageProcessor {
         project,
       });
       if (typeof locateResult === 'string') {
-        const [uri, startLine = '1', endLine = '1'] = locateResult.split(':');
+        const [uri, line = '1', column = '1'] = locateResult.split(':');
+        const location = new Position(parseInt(line, 10), parseInt(column, 10))
         return {
           uri,
-          range: new Range(
-            new Position(parseInt(startLine, 10), 0),
-            new Position(parseInt(endLine, 10), 0),
-          ),
+          range: new Range(location, location),
         };
       }
       return locateResult;


### PR DESCRIPTION
Our intention in Relay was for the response from the locate command to be treated as `path:line:column` to match the convention of path strings in CLI output used by most tools. For example, paths in stack traces or errors in compiler output.

This convention is a de facto standard understood by many terminal emulators. This means if a server implements a locate command it should be useful in GraphQL LSPs (like this one or Relay's) and also at the CLI, where a user could manually invoke the command and then cmd+click the result to jump to the correct location in their editor.

I'm not sure what if any tests/docs etc will need to change here, but I figured this PR could start the conversation.

https://github.com/user-attachments/assets/53eb897e-76e1-41df-b8c6-4b08599d7a95

