### PR TITLE
Fix: JS grammar detects `gql` tags in comments

### DIFF
--- a/.changeset/slimy-readers-heal.md
+++ b/.changeset/slimy-readers-heal.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Prevent JS grammar from detecting gql tags in comments

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -101,3 +101,7 @@ const queryWithLeadingAboveComment =
       }
     }
   `;
+
+// The comment below is its own standalone test:
+// comment with tag in it: gql `Hello` should be ignored
+const abc = "Hello";

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -37,7 +37,7 @@ const graphql = graphql(`
   }
 `);
 
-const after1 = "after";
+const after1 = 'after';
 
 const graphql = graphql(
   `
@@ -48,11 +48,11 @@ const graphql = graphql(
   [var1, var2],
 );
 
-const after2 = "after";
+const after2 = 'after';
 
-const query = /* GraphQL */ "query { id } ";
-const query = graphql("query($id: ID!) { id } ");
-const query = graphql("query($id: ID!) { test }");
+const query = /* GraphQL */ 'query { id } ';
+const query = graphql('query($id: ID!) { id } ');
+const query = graphql('query($id: ID!) { test }');
 
 const queryWithInlineComment = `#graphql
  query {
@@ -62,9 +62,9 @@ const queryWithInlineComment = `#graphql
     }
 `;
 
-const queryWithInlineComment = "#graphql query { id } ";
+const queryWithInlineComment = '#graphql query { id } ';
 
-const queryWithInlineComment = "#graphql query { id } ";
+const queryWithInlineComment = '#graphql query { id } ';
 
 const queryWithInlineComment = `#graphql
  query {
@@ -104,4 +104,4 @@ const queryWithLeadingAboveComment =
 
 // The comment below is its own standalone test:
 // comment with tag in it: gql `Hello` should be ignored
-const abc = "Hello";
+const abc = 'Hello';

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -37,7 +37,7 @@ const graphql = graphql(`
   }
 `);
 
-const after1 = 'after';
+const after1 = "after";
 
 const graphql = graphql(
   `
@@ -48,11 +48,11 @@ const graphql = graphql(
   [var1, var2],
 );
 
-const after2 = 'after';
+const after2 = "after";
 
-const query = /* GraphQL */ 'query { id } ';
-const query = graphql('query($id: ID!) { id } ');
-const query = graphql('query($id: ID!) { test }');
+const query = /* GraphQL */ "query { id } ";
+const query = graphql("query($id: ID!) { id } ");
+const query = graphql("query($id: ID!) { test }");
 
 const queryWithInlineComment = `#graphql
  query {
@@ -62,9 +62,9 @@ const queryWithInlineComment = `#graphql
     }
 `;
 
-const queryWithInlineComment = '#graphql query { id } ';
+const queryWithInlineComment = "#graphql query { id } ";
 
-const queryWithInlineComment = '#graphql query { id } ';
+const queryWithInlineComment = "#graphql query { id } ";
 
 const queryWithInlineComment = `#graphql
  query {

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -65,340 +65,411 @@ const { film } = json.data;                                     |
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple ecmascript file 1`] = `
-/* eslint-disable */                                     | 
-/* prettier-ignore */                                    | 
-// @ts-nocheck                                           | 
-                                                         | 
-const variable = 'test';                                 | 
-                                                         | 
-gql                                                      | entity.name.function.tagged-template.js
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-;                                                        | 
-                                                         | 
-graphql                                                  | entity.name.function.tagged-template.js
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-;                                                        | 
-                                                         | 
-const graphql =                                          | 
-                                                         | 
-graphql                                                  | entity.name.function.tagged-template.js
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-;                                                        | 
-                                                         | 
-const graphql =                                          | 
-graphql                                                  | entity.name.function.tagged-template.js
-(                                                        | 
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-"""                                                      | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                                       | meta.embedded.block.graphql comment.line.graphql.js
-"""                                                      | meta.embedded.block.graphql comment.line.graphql.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-)                                                        | 
-;                                                        | 
-                                                         | 
-const after1 = "after";                                  | 
-                                                         | 
-const graphql =                                          | 
-graphql                                                  | entity.name.function.tagged-template.js
-(                                                        | 
-                                                         | 
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql
-(                                                        | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                                      | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.variables.graphql
-ID                                                       | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                                        | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                                        | meta.embedded.block.graphql meta.brace.round.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-test                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-,                                                        | 
-  [var1, var2],                                          | 
-)                                                        | 
-;                                                        | 
-                                                         | 
-const after2 = "after";                                  | 
-                                                         | 
-const query = /* GraphQL */ "query { id } ";             | 
-const query =                                            | 
-graphql                                                  | entity.name.function.tagged-template.js
-(                                                        | 
-"query($id: ID!                                          | 
-)                                                        | 
- { id } ");                                              | 
-const query =                                            | 
-graphql                                                  | entity.name.function.tagged-template.js
-(                                                        | 
-"query($id: ID!                                          | 
-)                                                        | 
- { test }");                                             | 
-                                                         | 
-const queryWithInlineComment =                           | 
-\`                                                        | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                                                 | taggedTemplates comment.line.graphql.js
-                                                         | taggedTemplates meta.embedded.block.graphql
-query                                                    | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | taggedTemplates punctuation.definition.string.template.end.js
-;                                                        | 
-                                                         | 
-const queryWithInlineComment = "#graphql query { id } "; | 
-                                                         | 
-const queryWithInlineComment = "#graphql query { id } "; | 
-                                                         | 
-const queryWithInlineComment =                           | 
-\`                                                        | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                                                 | taggedTemplates comment.line.graphql.js
-                                                         | taggedTemplates meta.embedded.block.graphql
-query                                                    | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | taggedTemplates punctuation.definition.string.template.end.js
-;                                                        | 
-const queryWithInlineComment = \`                         | 
-#graphql                                                 | 
- query {                                                 | 
-        user(id: "5", name: boolean) {                   | 
-            something                                    | 
-        }                                                | 
-    }                                                    | 
-\`;                                                       | 
-                                                         | 
-const queryWithLeadingComment =                          | 
-                                                         | 
-/* GraphQL */                                            | comment.graphql.js
-                                                         | 
-\`                                                        | punctuation.definition.string.template.begin.js
-                                                         | meta.embedded.block.graphql
-query                                                    | meta.embedded.block.graphql keyword.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-"""                                                      | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                                       | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-"""                                                      | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                                         | meta.embedded.block.graphql meta.selectionset.graphql
-}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                                        | punctuation.definition.string.template.end.js
-;                                                        | 
-                                                         | 
-// TODO: fix this                                        | 
-const queryWithLeadingAboveComment =                     | 
-  /* GraphQL */                                          | 
-  \`                                                      | 
-    query {                                              | 
-      user(id: "5", name: boolean) {                     | 
-        something                                        | 
-      }                                                  | 
-    }                                                    | 
-  \`;                                                     | 
-                                                         | 
-// The comment below is its own standalone test:         | 
-// comment with tag in it:                               | 
-                                                         | 
-gql                                                      | entity.name.function.tagged-template.js
-                                                         | 
-\`                                                        | punctuation.definition.string.template.begin.js
-Hello                                                    | meta.embedded.block.graphql entity.name.function.graphql
-\`                                                        | punctuation.definition.string.template.end.js
- should be ignored                                       | 
-const abc = "Hello";                                     | 
-                                                         | 
+/* eslint-disable */                             | 
+/* prettier-ignore */                            | 
+// @ts-nocheck                                   | 
+                                                 | 
+const variable = 'test';                         | 
+                                                 | 
+gql                                              | entity.name.function.tagged-template.js
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+graphql                                          | entity.name.function.tagged-template.js
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+const graphql =                                  | 
+                                                 | 
+graphql                                          | entity.name.function.tagged-template.js
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+const graphql =                                  | 
+graphql                                          | entity.name.function.tagged-template.js
+(                                                | 
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+"""                                              | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                               | meta.embedded.block.graphql comment.line.graphql.js
+"""                                              | meta.embedded.block.graphql comment.line.graphql.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | punctuation.definition.string.template.end.js
+)                                                | 
+;                                                | 
+                                                 | 
+const after1 = 'after';                          | 
+                                                 | 
+const graphql =                                  | 
+graphql                                          | entity.name.function.tagged-template.js
+(                                                | 
+                                                 | 
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql
+(                                                | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                              | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.variables.graphql
+ID                                               | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                | meta.embedded.block.graphql meta.brace.round.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+test                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql
+\`                                                | punctuation.definition.string.template.end.js
+,                                                | 
+  [var1, var2],                                  | 
+)                                                | 
+;                                                | 
+                                                 | 
+const after2 = 'after';                          | 
+                                                 | 
+const query =                                    | 
+                                                 | 
+/* GraphQL */                                    | comment.graphql.js
+                                                 | 
+'                                                | punctuation.definition.string.template.begin.js
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql
+'                                                | punctuation.definition.string.template.end.js
+;                                                | 
+const query =                                    | 
+graphql                                          | entity.name.function.tagged-template.js
+(                                                | 
+'                                                | punctuation.definition.string.template.begin.js
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+(                                                | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                              | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.variables.graphql
+ID                                               | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                | meta.embedded.block.graphql meta.brace.round.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql
+'                                                | punctuation.definition.string.template.end.js
+)                                                | 
+;                                                | 
+const query =                                    | 
+graphql                                          | entity.name.function.tagged-template.js
+(                                                | 
+'                                                | punctuation.definition.string.template.begin.js
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+(                                                | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                              | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.variables.graphql
+ID                                               | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                | meta.embedded.block.graphql meta.brace.round.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+test                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                | punctuation.definition.string.template.end.js
+)                                                | 
+;                                                | 
+                                                 | 
+const queryWithInlineComment =                   | 
+\`                                                | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                         | taggedTemplates comment.line.graphql.js
+                                                 | taggedTemplates meta.embedded.block.graphql
+query                                            | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | taggedTemplates punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+const queryWithInlineComment =                   | 
+'                                                | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                         | taggedTemplates comment.line.graphql.js
+                                                 | taggedTemplates meta.embedded.block.graphql
+query                                            | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+id                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql
+'                                                | taggedTemplates punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+const queryWithInlineComment =                   | 
+'                                                | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                         | taggedTemplates comment.line.graphql.js
+                                                 | taggedTemplates meta.embedded.block.graphql
+query                                            | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+id                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql
+'                                                | taggedTemplates punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+const queryWithInlineComment =                   | 
+\`                                                | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                         | taggedTemplates comment.line.graphql.js
+                                                 | taggedTemplates meta.embedded.block.graphql
+query                                            | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | taggedTemplates punctuation.definition.string.template.end.js
+;                                                | 
+const queryWithInlineComment = \`                 | 
+#graphql                                         | 
+ query {                                         | 
+        user(id: "5", name: boolean) {           | 
+            something                            | 
+        }                                        | 
+    }                                            | 
+\`;                                               | 
+                                                 | 
+const queryWithLeadingComment =                  | 
+                                                 | 
+/* GraphQL */                                    | comment.graphql.js
+                                                 | 
+\`                                                | punctuation.definition.string.template.begin.js
+                                                 | meta.embedded.block.graphql
+query                                            | meta.embedded.block.graphql keyword.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+"""                                              | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                               | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+"""                                              | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+user                                             | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                 | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                | punctuation.definition.string.template.end.js
+;                                                | 
+                                                 | 
+// TODO: fix this                                | 
+const queryWithLeadingAboveComment =             | 
+  /* GraphQL */                                  | 
+  \`                                              | 
+    query {                                      | 
+      user(id: "5", name: boolean) {             | 
+        something                                | 
+      }                                          | 
+    }                                            | 
+  \`;                                             | 
+                                                 | 
+// The comment below is its own standalone test: | 
+// comment with tag in it:                       | 
+                                                 | 
+gql                                              | entity.name.function.tagged-template.js
+                                                 | 
+\`                                                | punctuation.definition.string.template.begin.js
+Hello                                            | meta.embedded.block.graphql entity.name.function.graphql
+\`                                                | punctuation.definition.string.template.end.js
+ should be ignored                               | 
+const abc = 'Hello';                             | 
+                                                 | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple svelte file 1`] = `

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -65,400 +65,340 @@ const { film } = json.data;                                     |
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple ecmascript file 1`] = `
-/* eslint-disable */                   | 
-/* prettier-ignore */                  | 
-// @ts-nocheck                         | 
-                                       | 
-const variable = 'test';               | 
-                                       | 
-gql                                    | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const graphql =                        | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const graphql =                        | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-"""                                    | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                     | meta.embedded.block.graphql comment.line.graphql.js
-"""                                    | meta.embedded.block.graphql comment.line.graphql.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-                                       | 
-const after1 = 'after';                | 
-                                       | 
-const graphql =                        | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-                                       | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-\`                                      | punctuation.definition.string.template.end.js
-,                                      | 
-  [var1, var2],                        | 
-)                                      | 
-;                                      | 
-                                       | 
-const after2 = 'after';                | 
-                                       | 
-const query =                          | 
-                                       | 
-/* GraphQL */                          | comment.graphql.js
-                                       | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-'                                      | punctuation.definition.string.template.end.js
-;                                      | 
-const query =                          | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-'                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-const query =                          | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-\`                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-'                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql
-'                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-'                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql
-'                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-\`                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-const queryWithInlineComment = \`       | 
-#graphql                               | 
- query {                               | 
-        user(id: "5", name: boolean) { | 
-            something                  | 
-        }                              | 
-    }                                  | 
-\`;                                     | 
-                                       | 
-const queryWithLeadingComment =        | 
-                                       | 
-/* GraphQL */                          | comment.graphql.js
-                                       | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                     | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-// TODO: fix this                      | 
-const queryWithLeadingAboveComment =   | 
-  /* GraphQL */                        | 
-  \`                                    | 
-    query {                            | 
-      user(id: "5", name: boolean) {   | 
-        something                      | 
-      }                                | 
-    }                                  | 
-  \`;                                   | 
-                                       | 
+/* eslint-disable */                                     | 
+/* prettier-ignore */                                    | 
+// @ts-nocheck                                           | 
+                                                         | 
+const variable = 'test';                                 | 
+                                                         | 
+gql                                                      | entity.name.function.tagged-template.js
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+;                                                        | 
+                                                         | 
+graphql                                                  | entity.name.function.tagged-template.js
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+;                                                        | 
+                                                         | 
+const graphql =                                          | 
+                                                         | 
+graphql                                                  | entity.name.function.tagged-template.js
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+;                                                        | 
+                                                         | 
+const graphql =                                          | 
+graphql                                                  | entity.name.function.tagged-template.js
+(                                                        | 
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+"""                                                      | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                                       | meta.embedded.block.graphql comment.line.graphql.js
+"""                                                      | meta.embedded.block.graphql comment.line.graphql.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+)                                                        | 
+;                                                        | 
+                                                         | 
+const after1 = "after";                                  | 
+                                                         | 
+const graphql =                                          | 
+graphql                                                  | entity.name.function.tagged-template.js
+(                                                        | 
+                                                         | 
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql
+(                                                        | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                                      | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.variables.graphql
+ID                                                       | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                        | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                        | meta.embedded.block.graphql meta.brace.round.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+test                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+,                                                        | 
+  [var1, var2],                                          | 
+)                                                        | 
+;                                                        | 
+                                                         | 
+const after2 = "after";                                  | 
+                                                         | 
+const query = /* GraphQL */ "query { id } ";             | 
+const query =                                            | 
+graphql                                                  | entity.name.function.tagged-template.js
+(                                                        | 
+"query($id: ID!                                          | 
+)                                                        | 
+ { id } ");                                              | 
+const query =                                            | 
+graphql                                                  | entity.name.function.tagged-template.js
+(                                                        | 
+"query($id: ID!                                          | 
+)                                                        | 
+ { test }");                                             | 
+                                                         | 
+const queryWithInlineComment =                           | 
+\`                                                        | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                 | taggedTemplates comment.line.graphql.js
+                                                         | taggedTemplates meta.embedded.block.graphql
+query                                                    | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | taggedTemplates punctuation.definition.string.template.end.js
+;                                                        | 
+                                                         | 
+const queryWithInlineComment = "#graphql query { id } "; | 
+                                                         | 
+const queryWithInlineComment = "#graphql query { id } "; | 
+                                                         | 
+const queryWithInlineComment =                           | 
+\`                                                        | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                 | taggedTemplates comment.line.graphql.js
+                                                         | taggedTemplates meta.embedded.block.graphql
+query                                                    | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | taggedTemplates punctuation.definition.string.template.end.js
+;                                                        | 
+const queryWithInlineComment = \`                         | 
+#graphql                                                 | 
+ query {                                                 | 
+        user(id: "5", name: boolean) {                   | 
+            something                                    | 
+        }                                                | 
+    }                                                    | 
+\`;                                                       | 
+                                                         | 
+const queryWithLeadingComment =                          | 
+                                                         | 
+/* GraphQL */                                            | comment.graphql.js
+                                                         | 
+\`                                                        | punctuation.definition.string.template.begin.js
+                                                         | meta.embedded.block.graphql
+query                                                    | meta.embedded.block.graphql keyword.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+"""                                                      | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+ this is a comment                                       | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+"""                                                      | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                         | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                        | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+;                                                        | 
+                                                         | 
+// TODO: fix this                                        | 
+const queryWithLeadingAboveComment =                     | 
+  /* GraphQL */                                          | 
+  \`                                                      | 
+    query {                                              | 
+      user(id: "5", name: boolean) {                     | 
+        something                                        | 
+      }                                                  | 
+    }                                                    | 
+  \`;                                                     | 
+                                                         | 
+// The comment below is its own standalone test:         | 
+// comment with tag in it:                               | 
+                                                         | 
+gql                                                      | entity.name.function.tagged-template.js
+                                                         | 
+\`                                                        | punctuation.definition.string.template.begin.js
+Hello                                                    | meta.embedded.block.graphql entity.name.function.graphql
+\`                                                        | punctuation.definition.string.template.end.js
+ should be ignored                                       | 
+const abc = "Hello";                                     | 
+                                                         | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple svelte file 1`] = `


### PR DESCRIPTION
Just a repro for now. `gql` tags inside of comments are detected by the grammar and should probably be ignored. Anyone motivated to fix this: please feel free to push to this branch (if you're able) or pick my repro commit to another PR and close this one out.

Had issues running `yarn vitest` and `yarn workspace vscode-graphql-syntax test` so I added `vitest` as a dev dependency (and matched the version the repo uses). Perhaps I'm missing the "right" way to run these tests.

Also: not obvious to me why git is detecting the entire file changes, but hiding whitespace while reviewing reveals the actual diff in the snapshot correctly.