### PR TITLE
feat: update to new Vue grammar scope name

### DIFF
--- a/.changeset/mean-tomatoes-happen.md
+++ b/.changeset/mean-tomatoes-happen.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Updated scopes to include new Vue grammar scope name

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "inline.graphql",
-  "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro) -source.graphql -inline.graphql -string -comment",
+  "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | text.html.vue | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro) -source.graphql -inline.graphql -string -comment",
   "patterns": [
     {
       "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*\\(",

--- a/packages/vscode-graphql-syntax/package.json
+++ b/packages/vscode-graphql-syntax/package.json
@@ -63,6 +63,7 @@
           "source.vue",
           "source.svelte",
           "source.astro",
+          "text.html.vue",
           "text.html.markdown",
           "text.html.derivative"
         ],


### PR DESCRIPTION
This PR adjusts the graphql grammar to work with the new Vue grammar scope name. 
Starting with version 3.2.0 of the Vue language tools the scope name was changed to "text.html.vue" instead of "source.vue" (See: https://github.com/vuejs/language-tools/pull/5856).

I am not sure if the addition in the `injectionSelector` is necessary, since in my testing i did not notice any difference, so maybe someone more knowledgeable can give me guidance on this. 

Closes: https://github.com/vuejs/language-tools/issues/5969