### PR TITLE
Regenerate lockfile in `ci:version`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "format-check": "oxfmt --check .",
     "svgo": "svgo --pretty --indent 2 --eol lf --final-newline -r -f . --exclude node_modules",
     "svgo-check": "yarn svgo && git diff --exit-code -- '*.svg'",
-    "ci:version": "yarn changeset version && yarn build && yarn fix",
+    "ci:version": "yarn changeset version && yarn install --no-immutable && yarn build && yarn fix",
     "release": "yarn build && yarn build-bundles && (wsrun release --exclude-missing --serial --recursive --changedSince main -- || true) && yarn changeset publish",
     "release:canary": "(node scripts/canary-release.mts && yarn build-bundles && yarn changeset publish --tag canary) || echo Skipping Canary...",
     "repo:lint": "manypkg check",


### PR DESCRIPTION
## Summary

`ci:version` runs `yarn changeset version` but never `yarn install`, so the Version Packages PR ends up with a stale `yarn.lock`. CI's `Yarn Dedupe Check` (added in #4223) catches this on `yarn install --immutable`.

Adding `yarn install --no-immutable` after the version step matches the recipe in other yarn-berry monorepos — e.g. [`medusajs/medusa`](https://github.com/medusajs/medusa/blob/ea2165be7d3963f016cfed31f47da4c9bd24e285/package.json#L164) and [`toeverything/blocksuite`](https://github.com/toeverything/blocksuite/blob/5cb5cb68471ca692f3c162258f0087cb22fcb82d/package.json#L23). Neither `changesets/action` nor `changesets` docs mention it.

### Why now

#4223 only just added the dedupe check. Before that, stale lockfiles landed quietly on `main`; the next contributor's local `yarn install` regenerated them, leaving a stray `yarn.lock` diff in their PR. Reviewers skip large lockfile diffs.

## Test plan

- [ ] Next Version Packages PR includes a `yarn.lock` diff and passes `Yarn Dedupe Check`.