### PR TITLE
v6: Add OKLCH design tokens (dark + light)

### DIFF
--- a/.changeset/oklch-tokens.md
+++ b/.changeset/oklch-tokens.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Introduce the v6 OKLCH design-token system with both dark and light theme palettes. Tokens (`--bg-canvas`, `--fg-default`, `--accent-blue`, etc.) are stored as OKLCH triplets so opacity can be combined at the call site. Themes are keyed off `data-theme` (`dark` is the default; `light` activates explicitly or via `prefers-color-scheme: light` when no override is set). Existing v5 variables are unchanged; component styles continue to use them until they are migrated.

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -1,3 +1,4 @@
+@import 'tokens.css';
 @import 'auto-insertion.css';
 @import 'editor.css';
 

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -1,0 +1,152 @@
+/*
+ * v6 design tokens.
+ *
+ * Color tokens are stored as OKLCH component triplets (L% C H) so callers
+ * can combine them with alpha at the use site:
+ *
+ *     background: oklch(var(--bg-canvas));
+ *     color: oklch(var(--fg-default) / 0.6);
+ *
+ * Variable names defined here are the supported retheming surface; class
+ * names and internal selectors are not public API.
+ */
+
+:root,
+[data-theme='dark'] {
+  /* Backgrounds */
+  --bg-canvas: 17.63% 0.014 258; /* #0D1117 */
+  --bg-elevated: 10.39% 0.019 248; /* #010409 */
+  --bg-subtle: 22.02% 0.016 257; /* #161B22 */
+  --bg-overlay: 26.66% 0.015 257; /* #21262D */
+
+  /* Borders */
+  --border-default: 24.58% 0.015 257; /* #1C2128 */
+  --border-muted: 26.66% 0.015 257; /* #21262D */
+  --border-strong: 33% 0.015 252; /* #30363D */
+
+  /* Foreground */
+  --fg-default: 85.69% 0.014 248; /* #C9D1D9 */
+  --fg-strong: 97.03% 0.01 248; /* #F0F6FC */
+  --fg-muted: 66.25% 0.018 251; /* #8B949E */
+  --fg-subtle: 61.37% 0.019 256; /* #7D8590 */
+  --fg-disabled: 56.29% 0.02 256; /* #6E7681 */
+  --fg-dim: 42.47% 0.017 255; /* #484F58 */
+
+  /* Accents */
+  --accent-blue: 78.57% 0.115 247; /* #79C0FF */
+  --accent-green: 69.51% 0.181 146; /* #3FB950 */
+  --accent-green-light: 84.16% 0.164 146; /* #7EE787 */
+  --accent-yellow: 85.74% 0.133 90; /* #F2CC60 */
+  --accent-orange: 79.91% 0.141 60; /* #FFA657 */
+  --accent-red: 66.51% 0.205 27; /* #F85149 */
+  --accent-purple: 80.05% 0.127 306; /* #D2A8FF */
+  --accent-pink: 73.45% 0.163 26; /* #FF7B72 */
+
+  /* Action button (Run) */
+  --btn-primary: 54.6% 0.147 146; /* #238636 */
+  --btn-primary-border: 62.22% 0.166 146; /* #2EA043 */
+
+  /* Typography */
+  --font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-family-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --font-size-body: 13px;
+  --font-size-small: 11px;
+  --font-size-mono: 12px;
+  --font-size-eyebrow: 10.5px;
+  --line-height-body: 18px;
+  --letter-spacing-ui: -0.005em;
+
+  /* Spacing scale */
+  --px-4: 4px;
+  --px-6: 6px;
+  --px-8: 8px;
+  --px-10: 10px;
+  --px-12: 12px;
+  --px-14: 14px;
+  --px-16: 16px;
+  --px-24: 24px;
+  --px-32: 32px;
+
+  /* Layout dimensions */
+  --top-bar-height: 40px;
+  --status-bar-height: 24px;
+  --rail-width: 48px;
+  --side-panel-width: 340px;
+  --tab-strip-height: 32px;
+
+  /* Radii */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+}
+
+[data-theme='light'] {
+  /* Backgrounds */
+  --bg-canvas: 99% 0.005 248;
+  --bg-elevated: 100% 0 248;
+  --bg-subtle: 96% 0.008 248;
+  --bg-overlay: 92% 0.01 248;
+
+  /* Borders */
+  --border-default: 90% 0.01 248;
+  --border-muted: 85% 0.01 248;
+  --border-strong: 78% 0.012 248;
+
+  /* Foreground */
+  --fg-default: 20% 0.013 248;
+  --fg-strong: 12% 0.011 248;
+  --fg-muted: 40% 0.013 248;
+  --fg-subtle: 50% 0.012 248;
+  --fg-disabled: 65% 0.012 248;
+  --fg-dim: 75% 0.011 248;
+
+  /* Accents — slightly darker / more saturated for AA contrast on light bg */
+  --accent-blue: 50% 0.193 248;
+  --accent-green: 50% 0.176 145;
+  --accent-green-light: 65% 0.19 145;
+  --accent-yellow: 70% 0.15 86;
+  --accent-orange: 62% 0.165 60;
+  --accent-red: 55% 0.224 27;
+  --accent-purple: 55% 0.18 295;
+  --accent-pink: 58% 0.22 17;
+
+  /* Action button (Run) — keeps the green; inverted bg lets it stand out */
+  --btn-primary: 51% 0.15 145;
+  --btn-primary-border: 45% 0.17 145;
+
+  /* Typography, spacing, dimensions, and radii are inherited from :root. */
+}
+
+/*
+ * Apply light overrides automatically when the system prefers light and the
+ * user has not pinned dark. The values are duplicated rather than relying on
+ * inheritance into a media query, which can resolve inconsistently across
+ * browsers when the source rule is keyed off a different selector.
+ */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme='dark']) {
+    --bg-canvas: 99% 0.005 248;
+    --bg-elevated: 100% 0 248;
+    --bg-subtle: 96% 0.008 248;
+    --bg-overlay: 92% 0.01 248;
+    --border-default: 90% 0.01 248;
+    --border-muted: 85% 0.01 248;
+    --border-strong: 78% 0.012 248;
+    --fg-default: 20% 0.013 248;
+    --fg-strong: 12% 0.011 248;
+    --fg-muted: 40% 0.013 248;
+    --fg-subtle: 50% 0.012 248;
+    --fg-disabled: 65% 0.012 248;
+    --fg-dim: 75% 0.011 248;
+    --accent-blue: 50% 0.193 248;
+    --accent-green: 50% 0.176 145;
+    --accent-green-light: 65% 0.19 145;
+    --accent-yellow: 70% 0.15 86;
+    --accent-orange: 62% 0.165 60;
+    --accent-red: 55% 0.224 27;
+    --accent-purple: 55% 0.18 295;
+    --accent-pink: 58% 0.22 17;
+    --btn-primary: 51% 0.15 145;
+    --btn-primary-border: 45% 0.17 145;
+  }
+}

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -153,6 +153,7 @@ nullthrows
 nulltype
 nvim
 objectvalues
+oklch
 onig
 ooops
 orche
@@ -182,6 +183,7 @@ randomthing
 ravikoti
 resi
 resizer
+retheming
 rikki
 roadmap
 roboto


### PR DESCRIPTION
## Summary

- Introduce a new `packages/graphiql-react/src/style/tokens.css` with the v6 OKLCH-based design token system. Both dark and light palettes ship together.
- Light theme activates explicitly via `data-theme="light"` or automatically via `prefers-color-scheme: light` when no theme is pinned. Dark remains the default.
- Existing v5 HSL variables are unchanged; nothing in `@graphiql/react` references the new tokens yet.
- Future PRs will restyle components to consume the new tokens and shim the v5 variables.

Refs: graphql/graphiql#4219