### PR TITLE
Rollback #3883

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "pretty": "yarn pretty-check --write",
     "pretty-check": "prettier --cache --check --ignore-path .gitignore --ignore-path resources/prettierignore --ignore-path .eslintignore .",
     "ci:version": "yarn changeset version && yarn build && yarn format",
-    "release": "yarn build && yarn build-bundles && wsrun release --exclude-missing --serial --recursive --changedSince main && yarn changeset publish",
+    "release": "yarn build && yarn build-bundles && (wsrun release --exclude-missing --serial --recursive --changedSince main -- || true) && yarn changeset publish",
     "release:canary": "(node scripts/canary-release.js && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",
     "repo:fix": "manypkg fix",


### PR DESCRIPTION
#3883 breaks release action, with the following errors https://github.com/graphql/graphiql/actions/runs/14684686099/job/41329136728

This PR rolls back the previous behaviour to unblock the release workflow. Let's figure out later what's a proper fix

