### PR TITLE
graphiql 5: reduce bundle size, import `prettier` dynamically to avoid bundling Prettier

### DIFF
--- a/.changeset/brave-points-bathe.md
+++ b/.changeset/brave-points-bathe.md
@@ -1,0 +1,13 @@
+---
+'@graphiql/react': patch
+'graphiql': patch
+---
+
+reduce bundle size, import `prettier` dynamically to avoid bundling Prettier
+
+diff from vite example
+
+```diff
+-dist/assets/index-BMgFrxsd.js             4,911.53 kB │ gzip: 1,339.77 kB
++dist/assets/index-BlpzusGL.js             4,221.28 kB │ gzip: 1,145.58 kB
+```

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -145,6 +145,7 @@ export const MONACO_GRAPHQL_API = initializeMode({
 
 export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] =
   async query => {
+    // We don't need to load Prettier initially; it's only used when the 'Format Query' button or shortcut is triggered
     // @ts-expect-error -- wrong types
     const { printers } = await import('prettier/plugins/graphql');
     const { parsers } = await import('prettier/parser-graphql');

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -1,9 +1,5 @@
 /* eslint-disable no-bitwise */
 import { initializeMode } from 'monaco-graphql/esm/lite.js';
-// @ts-expect-error -- wrong types
-import { printers } from 'prettier/plugins/graphql'; // eslint-disable-line import-x/no-duplicates
-import { parsers } from 'prettier/parser-graphql'; // eslint-disable-line import-x/no-duplicates
-import prettier from 'prettier/standalone';
 import type { DiagnosticSettings } from 'monaco-graphql';
 import { KeyCode, KeyMod, languages } from './monaco-editor';
 import type { EditorSlice } from './stores';
@@ -147,13 +143,20 @@ export const MONACO_GRAPHQL_API = initializeMode({
   diagnosticSettings: MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS,
 });
 
-export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] = query =>
-  prettier.format(query, {
-    parser: 'graphql',
-    plugins: [
-      // Fix: Couldn't find plugin for AST format "graphql"
-      { printers },
-      // @ts-expect-error -- Fix: Couldn't resolve parser "graphql"
-      { parsers },
-    ],
-  });
+export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] =
+  async query => {
+    // @ts-expect-error -- wrong types
+    const { printers } = await import('prettier/plugins/graphql');
+    const { parsers } = await import('prettier/parser-graphql');
+    const prettier = await import('prettier/standalone');
+
+    return prettier.format(query, {
+      parser: 'graphql',
+      plugins: [
+        // Fix: Couldn't find plugin for AST format "graphql"
+        { printers },
+        // @ts-expect-error -- Fix: Couldn't resolve parser "graphql"
+        { parsers },
+      ],
+    });
+  };

--- a/packages/graphiql-react/src/utility/jsonc.ts
+++ b/packages/graphiql-react/src/utility/jsonc.ts
@@ -5,7 +5,7 @@ import {
 } from 'jsonc-parser';
 
 export async function formatJSONC(content: string): Promise<string> {
-  // Import dynamically to avoid bundling Prettier
+  // We don't need to load Prettier initially; it's only used when the 'Format Query' button or shortcut is triggered
   const prettier = await import('prettier/standalone');
   // @ts-expect-error -- wrong types
   const { printers } = await import('prettier/plugins/estree');

--- a/packages/graphiql-react/src/utility/jsonc.ts
+++ b/packages/graphiql-react/src/utility/jsonc.ts
@@ -1,14 +1,16 @@
-import prettier from 'prettier/standalone';
-// @ts-expect-error -- wrong types
-import { printers } from 'prettier/plugins/estree';
-import { parsers } from 'prettier/parser-babel';
 import {
   parse as jsoncParse,
   ParseError,
   printParseErrorCode,
 } from 'jsonc-parser';
 
-export function formatJSONC(content: string) {
+export async function formatJSONC(content: string): Promise<string> {
+  // Import dynamically to avoid bundling Prettier
+  const prettier = await import('prettier/standalone');
+  // @ts-expect-error -- wrong types
+  const { printers } = await import('prettier/plugins/estree');
+  const { parsers } = await import('prettier/parser-babel');
+
   return prettier.format(content, {
     parser: 'jsonc',
     plugins: [


### PR DESCRIPTION
we don't need prettier on initial loading, it's only used by clicking on format query button/shortcut

diff from vite example

```diff
-dist/assets/index-BMgFrxsd.js             4,911.53 kB │ gzip: 1,339.77 kB
+dist/assets/index-BlpzusGL.js             4,221.28 kB │ gzip: 1,145.58 kB
```

cc @Benjie