### PR TITLE
Typecheck scripts and fix type errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "packageManager": "yarn@4.9.1",
   "scripts": {
-    "types:check": "turbo run types:check",
+    "types:check": "turbo run types:check && tsc --noEmit -p scripts/tsconfig.json",
     "dev:graphiql": "turbo run dev --filter=graphiql...",
     "dev:example-nextjs": "turbo run dev --filter=example-graphiql-nextjs...",
     "dev:example-vite": "turbo run dev --filter=example-graphiql-vite...",

--- a/scripts/set-resolution.mts
+++ b/scripts/set-resolution.mts
@@ -12,12 +12,13 @@ async function setResolution(): Promise<void> {
     throw new Error(`Invalid tag ${tag}`);
   }
 
-  if (pkgJson.resolutions) {
-    pkgJson.resolutions[pkg] = version;
-  } else {
-    pkgJson.resolutions = { [pkg]: version };
-  }
-  await writeFile('../package.json', JSON.stringify(pkgJson, null, 2), 'utf8');
+  await writeFile('../package.json', JSON.stringify({
+    ...pkgJson,
+    resolutions: {
+      ...pkgJson.resolutions,
+      [pkg]: version,
+    }
+  }, null, 2), 'utf8');
 }
 
 setResolution().catch((err: unknown) => {

--- a/scripts/set-resolution.mts
+++ b/scripts/set-resolution.mts
@@ -12,13 +12,21 @@ async function setResolution(): Promise<void> {
     throw new Error(`Invalid tag ${tag}`);
   }
 
-  await writeFile('../package.json', JSON.stringify({
-    ...pkgJson,
-    resolutions: {
-      ...pkgJson.resolutions,
-      [pkg]: version,
-    }
-  }, null, 2), 'utf8');
+  await writeFile(
+    '../package.json',
+    JSON.stringify(
+      {
+        ...pkgJson,
+        resolutions: {
+          ...pkgJson.resolutions,
+          [pkg]: version,
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
 }
 
 setResolution().catch((err: unknown) => {


### PR DESCRIPTION
Include the `scripts` dir in type checking to enforce that they're type safe.

Follow-up to https://github.com/graphql/graphiql/pull/4195.