### PR TITLE
Fix `license-check` so it actually checks the whole monorepo

### DIFF
--- a/js-green-licenses.json
+++ b/js-green-licenses.json
@@ -2,7 +2,15 @@
   "packageAllowlist": [
     // MIT, just lacking SPDX in manifest
     "valid-url",
-    "argparse"
+    "argparse",
+    "spawn-command",
+    "spawndamnit",
+    // BlueOak-1.0.0 — permissive, not in jsgl's default greenLicenses
+    "glob",
+    "minimatch",
+    "minipass",
+    "path-scurry",
+    "lru-cache"
   ],
   "dev": false
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "e2e": "yarn workspace graphiql e2e",
     "oxlint": "oxlint --max-warnings=0 --ignore-path .eslintignore",
     "fix": "yarn lint-fix && yarn format && yarn svgo",
-    "license-check": "jsgl --local packages/*",
+    "license-check": "jsgl --local .",
     "lint": "yarn oxlint && yarn format-check && yarn lint-cspell",
     "lint-cspell": "cspell --unique --no-progress --no-must-find-files",
     "lint-fix": "yarn oxlint --fix",

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -111,6 +111,7 @@ jeong
 jiti
 jonathanawesome
 jsdelivr
+jsgl
 kumar
 languageservice
 leebyron
@@ -132,6 +133,7 @@ medellín
 menlo
 meros
 middlewares
+minipass
 mockfs
 modulemap
 multipass
@@ -202,6 +204,7 @@ snyk
 socker
 sonarjs
 sorare
+spawndamnit
 squirrelly
 stonexer
 streamable

--- a/resources/patches/js-green-licenses+4.0.0.patch
+++ b/resources/patches/js-green-licenses+4.0.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/js-green-licenses/build/src/checker.js b/node_modules/js-green-licenses/build/src/checker.js
+index 79a88a3..2f8a355 100644
+--- a/node_modules/js-green-licenses/build/src/checker.js
++++ b/node_modules/js-green-licenses/build/src/checker.js
+@@ -229,7 +229,7 @@ class LicenseChecker extends events_1.EventEmitter {
+         if (this.failedPackages.has(spec))
+             return;
+         // remove tilde/caret to check for an exact version, ^0.5.0-rc.0 becomes 0.5.0-rc.0
+-        const version = versionSpec.replace(/^[^~]/, '');
++        const version = versionSpec.replace(/^[~^]/, '');
+         // if the dependency is a local package then skip verification at this step. will be checked independently
+         if (this.localPackages.has(`${packageName}@${version}`))
+             return;


### PR DESCRIPTION
## Summary

Three stacked bugs have made `yarn license-check` a near-no-op, and the alpha-release PR (#4239) recently surfaced one of them:

1. **`jsgl --local packages/*` was only ever checking one package.** The shell expands the glob, but `--local` is a `string` flag, so only the first arg (`packages/cm6-graphql`) is honored — every other workspace package is silently ignored. Switched to `jsgl --local .` so `js-green-licenses` walks the root + every `packages/*/package.json` itself, and registers them all as local.

2. **`js-green-licenses` has a regex bug** at `checker.js:232`:
    ```js
    const version = versionSpec.replace(/^[^~]/, '');  // [^~] = "not tilde"
    ```
   It's meant to strip a leading `^` so the local-package short-circuit at line 234 can match, but `[^~]` matches any first non-tilde char — so a pinned `5.5.1-alpha.0` becomes `.5.1-alpha.0` and the lookup misses. Patched via `patch-package`: `/^[^~]/` → `/^[~^]/`. This is the same fix as the (forever-unmerged) upstream PR [google/js-green-licenses#230](https://github.com/google/js-green-licenses/pull/230).

3. **Seven previously-hidden findings surface** once `--local .` actually walks the tree — all permissive in practice. Allowlisted them in `js-green-licenses.json`:
   - `BlueOak-1.0.0` (permissive, but not in jsgl's default green list): `glob`, `minimatch`, `minipass`, `path-scurry`, `lru-cache`
   - non-SPDX-in-manifest MIT: `spawn-command`, `spawndamnit`

Without this, alpha release PRs (and eventually any main release that bumps a cross-workspace dep) fail `Check Licenses` because the bumped workspace deps aren't on npm yet and the local-skip was misfiring.

`google/js-green-licenses` is archived, so a follow-up to replace it with a maintained tool will land separately.

## Test plan

- [x] Reproduced the original `VersionNotFoundError` locally on `changeset-release/graphiql-6` HEAD
- [x] After the fix, `yarn license-check` exits 0 on both `changeset-release/graphiql-6` (alpha state, includes `graphql-language-service@5.5.1-alpha.0`) and `main`
- [x] `yarn format-check` passes
- [ ] CI green