### PR TITLE
Fix (graphql-language-service) Hover for first line

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService.test.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { GraphQLConfig } from 'graphql-config';
 import { GraphQLLanguageService } from '../GraphQLLanguageService';
 import { SymbolKind } from 'vscode-languageserver-protocol';
-import { Position } from 'graphql-language-service';
+import { getRange, Position } from 'graphql-language-service';
 import { NoopLogger } from '../Logger';
 import { GraphQLEnumType } from 'graphql';
 
@@ -207,6 +207,7 @@ describe('GraphQLLanguageService', () => {
     );
     expect(definitionQueryResult?.definitions.length).toEqual(1);
   });
+  
   it('runs definition service on fragment spread', async () => {
     const definitionQueryResult = await languageService.getDefinition(
       'fragment TestFragment on Human { name }\nquery { ...TestFragment }',
@@ -234,6 +235,23 @@ describe('GraphQLLanguageService', () => {
       './queries/definitionQuery.graphql',
     );
     expect(definitionQueryResult?.definitions.length).toEqual(1);
+  });
+  
+  it('can get range on first line', async () => {
+    const range = await getRange(
+      { line: 0, column: 15},
+        `query myHero($id: ID) {
+          hero(id: $id) {
+            name
+            id
+          }
+        }
+    `);
+    
+    expect(range).toMatchObject({
+       end: { character: 23, line: -1 }, 
+       start: { character: 22, line: -1 }
+    });
   });
 
   it('runs hover service as expected', async () => {

--- a/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/GraphQLLanguageService.test.ts
@@ -207,7 +207,7 @@ describe('GraphQLLanguageService', () => {
     );
     expect(definitionQueryResult?.definitions.length).toEqual(1);
   });
-  
+
   it('runs definition service on fragment spread', async () => {
     const definitionQueryResult = await languageService.getDefinition(
       'fragment TestFragment on Human { name }\nquery { ...TestFragment }',
@@ -236,21 +236,22 @@ describe('GraphQLLanguageService', () => {
     );
     expect(definitionQueryResult?.definitions.length).toEqual(1);
   });
-  
+
   it('can get range on first line', async () => {
     const range = await getRange(
-      { line: 0, column: 15},
-        `query myHero($id: ID) {
+      { line: 0, column: 15 },
+      `query myHero($id: ID) {
           hero(id: $id) {
             name
             id
           }
         }
-    `);
-    
+    `,
+    );
+
     expect(range).toMatchObject({
-       end: { character: 23, line: -1 }, 
-       start: { character: 22, line: -1 }
+      end: { character: 23, line: -1 },
+      start: { character: 22, line: -1 },
     });
   });
 

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -181,7 +181,11 @@ export function getRange(location: SourceLocation, queryText: string): IRange {
 
   let stream = null;
 
-  for (let i = 0; i <= location.line; i++) {
+  for (
+    let i = 0;
+    location.line === 0 ? i <= location.line : i < location.line;
+    i++
+  ) {
     stream = new CharacterStream(lines[i]);
     while (!stream.eol()) {
       const style = parser.token(stream, state);

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -181,7 +181,7 @@ export function getRange(location: SourceLocation, queryText: string): IRange {
 
   let stream = null;
 
-  for (let i = 0; i < location.line; i++) {
+  for (let i = 0; i <= location.line; i++) {
     stream = new CharacterStream(lines[i]);
     while (!stream.eol()) {
       const style = parser.token(stream, state);

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -183,7 +183,7 @@ export function getRange(location: SourceLocation, queryText: string): IRange {
 
   for (
     let i = 0;
-    location.line === 0 ? i <= location.line : i < location.line;
+    i < location.line;
     i++
   ) {
     stream = new CharacterStream(lines[i]);

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -181,6 +181,7 @@ export function getRange(location: SourceLocation, queryText: string): IRange {
 
   let stream = null;
 
+  // LSP may count from 1, but monaco counts from 0
   for (
     let i = 0;
     location.line === 0 ? i <= location.line : i < location.line;

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -183,7 +183,7 @@ export function getRange(location: SourceLocation, queryText: string): IRange {
 
   for (
     let i = 0;
-    i < location.line;
+    location.line === 0 ? i <= location.line : i < location.line;
     i++
   ) {
     stream = new CharacterStream(lines[i]);

--- a/packages/graphql-language-service/src/parser/CharacterStream.ts
+++ b/packages/graphql-language-service/src/parser/CharacterStream.ts
@@ -46,7 +46,10 @@ export default class CharacterStream implements CharacterStreamInterface {
     return isMatched;
   }
 
-  public eol = (): boolean => this._sourceText.length === this._pos;
+  public eol = (): boolean => {
+    if (!this._sourceText) return true;
+    return this._sourceText.length === this._pos;
+  }
 
   public sol = (): boolean => this._pos === 0;
 

--- a/packages/graphql-language-service/src/parser/CharacterStream.ts
+++ b/packages/graphql-language-service/src/parser/CharacterStream.ts
@@ -47,9 +47,11 @@ export default class CharacterStream implements CharacterStreamInterface {
   }
 
   public eol = (): boolean => {
-    if (!this._sourceText) return true;
+    if (!this._sourceText) {
+      return true;
+    }
     return this._sourceText.length === this._pos;
-  }
+  };
 
   public sol = (): boolean => this._pos === 0;
 


### PR DESCRIPTION
fix hover for line 1 (0) in graphiql -> monaco-graphiql when hovering the first line

closes #4157 closes #3168 