### PR TITLE
Move `react-runtime-compiler` from `peerDependencies` to `dependencies`

### DIFF
--- a/.changeset/little-falcons-drum.md
+++ b/.changeset/little-falcons-drum.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/plugin-doc-explorer': patch
+'@graphiql/plugin-history': patch
+'@graphiql/react': patch
+---
+
+Remove `react-compiler-runtime` peer dependency

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -39,11 +39,11 @@
     "@graphiql/react": "^0.37.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
     "@headlessui/react": "^2.2",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -37,11 +37,11 @@
   "peerDependencies": {
     "@graphiql/react": "^0.37.0",
     "react": "^18 || ^19",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
     "@graphiql/toolkit": "^0.11.3",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -46,7 +46,6 @@
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
@@ -64,6 +63,7 @@
     "monaco-editor": "0.52.2",
     "monaco-graphql": "^1.7.3",
     "prettier": "^3.5.3",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "set-value": "^4.1.0",
     "zustand": "^5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,6 +3457,7 @@ __metadata:
     babel-plugin-react-compiler: "npm:19.1.0-rc.1"
     graphql: "npm:^16.9.0"
     react: "npm:^19.1.0"
+    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     vite: "npm:^6.3.4"
     vite-plugin-dts: "npm:^4.5.3"
@@ -3465,7 +3466,6 @@ __metadata:
     "@graphiql/react": ^0.37.0
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
     react: ^18 || ^19
-    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
@@ -3501,6 +3501,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.4.1"
     babel-plugin-react-compiler: "npm:19.1.0-rc.1"
     react: "npm:^19.1.0"
+    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     vite: "npm:^6.3.4"
     vite-plugin-dts: "npm:^4.5.3"
@@ -3508,7 +3509,6 @@ __metadata:
   peerDependencies:
     "@graphiql/react": ^0.37.0
     react: ^18 || ^19
-    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
@@ -3540,6 +3540,7 @@ __metadata:
     monaco-graphql: "npm:^1.7.3"
     prettier: "npm:^3.5.3"
     react: "npm:^19.1.0"
+    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     set-value: "npm:^4.1.0"
     typescript: "npm:^4.6.3"
@@ -3550,7 +3551,6 @@ __metadata:
   peerDependencies:
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
     react: ^18 || ^19
-    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Having `react-runtime-compiler` as a peer dependency is not recommended by [the react docs](https://react.dev/reference/react-compiler/compiling-libraries#install-runtime-package).

The current state forces library consumers to install the exact RC that's pinned (`19.1.0-rc.1`), so at the very least this should be careted (if this is currently a peer for technical reasons).

