### PR TITLE
fix: shared type excluded from non-first project caches

### DIFF
--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -1065,7 +1065,7 @@ export class MessageProcessor {
           version = schemaDocument.version++;
         }
         const schemaText = await readFile(uri, 'utf-8');
-        await this._cacheSchemaText(schemaUri, schemaText, version);
+        await this._cacheSchemaText(schemaUri, schemaText, version, project);
       }
     } catch (err) {
       this._logger.error(String(err));
@@ -1251,7 +1251,7 @@ export class MessageProcessor {
             return;
           }
 
-          await this._updateObjectTypeDefinition(uri, contents);
+          await this._updateObjectTypeDefinition(uri, contents, project);
           await this._updateFragmentDefinition(uri, contents);
           await this._invalidateCache({ version: 1, uri }, uri, contents);
         }),


### PR DESCRIPTION
This propagates the project when populating the cache.

For a config like this:

```yml
projects:
  public:
    schema:
      - ./public/schema.graphql
      - ./shared.graphql
    documents: ./public/documents.graphql
  private:
    schema:
      - ./private/schema.graphql
      - ./shared.graphql
    documents: ./private/documents.graphql
```

If `shared.graphql` contains a type used in both `./public/documents.graphql` and `./private/documents.graphql`, the cache will only be populated for the first project (public here). This causes features like "go to definition" to only work for that project.

Propagating the project adds the shared types to the cache for both projects, and makes "go to definition" work for both.

<details><summary>Example Project</summary>

```
$ tree -a
.
├── .graphqlrc.yml
├── private
│   ├── documents.graphql
│   └── schema.graphql
├── public
│   ├── documents.graphql
│   └── schema.graphql
└── shared.graphql

3 directories, 6 files
```

```graphql
# shared.graphql
type Book {
    title: String
}
```

```graphql
# private/documents.graphql
query ListBooks {
    books {
        title # << go to definition on this fails on master
    }
}
```

```graphql
# private/schema.graphql
type Query {
    books: [Book]
}

schema {
    query: Query
}
```

```graphql
# public/documents.graphql
query ListPublicBooks {
    publicBooks {
        title
    }
}
```

```graphql
# public/schema.graphql
type Query {
    publicBooks: [Book]
}

schema {
    query: Query
}
```

</details>