### PR TITLE
fix: doc-explorer search combobox null checks

### DIFF
--- a/packages/graphiql-plugin-doc-explorer/src/components/search.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.tsx
@@ -57,7 +57,10 @@ export const Search: FC = () => {
 
   const navItem = explorerNavStack.at(-1)!;
 
-  const onSelect = (def: TypeMatch | FieldMatch) => {
+  const onSelect = (def: TypeMatch | FieldMatch | null) => {
+    if (def === null) {
+      return;
+    }
     push(
       'field' in def
         ? { name: def.field.name, def: def.field }


### PR DESCRIPTION
This PR adds a null check to fix a bug in the doc explorer that happens when the search field loses focus when there is no text in the search input. To reproduce in the [Graphiql live demo](https://graphql.github.io/swapi-graphql/):
- Open the browser console
- Open the Documentation Explorer (upper left)
- Start searching in the pane
- Delete your search term and click away from the search bar
- See the console log this error: `Uncaught TypeError: right-hand side of 'in' should be an object, got null`

The cause:
The [headlessui combobox](https://headlessui.com/react/combobox#component-api) is nullable by default in ^2, a change in api from ^1 Our existing onChange handler does not expect null values to be passed

The fix:
Add an early null check to the onChange handler