### PR TITLE
fix: vs code extension setting `graphql-config.dotEnvPath` incorrect registration

### DIFF
--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -149,14 +149,14 @@
           ],
           "description": "legacy mode for graphql config v2 config",
           "default": null
+        },
+        "graphql-config.dotEnvPath": {
+          "type": [
+            "string"
+          ],
+          "description": "optional .env load file path, if not the default. specify a relative path to the .env file to be loaded by dotenv module. you can also import dotenv in the config file.",
+          "default": null
         }
-      },
-      "graphql-config.dotEnvPath": {
-        "type": [
-          "string"
-        ],
-        "description": "optional .env load file path, if not the default. specify a relative path to the .env file to be loaded by dotenv module. you can also import dotenv in the config file.",
-        "default": null
       }
     },
     "commands": [


### PR DESCRIPTION
The `graphql-config.dotEnvPath` is not being registered against the `config.properties` section in the `package.json` file. 

This causes VS Code to report the setting as `Unknown` and causes `graphql-language-service-server` to not correctly load the env file when set.

Before this fix, when attempting to set `graphql-config.dotEnvPath` in VS Code

![CleanShot 2025-05-22 at 12 23 52](https://github.com/user-attachments/assets/23eded7d-1a18-4ad0-80e7-bdcd6752d1ed)

After this fix, when attempting to set `graphql-config.dotEnvPath` in VS Code

![CleanShot 2025-05-22 at 12 25 08](https://github.com/user-attachments/assets/7b923397-3ff0-4572-b763-b3ec5a59f2e2)

