### PR TITLE
fix (graphiql-react): Text selection highlight does not match selection

### DIFF
--- a/.changeset/twelve-doors-guess.md
+++ b/.changeset/twelve-doors-guess.md
@@ -1,5 +1,5 @@
 ---
-"@graphiql/react": patch
+'@graphiql/react': patch
 ---
 
 Bugfix for multiline selection highlight styling: disabling Monaco's `roundedSelection` option prevents selection highlight from appearing to extend beyond actual text selection. See issue [#4094](https://github.com/graphql/graphiql/issues/4094).

--- a/.changeset/twelve-doors-guess.md
+++ b/.changeset/twelve-doors-guess.md
@@ -1,0 +1,5 @@
+---
+"@graphiql/react": patch
+---
+
+Bugfix for multiline selection highlight styling: disabling Monaco's `roundedSelection` option prevents selection highlight from appearing to extend beyond actual text selection. See issue [#4094](https://github.com/graphql/graphiql/issues/4094).

--- a/packages/graphiql-react/src/utility/create-editor.ts
+++ b/packages/graphiql-react/src/utility/create-editor.ts
@@ -63,6 +63,7 @@ export function createEditor(
     // See: https://github.com/graphql/graphiql/issues/4040
     fontLigatures: true,
     lineNumbersMinChars: 2, // reduce line numbers width on the left size
+    roundedSelection: false, // prevent multiline text selection from highlighting +1 characters after beginning/end of selection
     tabIndex: -1, // Do not allow tabbing into the editor, only via by pressing Enter or its container
     ...options,
   });


### PR DESCRIPTION
Addresses https://github.com/graphql/graphiql/issues/4094

Before:

<img width="228" height="98" alt="Screenshot 2026-05-07 at 4 12 12 PM" src="https://github.com/user-attachments/assets/17d32529-92e9-411e-9ed7-9a25b15eca3c" />

After:

<img width="239" height="101" alt="Screenshot 2026-05-07 at 4 13 30 PM" src="https://github.com/user-attachments/assets/ac16ccfb-8047-437d-8d16-a288cf6a6e92" />
