### PR TITLE
Ignore working-group agendas in oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -8,7 +8,8 @@
   "sortPackageJson": false,
   "ignorePatterns": [
     "packages/codemirror-graphql/src/__tests__/schema-kitchen-sink.graphql",
-    "**/CHANGELOG.md"
+    "**/CHANGELOG.md",
+    "working-group/agendas/**"
   ],
   "overrides": [
     {


### PR DESCRIPTION
## Summary

- Add `working-group/agendas/**` to `.oxfmtrc.json` `ignorePatterns` so oxfmt doesn't fight prettier over `wgutils`-generated agendas (see #4226).

## Changes

- `.oxfmtrc.json`: add `working-group/agendas/**` to `ignorePatterns`.

## Validation Steps

1. `yarn format-check` passes.
2. `git ls-files working-group/agendas | wc -l` files are skipped (visible in oxfmt's checked-file count).