### PR TITLE
fix: skip introspection when `IntrospectionQuery` is passed as `schema` prop

### DIFF
--- a/.changeset/fix-introspection-schema-prop.md
+++ b/.changeset/fix-introspection-schema-prop.md
@@ -1,0 +1,8 @@
+---
+'@graphiql/react': patch
+'graphiql': patch
+---
+
+Fix schema prop to skip introspection when IntrospectionQuery data is provided
+
+Previously, passing an `IntrospectionQuery` result as the `schema` prop would still trigger a network introspection request. The `shouldIntrospect` check only recognized `GraphQLSchema` instances (via `isSchema`), not raw introspection data. Now, when an `IntrospectionQuery` is passed, a schema is built from it directly using `buildClientSchema` and introspection is skipped.

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -45,9 +45,7 @@ import {
 } from '../constants';
 import { getDefaultTabState } from '../utility/tabs';
 
-function isIntrospectionData(
-  value: unknown,
-): value is IntrospectionQuery {
+function isIntrospectionData(value: unknown): value is IntrospectionQuery {
   return typeof value === 'object' && value !== null && '__schema' in value;
 }
 

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -329,12 +329,11 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
    * Synchronize prop changes with state
    */
   useEffect(() => {
-    const newSchema = isSchema(schema)
-      ? schema
-      : isIntrospectionData(schema)
-        ? buildClientSchema(schema)
-        : schema == null
-          ? schema
+    const newSchema =
+      isSchema(schema) || schema == null
+        ? schema
+        : isIntrospectionData(schema)
+          ? buildClientSchema(schema)
           : undefined;
 
     const validationErrors =

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -30,6 +30,8 @@ import type { SlicesWithActions } from '../types';
 import { useDidUpdate } from '../utility';
 import {
   FragmentDefinitionNode,
+  IntrospectionQuery,
+  buildClientSchema,
   parse,
   visit,
   isSchema,
@@ -42,6 +44,12 @@ import {
   STORAGE_KEY,
 } from '../constants';
 import { getDefaultTabState } from '../utility/tabs';
+
+function isIntrospectionData(
+  value: unknown,
+): value is IntrospectionQuery {
+  return typeof value === 'object' && value !== null && '__schema' in value;
+}
 
 interface GraphiQLProviderProps
   extends
@@ -323,7 +331,13 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
    * Synchronize prop changes with state
    */
   useEffect(() => {
-    const newSchema = isSchema(schema) || schema == null ? schema : undefined;
+    const newSchema = isSchema(schema)
+      ? schema
+      : isIntrospectionData(schema)
+        ? buildClientSchema(schema)
+        : schema == null
+          ? schema
+          : undefined;
 
     const validationErrors =
       !newSchema || dangerouslyAssumeSchemaIsValid
@@ -337,7 +351,7 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
        */
       requestCounter: requestCounter + 1,
       schema: newSchema,
-      shouldIntrospect: !isSchema(schema) && schema !== null,
+      shouldIntrospect: !newSchema && schema !== null,
       validationErrors,
     }));
 

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -12,6 +12,7 @@ import { act, render, waitFor, fireEvent } from '@testing-library/react';
 import { Component, FC, useEffect } from 'react';
 import { GraphiQL } from './GraphiQL';
 import type { Fetcher } from '@graphiql/toolkit';
+import { buildSchema, introspectionFromSchema } from 'graphql';
 import {
   ToolbarButton,
   useGraphiQL,
@@ -20,22 +21,11 @@ import {
 } from '@graphiql/react';
 import '@graphiql/react/setup-workers/vite';
 
-// The smallest possible introspection result that builds a schema.
-const simpleIntrospection = {
-  data: {
-    __schema: {
-      queryType: { name: 'Q' },
-      types: [
-        {
-          kind: 'OBJECT',
-          name: 'Q',
-          interfaces: [],
-          fields: [{ name: 'q', args: [], type: { name: 'Q' } }],
-        },
-      ],
-    },
-  },
-};
+const simpleSchema = buildSchema('type Query { q: Query }');
+const simpleIntrospectionData = introspectionFromSchema(simpleSchema);
+// Fetcher return type expects `data: Record<string, unknown>`, so we
+// spread into a plain object to satisfy both the Fetcher and schema prop types.
+const simpleIntrospection = { data: { ...simpleIntrospectionData } };
 
 beforeEach(() => {
   localStorage.clear();
@@ -172,7 +162,7 @@ describe('GraphiQL', () => {
         render(
           <GraphiQL
             fetcher={trackingFetcher}
-            schema={simpleIntrospection.data}
+            schema={simpleIntrospectionData}
           />,
         );
       });

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -151,14 +151,9 @@ describe('GraphiQL', () => {
     });
 
     it('should not introspect when IntrospectionQuery is provided as schema prop', async () => {
-      let fetcherCalled = false;
+      const trackingFetcher = vi.fn().mockResolvedValue(simpleIntrospection);
 
-      function trackingFetcher() {
-        fetcherCalled = true;
-        return Promise.resolve(simpleIntrospection);
-      }
-
-      await act(async () => {
+      await act(() => {
         render(
           <GraphiQL
             fetcher={trackingFetcher}
@@ -167,7 +162,7 @@ describe('GraphiQL', () => {
         );
       });
 
-      expect(fetcherCalled).toBe(false);
+      expect(trackingFetcher).not.toHaveBeenCalled();
     });
   }); // schema
 

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -159,6 +159,26 @@ describe('GraphiQL', () => {
         ).not.toThrow();
       });
     });
+
+    it('should not introspect when IntrospectionQuery is provided as schema prop', async () => {
+      let fetcherCalled = false;
+
+      function trackingFetcher() {
+        fetcherCalled = true;
+        return Promise.resolve(simpleIntrospection);
+      }
+
+      await act(async () => {
+        render(
+          <GraphiQL
+            fetcher={trackingFetcher}
+            schema={simpleIntrospection.data}
+          />,
+        );
+      });
+
+      expect(fetcherCalled).toBe(false);
+    });
   }); // schema
 
   describe('default query', () => {


### PR DESCRIPTION
The schema prop accepts `GraphQLSchema | IntrospectionQuery | null`, but `shouldIntrospect` only checked for a `GraphQLSchema` instance via `isSchema`. When an `IntrospectionQuery` was passed, it was ignored and a network introspection request was still triggered.

It now detects `IntrospectionQuery` data via `__schema` check, builds a `GraphQLSchema` from it, and correctly sets `shouldIntrospect` to `false`.