### PR TITLE
Remove deprecated `--frozen-lockfile` flag from CI workflows

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -31,7 +31,7 @@ jobs:
           path: |
             ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
 
   jest:
     name: Jest Unit Tests

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Force GraphQL ${{ matrix.release }} solution
         run: yarn repo:resolve graphql@${{ matrix.release }}
 
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
 
       - name: Unit Tests
         run: yarn test:ci

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
           path: |
             ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
 
   build:
     name: Build
@@ -292,7 +292,7 @@ jobs:
           path: |
             **/node_modules
           key: modules-${{ github.sha }}
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
       - name: License Check
         run: yarn license-check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           path: node_modules
           key: node_modules-${{hashFiles('yarn.lock')}}
           restore-keys: node_modules-
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
Flag is deprecated and redundant per the [migration guide](https://yarnpkg.com/migration/guide#migration-steps).