### PR TITLE
Fix `monaco-graphql` hover crashing on the first line

### DIFF
--- a/.changeset/fix-monaco-hover-line-zero.md
+++ b/.changeset/fix-monaco-hover-line-zero.md
@@ -1,0 +1,7 @@
+---
+'monaco-graphql': patch
+---
+
+Fix hover crashing on the first line of a query
+
+`GraphQLWorker.doHover` was passing 0-indexed positions to `getRange`, which expects a 1-indexed `SourceLocation` (per the GraphQL spec). On the first line this caused `Expected Parser stream to be available` to be logged and hover to return `null`. On other lines it returned the range of the previous line's last token rather than the token under the cursor. Use `getTokenAtPosition` to compute the actual token range instead.

--- a/packages/monaco-graphql/__tests__/GraphQLWorker.test.ts
+++ b/packages/monaco-graphql/__tests__/GraphQLWorker.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildSchema } from 'graphql';
+import { GraphQLWorker } from '../src/GraphQLWorker';
+
+const schema = buildSchema(`
+  type Query { hero: Hero }
+  type Hero { name: String }
+`);
+
+function createWorker(document: string) {
+  const uri = 'inmemory://model/1';
+  const ctx = {
+    getMirrorModels: () => [
+      {
+        uri: { toString: () => uri },
+        getValue: () => document,
+      },
+    ],
+  } as any;
+  const worker = new GraphQLWorker(ctx, {
+    languageId: 'graphql',
+    languageConfig: {
+      schemas: [{ uri: 'schema.graphql', schema }],
+    },
+    diagnosticSettings: {},
+  });
+  return { worker, uri };
+}
+
+describe('GraphQLWorker.doHover', () => {
+  it('returns hover info and a token range when hovering on the first line', async () => {
+    const { worker, uri } = createWorker('query { hero { name } }');
+    // Monaco positions are 1-indexed. Line 1 column 10 is 'e' of 'hero'.
+    const result = await worker.doHover(uri, {
+      lineNumber: 1,
+      column: 10,
+    } as any);
+
+    expect(result).not.toBeNull();
+    expect(result!.content).toContain('Query.hero');
+    // 'hero' spans 0-indexed characters 8..12, monaco columns 9..13.
+    expect(result!.range).toEqual({
+      startLineNumber: 1,
+      endLineNumber: 1,
+      startColumn: 9,
+      endColumn: 13,
+    });
+  });
+});

--- a/packages/monaco-graphql/__tests__/GraphQLWorker.test.ts
+++ b/packages/monaco-graphql/__tests__/GraphQLWorker.test.ts
@@ -8,7 +8,7 @@ const schema = buildSchema(`
 `);
 
 function createWorker(document: string) {
-  const uri = 'inmemory://model/1';
+  const uri = 'monaco://model/1';
   const ctx = {
     getMirrorModels: () => [
       {

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -7,7 +7,11 @@
 
 import { FormattingOptions, ICreateData, SchemaConfig } from './typings';
 import type * as monaco from './monaco-editor';
-import { getRange } from 'graphql-language-service';
+import {
+  getTokenAtPosition,
+  Position,
+  Range,
+} from 'graphql-language-service';
 import { LanguageService } from './LanguageService';
 import {
   toGraphQLPosition,
@@ -84,13 +88,15 @@ export class GraphQLWorker {
         document,
         graphQLPosition,
       );
-      const location = {
-        column: graphQLPosition.character,
-        line: graphQLPosition.line,
-      };
+      const token = getTokenAtPosition(document, graphQLPosition);
       return {
         content: hover,
-        range: toMonacoRange(getRange(location, document)),
+        range: toMonacoRange(
+          new Range(
+            new Position(graphQLPosition.line, token.start),
+            new Position(graphQLPosition.line, token.end),
+          ),
+        ),
       };
     } catch (err) {
       // eslint-disable-next-line no-console

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -7,11 +7,7 @@
 
 import { FormattingOptions, ICreateData, SchemaConfig } from './typings';
 import type * as monaco from './monaco-editor';
-import {
-  getTokenAtPosition,
-  Position,
-  Range,
-} from 'graphql-language-service';
+import { getTokenAtPosition, Position, Range } from 'graphql-language-service';
 import { LanguageService } from './LanguageService';
 import {
   toGraphQLPosition,


### PR DESCRIPTION
Hover is broken in `monaco-graphql`. On the first line it throws and renders nothing; on later lines it doesn't crash but highlights the wrong token.

`GraphQLWorker.doHover` passes a 0-indexed position to `getRange`, which actually wants a 1-indexed `SourceLocation` (per the GraphQL spec, and what its other callers pass via `error.locations[0]`). On line 0 the loop never runs and `Expected Parser stream to be available` fires. On later lines `getRange` parses to end-of-line and ignores `column`, so the range comes back pointing at the previous line's last token.

`getRange` was the wrong tool here anyway. It was built for diagnostics, not for finding the token under a cursor. `getTokenAtPosition` is what we want, and it's what the rest of the language service already uses.

Fixes #4157
Fixes #3168

Supersedes #4162, which tried to special-case `line === 0` inside `getRange` itself. That left `getRange` returning a `Position` with `line: -1` (which becomes `0` after `toMonacoRange`'s `+1`, invalid in Monaco's 1-indexed API), and didn't address the bigger problem that `getRange` doesn't compute a token range to begin with.

## Validation

```bash
yarn install
yarn build
yarn workspace example-monaco-graphql-react-vite dev
```

Open the URL Vite prints, with browser devtools open.

1. Hover the word `query` on the first line. Before: console logs `Error: Expected Parser stream to be available` and no popup appears. After: popup renders and `query` is highlighted.
2. Press Enter to push the query down a line, then hover a field name. Before: popup appears but the highlight is on the previous line's last token. After: the field under the cursor is highlighted.