### PR TITLE
graphiql 5: fix `Fixes Uncaught Error: can't access property "offsetNode", hitResult is null` on Mozilla

### DIFF
--- a/.changeset/wise-deers-bake.md
+++ b/.changeset/wise-deers-bake.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': patch
+'graphiql': patch
+---
+
+fix `Fixes Uncaught Error: can't access property "offsetNode", hitResult is null` on Mozilla

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -2,6 +2,7 @@
   "name": "@graphiql/react",
   "version": "0.35.1",
   "sideEffects": [
+    "dist/monaco-editor.js",
     "dist/setup-workers/webpack.js",
     "dist/setup-workers/vite.js"
   ],

--- a/packages/graphiql-react/src/monaco-editor.ts
+++ b/packages/graphiql-react/src/monaco-editor.ts
@@ -22,7 +22,7 @@ import { MouseTargetFactory } from 'monaco-editor/esm/vs/editor/browser/controll
  * The suggested patch https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-2406284453
  * no longer works in Mozilla Firefox
  */
-if (navigator.userAgent.startsWith('Mozilla')) {
+if (navigator.userAgent.includes('Firefox')) {
   const originalFn = MouseTargetFactory._doHitTestWithCaretPositionFromPoint;
 
   // @ts-expect-error -- internal override of Monaco method

--- a/packages/graphiql-react/src/monaco-editor.ts
+++ b/packages/graphiql-react/src/monaco-editor.ts
@@ -22,7 +22,7 @@ import { MouseTargetFactory } from 'monaco-editor/esm/vs/editor/browser/controll
  * The suggested patch https://github.com/microsoft/monaco-editor/issues/4679#issuecomment-2406284453
  * no longer works in Mozilla Firefox
  */
-if (navigator.userAgent.includes('Firefox')) {
+if (navigator.userAgent.includes('Firefox/')) {
   const originalFn = MouseTargetFactory._doHitTestWithCaretPositionFromPoint;
 
   // @ts-expect-error -- internal override of Monaco method


### PR DESCRIPTION
closes https://github.com/graphql/graphiql/issues/4041