### PR TITLE
Use headers from previous tabs, if available

### DIFF
--- a/.changeset/ninety-numbers-glow.md
+++ b/.changeset/ninety-numbers-glow.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Use headers from previous tabs, if available

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- @format -->
 
 # GraphQL IDE Monorepo

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -351,8 +351,10 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
           tabs,
           activeTabIndex,
         });
+        const headers =
+          defaultHeaders || tabs.find(tab => tab.headers)?.headers;
         const updated = {
-          tabs: [...updatedValues.tabs, createTab({ headers: defaultHeaders })],
+          tabs: [...updatedValues.tabs, createTab({ headers })],
           activeTabIndex: updatedValues.tabs.length,
         };
         actions.storeTabs(updated);


### PR DESCRIPTION
## Issue

When opening a new tab and no `defaultHeaders` is configured, headers are cleared. Rather than keeping the headers entered from previous tabs. 

Headers are often used for authorization. Having to re-enter the headers for every tab is very inconvenient.

## Demo of the bug

https://github.com/user-attachments/assets/e34e6271-9d53-4dc2-aa57-d5f7c6f695b6

## Demo of the fix


https://github.com/user-attachments/assets/d0625c68-255d-449b-9587-098efd35c74b

