### PR TITLE
Clean up `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,14 +3,7 @@
   "editor.formatOnSave": true,
   "files.insertFinalNewline": true,
   "editor.trimAutoWhitespace": false,
-  "coverage-gutters.showLineCoverage": true,
-  "coverage-gutters.coverageBaseDir": "coverage",
-  "coverage-gutters.coverageFileNames": [
-    "lcov.info",
-    "cov.xml",
-    "coverage.xml",
-    "jacoco.xml",
-    "coverage.cobertura.xml"
-  ],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "json.schemaDownload.trustedDomains": {
+    "https://unpkg.com": true
+  }
 }


### PR DESCRIPTION
Remove personal/deprecated VS Code settings (`coverage-gutters`, `typescript.tsdk`). Add `json.schemaDownload.trustedDomains` for `unpkg.com` to allow JSON schema resolution (used by `.changeset/config.json`).