### PR TITLE
pin vscode tsc to workspace version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "coverage.xml",
     "jacoco.xml",
     "coverage.cobertura.xml"
-  ]
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
This PR updates the VSCode settings file so that the workspace version of TypeScript is used for the project rather than the latest version.