### PR TITLE
fix(graphql-language-service): return `null` instead of empty `contents` array when hover results are empty

### DIFF
--- a/.changeset/wild-paws-smash.md
+++ b/.changeset/wild-paws-smash.md
@@ -1,0 +1,5 @@
+---
+"graphql-language-service-server": patch
+---
+
+return `null` instead of an empty `contents` array when hover results are empty

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -656,9 +656,9 @@ export class MessageProcessor {
 
   public async handleHoverRequest(
     params: TextDocumentPositionParams,
-  ): Promise<Hover> {
+  ): Promise<Hover | null> {
     if (!this._isInitialized) {
-      return { contents: [] };
+      return null;
     }
 
     this.validateDocumentAndPosition(params);
@@ -667,7 +667,7 @@ export class MessageProcessor {
 
     const cachedDocument = this._getCachedDocument(textDocument.uri);
     if (!cachedDocument) {
-      return { contents: [] };
+      return null;
     }
 
     const found = cachedDocument.contents.find(content => {
@@ -679,7 +679,7 @@ export class MessageProcessor {
 
     // If there is no GraphQL query in this file, return an empty result.
     if (!found) {
-      return { contents: [] };
+      return null;
     }
 
     const { query, range } = found;

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
@@ -553,7 +553,7 @@ describe('MessageProcessor', () => {
     messageProcessor._getCachedDocument = (_uri: string) => null;
 
     const result = await messageProcessor.handleHoverRequest(test);
-    expect(result).toEqual({ contents: [] });
+    expect(result).toBeNull();
   });
   it('handles provided config', async () => {
     const msgProcessor = new MessageProcessor({


### PR DESCRIPTION
I recently submitted a (rejected) [PR in Neovim](https://github.com/neovim/neovim/pull/33692) because LSPs including `graphiql` and `vtsls` are returning empty hover \`contents\` arrays when there is no result, which is almost always the case for `graphiql` since it would only ever be expected to produce hover results for embedded `#graphql` query strings.

The effect of this is that `graphiql` is showing up in the Neovim LSP hover summary every time a hover request is made, even when there are no results, at locations in the code where results from `graphiql` would never be expected:

![image](https://github.com/user-attachments/assets/ad04ca69-832e-4627-bf92-a97e99f41f15)

Since the [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover) allows a hover request to return \`null\`, this change is to align with the LSP spec to return an empty result (`null`) when there are no results instead of an empty `contents` array.

Thank you for the GraphiQL language server :)

Related PR: https://github.com/yioneko/vtsls/pull/248