### PR TITLE
Drop `mock-fs` to unblock final `vitest` migration

### DIFF
--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -68,11 +68,9 @@
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/mkdirp": "^1.0.1",
-    "@types/mock-fs": "^4.13.4",
     "@whatwg-node/fetch": "npm:^0.9.0",
     "cross-env": "^7.0.2",
     "debounce-promise": "^3.1.2",
-    "graphql": "^16.9.0",
-    "mock-fs": "^5.2.0"
+    "graphql": "^16.9.0"
   }
 }

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -6,7 +6,6 @@
  *  LICENSE file in the root directory of this source tree.
  *
  */
-// do not change to node:fs import, or it will break mock-fs
 import { existsSync, mkdirSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
@@ -244,8 +244,9 @@ describe('MessageProcessor with config', () => {
         { uri: project.uri('schema.graphql'), type: FileChangeType.Changed },
       ],
     });
-    const typeCache =
-      project.lsp._graphQLCache._typeDefinitionsCache.get(`${project.rootDir}-default`);
+    const typeCache = project.lsp._graphQLCache._typeDefinitionsCache.get(
+      `${project.rootDir}-default`,
+    );
     expect(typeCache?.get('Test')?.definition.name.value).toEqual('Test');
 
     // test in-file schema defs! important!
@@ -318,10 +319,9 @@ describe('MessageProcessor with config', () => {
     });
 
     // TODO: this interface should maybe not be tested here but in unit tests
-    const fragCache =
-      project.lsp._graphQLCache._fragmentDefinitionsCache.get(
-        `${project.rootDir}-default`,
-      );
+    const fragCache = project.lsp._graphQLCache._fragmentDefinitionsCache.get(
+      `${project.rootDir}-default`,
+    );
     expect(fragCache?.get('A')?.definition.name.value).toEqual('A');
     expect(fragCache?.get('B')?.definition.name.value).toEqual('B');
     const queryFieldDefRequest = await project.lsp.handleDefinitionRequest({

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
@@ -2,7 +2,6 @@ import { readFile, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import mockfs from 'mock-fs';
 import { MockFile, MockProject } from './__utils__/MockProject';
 import { FileChangeType } from 'vscode-languageserver';
 import { serializeRange } from './__utils__/utils';
@@ -67,14 +66,16 @@ const fooInlineTypePosition = {
   end: { line: 5, character: 24 },
 };
 
-const genSchemaPath = path.join(
-  tmpdir(),
-  'graphql-language-service',
-  'test',
-  'projects',
-  'default',
-  'generated-schema.graphql',
-);
+function getGenSchemaPath(project: MockProject, projectName = 'default') {
+  return path.join(
+    tmpdir(),
+    'graphql-language-service',
+    path.basename(project.rootDir),
+    'projects',
+    projectName,
+    'generated-schema.graphql',
+  );
+}
 
 // TODO:
 // - reorganize into multiple files
@@ -85,6 +86,8 @@ const genSchemaPath = path.join(
 // - fix TODO comments where bugs were found that couldn't be resolved quickly (2-4hr time box)
 
 describe('MessageProcessor with no config', () => {
+  let project: MockProject | undefined;
+
   beforeAll(async () => {
     await rm(path.join(tmpdir(), 'graphql-language-service'), {
       recursive: true,
@@ -93,12 +96,13 @@ describe('MessageProcessor with no config', () => {
   });
 
   afterEach(() => {
-    mockfs.restore();
+    project?.dispose();
+    project = undefined;
     fetchMock.restore();
   });
 
   it('fails to initialize with empty config file', async () => {
-    const project = new MockProject({
+    project = new MockProject({
       files: [...defaultFiles, ['graphql.config.json', '']],
     });
     await project.init();
@@ -116,7 +120,7 @@ describe('MessageProcessor with no config', () => {
   });
 
   it('fails to initialize with no config file present', async () => {
-    const project = new MockProject({
+    project = new MockProject({
       files: [...defaultFiles],
     });
     await project.init();
@@ -133,7 +137,7 @@ describe('MessageProcessor with no config', () => {
   });
 
   it('initializes when presented with a valid config later', async () => {
-    const project = new MockProject({
+    project = new MockProject({
       files: [...defaultFiles],
     });
     await project.init();
@@ -159,13 +163,16 @@ describe('MessageProcessor with no config', () => {
 });
 
 describe('MessageProcessor with config', () => {
+  let project: MockProject | undefined;
+
   afterEach(() => {
-    mockfs.restore();
+    project?.dispose();
+    project = undefined;
     fetchMock.restore();
   });
 
   it('caches files and schema with .graphql file config, and the schema updates with watched file changes', async () => {
-    const project = new MockProject({
+    project = new MockProject({
       files: [
         schemaFile,
         [
@@ -238,7 +245,7 @@ describe('MessageProcessor with config', () => {
       ],
     });
     const typeCache =
-      project.lsp._graphQLCache._typeDefinitionsCache.get('/tmp/test-default');
+      project.lsp._graphQLCache._typeDefinitionsCache.get(`${project.rootDir}-default`);
     expect(typeCache?.get('Test')?.definition.name.value).toEqual('Test');
 
     // test in-file schema defs! important!
@@ -296,7 +303,7 @@ describe('MessageProcessor with config', () => {
     expect(result.diagnostics[0].message).toEqual(
       'Cannot query field "bar" on type "Foo". Did you mean "bad"?',
     );
-    const generatedFile = existsSync(genSchemaPath);
+    const generatedFile = existsSync(getGenSchemaPath(project));
     // this generated file should not exist because the schema is local!
     expect(generatedFile).toEqual(false);
     // simulating codegen
@@ -313,7 +320,7 @@ describe('MessageProcessor with config', () => {
     // TODO: this interface should maybe not be tested here but in unit tests
     const fragCache =
       project.lsp._graphQLCache._fragmentDefinitionsCache.get(
-        '/tmp/test-default',
+        `${project.rootDir}-default`,
       );
     expect(fragCache?.get('A')?.definition.name.value).toEqual('A');
     expect(fragCache?.get('B')?.definition.name.value).toEqual('B');
@@ -371,7 +378,7 @@ describe('MessageProcessor with config', () => {
     const offset = parseInt(version, 10) > 16 ? 25 : 0;
     mockSchema(graphiqlSchema);
 
-    const project = new MockProject({
+    project = new MockProject({
       files: [
         ['query.graphql', 'query { test { isTest, ...T } }'],
         ['fragments.graphql', 'fragment T on Test {\n isTest \n}'],
@@ -394,6 +401,8 @@ describe('MessageProcessor with config', () => {
       'Cannot query field "or" on type "Test".',
     );
     expect(await project.lsp._graphQLCache.getSchema('default')).toBeDefined();
+
+    const genSchemaPath = getGenSchemaPath(project);
 
     // schema file is present and contains schema
     const file = await readFile(genSchemaPath, 'utf8');
@@ -504,7 +513,7 @@ describe('MessageProcessor with config', () => {
   it('caches multiple projects with files and schema with a URL config and a local schema', async () => {
     mockSchema(graphiqlSchema);
 
-    const project = new MockProject({
+    project = new MockProject({
       files: [
         [
           'a/fragments.ts',
@@ -567,7 +576,7 @@ describe('MessageProcessor with config', () => {
       (await project.lsp._graphQLCache.getSchema('a')).getType('example100'),
     ).toBeTruthy();
     await sleep(1000);
-    const file = await readFile(genSchemaPath.replace('default', 'a'), 'utf8');
+    const file = await readFile(getGenSchemaPath(project, 'a'), 'utf8');
     expect(file).toContain('example100');
     // add a new typescript file with empty query to the b project
     // and expect autocomplete to only show options for project b
@@ -644,7 +653,7 @@ describe('MessageProcessor with config', () => {
   });
 
   it('correctly handles a fragment inside a TypeScript file', async () => {
-    const project = new MockProject({
+    project = new MockProject({
       files: [
         [
           'schema.graphql',

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.test.ts
@@ -34,7 +34,7 @@ import type { DefinitionQueryResult, Outline } from 'graphql-language-service';
 
 import { NoopLogger } from '../Logger';
 import { pathToFileURL } from 'node:url';
-import mockfs from 'mock-fs';
+import * as fs from 'node:fs';
 import { join } from 'node:path';
 
 jest.mock('node:fs', () => ({
@@ -179,19 +179,22 @@ describe('MessageProcessor', () => {
       await messageProcessor._isGraphQLConfigFile('graphql.js');
     expect(falseResult).toEqual(false);
 
-    mockfs({ [`${__dirname}/package.json`]: '{"graphql": {}}' });
-    const pkgResult = await messageProcessor._isGraphQLConfigFile(
-      `file://${__dirname}/package.json`,
-    );
-    mockfs.restore();
-    expect(pkgResult).toEqual(true);
+    const pkgJsonPath = `${__dirname}/package.json`;
+    try {
+      fs.writeFileSync(pkgJsonPath, '{"graphql": {}}');
+      const pkgResult = await messageProcessor._isGraphQLConfigFile(
+        `file://${pkgJsonPath}`,
+      );
+      expect(pkgResult).toEqual(true);
 
-    mockfs({ [`${__dirname}/package.json`]: '{ }' });
-    const pkgFalseResult = await messageProcessor._isGraphQLConfigFile(
-      `file://${__dirname}/package.json`,
-    );
-    mockfs.restore();
-    expect(pkgFalseResult).toEqual(false);
+      fs.writeFileSync(pkgJsonPath, '{ }');
+      const pkgFalseResult = await messageProcessor._isGraphQLConfigFile(
+        `file://${pkgJsonPath}`,
+      );
+      expect(pkgFalseResult).toEqual(false);
+    } finally {
+      fs.rmSync(pkgJsonPath, { force: true });
+    }
   });
   it('runs completion requests properly', async () => {
     const uri = `${queryPathUri}/test2.graphql`;

--- a/packages/graphql-language-service-server/src/__tests__/__utils__/MockProject.ts
+++ b/packages/graphql-language-service-server/src/__tests__/__utils__/MockProject.ts
@@ -1,4 +1,6 @@
-import mockfs from 'mock-fs';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
 import { MessageProcessor } from '../../MessageProcessor';
 import { Logger as VSCodeLogger } from 'vscode-jsonrpc';
 import { URI } from 'vscode-uri';
@@ -14,54 +16,51 @@ export class MockLogger implements VSCodeLogger {
   log = jest.fn();
 }
 
-// when using mockfs with cosmic-config, a dynamic inline
-// require of parse-json creates the necessity for loading in the actual
-// modules to the mocked filesystem
-const modules = [
-  'parse-json',
-  'error-ex',
-  'is-arrayish',
-  'json-parse-even-better-errors',
-  'lines-and-columns',
-  '@babel/code-frame',
-  // these i think are just required by jest when you console log from a test
-  'jest-message-util',
-  'stack-utils',
-  'pretty-format',
-  'ansi-regex',
-  'js-tokens',
-  'escape-string-regexp',
-  'jest-worker',
-  'jiti',
-  'cosmiconfig',
-  'minimatch',
-  'tslib',
-];
-const defaultMocks = modules.reduce((acc, module) => {
-  acc[`node_modules/${module}`] = mockfs.load(`node_modules/${module}`);
-  return acc;
-}, {});
-
 type File = [filename: string, text: string];
 type Files = File[];
+
+// Track live instances so a process exit handler can clean up any that
+// `dispose()` didn't reach (e.g. if a test throws mid-setup).
+const liveInstances = new Set<MockProject>();
+let exitHandlerRegistered = false;
+function registerExitHandler() {
+  if (exitHandlerRegistered) {
+    return;
+  }
+  exitHandlerRegistered = true;
+  process.on('exit', () => {
+    for (const inst of liveInstances) {
+      try {
+        inst.dispose();
+      } catch {
+        // best-effort cleanup on exit
+      }
+    }
+  });
+}
 
 export class MockProject {
   private root: string;
   private fileCache: Map<string, string>;
   private messageProcessor: MessageProcessor;
+
   constructor({
     files = [],
-    root = '/tmp/test',
+    root,
     settings,
   }: {
     files: Files;
     root?: string;
     settings?: Record<string, any>;
   }) {
-    this.root = root;
+    registerExitHandler();
+    // Unique tmpdir per instance. `gls-test-` prefix makes leaked dirs
+    // identifiable across test runs.
+    this.root = root ?? fs.mkdtempSync(path.join(tmpdir(), 'gls-test-'));
     this.fileCache = new Map(files);
+    liveInstances.add(this);
 
-    this.mockFiles();
+    this.writeFiles();
     this.messageProcessor = new MessageProcessor({
       connection: {
         get workspace() {
@@ -74,7 +73,7 @@ export class MockProject {
       },
       logger: new MockLogger(),
       loadConfigOptions: {
-        rootDir: root,
+        rootDir: this.root,
       },
     });
   }
@@ -98,30 +97,37 @@ export class MockProject {
       },
     });
   }
-  private mockFiles() {
-    const mockFiles = {
-      ...defaultMocks,
-      // without this, the generated schema file may not be cleaned up by previous tests
-      '/tmp/graphql-language-service': mockfs.directory(),
-    };
+
+  /**
+   * Synchronously writes every cached file to disk. Creates parent dirs as needed.
+   * Called on construction and after every cache mutation so the on-disk state
+   * always matches `fileCache`.
+   */
+  private writeFiles() {
     for (const [filename, text] of this.fileCache) {
-      mockFiles[this.filePath(filename)] = text;
+      const dest = this.filePath(filename);
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, text);
     }
-    mockfs(mockFiles);
   }
+
   public filePath(filename: string) {
     return `${this.root}/${filename}`;
   }
+
   public uri(filename: string) {
     return URI.file(this.filePath(filename)).toString();
   }
+
   changeFile(filename: string, text: string) {
     this.fileCache.set(filename, text);
-    this.mockFiles();
+    const dest = this.filePath(filename);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, text);
   }
+
   async addFile(filename: string, text: string, watched = false) {
-    this.fileCache.set(filename, text);
-    this.mockFiles();
+    this.changeFile(filename, text);
     if (watched) {
       await this.lsp.handleWatchedFilesChangedNotification({
         changes: [
@@ -145,6 +151,7 @@ export class MockProject {
       },
     });
   }
+
   async changeWatchedFile(filename: string, text: string) {
     this.changeFile(filename, text);
     await this.lsp.handleWatchedFilesChangedNotification({
@@ -156,6 +163,7 @@ export class MockProject {
       ],
     });
   }
+
   async saveOpenFile(filename: string, text: string) {
     this.changeFile(filename, text);
     await this.lsp.handleDidOpenOrSaveNotification({
@@ -166,6 +174,7 @@ export class MockProject {
       },
     });
   }
+
   async addWatchedFile(filename: string, text: string) {
     this.changeFile(filename, text);
     await this.lsp.handleDidChangeNotification({
@@ -181,10 +190,14 @@ export class MockProject {
       },
     });
   }
+
   async deleteFile(filename: string) {
-    mockfs.restore();
     this.fileCache.delete(filename);
-    this.mockFiles();
+    try {
+      fs.rmSync(this.filePath(filename), { force: true });
+    } catch {
+      // ignore — file may already be gone
+    }
     await this.lsp.handleWatchedFilesChangedNotification({
       changes: [
         {
@@ -194,6 +207,25 @@ export class MockProject {
       ],
     });
   }
+
+  /**
+   * Remove this project's tmpdir and forget it. Idempotent.
+   * Callers should invoke in afterEach (or equivalent) for every instance.
+   */
+  public dispose() {
+    if (!liveInstances.has(this)) {
+      return;
+    }
+    liveInstances.delete(this);
+    fs.rmSync(this.root, { recursive: true, force: true });
+  }
+
+  /** Public accessor for the tmpdir path — tests need this to build assertions
+   * that reference graphql-config's project key (which derives from rootDir). */
+  public get rootDir() {
+    return this.root;
+  }
+
   get lsp() {
     return this.messageProcessor;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6774,15 +6774,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mock-fs@npm:^4.13.4":
-  version: 4.13.4
-  resolution: "@types/mock-fs@npm:4.13.4"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/687c8e36d91031529924fd89011b7a87167ea33a1b92a9d845f0feb1a5157f168412c62ee308e57b9a71fd938197b4c71ca1784eb44e8a7cbdd816011ffd7f65
-  languageName: node
-  linkType: hard
-
 "@types/ms@npm:*":
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
@@ -14977,7 +14968,6 @@ __metadata:
     "@graphql-tools/code-file-loader": "npm:8.0.3"
     "@types/glob": "npm:^8.1.0"
     "@types/mkdirp": "npm:^1.0.1"
-    "@types/mock-fs": "npm:^4.13.4"
     "@whatwg-node/fetch": "npm:^0.9.0"
     cosmiconfig-toml-loader: "npm:^1.0.0"
     cross-env: "npm:^7.0.2"
@@ -14990,7 +14980,6 @@ __metadata:
     graphql-language-service: "npm:^5.3.1"
     lru-cache: "npm:^10.2.0"
     mkdirp: "npm:^1.0.4"
-    mock-fs: "npm:^5.2.0"
     node-abort-controller: "npm:^3.0.1"
     nullthrows: "npm:^1.0.0"
     source-map-js: "npm:1.0.2"
@@ -19335,13 +19324,6 @@ __metadata:
     _mocha: bin/_mocha
     mocha: bin/mocha.js
   checksum: 10c0/45728af7cd5a640bd964e4c1d1c9e5318499e9ba3494493a4bd05b3f03ca55bc51397323e160baab29407a56e7a7223cbb23f03e95a69317b44660099521038f
-  languageName: node
-  linkType: hard
-
-"mock-fs@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "mock-fs@npm:5.2.0"
-  checksum: 10c0/e917e71295ee9d805c7d9ab0214a66658db0212f35731ba0c75dc1ccbb9964e6787a6d725561f05fcf569c64cf4a1176f5ce438f98b009227520f646f8abf174
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`mock-fs` is the main blocker for migrating `graphql-language-service-server` to vitest (the last package still on Jest). It patches Node's `fs` at the C++ binding level, which is fundamentally incompatible with vitest's worker-based architecture. It's also the reason for the `// do not change to node:fs import, or it will break mock-fs` comment in `MessageProcessor.ts` and the gnarly hack in `MockProject` that preloads 17 real `node_modules` directories into the virtual filesystem so `cosmiconfig` can resolve its dynamic `require()` calls.

This PR replaces all of that with real tmpdirs via `fs.mkdtempSync`. Each `MockProject` instance gets a unique directory under `os.tmpdir()`, writes real files, and cleans up after itself. This matches how the LSP server actually behaves in production — it already writes generated schemas to `os.tmpdir()`.

## Changes

- Rewrite `MockProject` to use real tmpdirs with a `dispose()` method for cleanup
- Wire `dispose()` into `afterEach` hooks across both `MessageProcessor` test files
- Replace hardcoded `/tmp/test-default` assertions with dynamic `project.rootDir`-based values
- Drop `mock-fs` and `@types/mock-fs` from devDependencies