### PR TITLE
Add `@graphiql/react` devDep to doc-explorer and history plugins

### DIFF
--- a/.changeset/fix-plugin-d-ts-build-deps.md
+++ b/.changeset/fix-plugin-d-ts-build-deps.md
@@ -1,0 +1,10 @@
+---
+'@graphiql/plugin-doc-explorer': patch
+'@graphiql/plugin-history': patch
+---
+
+Fix degraded type declarations in published packages
+
+Both packages import from `@graphiql/react` at build time but only declared it as a peer dependency. Yarn workspaces topologically orders builds via `dependencies`/`devDependencies`, not `peerDependencies`, so on a clean checkout these plugins built before `@graphiql/react` had emitted its `dist/*.d.ts`. `vite-plugin-dts` then ran `tsc` against unresolved `@graphiql/react` imports, fell back to `any` for any return type that flowed through `useGraphiQL`, and published `.d.ts` artifacts where hooks like `useDocExplorer` and `useDocExplorerActions` resolved to `() => any` instead of their real shapes.
+
+Adding `@graphiql/react` as a `devDependency` matches the pattern already in `@graphiql/plugin-explorer` and `@graphiql/plugin-code-exporter` and lets the build run in topological order.

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -49,6 +49,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
+    "@graphiql/react": "^0.37.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -47,6 +47,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
+    "@graphiql/react": "^0.37.0",
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,6 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-doc-explorer@workspace:packages/graphiql-plugin-doc-explorer"
   dependencies:
+    "@graphiql/react": "npm:^0.37.0"
     "@headlessui/react": "npm:^2.2"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -3080,6 +3081,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-history@workspace:packages/graphiql-plugin-history"
   dependencies:
+    "@graphiql/react": "npm:^0.37.0"
     "@graphiql/toolkit": "npm:^0.11.3"
     "@testing-library/react": "npm:^16.1.0"
     "@vitejs/plugin-react": "npm:^4.4.1"


### PR DESCRIPTION
## Summary

- `@graphiql/plugin-doc-explorer` and `@graphiql/plugin-history` import from `@graphiql/react` at build time but only declared it as a peer dep.
- Yarn workspaces topologically orders builds via `dependencies`/`devDependencies`, not `peerDependencies`, so on a clean checkout these plugins built before `@graphiql/react` emitted its `dist/*.d.ts`. `vite-plugin-dts` then ran `tsc` against unresolved `@graphiql/react` imports and published `.d.ts` artifacts with degraded types — hooks like `useDocExplorer` and `useDocExplorerActions` resolve to `() => any` in `@graphiql/plugin-doc-explorer@0.4.1` on npm.
- Matches the pattern already used in `@graphiql/plugin-explorer` and `@graphiql/plugin-code-exporter`.

## Impact on published types

Diff between `@graphiql/plugin-doc-explorer@0.4.1` on npm (built without this fix) and `dist/` produced after this change:

```diff
--- dist/context.d.ts (npm 0.4.1)
+++ dist/context.d.ts (after fix)
-export declare type DocExplorerFieldDef = ...
+export type DocExplorerFieldDef = ...

-export declare const useDocExplorer: () => any;
+export declare const useDocExplorer: () => DocExplorerNavStack;

-export declare const useDocExplorerActions: () => any;
+export declare const useDocExplorerActions: () => {
+    push(item: DocExplorerNavStackItem): void;
+    pop(): void;
+    reset(): void;
+    resolveSchemaReferenceToNavItem(schemaReference: SchemaReference | null): void;
+    rebuildNavStackWithSchema(schema: GraphQLSchema): void;
+};
```

```diff
--- dist/deprecated.d.ts (npm 0.4.1)
+++ dist/deprecated.d.ts (after fix)
-export declare function useExplorerContext(): any;
+export declare function useExplorerContext(): {
+    explorerNavStack: import('./context').DocExplorerNavStack;
+    push(item: import('./context').DocExplorerNavStackItem): void;
+    pop(): void;
+    reset(): void;
+    resolveSchemaReferenceToNavItem(schemaReference: import('@graphiql/react').SchemaReference | null): void;
+    rebuildNavStackWithSchema(schema: import('graphql').GraphQLSchema): void;
+};
```

Every other `.d.ts` file in the package also flips `declare type X` to `type X` — a tsc artifact of the resolution failure, not user-visible.

## Changes

- Add `"@graphiql/react": "^0.37.0"` to `devDependencies` in `packages/graphiql-plugin-doc-explorer/package.json` and `packages/graphiql-plugin-history/package.json`.
- Lockfile + `patch` changeset for both packages.

## Validation Steps

1. **Reproduce the published bug**:
   ```sh
   npm pack @graphiql/plugin-doc-explorer@0.4.1
   tar xzf graphiql-plugin-doc-explorer-0.4.1.tgz
   grep useDocExplorer package/dist/context.d.ts
   # → useDocExplorer: () => any
   ```
2. **Confirm fix**: check out this branch, run `yarn build`, then:
   ```sh
   grep useDocExplorer packages/graphiql-plugin-doc-explorer/dist/context.d.ts
   # → useDocExplorer: () => DocExplorerNavStack
   ```
3. **Build order**: `@graphiql/react` should appear before both plugins in `yarn build` output.
4. The Release workflow on this PR should no longer log `TS2307: Cannot find module '@graphiql/react'` (compare to [run 25513011736](https://github.com/graphql/graphiql/actions/runs/25513011736/job/74876486867) for the broken baseline).