### PR TITLE
Enable alpha releases on `graphiql-6`

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,29 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "example-graphiql-vite": "0.0.0",
+    "example-graphiql-vite-react-router": "1.0.0",
+    "example-graphiql-webpack": "0.0.0",
+    "example-monaco-graphql-nextjs": "0.0.0",
+    "example-monaco-graphql-react-vite": "0.0.0",
+    "example-monaco-graphql-webpack": "0.0.0",
+    "cm6-graphql": "0.2.1",
+    "codemirror-graphql": "2.2.4",
+    "graphiql": "5.2.2",
+    "@graphiql/plugin-code-exporter": "5.1.1",
+    "@graphiql/plugin-doc-explorer": "0.4.1",
+    "@graphiql/plugin-explorer": "5.1.1",
+    "@graphiql/plugin-history": "0.4.1",
+    "@graphiql/react": "0.37.3",
+    "@graphiql/toolkit": "0.11.3",
+    "graphql-language-service": "5.5.0",
+    "graphql-language-service-cli": "3.5.0",
+    "graphql-language-service-server": "2.14.8",
+    "monaco-graphql": "1.7.3",
+    "vscode-graphql": "0.13.2",
+    "vscode-graphql-execution": "0.3.2",
+    "vscode-graphql-syntax": "1.3.8"
+  },
+  "changesets": []
+}

--- a/.changeset/v6-alpha-line.md
+++ b/.changeset/v6-alpha-line.md
@@ -1,0 +1,5 @@
+---
+'graphiql': major
+---
+
+Initial v6 alpha. Refs graphql/graphiql#4219.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    branches: [main, graphiql-5]
+    branches: [main, graphiql-6]
 permissions: {}
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Swap the vestigial `graphiql-5` reference in `.github/workflows/release.yml` for `graphiql-6` so the changesets-action runs on pushes to the integration branch.
- Enter changesets pre-mode with the `alpha` tag so merges aggregate into `6.0.0-alpha.N` prereleases.
- Add a changeset that seeds the alpha release line by bumping `graphiql` to v6. No functional change — subsequent alphas accumulate the redesign work.

## Test plan

- [ ] On merge: changesets-action opens a "Version Packages (alpha)" PR bumping `graphiql` to `6.0.0-alpha.0`.
- [ ] Merging the version PR publishes `graphiql@6.0.0-alpha.0` to npm with the `alpha` dist-tag.

Refs: graphql/graphiql#4219