### PR TITLE
Set `oxc` as the default VSCode formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "npm.packageManager": "yarn",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
   "files.insertFinalNewline": true,
   "editor.trimAutoWhitespace": false,


### PR DESCRIPTION
Sets `editor.defaultFormatter` to `oxc.oxc-vscode` in workspace settings. Most people probably have `prettier` configured (I did) which led to format on save being incorrect in small ways.