### PR TITLE
Remove `vitest` globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -510,11 +510,15 @@ module.exports = {
       // Rule for ignoring imported dependencies from tests files
       files: [
         '**/__tests__/**',
-        'webpack.config.js',
+        '**/__mocks__/**',
         '**/tests/**',
+        '**/*.spec.{ts,tsx,js,jsx}',
+        '**/*.test-d.{ts,tsx}',
+        'webpack.config.js',
         'test.config.js',
         'vitest.config.mts',
         'setup-files.ts',
+        'setup-window.ts',
       ],
       rules: {
         'import-x/no-extraneous-dependencies': 'off',

--- a/packages/codemirror-graphql/src/__tests__/hint.test.ts
+++ b/packages/codemirror-graphql/src/__tests__/hint.test.ts
@@ -6,7 +6,6 @@
  *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
-
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
 import {
@@ -20,6 +19,7 @@ import {
   __Schema,
   __Type,
 } from 'graphql';
+import { describe, expect, it } from 'vitest';
 import '../hint';
 import type { GraphQLHintOptions, IHint, IHints } from '../hint';
 import '../mode';

--- a/packages/codemirror-graphql/src/__tests__/lint.test.ts
+++ b/packages/codemirror-graphql/src/__tests__/lint.test.ts
@@ -12,6 +12,7 @@ import 'codemirror/addon/lint/lint';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { GraphQLError, OperationDefinitionNode, version } from 'graphql';
+import { describe, expect, it } from 'vitest';
 import '../lint';
 import '../mode';
 import { TestSchema } from './testSchema';

--- a/packages/codemirror-graphql/src/__tests__/mode.test.ts
+++ b/packages/codemirror-graphql/src/__tests__/mode.test.ts
@@ -11,6 +11,7 @@ import CodeMirror from 'codemirror';
 import 'codemirror/addon/runmode/runmode';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 import '../mode';
 
 describe('graphql-mode', () => {

--- a/packages/codemirror-graphql/src/results/__tests__/mode.test.ts
+++ b/packages/codemirror-graphql/src/results/__tests__/mode.test.ts
@@ -9,6 +9,7 @@
 
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/runmode/runmode';
+import { describe, expect, it } from 'vitest';
 import '../mode';
 
 describe('graphql-results-mode', () => {

--- a/packages/codemirror-graphql/src/utils/__tests__/jsonParse.test.ts
+++ b/packages/codemirror-graphql/src/utils/__tests__/jsonParse.test.ts
@@ -6,6 +6,7 @@
  *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
+import { describe, expect, it } from 'vitest';
 import jsonParse, { ParseTokenOutput } from '../jsonParse';
 
 describe('jsonParse', () => {

--- a/packages/codemirror-graphql/src/variables/__tests__/hint.test.ts
+++ b/packages/codemirror-graphql/src/variables/__tests__/hint.test.ts
@@ -10,6 +10,7 @@
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/hint/show-hint';
 import { GraphQLEnumType, GraphQLInputObjectType, parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
 import { IHint, IHints } from '../../hint';
 import collectVariables from '../../utils/collectVariables';
 import { TestSchema } from '../../__tests__/testSchema';

--- a/packages/codemirror-graphql/src/variables/__tests__/lint.test.ts
+++ b/packages/codemirror-graphql/src/variables/__tests__/lint.test.ts
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { describe, expect, it } from 'vitest';
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/lint/lint';
 import { parse } from 'graphql';

--- a/packages/codemirror-graphql/src/variables/__tests__/mode.test.ts
+++ b/packages/codemirror-graphql/src/variables/__tests__/mode.test.ts
@@ -9,6 +9,7 @@
 
 import CodeMirror from 'codemirror';
 import 'codemirror/addon/runmode/runmode';
+import { describe, expect, it } from 'vitest';
 import '../mode';
 
 describe('graphql-variables-mode', () => {

--- a/packages/codemirror-graphql/vitest.config.mts
+++ b/packages/codemirror-graphql/vitest.config.mts
@@ -5,7 +5,6 @@ const require = createRequire(import.meta.url);
 
 export default defineConfig({
   test: {
-    globals: true,
     environment: 'jsdom',
     setupFiles: ['./setup-files.ts'],
     alias: {

--- a/packages/graphiql-plugin-doc-explorer/setup-files.ts
+++ b/packages/graphiql-plugin-doc-explorer/setup-files.ts
@@ -1,6 +1,10 @@
 'use no memo';
 
+import { vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
 
 // to make it works like Jest (auto-mocking)
 vi.mock('zustand');

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
@@ -1,4 +1,4 @@
-import type { Mock } from 'vitest';
+import { type Mock, describe, it, expect, vi, beforeEach } from 'vitest';
 import { useGraphiQL as $useGraphiQL } from '@graphiql/react';
 import { render } from '@testing-library/react';
 import { GraphQLInt, GraphQLObjectType, GraphQLSchema } from 'graphql';

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/field-documentation.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/field-documentation.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { FC, useEffect } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { GraphQLString, GraphQLObjectType, Kind } from 'graphql';

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/type-documentation.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/type-documentation.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { FC, useEffect } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import type { GraphQLNamedType } from 'graphql';

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/type-link.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/type-link.spec.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { FC, useEffect } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { GraphQLNonNull, GraphQLList, GraphQLString } from 'graphql';

--- a/packages/graphiql-plugin-doc-explorer/vitest.config.mts
+++ b/packages/graphiql-plugin-doc-explorer/vitest.config.mts
@@ -5,7 +5,6 @@ import { plugins } from './vite.config.mjs';
 export default defineConfig({
   plugins,
   test: {
-    globals: true,
     environment: 'jsdom',
     setupFiles: ['./setup-files.ts'],
     alias: [

--- a/packages/graphiql-plugin-history/setup-files.ts
+++ b/packages/graphiql-plugin-history/setup-files.ts
@@ -1,6 +1,10 @@
 'use no memo';
 
+import { vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
 
 // to make it works like Jest (auto-mocking)
 vi.mock('zustand');

--- a/packages/graphiql-plugin-history/src/__tests__/components.spec.tsx
+++ b/packages/graphiql-plugin-history/src/__tests__/components.spec.tsx
@@ -1,4 +1,4 @@
-import type { Mock } from 'vitest';
+import { type Mock, describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { formatQuery, HistoryItem } from '../components';

--- a/packages/graphiql-plugin-history/vitest.config.mts
+++ b/packages/graphiql-plugin-history/vitest.config.mts
@@ -5,7 +5,6 @@ import { plugins } from './vite.config.mjs';
 export default defineConfig({
   plugins,
   test: {
-    globals: true,
     environment: 'jsdom',
     setupFiles: ['./setup-files.ts', '../graphiql/setup-window.ts'],
     alias: [

--- a/packages/graphiql-react/setup-files.ts
+++ b/packages/graphiql-react/setup-files.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 // to make it works like Jest (auto-mocking)
 vi.mock('monaco-editor');
 

--- a/packages/graphiql-react/src/types.test-d.ts
+++ b/packages/graphiql-react/src/types.test-d.ts
@@ -1,3 +1,4 @@
+import { expectTypeOf } from 'vitest';
 import type {
   EditorSlice,
   ExecutionSlice,

--- a/packages/graphiql-react/src/utility/tabs.spec.ts
+++ b/packages/graphiql-react/src/utility/tabs.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { StorageAPI } from '@graphiql/toolkit';
 import {
   createTab,

--- a/packages/graphiql-react/src/utility/whitespace.spec.ts
+++ b/packages/graphiql-react/src/utility/whitespace.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { invalidCharacters, normalizeWhitespace } from './whitespace';
 
 describe('normalizeWhitespace', () => {

--- a/packages/graphiql-react/tsconfig.json
+++ b/packages/graphiql-react/tsconfig.json
@@ -15,8 +15,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "declaration": true,
-    "noUncheckedIndexedAccess": true,
-    "types": ["vitest/globals"]
+    "noUncheckedIndexedAccess": true
   },
   "exclude": ["src/setup-workers"]
 }

--- a/packages/graphiql-react/vitest.config.mts
+++ b/packages/graphiql-react/vitest.config.mts
@@ -5,7 +5,6 @@ import { plugins } from './vite.config.mjs';
 export default defineConfig({
   plugins,
   test: {
-    globals: true,
     environment: 'jsdom',
     setupFiles: ['./setup-files.ts'],
     alias: [

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/acceptHeaders.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from 'vitest';
 import { createSimpleFetcher, createMultipartFetcher } from '../lib';
 
 const SPEC_ACCEPT = 'application/graphql-response+json, application/json;q=0.9';

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
@@ -1,4 +1,4 @@
-import { Mock } from 'vitest';
+import { type Mock, describe, it, expect, vi, afterEach } from 'vitest';
 import { parse, getIntrospectionQuery } from 'graphql';
 import { createGraphiQLFetcher } from '../createFetcher';
 

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/lib.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/lib.spec.ts
@@ -1,4 +1,4 @@
-import { Mock } from 'vitest';
+import { type Mock, describe, it, expect, vi, afterEach } from 'vitest';
 import { parse } from 'graphql';
 import {
   isSubscriptionWithName,

--- a/packages/graphiql-toolkit/src/graphql-helpers/__tests__/merge-ast.spec.ts
+++ b/packages/graphiql-toolkit/src/graphql-helpers/__tests__/merge-ast.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import {
   GraphQLInt,
   GraphQLObjectType,

--- a/packages/graphiql-toolkit/src/storage/__tests__/base.spec.ts
+++ b/packages/graphiql-toolkit/src/storage/__tests__/base.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 import { StorageAPI } from '../base';
 
 describe('StorageAPI', () => {

--- a/packages/graphiql-toolkit/src/storage/__tests__/query.spec.ts
+++ b/packages/graphiql-toolkit/src/storage/__tests__/query.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { StorageAPI } from '../base';
 import { QueryStore } from '../query';
 

--- a/packages/graphiql-toolkit/tsconfig.json
+++ b/packages/graphiql-toolkit/tsconfig.json
@@ -9,8 +9,7 @@
     "skipLibCheck": true,
     "allowJs": true,
     "lib": ["es2022", "dom"],
-    "moduleResolution": "nodenext",
-    "types": ["vitest/globals"]
+    "moduleResolution": "nodenext"
   },
   "include": ["src", "tsup.config.ts"]
 }

--- a/packages/graphiql-toolkit/vitest.config.mts
+++ b/packages/graphiql-toolkit/vitest.config.mts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    globals: true,
     environment: 'jsdom',
   },
 });

--- a/packages/graphiql/__mocks__/monaco-editor.ts
+++ b/packages/graphiql/__mocks__/monaco-editor.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { defineWebWorkers } from '@vitest/web-worker/pure';
 /**
  * Fixes TypeError: Cannot read properties of null (reading 'webkitBackingStorePixelRatio')

--- a/packages/graphiql/__mocks__/monaco-editor.ts
+++ b/packages/graphiql/__mocks__/monaco-editor.ts
@@ -57,5 +57,5 @@ process.on('unhandledRejection', reason => {
   throw reason;
 });
 
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports, import-x/no-extraneous-dependencies
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from 'monaco-editor';

--- a/packages/graphiql/__mocks__/zustand.ts
+++ b/packages/graphiql/__mocks__/zustand.ts
@@ -7,7 +7,6 @@
 
 import { afterEach } from 'vitest';
 import { act } from '@testing-library/react';
-// eslint-disable-next-line import-x/no-extraneous-dependencies
 import {
   create as originalCreate,
   createStore as originalCreateStore,

--- a/packages/graphiql/__mocks__/zustand.ts
+++ b/packages/graphiql/__mocks__/zustand.ts
@@ -5,6 +5,7 @@
  * @see https://zustand.docs.pmnd.rs/guides/testing#vitest
  */
 
+import { afterEach } from 'vitest';
 import { act } from '@testing-library/react';
 // eslint-disable-next-line import-x/no-extraneous-dependencies
 import {

--- a/packages/graphiql/setup-files.ts
+++ b/packages/graphiql/setup-files.ts
@@ -1,7 +1,10 @@
 'use no memo';
 
+import { vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { configure } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
+
+afterEach(cleanup);
 
 // to make it works like Jest (auto-mocking)
 vi.mock('zustand');

--- a/packages/graphiql/setup-window.ts
+++ b/packages/graphiql/setup-window.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 /**
  * Fixes TypeError: mainWindow.matchMedia is not a function
  * @see https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -1,5 +1,7 @@
 'use no memo';
 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
 /**
  *  Copyright (c) 2021 GraphQL Contributors.
  *

--- a/packages/graphiql/vitest.config.mts
+++ b/packages/graphiql/vitest.config.mts
@@ -5,7 +5,6 @@ import { plugins } from './vite.config.mjs';
 export default defineConfig({
   plugins,
   test: {
-    globals: true,
     environment: 'jsdom',
     setupFiles: ['./setup-files.ts', './setup-window.ts'],
     // Since we increased `waitFor` timeout in setup-files.ts

--- a/packages/graphql-language-service-cli/src/__tests__/client.test.ts
+++ b/packages/graphql-language-service-cli/src/__tests__/client.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service-cli/src/__tests__/index.test.ts
+++ b/packages/graphql-language-service-cli/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service-cli/tsconfig.json
+++ b/packages/graphql-language-service-cli/tsconfig.json
@@ -4,8 +4,7 @@
     "composite": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "target": "ES2018",
-    "types": ["vitest/globals"]
+    "target": "ES2018"
   },
   "references": [
     {

--- a/packages/graphql-language-service-cli/vitest.config.mts
+++ b/packages/graphql-language-service-cli/vitest.config.mts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    globals: true,
-  },
+  test: {},
 });

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/interface/__tests__/getDefinition.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDefinition.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
 import {
   getDefinitionQueryResultForFragmentSpread,
   getDefinitionQueryResultForNamedType,

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/interface/__tests__/getOutline.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getOutline.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/parser/__tests__/CharacterStream.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/CharacterStream.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import CharacterStream from '../CharacterStream';
 
 describe('CharacterStream', () => {

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /* eslint-disable vitest/expect-expect */
 import OnlineParser from '../onlineParser';
 import {

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import OnlineParser from '../onlineParser';
 import CharacterStream from '../CharacterStream';
 import { RuleKind } from '../types';

--- a/packages/graphql-language-service/src/parser/__tests__/RuleHelpers.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/RuleHelpers.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { opt, list, butNot, t, p } from '../RuleHelpers';
 
 describe('opt', () => {

--- a/packages/graphql-language-service/src/utils/__tests__/Range.test.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/Range.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/utils/__tests__/collectVariables.test.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/collectVariables.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors.
  *

--- a/packages/graphql-language-service/src/utils/__tests__/getASTNodeAtPosition.test.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getASTNodeAtPosition.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.test.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/getVariablesJSONSchema.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/src/utils/__tests__/validateWithCustomRules.test.ts
+++ b/packages/graphql-language-service/src/utils/__tests__/validateWithCustomRules.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach } from 'vitest';
 /**
  *  Copyright (c) 2021 GraphQL Contributors
  *  All rights reserved.

--- a/packages/graphql-language-service/vitest.config.mts
+++ b/packages/graphql-language-service/vitest.config.mts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    globals: true,
-  },
+  test: {},
 });

--- a/packages/monaco-graphql/vitest.config.mts
+++ b/packages/monaco-graphql/vitest.config.mts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  test: {
-    globals: true,
-  },
+  test: {},
 });

--- a/packages/vscode-graphql-syntax/tests/__utilities__/serializer.ts
+++ b/packages/vscode-graphql-syntax/tests/__utilities__/serializer.ts
@@ -1,3 +1,4 @@
+import { expect } from 'vitest';
 import { Token } from './utilities';
 
 function formatTokens(tokens: Token[]): string {

--- a/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('source.graphql grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/js-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/js-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/markdown-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/markdown-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql.markdown.codeblock grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/php-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/php-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql.php grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/python-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/python-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql.python grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/reason-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/reason-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql.reason grammar', () => {

--- a/packages/vscode-graphql-syntax/tests/scala-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/scala-grammar.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest';
 import { tokenizeFile } from './__utilities__/utilities';
 
 describe('inline.graphql.scala grammar', () => {

--- a/packages/vscode-graphql-syntax/vitest.config.mts
+++ b/packages/vscode-graphql-syntax/vitest.config.mts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    globals: true,
     setupFiles: ['./tests/__utilities__/serializer.ts'],
     include: ['**/*.spec.ts'],
   },


### PR DESCRIPTION
Removes `vitest` globals, prefer explicitness.
https://vitest.dev/config/globals.html

`@testing-library/react` cleanup depends on globals, so we added manual cleanup in setup scripts.