### PR TITLE
Send spec-compliant Accept header in fetcher

### DIFF
--- a/.changeset/fetcher-spec-accept-header.md
+++ b/.changeset/fetcher-spec-accept-header.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': minor
+---
+
+Send spec-compliant `Accept` header (`application/graphql-response+json`) in fetchers

--- a/.changeset/fetcher-spec-accept-header.md
+++ b/.changeset/fetcher-spec-accept-header.md
@@ -2,4 +2,4 @@
 '@graphiql/toolkit': minor
 ---
 
-Send spec-compliant `Accept` header (`application/graphql-response+json`) in fetchers
+Send spec-compliant `Accept` header (`application/graphql-response+json`) in `createSimpleFetcher`

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
@@ -2,6 +2,8 @@ import { createSimpleFetcher, createMultipartFetcher } from '../lib';
 
 const SPEC_ACCEPT = 'application/graphql-response+json, application/json;q=0.9';
 const MULTIPART_ACCEPT = `${SPEC_ACCEPT}, multipart/mixed`;
+const QUERY = '{ __typename }';
+const BASE_URL = 'http://localhost';
 
 function mockFetch() {
   return vi.fn().mockResolvedValue({
@@ -13,8 +15,8 @@ function mockFetch() {
 describe('createSimpleFetcher', () => {
   it('sends spec-compliant accept header', async () => {
     const fetch = mockFetch();
-    const fetcher = createSimpleFetcher({ url: 'http://localhost' }, fetch);
-    await fetcher({ query: '{ __typename }' }, {});
+    const fetcher = createSimpleFetcher({ url: BASE_URL }, fetch);
+    await fetcher({ query: QUERY }, {});
 
     expect(fetch.mock.calls[0][1].headers.accept).toBe(SPEC_ACCEPT);
   });
@@ -22,21 +24,18 @@ describe('createSimpleFetcher', () => {
   it('allows options.headers to override accept', async () => {
     const fetch = mockFetch();
     const fetcher = createSimpleFetcher(
-      { url: 'http://localhost', headers: { accept: 'text/plain' } },
+      { url: BASE_URL, headers: { accept: 'text/plain' } },
       fetch,
     );
-    await fetcher({ query: '{ __typename }' }, {});
+    await fetcher({ query: QUERY }, {});
 
     expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
   });
 
   it('allows per-request fetcherOpts headers to override accept', async () => {
     const fetch = mockFetch();
-    const fetcher = createSimpleFetcher({ url: 'http://localhost' }, fetch);
-    await fetcher(
-      { query: '{ __typename }' },
-      { headers: { accept: 'text/plain' } },
-    );
+    const fetcher = createSimpleFetcher({ url: BASE_URL }, fetch);
+    await fetcher({ query: QUERY }, { headers: { accept: 'text/plain' } });
 
     expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
   });
@@ -45,8 +44,8 @@ describe('createSimpleFetcher', () => {
 describe('createMultipartFetcher', () => {
   it('sends spec-compliant accept header with multipart support', async () => {
     const fetch = mockFetch();
-    const fetcher = createMultipartFetcher({ url: 'http://localhost' }, fetch);
-    const result = fetcher({ query: '{ __typename }' }, {});
+    const fetcher = createMultipartFetcher({ url: BASE_URL }, fetch);
+    const result = fetcher({ query: QUERY }, {});
     // @ts-expect-error -- result is an async generator at runtime
     await result.next();
 
@@ -56,10 +55,10 @@ describe('createMultipartFetcher', () => {
   it('allows options.headers to override accept', async () => {
     const fetch = mockFetch();
     const fetcher = createMultipartFetcher(
-      { url: 'http://localhost', headers: { accept: 'text/plain' } },
+      { url: BASE_URL, headers: { accept: 'text/plain' } },
       fetch,
     );
-    const result = fetcher({ query: '{ __typename }' }, {});
+    const result = fetcher({ query: QUERY }, {});
     // @ts-expect-error -- result is an async generator at runtime
     await result.next();
 

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
@@ -1,0 +1,67 @@
+import { createSimpleFetcher, createMultipartFetcher } from '../lib';
+
+const SPEC_ACCEPT =
+  'application/graphql-response+json, application/json;q=0.9';
+const MULTIPART_ACCEPT = `${SPEC_ACCEPT}, multipart/mixed`;
+
+function mockFetch() {
+  return vi.fn().mockResolvedValue({
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => ({}),
+  });
+}
+
+describe('createSimpleFetcher', () => {
+  it('sends spec-compliant accept header', async () => {
+    const fetch = mockFetch();
+    const fetcher = createSimpleFetcher({ url: 'http://localhost' }, fetch);
+    await fetcher({ query: '{ __typename }' }, {});
+
+    expect(fetch.mock.calls[0][1].headers.accept).toBe(SPEC_ACCEPT);
+  });
+
+  it('allows options.headers to override accept', async () => {
+    const fetch = mockFetch();
+    const fetcher = createSimpleFetcher(
+      { url: 'http://localhost', headers: { accept: 'text/plain' } },
+      fetch,
+    );
+    await fetcher({ query: '{ __typename }' }, {});
+
+    expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
+  });
+
+  it('allows per-request fetcherOpts headers to override accept', async () => {
+    const fetch = mockFetch();
+    const fetcher = createSimpleFetcher({ url: 'http://localhost' }, fetch);
+    await fetcher(
+      { query: '{ __typename }' },
+      { headers: { accept: 'text/plain' } },
+    );
+
+    expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
+  });
+});
+
+describe('createMultipartFetcher', () => {
+  it('sends spec-compliant accept header with multipart support', async () => {
+    const fetch = mockFetch();
+    const fetcher = createMultipartFetcher({ url: 'http://localhost' }, fetch);
+    const gen = fetcher({ query: '{ __typename }' }, {});
+    await gen.next();
+
+    expect(fetch.mock.calls[0][1].headers.accept).toBe(MULTIPART_ACCEPT);
+  });
+
+  it('allows options.headers to override accept', async () => {
+    const fetch = mockFetch();
+    const fetcher = createMultipartFetcher(
+      { url: 'http://localhost', headers: { accept: 'text/plain' } },
+      fetch,
+    );
+    const gen = fetcher({ query: '{ __typename }' }, {});
+    await gen.next();
+
+    expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
+  });
+});

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
@@ -1,7 +1,6 @@
 import { createSimpleFetcher, createMultipartFetcher } from '../lib';
 
-const SPEC_ACCEPT =
-  'application/graphql-response+json, application/json;q=0.9';
+const SPEC_ACCEPT = 'application/graphql-response+json, application/json;q=0.9';
 const MULTIPART_ACCEPT = `${SPEC_ACCEPT}, multipart/mixed`;
 
 function mockFetch() {
@@ -47,8 +46,9 @@ describe('createMultipartFetcher', () => {
   it('sends spec-compliant accept header with multipart support', async () => {
     const fetch = mockFetch();
     const fetcher = createMultipartFetcher({ url: 'http://localhost' }, fetch);
-    const gen = fetcher({ query: '{ __typename }' }, {});
-    await gen.next();
+    const result = fetcher({ query: '{ __typename }' }, {});
+    // @ts-expect-error -- result is an async generator at runtime
+    await result.next();
 
     expect(fetch.mock.calls[0][1].headers.accept).toBe(MULTIPART_ACCEPT);
   });
@@ -59,8 +59,9 @@ describe('createMultipartFetcher', () => {
       { url: 'http://localhost', headers: { accept: 'text/plain' } },
       fetch,
     );
-    const gen = fetcher({ query: '{ __typename }' }, {});
-    await gen.next();
+    const result = fetcher({ query: '{ __typename }' }, {});
+    // @ts-expect-error -- result is an async generator at runtime
+    await result.next();
 
     expect(fetch.mock.calls[0][1].headers.accept).toBe('text/plain');
   });

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
@@ -1,7 +1,7 @@
 import { createSimpleFetcher, createMultipartFetcher } from '../lib';
 
 const SPEC_ACCEPT = 'application/graphql-response+json, application/json;q=0.9';
-const MULTIPART_ACCEPT = `${SPEC_ACCEPT}, multipart/mixed`;
+const MULTIPART_ACCEPT = 'application/json, multipart/mixed';
 const QUERY = '{ __typename }';
 const BASE_URL = 'http://localhost';
 
@@ -42,7 +42,7 @@ describe('createSimpleFetcher', () => {
 });
 
 describe('createMultipartFetcher', () => {
-  it('sends spec-compliant accept header with multipart support', async () => {
+  it('sends accept header with multipart support', async () => {
     const fetch = mockFetch();
     const fetcher = createMultipartFetcher({ url: BASE_URL }, fetch);
     const result = fetcher({ query: QUERY }, {});

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -62,8 +62,7 @@ export const createSimpleFetcher =
       body: JSON.stringify(graphQLParams),
       headers: {
         'content-type': 'application/json',
-        accept:
-          'application/graphql-response+json, application/json;q=0.9',
+        accept: 'application/graphql-response+json, application/json;q=0.9',
         ...options.headers,
         ...fetcherOpts?.headers,
       },

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -62,6 +62,8 @@ export const createSimpleFetcher =
       body: JSON.stringify(graphQLParams),
       headers: {
         'content-type': 'application/json',
+        accept:
+          'application/graphql-response+json, application/json;q=0.9',
         ...options.headers,
         ...fetcherOpts?.headers,
       },
@@ -146,7 +148,8 @@ export const createMultipartFetcher = (
       body: JSON.stringify(graphQLParams),
       headers: {
         'content-type': 'application/json',
-        accept: 'application/json, multipart/mixed',
+        accept:
+          'application/graphql-response+json, application/json;q=0.9, multipart/mixed',
         ...options.headers,
         // allow user-defined headers to override
         // the static provided headers

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -148,8 +148,7 @@ export const createMultipartFetcher = (
       body: JSON.stringify(graphQLParams),
       headers: {
         'content-type': 'application/json',
-        accept:
-          'application/graphql-response+json, application/json;q=0.9, multipart/mixed',
+        accept: 'application/json, multipart/mixed',
         ...options.headers,
         // allow user-defined headers to override
         // the static provided headers


### PR DESCRIPTION
## Summary

- Send `application/graphql-response+json` as the preferred content type per the [GraphQL over HTTP spec](https://graphql.github.io/graphql-over-http/draft/#sel-GALHJNABAB5Br8e), falling back to `application/json;q=0.9`
- Applied to `createSimpleFetcher`, which previously sent no `Accept` header
- `createMultipartFetcher` is left unchanged — the correct `Accept` header for `multipart/mixed` responses is [still under discussion](https://github.com/graphql/graphql-over-http/issues/167)

Closes #4189

## Changes

- `createSimpleFetcher`: added `accept: 'application/graphql-response+json, application/json;q=0.9'`
- Both fetchers continue to allow user-provided headers (`options.headers`, `fetcherOpts.headers`) to override the default
- Added `acceptHeaders.spec.ts` with tests covering default headers and override behavior

## Validation Steps

1. `yarn dev:graphiql` to start the dev server
2. Open GraphiQL in the browser and run a query (e.g. `{ __typename }`)
3. In DevTools Network tab, inspect the fetch request to the GraphQL endpoint — the `Accept` request header should be `application/graphql-response+json, application/json;q=0.9`