### PR TITLE
Export GraphiQLProps

### DIFF
--- a/packages/graphiql/src/index.ts
+++ b/packages/graphiql/src/index.ts
@@ -8,6 +8,6 @@
  */
 import './style.css';
 
-export { GraphiQL } from './GraphiQL';
+export { GraphiQL, GraphiQLProps } from './GraphiQL';
 
 export { HISTORY_PLUGIN } from '@graphiql/plugin-history';


### PR DESCRIPTION
Not sure if this is the right fix, but it feels like we should expose GraphiQLProps?