### PR TITLE
Migrate to `moduleResolution: "nodenext"`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -447,6 +447,8 @@ module.exports = {
             'packages/graphql-language-service-server/src/__tests__/__utils__/utils.ts',
             'packages/graphql-language-service-server/src/__tests__/__utils__/MockProject.ts',
 
+            'packages/graphiql-react/src/setup-workers/*.ts',
+
             'packages/vscode-graphql-syntax/tests/__utilities__/serializer.ts',
             'packages/vscode-graphql-syntax/tests/__utilities__/utilities.ts',
 

--- a/packages/cm6-graphql/tsconfig.json
+++ b/packages/cm6-graphql/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "strict": true,
     "target": "es6",
-    "module": "es2020",
+    "module": "nodenext",
     "newLine": "lf",
     "declaration": true,
-    "moduleResolution": "node",
     "outDir": "dist"
   },
   "include": ["src", "__tests__"],

--- a/packages/codemirror-graphql/tsconfig.esm.json
+++ b/packages/codemirror-graphql/tsconfig.esm.json
@@ -5,8 +5,7 @@
     "outDir": "./esm",
     "composite": true,
     "jsx": "react",
-    "strictPropertyInitialization": false,
-    "baseUrl": "."
+    "strictPropertyInitialization": false
   },
   "include": ["src"],
   "exclude": [

--- a/packages/codemirror-graphql/tsconfig.json
+++ b/packages/codemirror-graphql/tsconfig.json
@@ -6,7 +6,6 @@
     "composite": true,
     "jsx": "react",
     "target": "es5",
-    "baseUrl": ".",
     "strictPropertyInitialization": false
   },
   "include": ["src"],

--- a/packages/graphiql-plugin-code-exporter/vite.config.mts
+++ b/packages/graphiql-plugin-code-exporter/vite.config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import packageJSON from './package.json';
+import packageJSON from './package.json' with { type: 'json' };
 import dts from 'vite-plugin-dts';
 
 export default defineConfig({

--- a/packages/graphiql-plugin-doc-explorer/vite.config.mts
+++ b/packages/graphiql-plugin-doc-explorer/vite.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig, PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import type { PluginOptions as ReactCompilerConfig } from 'babel-plugin-react-compiler';
-import packageJSON from './package.json' assert { type: 'json' };
+import packageJSON from './package.json' with { type: 'json' };
 import dts from 'vite-plugin-dts';
 import { reactCompilerConfig as $reactCompilerConfig } from '../graphiql-react/vite.config.mjs';
 

--- a/packages/graphiql-plugin-explorer/vite.config.mts
+++ b/packages/graphiql-plugin-explorer/vite.config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import dts from 'vite-plugin-dts';
-import packageJSON from './package.json';
+import packageJSON from './package.json' with { type: 'json' };
 
 export default defineConfig({
   plugins: [

--- a/packages/graphiql-plugin-history/vite.config.mts
+++ b/packages/graphiql-plugin-history/vite.config.mts
@@ -1,7 +1,7 @@
 import { defineConfig, PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import type { PluginOptions as ReactCompilerConfig } from 'babel-plugin-react-compiler';
-import packageJSON from './package.json' assert { type: 'json' };
+import packageJSON from './package.json' with { type: 'json' };
 import dts from 'vite-plugin-dts';
 import { reactCompilerConfig as $reactCompilerConfig } from '../graphiql-react/vite.config.mjs';
 

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -159,7 +159,6 @@ export const DEFAULT_PRETTIFY_QUERY: EditorSlice['onPrettifyQuery'] =
       plugins: [
         // Fix: Couldn't find plugin for AST format "graphql"
         { printers },
-        // @ts-expect-error -- Fix: Couldn't resolve parser "graphql"
         { parsers },
       ],
     });

--- a/packages/graphiql-react/src/utility/jsonc.ts
+++ b/packages/graphiql-react/src/utility/jsonc.ts
@@ -22,7 +22,6 @@ export async function formatJSONC(content: string): Promise<string> {
     plugins: [
       // Fix: Couldn't find plugin for AST format "estree"
       { printers },
-      // @ts-expect-error -- Fix Couldn't resolve parser "jsonc"
       { parsers },
     ],
     // always split into new lines, e.g. {"foo":true} => {\n  "foo": true\n}

--- a/packages/graphiql-react/tsconfig.json
+++ b/packages/graphiql-react/tsconfig.json
@@ -9,13 +9,14 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "declaration": true,
     "noUncheckedIndexedAccess": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
-  }
+  },
+  "exclude": ["src/setup-workers"]
 }

--- a/packages/graphiql-react/vite.config.mts
+++ b/packages/graphiql-react/vite.config.mts
@@ -5,7 +5,7 @@ import { defineConfig, PluginOption } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import type { PluginOptions as ReactCompilerConfig } from 'babel-plugin-react-compiler';
-import packageJSON from './package.json' assert { type: 'json' };
+import packageJSON from './package.json' with { type: 'json' };
 import dts from 'vite-plugin-dts';
 
 export const reactCompilerConfig: Partial<ReactCompilerConfig> = {

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -1,5 +1,5 @@
 import { DocumentNode, visit } from 'graphql';
-import { meros } from 'meros';
+import { meros } from 'meros/browser';
 import type {
   Client,
   ClientOptions,

--- a/packages/graphiql-toolkit/tsconfig.json
+++ b/packages/graphiql-toolkit/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "module": "ESNext",
+    "module": "nodenext",
     "declaration": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "lib": ["es2022", "dom"],
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "types": ["vitest/globals"]
   },
   "include": ["src", "tsup.config.ts"]

--- a/packages/graphiql/vite.config.mts
+++ b/packages/graphiql/vite.config.mts
@@ -4,7 +4,7 @@ import dts from 'vite-plugin-dts';
 import react from '@vitejs/plugin-react';
 import { reactCompilerConfig as $reactCompilerConfig } from '../graphiql-react/vite.config.mjs';
 import type { PluginOptions as ReactCompilerConfig } from 'babel-plugin-react-compiler';
-import packageJSON from './package.json';
+import packageJSON from './package.json' with { type: 'json' };
 
 const reactCompilerConfig: Partial<ReactCompilerConfig> = {
   ...$reactCompilerConfig,

--- a/packages/graphql-language-service-server/src/MessageProcessor.ts
+++ b/packages/graphql-language-service-server/src/MessageProcessor.ts
@@ -13,13 +13,12 @@ import { URI } from 'vscode-uri';
 import {
   CachedContent,
   Uri,
-  GraphQLConfig,
-  GraphQLProjectConfig,
   FileChangeTypeKind,
   Range,
   Position,
   IPosition,
 } from 'graphql-language-service';
+import type { GraphQLConfig, GraphQLProjectConfig } from 'graphql-config';
 
 import { GraphQLLanguageService } from './GraphQLLanguageService';
 

--- a/packages/graphql-language-service/tsconfig.json
+++ b/packages/graphql-language-service/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": "./src",
-    "outDir": "./dist",
-    "baseUrl": "."
+    "outDir": "./dist"
   },
   "include": ["src"],
   "exclude": ["**/__tests__/**", "**/*.spec.*"]

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -132,7 +132,6 @@ export class GraphQLWorker {
 
     return prettierStandalone.format(document, {
       parser: 'graphql',
-      // @ts-expect-error -- should be fixed by pnpm migration
       plugins: [prettierGraphqlParser],
       ...this._formattingOptions?.prettierConfig,
     });

--- a/packages/monaco-graphql/src/initialize.ts
+++ b/packages/monaco-graphql/src/initialize.ts
@@ -33,5 +33,5 @@ export function initializeMode(
 }
 
 function getMode(): Promise<typeof GraphQLMode> {
-  return import('./graphqlMode');
+  return import('./graphqlMode.js');
 }

--- a/packages/monaco-graphql/tsconfig.esm.json
+++ b/packages/monaco-graphql/tsconfig.esm.json
@@ -1,16 +1,10 @@
 {
   "extends": "../../resources/tsconfig.base.esm.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "node",
     "target": "ESNext",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./esm",
-    "lib": ["dom", "ESNext"],
-    "paths": {
-      "*": ["*"]
-    }
+    "lib": ["dom", "ESNext"]
   },
   "references": [
     {

--- a/packages/monaco-graphql/tsconfig.json
+++ b/packages/monaco-graphql/tsconfig.json
@@ -1,16 +1,11 @@
 {
   "extends": "../../resources/tsconfig.base.cjs.json",
   "compilerOptions": {
-    "moduleResolution": "node",
-    "baseUrl": ".",
     "rootDir": "./src",
     "outDir": "./dist",
     "target": "es2015",
     "noUncheckedIndexedAccess": true,
-    "lib": ["dom", "ESNext"],
-    "paths": {
-      "*": ["*"]
-    }
+    "lib": ["dom", "ESNext"]
   },
   "references": [
     {

--- a/packages/vscode-graphql-execution/tsconfig.json
+++ b/packages/vscode-graphql-execution/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../resources/tsconfig.base.esm.json",
+  "extends": "../../resources/tsconfig.base.cjs.json",
   "compilerOptions": {
     "target": "ES2018",
-    "module": "CommonJS",
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/vscode-graphql-syntax/tests/__utilities__/utilities.ts
+++ b/packages/vscode-graphql-syntax/tests/__utilities__/utilities.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as oniguruma from 'vscode-oniguruma';
 import * as tm from 'vscode-textmate';
-import packageJson from '../../package.json' assert { type: 'json' };
+import packageJson from '../../package.json' with { type: 'json' };
 
 export type Token = {
   text: string;

--- a/packages/vscode-graphql/tsconfig.json
+++ b/packages/vscode-graphql/tsconfig.json
@@ -1,8 +1,7 @@
 {
-  "extends": "../../resources/tsconfig.base.esm.json",
+  "extends": "../../resources/tsconfig.base.cjs.json",
   "compilerOptions": {
     "target": "ES2018",
-    "module": "CommonJS",
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist"

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -142,6 +142,7 @@ nodenext
 nishchit
 nocheck
 nocursor
+nodenext
 nonmatchingbracket
 novvum
 nowdoc

--- a/resources/tsconfig.base.cjs.json
+++ b/resources/tsconfig.base.cjs.json
@@ -2,14 +2,13 @@
   "compilerOptions": {
     "composite": true,
     "target": "es6",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
-    "downlevelIteration": true,
     "removeComments": true,
     "strict": true,
     "jsx": "react",
@@ -21,8 +20,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["dom", "es2017", "es2018", "es2021", "esnext"],
-    "types": ["node", "jest"],
-    "baseUrl": "."
+    "types": ["node", "jest"]
   },
   "exclude": [
     "**/__tests__/**",

--- a/resources/tsconfig.base.esm.json
+++ b/resources/tsconfig.base.esm.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.base.cjs.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "target": "es6"
   }
 }

--- a/resources/tsconfig.build.cjs.json
+++ b/resources/tsconfig.build.cjs.json
@@ -12,9 +12,6 @@
       "path": "../packages/codemirror-graphql"
     },
     {
-      "path": "../packages/cm6-graphql"
-    },
-    {
       "path": "../packages/graphql-language-service"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2344,16 +2344,16 @@ __metadata:
   linkType: hard
 
 "@codemirror/language@npm:^6.0.0":
-  version: 6.2.1
-  resolution: "@codemirror/language@npm:6.2.1"
+  version: 6.12.3
+  resolution: "@codemirror/language@npm:6.12.3"
   dependencies:
     "@codemirror/state": "npm:^6.0.0"
-    "@codemirror/view": "npm:^6.0.0"
-    "@lezer/common": "npm:^1.0.0"
+    "@codemirror/view": "npm:^6.23.0"
+    "@lezer/common": "npm:^1.5.0"
     "@lezer/highlight": "npm:^1.0.0"
     "@lezer/lr": "npm:^1.0.0"
     style-mod: "npm:^4.0.0"
-  checksum: 10c0/9cdb6ea913c026511584241a60fea47549f33425f438dd1d4a4ccf0ae878d7a0b74aaf07d65a15b4da5af31211d2543de38bc186da9cf5fe0010e57e2a4ae4aa
+  checksum: 10c0/682d476f35f187a8d2f59f9b2e561045353c87736e5774b5b8dd22ade7deb3c85b9d3cdde988b00aafb345732144c134adf45dadab067430aaee159abcc456a4
   languageName: node
   linkType: hard
 
@@ -2375,6 +2375,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@codemirror/state@npm:^6.6.0":
+  version: 6.6.0
+  resolution: "@codemirror/state@npm:6.6.0"
+  dependencies:
+    "@marijn/find-cluster-break": "npm:^1.0.0"
+  checksum: 10c0/4e5d6ddd28fc642e8d749fe80a7dd278afd547e4d93c562eaab6f23bdf25bb12a94226db3efab6321d458c531eb6d357184809f3704aee419fe3230d53f16e24
+  languageName: node
+  linkType: hard
+
 "@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0":
   version: 6.33.0
   resolution: "@codemirror/view@npm:6.33.0"
@@ -2383,6 +2392,18 @@ __metadata:
     style-mod: "npm:^4.1.0"
     w3c-keyname: "npm:^2.2.4"
   checksum: 10c0/d5811048d84ff4682354ac6e59e42ea008e5a425746ecf7c6dca2f6df675b548c25e339040f1da038b318a306cbd90fb279f15b4f694fadc721f0d8d31a68ff8
+  languageName: node
+  linkType: hard
+
+"@codemirror/view@npm:^6.23.0":
+  version: 6.41.1
+  resolution: "@codemirror/view@npm:6.41.1"
+  dependencies:
+    "@codemirror/state": "npm:^6.6.0"
+    crelt: "npm:^1.0.6"
+    style-mod: "npm:^4.1.0"
+    w3c-keyname: "npm:^2.2.4"
+  checksum: 10c0/09fe1c114a1a35e6bfa8bd001904ff8ce5ba36f916b6517d82f48beaad05aa614a1d96b2dfe6639ce64229f9201759903836da813689a4a8439d381383f115dd
   languageName: node
   linkType: hard
 
@@ -4521,10 +4542,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0":
-  version: 1.2.1
-  resolution: "@lezer/common@npm:1.2.1"
-  checksum: 10c0/af61436dc026f8deebaded13d8e1beea2ae307cbbfb270116cdedadb8208f0674da9c3b5963128a2b1cd4072b4e90bc8128133f4feaf31b6e801e4568f1a15a6
+"@lezer/common@npm:^1.0.0, @lezer/common@npm:^1.1.0, @lezer/common@npm:^1.3.0, @lezer/common@npm:^1.5.0":
+  version: 1.5.2
+  resolution: "@lezer/common@npm:1.5.2"
+  checksum: 10c0/e39b46d74899409eab549df7942f00cd8c7f46c81ef0e2f079654ca96d262fca009927328bcd500d69270f5f09986e74768bed19c0acaadbd22f1a6c7dd9bd85
   languageName: node
   linkType: hard
 
@@ -4541,11 +4562,11 @@ __metadata:
   linkType: hard
 
 "@lezer/highlight@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@lezer/highlight@npm:1.0.0"
+  version: 1.2.3
+  resolution: "@lezer/highlight@npm:1.2.3"
   dependencies:
-    "@lezer/common": "npm:^1.0.0"
-  checksum: 10c0/99d29fc04074921dd26229f0a60e6e97d7d0a3f762e2164607aac6b17e61a5a6ebe9b643af9a2939e000b049ebbeabcc1d803477aafb4606f4cf664131cc5707
+    "@lezer/common": "npm:^1.3.0"
+  checksum: 10c0/3bcb4fce7a1a45b5973895d7cb2be47970a0098700f2a0970aef9878ffd37f540285a2d7388ec1f524726ec90cc5196b5701bbb9764b7e7300786d772b7d2ce2
   languageName: node
   linkType: hard
 
@@ -4581,6 +4602,13 @@ __metadata:
     globby: "npm:^11.0.0"
     read-yaml-file: "npm:^1.1.0"
   checksum: 10c0/f05907d1174ae28861eaa06d0efdc144f773d9a4b8b65e1e7cdc01eb93361d335351b4a336e05c6aac02661be39e8809a3f7ad28bc67b6b338071434ab442130
+  languageName: node
+  linkType: hard
+
+"@marijn/find-cluster-break@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "@marijn/find-cluster-break@npm:1.0.2"
+  checksum: 10c0/1a17a60b16083cc5f7ce89d7b7d8aa87ce4099723e3e9e34e229ef2cd8a980e69d481ca8ee90ffedfec5119af1aed581642fb60ed0365e7e90634c81ea6b630f
   languageName: node
   linkType: hard
 
@@ -10021,10 +10049,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001716":
+"caniuse-lite@npm:^1.0.30001579":
   version: 1.0.30001790
   resolution: "caniuse-lite@npm:1.0.30001790"
   checksum: 10c0/eec0adc1dcb35d51e57bcfa0657493cb57ef43f0ceb03c1edcfee34d43e7a938e6beed2781118c7a5ee99d4f71d443977f08ca5a549005cf89260733af9ad3f8
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001716":
+  version: 1.0.30001717
+  resolution: "caniuse-lite@npm:1.0.30001717"
+  checksum: 10c0/6c0bb1e5182fd578ebe97ee2203250849754a4e17d985839fab527ad27e125a4c4ffce3ece5505217fedf30ea0bbc17ac9f93e9ac525c0389ccba61c6e8345dc
   languageName: node
   linkType: hard
 
@@ -11018,6 +11053,13 @@ __metadata:
   version: 1.0.5
   resolution: "crelt@npm:1.0.5"
   checksum: 10c0/c2ed4111254b710e8baf328770bcdd50f2a8e7aa8abc8a10497bfc04110f6f80cb4aa9f9008fb800873af9533d65d4b00a44e0546ff7d80138a48561f14bf468
+  languageName: node
+  linkType: hard
+
+"crelt@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "crelt@npm:1.0.6"
+  checksum: 10c0/e0fb76dff50c5eb47f2ea9b786c17f9425c66276025adee80876bdbf4a84ab72e899e56d3928431ab0cb057a105ef704df80fe5726ef0f7b1658f815521bdf09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Splits out the tsconfig modernization from #4207 (tsgo adoption) since it's useful on its own.

## Changes

Switches all packages from the legacy `node` (node10) module resolution to `nodenext`. This also meant updating `module` to `nodenext` in the base configs and cleaning up some deprecated options (`downlevelIteration`, `baseUrl`).

The stricter resolution surfaced a handful of issues in source code:
- `import assert` → `import with` (import attributes) in vite configs
- `meros` import needed the browser subpath for correct `Response` types
- Missing `.js` extension on a dynamic import in `monaco-graphql`
- Stale `@ts-expect-error` directives and a `graphql-config` type mismatch in `MessageProcessor`

Also removed `cm6-graphql` from the CJS build references — it uses `cm-buildhelper`, not tsc.

## `setup-workers` quirk

`graphiql-react` has a `setup-workers` file that uses `import.meta.url`. Under `nodenext`, tsc correctly flags this in the CJS tsconfig since `import.meta` isn't available in CJS. The file is excluded from type-checking and added to eslint's `allowDefaultProject` so it still gets linted.