### PR TITLE
 fix: add `*.css` to `sideEffects` in all CSS-exporting graphiql packages

### DIFF
--- a/.changeset/quick-cars-bathe.md
+++ b/.changeset/quick-cars-bathe.md
@@ -1,0 +1,10 @@
+---
+"@graphiql/plugin-code-exporter": minor
+"@graphiql/plugin-doc-explorer": minor
+"@graphiql/plugin-explorer": minor
+"@graphiql/plugin-history": minor
+"@graphiql/react": minor
+"graphiql": minor
+---
+
+Add \*.css to sideEffects to allow import of CSS in Webpack Javascript

--- a/.changeset/quick-cars-bathe.md
+++ b/.changeset/quick-cars-bathe.md
@@ -1,10 +1,10 @@
 ---
-"@graphiql/plugin-code-exporter": minor
-"@graphiql/plugin-doc-explorer": minor
-"@graphiql/plugin-explorer": minor
-"@graphiql/plugin-history": minor
-"@graphiql/react": minor
-"graphiql": minor
+'@graphiql/plugin-code-exporter': patch
+'@graphiql/plugin-doc-explorer': patch
+'@graphiql/plugin-explorer': patch
+'@graphiql/plugin-history': patch
+'@graphiql/react': patch
+'graphiql': patch
 ---
 
 Add \*.css to sideEffects to allow import of CSS in Webpack Javascript

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@graphiql/plugin-code-exporter",
   "version": "5.1.1",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/graphql/graphiql",

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@graphiql/plugin-doc-explorer",
   "version": "0.4.1",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/graphql/graphiql",

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@graphiql/plugin-explorer",
   "version": "5.1.1",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/graphql/graphiql",

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@graphiql/plugin-history",
   "version": "0.4.1",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/graphql/graphiql",

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -2,7 +2,8 @@
   "name": "@graphiql/react",
   "version": "0.37.3",
   "sideEffects": [
-    "dist/setup-workers/*"
+    "dist/setup-workers/*",
+    "*.css"
   ],
   "repository": {
     "type": "git",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -2,7 +2,8 @@
   "name": "graphiql",
   "version": "5.2.2",
   "sideEffects": [
-    "dist/setup-workers/*"
+    "dist/setup-workers/*",
+    "*.css"
   ],
   "description": "An graphical interactive in-browser GraphQL IDE.",
   "contributors": [


### PR DESCRIPTION
When attempting to set up `graphiql` in my Webpack 5 environment, and follow the example code https://github.com/graphql/graphiql/tree/main/packages/graphiql#using-as-package, I noticed that the line:

```js
import 'graphiql/style.css';
```

was having no effect. The line was being processed, but Webpack was not emitting CSS. The resulting page looked like this, a working UI, but no CSS styles:

<img width="30%" alt="image" src="https://github.com/user-attachments/assets/a276f4fd-49e3-4430-b092-239aa0332bcb" />

The cause is that the `graphiql` package has a `sideEffects` property in its `package.json`, which is set up to allow side effects but only for `dist/setup-workers/*`. Because `graphiql/style.css` (aka `dist/style.css`) falls outside of this path, Webpack ignores the imported CSS.

This is explained at https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free, down the bottom of this section:

> Note that any imported file is subject to tree shaking. This means if you use something like css-loader in your project and import a CSS file, it needs to be added to the side effect list so it will not be unintentionally dropped in production mode:
>
> ```js
> {
>  "name": "your-project",
>  "sideEffects": ["./src/some-side-effectful-file.js", "*.css"]
> }
> ```

This PR follows that directive and adds the required `sideEffects` entry to all packages - especially `graphiql` - that have CSS exports in their `package.json` files. Testing locally by patching this in to my build pipeline sees the JS `import` line now working.

----

Ahead of this PR being accepted, a Webpack configuration can manually override `sideEffects` like so:

```js
const config = {
  module: {
    rules: [
      ...,
      {
        test: /graphiql/,
        sideEffects: true,
      }
    ]
  }
}
```

That forces `sideEffects` to be on for all files, but in Webpack, it's only able to be a Boolean.

Another workaround is to use Sass/SCSS or another CSS preprocessor and `@use 'graphiql/style.css';` instead -- using another tool bypasses Webpack's checking of `sideEffects`. This is actually how I found the issue in the first place -- importing within Sass worked fine, but when using `import` in JS, nothing loaded. 