### PR TITLE
Add `yarn dedupe` check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -49,6 +49,18 @@ jobs:
       - run: yarn format-check
       - run: yarn svgo-check
 
+  dedupe-check:
+    name: Yarn Dedupe Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn dedupe --check
+
   vitest:
     name: Vitest Unit Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/graphql/graphiql/pull/4222 encountered surprising errors after running `yarn dedupe` due to inconsistent versions of `prettier` in the lockfile. This check ensures we're using the same versions of dependencies across the repo whenever possible.