### PR TITLE
Expose GraphiQLInterfaceProps alongside GraphiQLInterface

### DIFF
--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -140,7 +140,7 @@ type VariableEditorProps = ComponentPropsWithoutRef<typeof VariableEditor>;
 type HeaderEditorProps = ComponentPropsWithoutRef<typeof HeaderEditor>;
 type ResponseEditorProps = ComponentPropsWithoutRef<typeof ResponseEditor>;
 
-interface GraphiQLInterfaceProps
+export interface GraphiQLInterfaceProps
   extends EditorProps,
     AddSuffix<Pick<QueryEditorProps, 'onEdit'>, 'Query'>,
     AddSuffix<Pick<VariableEditorProps, 'onEdit'>, 'Variables'>,

--- a/packages/graphiql/src/index.ts
+++ b/packages/graphiql/src/index.ts
@@ -14,6 +14,7 @@ export {
   // https://github.com/graphql/graphiql/issues/4057
   GraphiQLInterface,
   type GraphiQLProps,
+  type GraphiQLInterfaceProps,
 } from './GraphiQL';
 
 export { HISTORY_PLUGIN } from '@graphiql/plugin-history';


### PR DESCRIPTION
As a temporary workaround, users can do:

```ts
type GraphiQLInterfaceProps = ComponentProps<typeof GraphiQLInterface>
```