### PR TITLE
docs(README): fix broken link and close #3890 👨‍🔧

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The purpose of this monorepo is to give the GraphQL Community:
 
 _/ˈɡrafək(ə)l/_ A graphical interactive in-browser GraphQL IDE.
 [Try the live demo](https://graphql.org/swapi-graphql). We also have
-[a demo using our latest netlify build](http://graphiql-test.netlify.com) for
+[a demo using our latest netlify build](http://graphiql-test.netlify.app) for
 the `main` branch.
 
 The GraphiQL IDE, implemented in React, currently using

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- @format -->
 
 # GraphQL IDE Monorepo


### PR DESCRIPTION
# 📝 Docs update
- This pull request fixes a broken link in the [README.md](https://github.com/graphql/graphiql/blob/main/README.md) file.
- Closes [issue - #3890](https://github.com/graphql/graphiql/issues/3890)
- Fixes an existing  Github PR Action failure, due to `prettier` checks 👨‍🔧

# ⁉️ Previous Context
- [pull #4111](https://github.com/graphql/graphiql/pull/4111#issuecomment-3357350024)