### PR TITLE
fix multiple GraphiQL instances, append an incremented number for operation, request headers, variables and reponse URI.

### DIFF
--- a/.changeset/five-ghosts-bathe.md
+++ b/.changeset/five-ghosts-bathe.md
@@ -1,0 +1,21 @@
+---
+'@graphiql/react': patch
+'graphiql': patch
+---
+
+fix multiple GraphiQL instances, append an incremented number for operation, request headers, variables and reponse URI.
+
+E.g. the first GraphiQL instance will have:
+- `operation1.graphql`
+- `request-headers1.json`
+- `variables1.json`
+- `response1.json`
+
+The 2nd instance will have:
+
+- `operation2.graphql`
+- `request-headers2.json`
+- `variables2.json`
+- `response2.json`
+
+etc.

--- a/.changeset/five-ghosts-bathe.md
+++ b/.changeset/five-ghosts-bathe.md
@@ -3,19 +3,19 @@
 'graphiql': patch
 ---
 
-fix multiple GraphiQL instances, append an incremented number for operation, request headers, variables and reponse URI.
+fix multiple GraphiQL instances, suffix a unique id for operation, request headers, variables and response URI.
 
 E.g., the first GraphiQL instance will have:
-- `1operation.graphql`
-- `1request-headers.json`
-- `1variables.json`
-- `1response.json`
+- `1-operation.graphql`
+- `1-request-headers.json`
+- `1-variables.json`
+- `1-response.json`
 
 The 2nd instance will have:
 
-- `2operation.graphql`
-- `2request-headers.json`
-- `2variables.json`
-- `2response.json`
+- `2-operation.graphql`
+- `2-request-headers.json`
+- `2-variables.json`
+- `2-response.json`
 
 etc.

--- a/.changeset/five-ghosts-bathe.md
+++ b/.changeset/five-ghosts-bathe.md
@@ -5,17 +5,17 @@
 
 fix multiple GraphiQL instances, append an incremented number for operation, request headers, variables and reponse URI.
 
-E.g. the first GraphiQL instance will have:
-- `operation1.graphql`
-- `request-headers1.json`
-- `variables1.json`
-- `response1.json`
+E.g., the first GraphiQL instance will have:
+- `1operation.graphql`
+- `1request-headers.json`
+- `1variables.json`
+- `1response.json`
 
 The 2nd instance will have:
 
-- `operation2.graphql`
-- `request-headers2.json`
-- `variables2.json`
-- `response2.json`
+- `2operation.graphql`
+- `2request-headers.json`
+- `2variables.json`
+- `2response.json`
 
 etc.

--- a/.changeset/proud-bottles-punch.md
+++ b/.changeset/proud-bottles-punch.md
@@ -5,4 +5,4 @@
 
 - use `allowTrailingComma` option in jsonc parser to make `tryParseJsonObject` sync
 - parse introspection headers with jsonc parser
-- use prettier format for query editor since we already use prettier for jsonc editors
+- use prettier format for operation editor since we already use prettier for jsonc editors

--- a/docs/migration/graphiql-2.0.0.md
+++ b/docs/migration/graphiql-2.0.0.md
@@ -229,10 +229,10 @@ override certain parts of the UI:
 
 - `GraphiQL.Logo`: Overrides the "logo" at the top right of the screen. By
   default, it contains the text "Graph*i*QL".
-- `GraphiQL.Toolbar`: Overrides the toolbar next to the query editor. By
+- `GraphiQL.Toolbar`: Overrides the toolbar next to the operation editor. By
   default, if contains buttons for prettifying the current editor contents,
   merging fragment definitions into the operation definition and copying the
-  contents of the query editor to the clipboard. Note that the default buttons
+  contents of the operation editor to the clipboard. Note that the default buttons
   will not be shown when passing this component as child to `GraphiQL`, instead
   it will show the children you pass to `GraphiQL.Toolbar`. The execute button
   will always be shown. If you want to keep the default buttons and add

--- a/docs/migration/graphiql-5.0.0.md
+++ b/docs/migration/graphiql-5.0.0.md
@@ -132,7 +132,7 @@ function App() {
 
 - Migration from Codemirror to [Monaco Editor](https://github.com/microsoft/monaco-editor)
   - Replacing `codemirror-graphql` with [`monaco-graphql`](../../packages/monaco-graphql)
-  - Clicking on a reference in the query editor now works by holding `Cmd` on macOS or `Ctrl` on Windows/Linux
+  - Clicking on a reference in the operation editor now works by holding `Cmd` on macOS or `Ctrl` on Windows/Linux
 - Support for comments in **Variables** and **Headers** editors
 - Added new examples: [**GraphiQL x Vite**](../../examples/graphiql-vite) and [**GraphiQL x Next.js**](../../examples/graphiql-nextjs)
 - Removed examples: **GraphiQL x Parcel** and **GraphiQL x Create React App**
@@ -149,7 +149,7 @@ function App() {
 >
 > If you used `query`, `variables` and `headers` in integration tests, you can use the new `initialQuery`,
 > `initialVariables` and `initialHeaders` props instead. These props will only be used for the first tab.
-> When opening more tabs, the query editor will start out empty.
+> When opening more tabs, the operation editor will start out empty.
 
 - Added new props
   - `initialQuery`
@@ -163,14 +163,14 @@ function App() {
 
 > [!IMPORTANT]
 >
-> Clicking on a reference in the Query editor now works by holding `Cmd` on macOS or `Ctrl` on Windows/Linux.
+> Clicking on a reference in the operation editor now works by holding `Cmd` on macOS or `Ctrl` on Windows/Linux.
 
 - `usePrettifyEditors`, `useCopyQuery`, `useMergeQuery`, `useExecutionContext`, `usePluginContext`, `useSchemaContext`, `useStorageContext` hooks are deprecated.
 - Add new `useGraphiQL` and `useGraphiQLActions` hooks instead. See updated [README](../../packages/graphiql-react/README.md#available-stores) for more details about them.
 - remove `useSynchronizeValue` hook
 - fix `defaultQuery` with empty string does not result in an empty default query
-- fix `defaultQuery`, when is set will only be used for the first tab. When opening more tabs, the query editor will start out empty
-- fix execute query shortcut in query editor, run it even there are no operations in query editor
+- fix `defaultQuery`, when is set will only be used for the first tab. When opening more tabs, the operation editor will start out empty
+- fix execute query shortcut in operation editor, run it even there are no operations in the operation editor
 - fix plugin store, save last opened plugin in storage
 - remove `onClickReference` from variable editor
 - fix shortcut text per OS for default query and in run query in execute query button's tooltip

--- a/packages/graphiql-react/README.md
+++ b/packages/graphiql-react/README.md
@@ -44,7 +44,7 @@ function MyGraphQLIDE() {
 ```
 
 Inside the provider you can now use any UI component provided by
-`@graphiql/react`. For example, you can render a query editor like this:
+`@graphiql/react`. For example, you can render an operation editor like this:
 
 ```jsx
 import { QueryEditor } from '@graphiql/react';

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -2,12 +2,12 @@ export { ExecuteButton } from './execute-button';
 export { ToolbarButton } from './toolbar-button';
 export { ToolbarMenu } from './toolbar-menu';
 
-export { HeaderEditor } from './header-editor';
+export { RequestHeadersEditor as HeaderEditor } from './request-headers-editor';
 export { ImagePreview } from './image-preview';
 export { GraphiQLProvider, useGraphiQL, useGraphiQLActions } from './provider';
-export { QueryEditor } from './query-editor';
+export { OperationEditor as QueryEditor } from './operation-editor';
 export { ResponseEditor } from './response-editor';
-export { VariableEditor } from './variable-editor';
+export { VariablesEditor as VariableEditor } from './variables-editor';
 
 export { Button, UnStyledButton } from './button';
 export { ButtonGroup } from './button-group';

--- a/packages/graphiql-react/src/components/markdown-content/index.css
+++ b/packages/graphiql-react/src/components/markdown-content/index.css
@@ -1,8 +1,8 @@
 /**
  * We render markdown in the following places:
- * - In the hint tooltip when typing in the query editor (field description
+ * - In the hint tooltip when typing in the operation editor (field description
  *   and, optionally, deprecation reason).
- * - In the info tooltip when hovering over a field in the query editor
+ * - In the info tooltip when hovering over a field in the operation editor
  *   (field description and, optionally, deprecation reason).
  */
 
@@ -123,8 +123,8 @@
 
 /**
  * We show deprecations in the following places:
- * - In the hint tooltip when typing in the query editor.
- * - In the info tooltip when hovering over a field in the query editor.
+ * - In the hint tooltip when typing in the operation editor.
+ * - In the info tooltip when hovering over a field in the operation editor.
  */
 
 .CodeMirror-hint-information-deprecation,

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -20,6 +20,7 @@ import {
   URI_NAME,
   STORAGE_KEY,
   MONACO_GRAPHQL_CONFIG,
+  JSON_DIAGNOSTIC_OPTIONS,
 } from '../constants';
 import {
   type editor as monacoEditor,
@@ -31,7 +32,7 @@ import * as monaco from '../monaco-editor';
 import { getContextAtPosition } from 'graphql-language-service/esm/parser';
 import { toGraphQLPosition } from 'monaco-graphql/esm/utils';
 
-interface QueryEditorProps extends EditorProps {
+interface OperationEditorProps extends EditorProps {
   /**
    * Invoked when a reference to the GraphQL schema (type or field) is clicked
    * as part of the editor or one of its tooltips.
@@ -40,14 +41,14 @@ interface QueryEditorProps extends EditorProps {
   onClickReference?(reference: SchemaReference): void;
 
   /**
-   * Invoked when the contents of the query editor change.
+   * Invoked when the contents of the operation editor change.
    * @param value - The new contents of the editor.
    * @param documentAST - The editor contents parsed into a GraphQL document.
    */
   onEdit?(value: string, documentAST?: DocumentNode): void;
 }
 
-export const OperationEditor: FC<QueryEditorProps> = ({
+export const OperationEditor: FC<OperationEditorProps> = ({
   onClickReference,
   onEdit,
   ...props
@@ -85,7 +86,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
   );
   const storage = useStorage();
   const ref = useRef<HTMLDivElement>(null!);
-  const onClickReferenceRef = useRef<QueryEditorProps['onClickReference']>(
+  const onClickReferenceRef = useRef<OperationEditorProps['onClickReference']>(
     null!,
   );
   const monacoGraphQLApiRef = useRef<ReturnType<typeof initializeMode>>(null!);
@@ -102,7 +103,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
           closeOnUnfocus: false,
           completeSingle: false,
           autocompleteOptions: {
-            // for the query editor, restrict to executable type definitions
+            // for the operation editor, restrict to executable type definitions
             mode: GraphQLDocumentMode.EXECUTABLE,
           },
         },
@@ -219,7 +220,8 @@ export const OperationEditor: FC<QueryEditorProps> = ({
      */
     const { validateVariablesJSON } = MONACO_GRAPHQL_CONFIG.diagnosticSettings!;
     validateVariablesJSON![operationUri.toString()] = [variablesUri.toString()];
-
+    // Set diagnostics options for JSON
+    languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DIAGNOSTIC_OPTIONS);
     monacoGraphQLApiRef.current = initializeMode(MONACO_GRAPHQL_CONFIG);
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -213,15 +213,13 @@ export const OperationEditor: FC<QueryEditorProps> = ({
   }, [operationName, operations, run, setOperationName]);
 
   useEffect(() => {
-    const operationUri = Uri.file(
-      `${uriInstanceId}${URI_NAME.operation}`,
-    ).toString();
+    const operationUri = Uri.file(`${uriInstanceId}${URI_NAME.operation}`);
     const variablesUri = Uri.file(`${uriInstanceId}${URI_NAME.variables}`);
     /**
      * Mutate the global `validateVariablesJSON` object to setup which operation editor is validated
      * by which variables editor. Since we can have multiple GraphiQL instances on the same page.
      */
-    validateVariablesJSON[operationUri] = [variablesUri.toString()];
+    validateVariablesJSON[operationUri.toString()] = [variablesUri.toString()];
 
     monacoGraphQLApiRef.current = initializeMode({
       diagnosticSettings: {
@@ -236,7 +234,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     });
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
-      uri: operationUri.replace('file:///', ''),
+      uri: operationUri.path.replace('/', ''),
       value: initialQuery,
     });
     const editor = createEditor(ref, { model });
@@ -356,6 +354,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     setSchemaReference,
     setVisiblePlugin,
     externalFragments,
+    uriInstanceId,
   ]);
 
   return (

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -212,10 +212,10 @@ export const OperationEditor: FC<QueryEditorProps> = ({
 
   useEffect(() => {
     const operationUri = Uri.file(
-      `${URI_NAME.operation}${uriInstanceId}.graphql`,
+      `${uriInstanceId}${URI_NAME.operation}`,
     ).toString();
     const variablesUri = Uri.file(
-      `${URI_NAME.variables}${uriInstanceId}.json`,
+      `${uriInstanceId}${URI_NAME.variables}`,
     ).toString();
 
     console.log({ operationUri, variablesUri });
@@ -235,8 +235,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     });
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
-      uriName: operationUri.replace('file:///', '').replace('.graphql', ''),
-      language: 'graphql',
+      uri: operationUri.replace('file:///', ''),
       value: initialQuery,
     });
     const editor = createEditor(ref, { model });
@@ -287,7 +286,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     }
     const monacoGraphQLApi = monacoGraphQLApiRef.current;
     monacoGraphQLApi.setSchemaConfig([
-      { uri: `${URI_NAME.schema}${uriInstanceId}.graphql`, schema },
+      { uri: `${uriInstanceId}${URI_NAME.schema}`, schema },
     ]);
     monacoGraphQLApi.setExternalFragmentDefinitions([
       ...externalFragments.values(),

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -25,6 +25,7 @@ import {
   type editor as monacoEditor,
   languages,
   Range,
+  Uri,
 } from '../monaco-editor';
 import * as monaco from '../monaco-editor';
 import { getContextAtPosition } from 'graphql-language-service/esm/parser';
@@ -210,8 +211,14 @@ export const OperationEditor: FC<QueryEditorProps> = ({
   }, [operationName, operations, run, setOperationName]);
 
   useEffect(() => {
-    const operationUri = `${URI_NAME.operation}${uriInstanceId}.graphql`;
-    const variablesUri = `${URI_NAME.variables}${uriInstanceId}.json`;
+    const operationUri = Uri.file(
+      `${URI_NAME.operation}${uriInstanceId}.graphql`,
+    ).toString();
+    const variablesUri = Uri.file(
+      `${URI_NAME.variables}${uriInstanceId}.json`,
+    ).toString();
+
+    console.log({ operationUri, variablesUri });
 
     monacoGraphQLApiRef.current = initializeMode({
       diagnosticSettings: {
@@ -228,7 +235,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     });
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
-      uriName: operationUri.replace('.graphql', ''),
+      uriName: operationUri.replace('file:///', '').replace('.graphql', ''),
       language: 'graphql',
       value: initialQuery,
     });

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -18,8 +18,7 @@ import type { MonacoEditor, EditorProps, SchemaReference } from '../types';
 import {
   KEY_BINDINGS,
   JSON_DIAGNOSTIC_OPTIONS,
-  OPERATION_URI,
-  VARIABLES_URI,
+  URI_NAME,
   STORAGE_KEY,
 } from '../constants';
 import {
@@ -211,8 +210,8 @@ export const OperationEditor: FC<QueryEditorProps> = ({
   }, [operationName, operations, run, setOperationName]);
 
   useEffect(() => {
-    const operationUri = `${OPERATION_URI}${uriInstanceId}`;
-    const variablesUri = `${VARIABLES_URI}${uriInstanceId}`;
+    const operationUri = `${URI_NAME.operation}${uriInstanceId}.graphql`;
+    const variablesUri = `${URI_NAME.variables}${uriInstanceId}.json`;
 
     monacoGraphQLApiRef.current = initializeMode({
       diagnosticSettings: {
@@ -229,7 +228,8 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     });
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
-      uri: operationUri,
+      uriName: operationUri.replace('.graphql', ''),
+      language: 'graphql',
       value: initialQuery,
     });
     const editor = createEditor(ref, { model });
@@ -280,7 +280,7 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     }
     const monacoGraphQLApi = monacoGraphQLApiRef.current;
     monacoGraphQLApi.setSchemaConfig([
-      { uri: `schema${uriInstanceId}.graphql`, schema },
+      { uri: `${URI_NAME.schema}${uriInstanceId}.graphql`, schema },
     ]);
     monacoGraphQLApi.setExternalFragmentDefinitions([
       ...externalFragments.values(),

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -2,7 +2,6 @@ import { getSelectedOperationName } from '@graphiql/toolkit';
 import type { DocumentNode } from 'graphql';
 import { getOperationFacts } from 'graphql-language-service';
 import { FC, useEffect, useRef } from 'react';
-import { initializeMode } from 'monaco-graphql/esm/lite.js';
 import { useStorage } from '../stores';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import {
@@ -19,8 +18,8 @@ import {
   KEY_BINDINGS,
   URI_NAME,
   STORAGE_KEY,
-  MONACO_GRAPHQL_CONFIG,
-  JSON_DIAGNOSTIC_OPTIONS,
+  MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS,
+  MONACO_GRAPHQL_API,
 } from '../constants';
 import {
   type editor as monacoEditor,
@@ -89,7 +88,6 @@ export const OperationEditor: FC<OperationEditorProps> = ({
   const onClickReferenceRef = useRef<OperationEditorProps['onClickReference']>(
     null!,
   );
-  const monacoGraphQLApiRef = useRef<ReturnType<typeof initializeMode>>(null!);
   useEffect(() => {
     onClickReferenceRef.current = onClickReference;
   }, [onClickReference]);
@@ -218,11 +216,11 @@ export const OperationEditor: FC<OperationEditorProps> = ({
      * Mutate the global `validateVariablesJSON` object to setup which operation editor is validated
      * by which variables editor. Since we can have multiple GraphiQL instances on the same page.
      */
-    const { validateVariablesJSON } = MONACO_GRAPHQL_CONFIG.diagnosticSettings!;
+    const { validateVariablesJSON } = MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS;
     validateVariablesJSON![operationUri.toString()] = [variablesUri.toString()];
-    // Set diagnostics options for JSON
-    languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DIAGNOSTIC_OPTIONS);
-    monacoGraphQLApiRef.current = initializeMode(MONACO_GRAPHQL_CONFIG);
+    MONACO_GRAPHQL_API.setDiagnosticSettings(
+      MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS,
+    );
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
       uri: operationUri.path.replace('/', ''),
@@ -274,11 +272,10 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     if (!schema) {
       return;
     }
-    const monacoGraphQLApi = monacoGraphQLApiRef.current;
-    monacoGraphQLApi.setSchemaConfig([
+    MONACO_GRAPHQL_API.setSchemaConfig([
       { uri: `${uriInstanceId}${URI_NAME.schema}`, schema },
     ]);
-    monacoGraphQLApi.setExternalFragmentDefinitions([
+    MONACO_GRAPHQL_API.setExternalFragmentDefinitions([
       ...externalFragments.values(),
     ]);
     if (!referencePlugin) {

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -17,9 +17,9 @@ import {
 import type { MonacoEditor, EditorProps, SchemaReference } from '../types';
 import {
   KEY_BINDINGS,
-  JSON_DIAGNOSTIC_OPTIONS,
   URI_NAME,
   STORAGE_KEY,
+  MONACO_GRAPHQL_CONFIG,
 } from '../constants';
 import {
   type editor as monacoEditor,
@@ -46,8 +46,6 @@ interface QueryEditorProps extends EditorProps {
    */
   onEdit?(value: string, documentAST?: DocumentNode): void;
 }
-
-const validateVariablesJSON: Record<string, string[]> = Object.create(null);
 
 export const OperationEditor: FC<QueryEditorProps> = ({
   onClickReference,
@@ -219,19 +217,10 @@ export const OperationEditor: FC<QueryEditorProps> = ({
      * Mutate the global `validateVariablesJSON` object to setup which operation editor is validated
      * by which variables editor. Since we can have multiple GraphiQL instances on the same page.
      */
-    validateVariablesJSON[operationUri.toString()] = [variablesUri.toString()];
+    const { validateVariablesJSON } = MONACO_GRAPHQL_CONFIG.diagnosticSettings!;
+    validateVariablesJSON![operationUri.toString()] = [variablesUri.toString()];
 
-    monacoGraphQLApiRef.current = initializeMode({
-      diagnosticSettings: {
-        validateVariablesJSON,
-        jsonDiagnosticSettings: {
-          validate: true,
-          schemaValidation: 'error',
-          // Set these again, because we are entirely re-setting them here
-          ...JSON_DIAGNOSTIC_OPTIONS,
-        },
-      },
-    });
+    monacoGraphQLApiRef.current = initializeMode(MONACO_GRAPHQL_CONFIG);
     globalThis.__MONACO = monaco;
     const model = getOrCreateModel({
       uri: operationUri.path.replace('/', ''),

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -47,6 +47,8 @@ interface QueryEditorProps extends EditorProps {
   onEdit?(value: string, documentAST?: DocumentNode): void;
 }
 
+const validateVariablesJSON: Record<string, string[]> = Object.create(null);
+
 export const OperationEditor: FC<QueryEditorProps> = ({
   onClickReference,
   onEdit,
@@ -214,17 +216,16 @@ export const OperationEditor: FC<QueryEditorProps> = ({
     const operationUri = Uri.file(
       `${uriInstanceId}${URI_NAME.operation}`,
     ).toString();
-    const variablesUri = Uri.file(
-      `${uriInstanceId}${URI_NAME.variables}`,
-    ).toString();
-
-    console.log({ operationUri, variablesUri });
+    const variablesUri = Uri.file(`${uriInstanceId}${URI_NAME.variables}`);
+    /**
+     * Mutate the global `validateVariablesJSON` object to setup which operation editor is validated
+     * by which variables editor. Since we can have multiple GraphiQL instances on the same page.
+     */
+    validateVariablesJSON[operationUri] = [variablesUri.toString()];
 
     monacoGraphQLApiRef.current = initializeMode({
       diagnosticSettings: {
-        validateVariablesJSON: {
-          [operationUri]: [variablesUri],
-        },
+        validateVariablesJSON,
         jsonDiagnosticSettings: {
           validate: true,
           schemaValidation: 'error',

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -213,8 +213,11 @@ const InnerGraphiQLProvider: FC<InnerGraphiQLProviderProps> = ({
           onTabChange,
           shouldPersistHeaders: $shouldPersistHeaders,
           tabs,
-          // Strip colons because it breaks monaco-editor variables autocomplete
-          uriInstanceId: uriInstanceId.replaceAll(':', '') + '-',
+          /**
+           * Strip colons (React 18) and arrows (React 19) because it breaks monaco-editor
+           * variables autocomplete
+           */
+          uriInstanceId: uriInstanceId.replaceAll(/[:«»]/g, '') + '-',
         })(...args);
         const executionSlice = createExecutionSlice({
           fetcher,

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -1,6 +1,6 @@
 /* eslint sort-keys: "error" */
 import type { ComponentPropsWithoutRef, FC, ReactNode, RefObject } from 'react';
-import { createContext, useContext, useRef, useEffect } from 'react';
+import { createContext, useContext, useRef, useEffect, useId } from 'react';
 import { create, useStore, UseBoundStore, StoreApi } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 import {
@@ -156,7 +156,7 @@ const InnerGraphiQLProvider: FC<InnerGraphiQLProviderProps> = ({
 }) => {
   const storage = useStorage();
   const storeRef = useRef<GraphiQLStore>(null!);
-
+  const uriInstanceId = useId();
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- false positive
   if (storeRef.current === null) {
     function getInitialVisiblePlugin() {
@@ -213,6 +213,8 @@ const InnerGraphiQLProvider: FC<InnerGraphiQLProviderProps> = ({
           onTabChange,
           shouldPersistHeaders: $shouldPersistHeaders,
           tabs,
+          // Strip colons because it breaks monaco-editor variables autocomplete
+          uriInstanceId: uriInstanceId.replaceAll(':', '') + '-',
         })(...args);
         const executionSlice = createExecutionSlice({
           fetcher,

--- a/packages/graphiql-react/src/components/request-headers-editor.tsx
+++ b/packages/graphiql-react/src/components/request-headers-editor.tsx
@@ -14,7 +14,7 @@ import {
 
 interface RequestHeadersEditorProps extends EditorProps {
   /**
-   * Invoked when the contents of the headers editor change.
+   * Invoked when the contents of the request headers editor change.
    * @param value - The new contents of the editor.
    */
   onEdit?(value: string): void;

--- a/packages/graphiql-react/src/components/request-headers-editor.tsx
+++ b/packages/graphiql-react/src/components/request-headers-editor.tsx
@@ -35,10 +35,9 @@ export const RequestHeadersEditor: FC<RequestHeadersEditorProps> = ({
     'headers',
   );
   useEffect(() => {
-    const requestHeadersUri = `${URI_NAME.requestHeaders}${uriInstanceId}`;
+    const requestHeadersUri = `${uriInstanceId}${URI_NAME.requestHeaders}`;
     const model = getOrCreateModel({
-      uriName: requestHeadersUri,
-      language: 'json',
+      uri: requestHeadersUri,
       value: initialHeaders,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/request-headers-editor.tsx
+++ b/packages/graphiql-react/src/components/request-headers-editor.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef } from 'react';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import type { EditorProps } from '../types';
-import { REQUEST_HEADERS_URI, KEY_BINDINGS, STORAGE_KEY } from '../constants';
+import { URI_NAME, KEY_BINDINGS, STORAGE_KEY } from '../constants';
 import {
   getOrCreateModel,
   createEditor,
@@ -35,9 +35,10 @@ export const RequestHeadersEditor: FC<RequestHeadersEditorProps> = ({
     'headers',
   );
   useEffect(() => {
-    const requestHeadersUri = `${REQUEST_HEADERS_URI}${uriInstanceId}`;
+    const requestHeadersUri = `${URI_NAME.requestHeaders}${uriInstanceId}`;
     const model = getOrCreateModel({
-      uri: requestHeadersUri,
+      uriName: requestHeadersUri,
+      language: 'json',
       value: initialHeaders,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/request-headers-editor.tsx
+++ b/packages/graphiql-react/src/components/request-headers-editor.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef } from 'react';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import type { EditorProps } from '../types';
-import { HEADER_URI, KEY_BINDINGS, STORAGE_KEY } from '../constants';
+import { REQUEST_HEADERS_URI, KEY_BINDINGS, STORAGE_KEY } from '../constants';
 import {
   getOrCreateModel,
   createEditor,
@@ -12,7 +12,7 @@ import {
   cn,
 } from '../utility';
 
-interface HeaderEditorProps extends EditorProps {
+interface RequestHeadersEditorProps extends EditorProps {
   /**
    * Invoked when the contents of the headers editor change.
    * @param value - The new contents of the editor.
@@ -20,10 +20,13 @@ interface HeaderEditorProps extends EditorProps {
   onEdit?(value: string): void;
 }
 
-export const HeaderEditor: FC<HeaderEditorProps> = ({ onEdit, ...props }) => {
+export const RequestHeadersEditor: FC<RequestHeadersEditorProps> = ({
+  onEdit,
+  ...props
+}) => {
   const { setEditor, run, prettifyEditors, mergeQuery } = useGraphiQLActions();
-  const { initialHeaders, shouldPersistHeaders } = useGraphiQL(
-    pick('initialHeaders', 'shouldPersistHeaders'),
+  const { initialHeaders, shouldPersistHeaders, uriInstanceId } = useGraphiQL(
+    pick('initialHeaders', 'shouldPersistHeaders', 'uriInstanceId'),
   );
   const ref = useRef<HTMLDivElement>(null!);
   useChangeHandler(
@@ -32,7 +35,11 @@ export const HeaderEditor: FC<HeaderEditorProps> = ({ onEdit, ...props }) => {
     'headers',
   );
   useEffect(() => {
-    const model = getOrCreateModel({ uri: HEADER_URI, value: initialHeaders });
+    const requestHeadersUri = `${REQUEST_HEADERS_URI}${uriInstanceId}`;
+    const model = getOrCreateModel({
+      uri: requestHeadersUri,
+      value: initialHeaders,
+    });
     const editor = createEditor(ref, { model });
     setEditor({ headerEditor: editor });
     const disposables = [

--- a/packages/graphiql-react/src/components/request-headers-editor.tsx
+++ b/packages/graphiql-react/src/components/request-headers-editor.tsx
@@ -35,9 +35,8 @@ export const RequestHeadersEditor: FC<RequestHeadersEditorProps> = ({
     'headers',
   );
   useEffect(() => {
-    const requestHeadersUri = `${uriInstanceId}${URI_NAME.requestHeaders}`;
     const model = getOrCreateModel({
-      uri: requestHeadersUri,
+      uri: `${uriInstanceId}${URI_NAME.requestHeaders}`,
       value: initialHeaders,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -54,9 +54,8 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   }, [responseEditor, fetchError, validationErrors]);
 
   useEffect(() => {
-    const responseUri = `${uriInstanceId}${URI_NAME.response}`;
     const model = getOrCreateModel({
-      uri: responseUri,
+      uri: `${uriInstanceId}${URI_NAME.response}`,
       value: '',
     });
     const editor = createEditor(ref, {

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -54,10 +54,9 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   }, [responseEditor, fetchError, validationErrors]);
 
   useEffect(() => {
-    const responseUri = `${URI_NAME.response}${uriInstanceId}`;
+    const responseUri = `${uriInstanceId}${URI_NAME.response}`;
     const model = getOrCreateModel({
-      uriName: responseUri,
-      language: 'json',
+      uri: responseUri,
       value: '',
     });
     const editor = createEditor(ref, {

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -39,9 +39,10 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   ...props
 }) => {
   const { setEditor, run } = useGraphiQLActions();
-  const { fetchError, validationErrors, responseEditor } = useGraphiQL(
-    pick('fetchError', 'validationErrors', 'responseEditor'),
-  );
+  const { fetchError, validationErrors, responseEditor, uriInstanceId } =
+    useGraphiQL(
+      pick('fetchError', 'validationErrors', 'responseEditor', 'uriInstanceId'),
+    );
   const ref = useRef<HTMLDivElement>(null!);
   useEffect(() => {
     if (fetchError) {
@@ -53,7 +54,11 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   }, [responseEditor, fetchError, validationErrors]);
 
   useEffect(() => {
-    const model = getOrCreateModel({ uri: RESPONSE_URI, value: '' });
+    const responseUri = `${RESPONSE_URI}${uriInstanceId}`;
+    const model = getOrCreateModel({
+      uri: responseUri,
+      value: '',
+    });
     const editor = createEditor(ref, {
       model,
       readOnly: true,

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -11,7 +11,7 @@ import {
   cleanupDisposables,
   cn,
 } from '../utility';
-import { KEY_BINDINGS, RESPONSE_URI } from '../constants';
+import { KEY_BINDINGS, URI_NAME } from '../constants';
 import type { EditorProps } from '../types';
 import type { editor as monacoEditor, Position } from '../monaco-editor';
 import { Range, languages } from '../monaco-editor';
@@ -54,9 +54,10 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   }, [responseEditor, fetchError, validationErrors]);
 
   useEffect(() => {
-    const responseUri = `${RESPONSE_URI}${uriInstanceId}`;
+    const responseUri = `${URI_NAME.response}${uriInstanceId}`;
     const model = getOrCreateModel({
-      uri: responseUri,
+      uriName: responseUri,
+      language: 'json',
       value: '',
     });
     const editor = createEditor(ref, {

--- a/packages/graphiql-react/src/components/variables-editor.tsx
+++ b/packages/graphiql-react/src/components/variables-editor.tsx
@@ -12,7 +12,7 @@ import {
   pick,
 } from '../utility';
 
-interface VariableEditorProps extends EditorProps {
+interface VariablesEditorProps extends EditorProps {
   /**
    * Invoked when the contents of the variables' editor change.
    * @param value - The new contents of the editor.
@@ -20,7 +20,7 @@ interface VariableEditorProps extends EditorProps {
   onEdit?(value: string): void;
 }
 
-export const VariablesEditor: FC<VariableEditorProps> = ({
+export const VariablesEditor: FC<VariablesEditorProps> = ({
   onEdit,
   ...props
 }) => {

--- a/packages/graphiql-react/src/components/variables-editor.tsx
+++ b/packages/graphiql-react/src/components/variables-editor.tsx
@@ -30,10 +30,9 @@ export const VariablesEditor: FC<VariablesEditorProps> = ({
   );
   const ref = useRef<HTMLDivElement>(null!);
   useChangeHandler(onEdit, STORAGE_KEY.variables, 'variables');
-  const variableUri = `${uriInstanceId}${URI_NAME.variables}`;
   useEffect(() => {
     const model = getOrCreateModel({
-      uri: variableUri,
+      uri: `${uriInstanceId}${URI_NAME.variables}`,
       value: initialVariables,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/variables-editor.tsx
+++ b/packages/graphiql-react/src/components/variables-editor.tsx
@@ -30,11 +30,10 @@ export const VariablesEditor: FC<VariableEditorProps> = ({
   );
   const ref = useRef<HTMLDivElement>(null!);
   useChangeHandler(onEdit, STORAGE_KEY.variables, 'variables');
-  const variableUri = `${URI_NAME.variables}${uriInstanceId}`;
+  const variableUri = `${uriInstanceId}${URI_NAME.variables}`;
   useEffect(() => {
     const model = getOrCreateModel({
-      uriName: variableUri,
-      language: 'json',
+      uri: variableUri,
       value: initialVariables,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/variables-editor.tsx
+++ b/packages/graphiql-react/src/components/variables-editor.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef } from 'react';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import type { EditorProps } from '../types';
-import { KEY_BINDINGS, STORAGE_KEY, VARIABLE_URI } from '../constants';
+import { KEY_BINDINGS, STORAGE_KEY, VARIABLES_URI } from '../constants';
 import {
   getOrCreateModel,
   createEditor,
@@ -9,6 +9,7 @@ import {
   onEditorContainerKeyDown,
   cleanupDisposables,
   cn,
+  pick,
 } from '../utility';
 
 interface VariableEditorProps extends EditorProps {
@@ -19,17 +20,20 @@ interface VariableEditorProps extends EditorProps {
   onEdit?(value: string): void;
 }
 
-export const VariableEditor: FC<VariableEditorProps> = ({
+export const VariablesEditor: FC<VariableEditorProps> = ({
   onEdit,
   ...props
 }) => {
   const { setEditor, run, prettifyEditors, mergeQuery } = useGraphiQLActions();
-  const initialVariables = useGraphiQL(state => state.initialVariables);
+  const { initialVariables, uriInstanceId } = useGraphiQL(
+    pick('initialVariables', 'uriInstanceId'),
+  );
   const ref = useRef<HTMLDivElement>(null!);
   useChangeHandler(onEdit, STORAGE_KEY.variables, 'variables');
+  const variableUri = `${VARIABLES_URI}${uriInstanceId}`;
   useEffect(() => {
     const model = getOrCreateModel({
-      uri: VARIABLE_URI,
+      uri: variableUri,
       value: initialVariables,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/components/variables-editor.tsx
+++ b/packages/graphiql-react/src/components/variables-editor.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef } from 'react';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import type { EditorProps } from '../types';
-import { KEY_BINDINGS, STORAGE_KEY, VARIABLES_URI } from '../constants';
+import { KEY_BINDINGS, STORAGE_KEY, URI_NAME } from '../constants';
 import {
   getOrCreateModel,
   createEditor,
@@ -30,10 +30,11 @@ export const VariablesEditor: FC<VariableEditorProps> = ({
   );
   const ref = useRef<HTMLDivElement>(null!);
   useChangeHandler(onEdit, STORAGE_KEY.variables, 'variables');
-  const variableUri = `${VARIABLES_URI}${uriInstanceId}`;
+  const variableUri = `${URI_NAME.variables}${uriInstanceId}`;
   useEffect(() => {
     const model = getOrCreateModel({
-      uri: variableUri,
+      uriName: variableUri,
+      language: 'json',
       value: initialVariables,
     });
     const editor = createEditor(ref, { model });

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -3,7 +3,7 @@
 import { printers } from 'prettier/plugins/graphql'; // eslint-disable-line import-x/no-duplicates
 import { parsers } from 'prettier/parser-graphql'; // eslint-disable-line import-x/no-duplicates
 import prettier from 'prettier/standalone';
-import { KeyCode, KeyMod, Uri, languages } from './monaco-editor';
+import { KeyCode, KeyMod, languages } from './monaco-editor';
 import type { EditorSlice } from './stores';
 
 export const isMacOs =

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-bitwise */
-import { initializeMode } from 'monaco-graphql/esm/lite.js';
 // @ts-expect-error -- wrong types
 import { printers } from 'prettier/plugins/graphql'; // eslint-disable-line import-x/no-duplicates
 import { parsers } from 'prettier/parser-graphql'; // eslint-disable-line import-x/no-duplicates
@@ -115,13 +114,13 @@ export const KEY_BINDINGS = {
   },
 } as const;
 
-export const QUERY_URI = Uri.file('query.graphql');
-export const VARIABLE_URI = Uri.file('variable.json');
-export const HEADER_URI = Uri.file('header.json');
+export const OPERATION_URI = Uri.file('operation.graphql');
+export const VARIABLES_URI = Uri.file('variables.json');
+export const REQUEST_HEADERS_URI = Uri.file('request-headers.json');
 export const RESPONSE_URI = Uri.file('response.json');
 
 // set these early on so that initial variables with comments don't flash an error
-const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
+export const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
   // Fixes Comments are not permitted in JSON.(521)
   allowComments: true,
   // Fixes Trailing comma json(519)
@@ -130,20 +129,6 @@ const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
 
 // Set diagnostics options for JSON
 languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DIAGNOSTIC_OPTIONS);
-
-export const MONACO_GRAPHQL_API = initializeMode({
-  diagnosticSettings: {
-    validateVariablesJSON: {
-      [QUERY_URI.toString()]: [VARIABLE_URI.toString()],
-    },
-    jsonDiagnosticSettings: {
-      validate: true,
-      schemaValidation: 'error',
-      // Set these again, because we are entirely re-setting them here
-      ...JSON_DIAGNOSTIC_OPTIONS,
-    },
-  },
-});
 
 export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] = query =>
   prettier.format(query, {

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -114,10 +114,13 @@ export const KEY_BINDINGS = {
   },
 } as const;
 
-export const OPERATION_URI = Uri.file('operation.graphql');
-export const VARIABLES_URI = Uri.file('variables.json');
-export const REQUEST_HEADERS_URI = Uri.file('request-headers.json');
-export const RESPONSE_URI = Uri.file('response.json');
+export const URI_NAME = {
+  operation: 'operation',
+  variables: 'variables',
+  request_headers: 'request-headers',
+  schema: 'schema',
+  response: 'response',
+} as const;
 
 // set these early on so that initial variables with comments don't flash an error
 export const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -115,11 +115,12 @@ export const KEY_BINDINGS = {
 } as const;
 
 export const URI_NAME = {
-  operation: 'operation',
-  variables: 'variables',
-  requestHeaders: 'request-headers',
-  schema: 'schema',
-  response: 'response',
+  operation: 'operation.graphql',
+  schema: 'schema.graphql',
+
+  variables: 'variables.json',
+  requestHeaders: 'request-headers.json',
+  response: 'response.json',
 } as const;
 
 // set these early on so that initial variables with comments don't flash an error

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -125,7 +125,7 @@ export const URI_NAME = {
 } as const;
 
 // set these early on so that initial variables with comments don't flash an error
-const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
+export const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
   // Fixes Comments are not permitted in JSON.(521)
   allowComments: true,
   // Fixes Trailing comma json(519)
@@ -143,9 +143,6 @@ export const MONACO_GRAPHQL_CONFIG: MonacoGraphQLInitializeConfig = {
     },
   },
 };
-
-// Set diagnostics options for JSON
-languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DIAGNOSTIC_OPTIONS);
 
 export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] = query =>
   prettier.format(query, {

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-bitwise */
+import { initializeMode } from 'monaco-graphql/esm/lite.js';
 // @ts-expect-error -- wrong types
 import { printers } from 'prettier/plugins/graphql'; // eslint-disable-line import-x/no-duplicates
 import { parsers } from 'prettier/parser-graphql'; // eslint-disable-line import-x/no-duplicates
 import prettier from 'prettier/standalone';
-import type { MonacoGraphQLInitializeConfig } from 'monaco-graphql';
+import type { DiagnosticSettings } from 'monaco-graphql';
 import { KeyCode, KeyMod, languages } from './monaco-editor';
 import type { EditorSlice } from './stores';
 
@@ -125,24 +126,29 @@ export const URI_NAME = {
 } as const;
 
 // set these early on so that initial variables with comments don't flash an error
-export const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
+const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
   // Fixes Comments are not permitted in JSON.(521)
   allowComments: true,
   // Fixes Trailing comma json(519)
   trailingCommas: 'ignore',
 };
 
-export const MONACO_GRAPHQL_CONFIG: MonacoGraphQLInitializeConfig = {
-  diagnosticSettings: {
-    validateVariablesJSON: {},
-    jsonDiagnosticSettings: {
-      validate: true,
-      schemaValidation: 'error',
-      // Set these again, because we are entirely re-setting them here
-      ...JSON_DIAGNOSTIC_OPTIONS,
-    },
+// Set diagnostics options for JSON
+languages.json.jsonDefaults.setDiagnosticsOptions(JSON_DIAGNOSTIC_OPTIONS);
+
+export const MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS: DiagnosticSettings = {
+  validateVariablesJSON: {},
+  jsonDiagnosticSettings: {
+    validate: true,
+    schemaValidation: 'error',
+    // Set these again, because we are entirely re-setting them here
+    ...JSON_DIAGNOSTIC_OPTIONS,
   },
 };
+
+export const MONACO_GRAPHQL_API = initializeMode({
+  diagnosticSettings: MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS,
+});
 
 export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] = query =>
   prettier.format(query, {

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -117,7 +117,7 @@ export const KEY_BINDINGS = {
 export const URI_NAME = {
   operation: 'operation',
   variables: 'variables',
-  request_headers: 'request-headers',
+  requestHeaders: 'request-headers',
   schema: 'schema',
   response: 'response',
 } as const;

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -3,6 +3,7 @@
 import { printers } from 'prettier/plugins/graphql'; // eslint-disable-line import-x/no-duplicates
 import { parsers } from 'prettier/parser-graphql'; // eslint-disable-line import-x/no-duplicates
 import prettier from 'prettier/standalone';
+import type { MonacoGraphQLInitializeConfig } from 'monaco-graphql';
 import { KeyCode, KeyMod, languages } from './monaco-editor';
 import type { EditorSlice } from './stores';
 
@@ -124,11 +125,23 @@ export const URI_NAME = {
 } as const;
 
 // set these early on so that initial variables with comments don't flash an error
-export const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
+const JSON_DIAGNOSTIC_OPTIONS: languages.json.DiagnosticsOptions = {
   // Fixes Comments are not permitted in JSON.(521)
   allowComments: true,
   // Fixes Trailing comma json(519)
   trailingCommas: 'ignore',
+};
+
+export const MONACO_GRAPHQL_CONFIG: MonacoGraphQLInitializeConfig = {
+  diagnosticSettings: {
+    validateVariablesJSON: {},
+    jsonDiagnosticSettings: {
+      validate: true,
+      schemaValidation: 'error',
+      // Set these again, because we are entirely re-setting them here
+      ...JSON_DIAGNOSTIC_OPTIONS,
+    },
+  },
 };
 
 // Set diagnostics options for JSON

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -21,15 +21,13 @@ import type { SlicesWithActions, MonacoEditor } from '../types';
 import { debounce, formatJSONC } from '../utility';
 import { STORAGE_KEY } from '../constants';
 
-let uriInstanceId = 0;
-
 export interface EditorSlice extends TabsState {
   /**
-   * Unique ID of the GraphiQL instance, which will be appended to the URIs for operations, variables, headers, and responses.
+   * Unique ID of the GraphiQL instance, which will be suffixed to the URIs for operations, variables, headers, and responses.
    *
    * @see https://github.com/microsoft/monaco-editor#uris
    */
-  uriInstanceId: number;
+  uriInstanceId: string;
   /**
    * The Monaco Editor instance used in the header editor, used to edit HTTP headers.
    */
@@ -294,6 +292,7 @@ type CreateEditorSlice = (
     | 'defaultHeaders'
     | 'onPrettifyQuery'
     | 'onCopyQuery'
+    | 'uriInstanceId'
   >,
 ) => StateCreator<
   SlicesWithActions,
@@ -537,12 +536,8 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
       queryEditor!.setValue(print(mergeAst(documentAST, schema)));
     },
   };
-
-  uriInstanceId += 1;
-
   return {
     ...initial,
-    uriInstanceId,
     actions: $actions,
   };
 };

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -29,12 +29,12 @@ export interface EditorSlice extends TabsState {
    */
   uriInstanceId: string;
   /**
-   * The Monaco Editor instance used in the header editor, used to edit HTTP headers.
+   * The Monaco Editor instance used in the request headers editor, used to edit HTTP headers.
    */
   headerEditor?: MonacoEditor;
 
   /**
-   * The Monaco Editor instance used in the query editor.
+   * The Monaco Editor instance used in the operation editor.
    */
   queryEditor?: MonacoEditor;
 
@@ -44,18 +44,18 @@ export interface EditorSlice extends TabsState {
   responseEditor?: MonacoEditor;
 
   /**
-   * The Monaco Editor instance used in the variable editor.
+   * The Monaco Editor instance used in the variables editor.
    */
   variableEditor?: MonacoEditor;
 
   /**
-   * The contents of the headers editor when initially rendering the provider
+   * The contents of the request headers editor when initially rendering the provider
    * component.
    */
   initialHeaders: string;
 
   /**
-   * The contents of the query editor when initially rendering the provider
+   * The contents of the operation editor when initially rendering the provider
    * component.
    */
   initialQuery: string;
@@ -73,16 +73,16 @@ export interface EditorSlice extends TabsState {
   externalFragments: Map<string, FragmentDefinitionNode>;
 
   /**
-   * If the contents of the headers editor are persisted in storage.
+   * If the contents of the request headers editor are persisted in storage.
    */
   shouldPersistHeaders: boolean;
 
   /**
-   * The initial content of the query editor when loading GraphiQL and there is
+   * The initial content of the operation editor when loading GraphiQL and there is
    * no saved query in storage and no `initialQuery` prop.
    *
    * This value is used only for the first tab. Additional tabs will open with
-   * an empty query editor.
+   * an empty operation editor.
    *
    * @default "# Welcome to GraphiQL..."
    */
@@ -90,7 +90,7 @@ export interface EditorSlice extends TabsState {
 
   /**
    * Invoked when the operation name changes. Possible triggers are:
-   * - Editing the contents of the query editor
+   * - Editing the contents of the operation editor
    * - Selecting an operation for execution in a document that contains multiple
    *   operation definitions
    * @param operationName - The operation name after it has been changed.
@@ -113,7 +113,7 @@ export interface EditorSlice extends TabsState {
   defaultHeaders?: string;
 
   /**
-   * Invoked when the current contents of the query editor are copied to the
+   * Invoked when the current contents of the operation editor are copied to the
    * clipboard.
    * @param query - The content that has been copied.
    */
@@ -121,7 +121,7 @@ export interface EditorSlice extends TabsState {
 
   /**
    * Invoked when the prettify callback is invoked.
-   * @param query - The current value of the query editor.
+   * @param query - The current value of the operation editor.
    * @default
    * import prettier from 'prettier/standalone'
    *
@@ -130,7 +130,7 @@ export interface EditorSlice extends TabsState {
    */
   onPrettifyQuery: (query: string) => MaybePromise<string>;
 
-  // Operation facts that are derived from the query editor.
+  // Operation facts that are derived from the operation editor.
 
   /**
    * @remarks from graphiql 5
@@ -224,7 +224,7 @@ export interface EditorActions {
   mergeQuery: () => void;
 
   /**
-   * Prettify query, variable and header editors.
+   * Prettify query, variables and request headers editors.
    */
   prettifyEditors: () => Promise<void>;
 }
@@ -264,7 +264,7 @@ export interface EditorProps
   defaultTabs?: TabDefinition[];
 
   /**
-   * This prop toggles if the contents of the headers editor are persisted in
+   * This prop toggles if the contents of the request headers editor are persisted in
    * storage.
    * @default false
    */

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -25,6 +25,12 @@ let uriInstanceId = 0;
 
 export interface EditorSlice extends TabsState {
   /**
+   * Unique ID of the GraphiQL instance, which will be appended to the URIs for operations, variables, headers, and responses.
+   *
+   * @see https://github.com/microsoft/monaco-editor#uris
+   */
+  uriInstanceId: number;
+  /**
    * The Monaco Editor instance used in the header editor, used to edit HTTP headers.
    */
   headerEditor?: MonacoEditor;
@@ -532,7 +538,7 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
     },
   };
 
-  uriInstanceId += 1
+  uriInstanceId += 1;
 
   return {
     ...initial,

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -21,6 +21,8 @@ import type { SlicesWithActions, MonacoEditor } from '../types';
 import { debounce, formatJSONC } from '../utility';
 import { STORAGE_KEY } from '../constants';
 
+let uriInstanceId = 0;
+
 export interface EditorSlice extends TabsState {
   /**
    * The Monaco Editor instance used in the header editor, used to edit HTTP headers.
@@ -530,8 +532,11 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
     },
   };
 
+  uriInstanceId += 1
+
   return {
     ...initial,
+    uriInstanceId,
     actions: $actions,
   };
 };

--- a/packages/graphiql-react/src/utility/create-editor.ts
+++ b/packages/graphiql-react/src/utility/create-editor.ts
@@ -1,6 +1,5 @@
 import type { KeyboardEventHandler, RefObject } from 'react';
-import type { Uri } from '../monaco-editor';
-import { editor as monacoEditor } from '../monaco-editor';
+import { editor as monacoEditor, Uri } from '../monaco-editor';
 import type { MonacoEditor } from '../types';
 
 export const EDITOR_THEME = {
@@ -19,7 +18,8 @@ export const onEditorContainerKeyDown: KeyboardEventHandler<
   }
 };
 
-export function getOrCreateModel({ uri, value }: { uri: Uri; value: string }) {
+export function getOrCreateModel({ uri: $uri, value }: { uri: string; value: string }) {
+  const uri = Uri.file($uri)
   const model = monacoEditor.getModel(uri);
   const language = uri.path.split('.').at(-1)!;
   return model ?? monacoEditor.createModel(value, language, uri);

--- a/packages/graphiql-react/src/utility/create-editor.ts
+++ b/packages/graphiql-react/src/utility/create-editor.ts
@@ -19,15 +19,16 @@ export const onEditorContainerKeyDown: KeyboardEventHandler<
 };
 
 export function getOrCreateModel({
-  uri: $uri,
+  uriName,
   value,
+  language,
 }: {
-  uri: string;
+  uriName: string;
   value: string;
+  language: 'graphql' | 'json';
 }) {
-  const uri = Uri.file($uri);
+  const uri = Uri.file(`${uriName}.${language}`);
   const model = monacoEditor.getModel(uri);
-  const language = uri.path.split('.').at(-1)!;
   return model ?? monacoEditor.createModel(value, language, uri);
 }
 

--- a/packages/graphiql-react/src/utility/create-editor.ts
+++ b/packages/graphiql-react/src/utility/create-editor.ts
@@ -19,16 +19,15 @@ export const onEditorContainerKeyDown: KeyboardEventHandler<
 };
 
 export function getOrCreateModel({
-  uriName,
+  uri: $uri,
   value,
-  language,
 }: {
-  uriName: string;
+  uri: string;
   value: string;
-  language: 'graphql' | 'json';
 }) {
-  const uri = Uri.file(`${uriName}.${language}`);
+  const uri = Uri.file($uri);
   const model = monacoEditor.getModel(uri);
+  const language = uri.path.split('.').at(-1)!;
   return model ?? monacoEditor.createModel(value, language, uri);
 }
 

--- a/packages/graphiql-react/src/utility/create-editor.ts
+++ b/packages/graphiql-react/src/utility/create-editor.ts
@@ -18,8 +18,14 @@ export const onEditorContainerKeyDown: KeyboardEventHandler<
   }
 };
 
-export function getOrCreateModel({ uri: $uri, value }: { uri: string; value: string }) {
-  const uri = Uri.file($uri)
+export function getOrCreateModel({
+  uri: $uri,
+  value,
+}: {
+  uri: string;
+  value: string;
+}) {
+  const uri = Uri.file($uri);
   const model = monacoEditor.getModel(uri);
   const language = uri.path.split('.').at(-1)!;
   return model ?? monacoEditor.createModel(value, language, uri);

--- a/packages/graphiql-react/src/utility/tabs.ts
+++ b/packages/graphiql-react/src/utility/tabs.ts
@@ -5,15 +5,15 @@ import { storageStore } from '../stores';
 
 export interface TabDefinition {
   /**
-   * The contents of the query editor of this tab.
+   * The contents of the operation editor of this tab.
    */
   query: string | null;
   /**
-   * The contents of the variable editor of this tab.
+   * The contents of the variables editor of this tab.
    */
   variables?: string | null;
   /**
-   * The contents of the headers editor of this tab.
+   * The contents of the request headers editor of this tab.
    */
   headers?: string | null;
 }
@@ -29,7 +29,7 @@ export interface TabState extends TabDefinition {
 
   /**
    * A hash that is unique for a combination of the contents of the query
-   * editor, the variable editor and the header editor (i.e. all the editor
+   * editor, the variables editor and the request headers editor (i.e., all the editor
    * where the contents are persisted in storage).
    */
   hash: string;
@@ -40,7 +40,7 @@ export interface TabState extends TabDefinition {
   title: string;
 
   /**
-   * The operation name derived from the contents of the query editor of this
+   * The operation name derived from the contents of the operation editor of this
    * tab.
    */
   operationName: string | null;

--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -99,9 +99,9 @@ export interface CreateFetcherOptions {
    */
   legacyClient?: any;
   /**
-   * Headers you can provide statically.
+   * Request headers you can provide statically.
    *
-   * If you enable the headers editor and the user provides
+   * If you enable the request headers editor and the user provides
    * A header you set statically here, it will be overridden by their value.
    */
   headers?: Record<string, string>;

--- a/packages/graphiql/cypress/e2e/lint.cy.ts
+++ b/packages/graphiql/cypress/e2e/lint.cy.ts
@@ -62,7 +62,7 @@ describe('Linting', () => {
       '"42"',
       'error',
       'Expected comma or closing brace',
-      'variable.json',
+      'variables.json',
     );
   });
 
@@ -98,7 +98,7 @@ describe('Linting', () => {
       '42',
       'error',
       'Incorrect type. Expected one of string, null.',
-      'variable.json',
+      'variables.json',
     );
   });
 
@@ -116,7 +116,7 @@ describe('Linting', () => {
       'null',
       'error',
       'Incorrect type. Expected "string".',
-      'variable.json',
+      'variables.json',
     );
   });
 
@@ -134,7 +134,7 @@ describe('Linting', () => {
       '"42"',
       'error',
       'Incorrect type. Expected "object".',
-      'variable.json',
+      'variables.json',
     );
   });
 

--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -46,7 +46,7 @@ declare namespace Cypress {
       text: string,
       severity: 'error' | 'warning',
       message: string,
-      uri?: 'query.graphql' | 'variable.json',
+      uri?: 'operation.graphql' | 'variables.json',
     ): Chainable<Element>;
   }
 }
@@ -151,13 +151,15 @@ Cypress.Commands.add('containQueryResult', expected => {
 
 Cypress.Commands.add(
   'assertLinterMarkWithMessage',
-  (text, severity, message, uri = 'query.graphql') => {
+  (text, severity, message, uri = 'operation.graphql') => {
     // Ensure error is visible in the DOM
-    cy.get(`.squiggly-${severity}`, { timeout: 10_000 });
+    cy.get(`.squiggly-${severity}`, { timeout: 15_000 });
     cy.window().then(win => {
-      const { editor, Uri, MarkerSeverity } = win.__MONACO;
+      const { editor, MarkerSeverity } = win.__MONACO;
+      const models = editor.getModels();
+      const model = models.find(m => m.uri.path.endsWith(uri))!;
       const markers = editor.getModelMarkers({
-        resource: Uri.parse(uri),
+        resource: model.uri,
       });
       // Only "Property is not allowed." isn't added in model markers
       if (!message.endsWith(' is not allowed.')) {

--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -153,7 +153,7 @@ Cypress.Commands.add(
   'assertLinterMarkWithMessage',
   (text, severity, message, uri = 'operation.graphql') => {
     // Ensure error is visible in the DOM
-    cy.get(`.squiggly-${severity}`, { timeout: 15_000 });
+    cy.get(`.squiggly-${severity}`, { timeout: 10_000 });
     cy.window().then(win => {
       const { editor, MarkerSeverity } = win.__MONACO;
       const models = editor.getModels();

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -246,7 +246,7 @@ describe('GraphiQL', () => {
       });
     });
 
-    it('correctly displays headers editor when using defaultEditorToolsVisibility prop', async () => {
+    it('correctly displays request headers editor when using defaultEditorToolsVisibility prop', async () => {
       const { container } = render(
         <GraphiQL
           fetcher={noOpFetcher}

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -156,7 +156,7 @@ interface GraphiQLInterfaceProps
    * - `false` hides the editor tools
    * - `true` shows the editor tools
    * - `'variables'` specifically shows the variables editor
-   * - `'headers'` specifically shows the headers editor
+   * - `'headers'` specifically shows the request headers editor
    * By default, the editor tools are initially shown when at least one of the
    * editors has contents.
    */
@@ -350,7 +350,7 @@ const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     <div className="graphiql-editors" ref={editorResize.firstRef}>
       <section
         className="graphiql-query-editor"
-        aria-label="Query Editor"
+        aria-label="Operation Editor"
         ref={editorToolsResize.firstRef}
       >
         <QueryEditor onClickReference={onClickReference} onEdit={onEditQuery} />

--- a/packages/graphiql/src/style.css
+++ b/packages/graphiql/src/style.css
@@ -56,7 +56,7 @@
 /* The current session and tabs */
 .graphiql-container .graphiql-sessions {
   background-color: hsla(var(--color-neutral), var(--alpha-background-light));
-  /* Adding the 8px of padding to the inner border radius of the query editor */
+  /* Adding the 8px of padding to the inner border radius of the operation editor */
   border-radius: calc(var(--border-radius-12) + var(--px-8));
   display: flex;
   flex-direction: column;
@@ -113,7 +113,7 @@ button.graphiql-tab-add {
   padding: 0 var(--px-8) var(--px-8);
 }
 
-/* All editors (query, variable, headers) */
+/* All editors (operation, variable, request headers) */
 .graphiql-container .graphiql-editors {
   background-color: hsl(var(--color-base));
   border-radius: 0 0 var(--border-radius-12) var(--border-radius-12);
@@ -123,7 +123,7 @@ button.graphiql-tab-add {
   flex-direction: column;
 }
 
-/* The query editor and the toolbar */
+/* The operation editor and the toolbar */
 .graphiql-container .graphiql-query-editor {
   border-bottom: 1px solid
     hsla(var(--color-neutral), var(--alpha-background-heavy));
@@ -133,7 +133,7 @@ button.graphiql-tab-add {
   width: 100%;
 }
 
-/* The vertical toolbar next to the query editor */
+/* The vertical toolbar next to the operation editor */
 .graphiql-container .graphiql-toolbar {
   width: var(--toolbar-width);
   display: flex;
@@ -181,7 +181,7 @@ button.graphiql-tab-add {
   margin-left: auto;
 }
 
-/* An editor tool, e.g. variable or header editor */
+/* An editor tool, e.g. variables or request headers editor */
 .graphiql-container .graphiql-editor-tool {
   flex: 1;
   padding: var(--px-16);


### PR DESCRIPTION
fix multiple GraphiQL instances, suffix a unique id for operation, request headers, variables and response URI.

E.g., the first GraphiQL instance will have:
- `1-operation.graphql`
- `1-request-headers.json`
- `1-variables.json`
- `1-response.json`

The 2nd instance will have:

- `2-operation.graphql`
- `2-request-headers.json`
- `2-variables.json`
- `2-response.json`

etc.