### PR TITLE
feat (graphiql-plugin-doc-explorer): virtualized schema types list in Docs pane

### DIFF
--- a/.changeset/good-files-enjoy.md
+++ b/.changeset/good-files-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-doc-explorer': minor
+---
+
+Virtualize the All Types list in the Docs pane when the schema contains more than 1000 elements

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2",
+    "@tanstack/react-virtual": "^3.13.24",
     "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/schema-documentation.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/schema-documentation.spec.tsx
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  type GraphQLFieldConfigMap,
+} from 'graphql';
+import { SchemaDocumentation } from '../schema-documentation';
+
+vi.mock('../virtual-list', () => ({
+  VirtualList: vi.fn(() => <div data-testid="mock-virtual-list" />),
+}));
+
+// Imported after the mock so we get the mocked reference.
+const { VirtualList } = await import('../virtual-list');
+const VirtualListMock = vi.mocked(VirtualList);
+
+function makeSchemaWithNTypes(typeCount: number): GraphQLSchema {
+  const userTypes = Array.from(
+    { length: typeCount },
+    (_, i) =>
+      new GraphQLObjectType({
+        name: `UserType${i}`,
+        fields: { name: { type: GraphQLString } },
+      }),
+  );
+  const queryFields: GraphQLFieldConfigMap<unknown, unknown> = {};
+  for (const [i, t] of userTypes.entries()) {
+    queryFields[`field${i}`] = { type: t };
+  }
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({ name: 'Query', fields: queryFields }),
+    types: userTypes,
+  });
+}
+
+describe('SchemaDocumentation', () => {
+  beforeEach(() => {
+    VirtualListMock.mockClear();
+  });
+
+  it('renders VirtualList when there are more than 1000 types in allTypes', () => {
+    const schema = makeSchemaWithNTypes(1500);
+    render(<SchemaDocumentation schema={schema} />);
+
+    expect(VirtualListMock).toHaveBeenCalledTimes(1);
+    const items = VirtualListMock.mock.calls[0]![0].items as unknown[];
+    expect(items.length).toBeGreaterThan(1000);
+  });
+
+  it('renders a plain list (not VirtualList) for small schemas', () => {
+    const schema = makeSchemaWithNTypes(5);
+    const { container } = render(<SchemaDocumentation schema={schema} />);
+
+    expect(VirtualListMock).not.toHaveBeenCalled();
+    // Every UserType plus the built-in String scalar should render a TypeLink.
+    const typeLinks = container.querySelectorAll(
+      '.graphiql-doc-explorer-section--all-types .graphiql-doc-explorer-type-name',
+    );
+    expect(typeLinks.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/schema-documentation.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/schema-documentation.spec.tsx
@@ -7,13 +7,12 @@ import {
   type GraphQLFieldConfigMap,
 } from 'graphql';
 import { SchemaDocumentation } from '../schema-documentation';
+import { VirtualList } from '../virtual-list';
 
 vi.mock('../virtual-list', () => ({
   VirtualList: vi.fn(() => <div data-testid="mock-virtual-list" />),
 }));
 
-// Imported after the mock so we get the mocked reference.
-const { VirtualList } = await import('../virtual-list');
 const VirtualListMock = vi.mocked(VirtualList);
 
 function makeSchemaWithNTypes(typeCount: number): GraphQLSchema {

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/virtual-list.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/virtual-list.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { VirtualList } from '../virtual-list';
+
+describe('VirtualList', () => {
+  it('renders every item via the fallback path when the scroll element has no layout (JSDOM)', () => {
+    const items = Array.from({ length: 5 }, (_, i) => `item-${i}`);
+    const { container } = render(
+      <VirtualList
+        items={items}
+        estimateSize={() => 36}
+        renderItem={item => <span data-testid="item">{item}</span>}
+      />,
+    );
+
+    const rendered = container.querySelectorAll('[data-testid="item"]');
+    expect(rendered).toHaveLength(5);
+    expect(Array.from(rendered, el => el.textContent)).toEqual([
+      'item-0',
+      'item-1',
+      'item-2',
+      'item-3',
+      'item-4',
+    ]);
+  });
+
+  it('renders nothing and does not crash with an empty items array', () => {
+    const { container } = render(
+      <VirtualList
+        items={[]}
+        estimateSize={() => 36}
+        renderItem={item => <span data-testid="item">{String(item)}</span>}
+      />,
+    );
+
+    expect(container.querySelectorAll('[data-testid="item"]')).toHaveLength(0);
+  });
+});

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -37,6 +37,7 @@
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 2;
 
   &:focus-within {
     left: 0;

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -98,6 +98,7 @@ a.graphiql-doc-explorer-back {
   flex: 1;
   flex-direction: column;
   min-height: 0;
+  overflow: auto;
 }
 
 .graphiql-doc-explorer-content > * {

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -1,3 +1,9 @@
+.graphiql-doc-explorer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 /* The header of the doc explorer */
 .graphiql-doc-explorer-header {
   display: flex;
@@ -87,6 +93,13 @@ a.graphiql-doc-explorer-back {
 }
 
 /* The contents of the currently active page in the doc explorer */
+.graphiql-doc-explorer-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
 .graphiql-doc-explorer-content > * {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   margin-top: var(--px-20);

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
@@ -3,6 +3,7 @@ import type { GraphQLSchema } from 'graphql';
 import { MarkdownContent } from '@graphiql/react';
 import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
+import { VirtualList } from './virtual-list';
 import './schema-documentation.css';
 
 type SchemaDocumentationProps = {
@@ -24,6 +25,11 @@ export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
     mutationType?.name,
     subscriptionType?.name,
   ];
+  const allTypes = Object.values(typeMap).filter(
+    type =>
+      !ignoreTypesInAllSchema.includes(type.name) &&
+      !type.name.startsWith('__'),
+  );
 
   return (
     <>
@@ -57,22 +63,11 @@ export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
         )}
       </ExplorerSection>
       <ExplorerSection title="All Schema Types">
-        <div>
-          {Object.values(typeMap).map(type => {
-            if (
-              ignoreTypesInAllSchema.includes(type.name) ||
-              type.name.startsWith('__')
-            ) {
-              return null;
-            }
-
-            return (
-              <div key={type.name}>
-                <TypeLink type={type} />
-              </div>
-            );
-          })}
-        </div>
+        <VirtualList
+          items={allTypes}
+          estimateSize={() => 36}
+          renderItem={type => <TypeLink type={type} />}
+        />
       </ExplorerSection>
     </>
   );

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
@@ -64,7 +64,7 @@ export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
           </div>
         )}
       </ExplorerSection>
-      <ExplorerSection title="All Schema Types">
+      <ExplorerSection className="all-types" title="All Schema Types">
         {allTypes.length > UNVIRTUALIZED_MAX_LENGTH ? (
           <VirtualList
             items={allTypes}

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
@@ -13,6 +13,8 @@ type SchemaDocumentationProps = {
   schema: GraphQLSchema;
 };
 
+const UNVIRTUALIZED_MAX_LENGTH = 1000;
+
 export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
   schema,
 }) => {
@@ -63,11 +65,21 @@ export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
         )}
       </ExplorerSection>
       <ExplorerSection title="All Schema Types">
-        <VirtualList
-          items={allTypes}
-          estimateSize={() => 36}
-          renderItem={type => <TypeLink type={type} />}
-        />
+        {allTypes.length > UNVIRTUALIZED_MAX_LENGTH ? (
+          <VirtualList
+            items={allTypes}
+            estimateSize={() => 23}
+            renderItem={type => <TypeLink type={type} />}
+          />
+        ) : (
+          <div>
+            {allTypes.map(type => (
+              <div key={type.name}>
+                <TypeLink type={type} />
+              </div>
+            ))}
+          </div>
+        )}
       </ExplorerSection>
     </>
   );

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -1,7 +1,5 @@
 .graphiql-doc-explorer-search {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
-  position: relative;
-  z-index: 2;
 
   &:not([data-state='idle']) {
     border: var(--popover-border);

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -1,5 +1,7 @@
 .graphiql-doc-explorer-search {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
+  position: relative;
+  z-index: 2;
 
   &:not([data-state='idle']) {
     border: var(--popover-border);

--- a/packages/graphiql-plugin-doc-explorer/src/components/section.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/section.css
@@ -28,7 +28,8 @@
   min-height: 0;
 }
 
-.graphiql-doc-explorer-section:last-child > .graphiql-doc-explorer-section-content {
+.graphiql-doc-explorer-section:last-child
+  > .graphiql-doc-explorer-section-content {
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/packages/graphiql-plugin-doc-explorer/src/components/section.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/section.css
@@ -20,3 +20,17 @@
     margin-top: var(--px-16);
   }
 }
+
+.graphiql-doc-explorer-section:last-child {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.graphiql-doc-explorer-section:last-child > .graphiql-doc-explorer-section-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/section.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/section.tsx
@@ -33,15 +33,23 @@ type ExplorerSectionProps = {
     | 'Deprecated Enum Values'
     | 'Directives'
     | 'All Schema Types';
+  /**
+   * Optionally pass a classname for an ExplorerSection instance
+   */
+  className?: string;
 };
 
 export const ExplorerSection: FC<ExplorerSectionProps> = ({
   title,
   children,
+  className = '',
 }) => {
   const Icon = TYPE_TO_ICON[title];
+  const additionalClassName = className
+    ? ` ${className} graphiql-doc-explorer-section--${className}`
+    : '';
   return (
-    <div className="graphiql-doc-explorer-section">
+    <div className={`graphiql-doc-explorer-section${additionalClassName}`}>
       <div className="graphiql-doc-explorer-section-title">
         <Icon />
         {title}

--- a/packages/graphiql-plugin-doc-explorer/src/components/section.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/section.tsx
@@ -41,7 +41,7 @@ export const ExplorerSection: FC<ExplorerSectionProps> = ({
 }) => {
   const Icon = TYPE_TO_ICON[title];
   return (
-    <div>
+    <div className="graphiql-doc-explorer-section">
       <div className="graphiql-doc-explorer-section-title">
         <Icon />
         {title}

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
@@ -17,6 +17,7 @@ import { DeprecationReason } from './deprecation-reason';
 import { FieldLink } from './field-link';
 import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
+import { VirtualList } from './virtual-list';
 import './type-documentation.css';
 
 type TypeDocumentationProps = {
@@ -88,17 +89,21 @@ const Fields: FC<{ type: GraphQLNamedType }> = ({ type }) => {
     <>
       {fields.length > 0 ? (
         <ExplorerSection title="Fields">
-          {fields.map(field => (
-            <Field key={field.name} field={field} />
-          ))}
+          <VirtualList
+            items={fields}
+            estimateSize={() => 64}
+            renderItem={field => <Field field={field} />}
+          />
         </ExplorerSection>
       ) : null}
       {deprecatedFields.length > 0 ? (
         showDeprecated || fields.length === 0 ? (
           <ExplorerSection title="Deprecated Fields">
-            {deprecatedFields.map(field => (
-              <Field key={field.name} field={field} />
-            ))}
+            <VirtualList
+              items={deprecatedFields}
+              estimateSize={() => 64}
+              renderItem={field => <Field field={field} />}
+            />
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
@@ -175,17 +180,21 @@ const EnumValues: FC<{ type: GraphQLNamedType }> = ({ type }) => {
     <>
       {values.length > 0 && (
         <ExplorerSection title="Enum Values">
-          {values.map(value => (
-            <EnumValue key={value.name} value={value} />
-          ))}
+          <VirtualList
+            items={values}
+            estimateSize={() => 40}
+            renderItem={value => <EnumValue value={value} />}
+          />
         </ExplorerSection>
       )}
       {deprecatedValues.length > 0 &&
         (showDeprecated || !values.length ? (
           <ExplorerSection title="Deprecated Enum Values">
-            {deprecatedValues.map(value => (
-              <EnumValue key={value.name} value={value} />
-            ))}
+            <VirtualList
+              items={deprecatedValues}
+              estimateSize={() => 40}
+              renderItem={value => <EnumValue value={value} />}
+            />
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
@@ -219,15 +228,16 @@ const PossibleTypes: FC<{ type: GraphQLNamedType }> = ({ type }) => {
   if (!schema || !isAbstractType(type)) {
     return null;
   }
+  const possibleTypes = schema.getPossibleTypes(type);
   return (
     <ExplorerSection
       title={isInterfaceType(type) ? 'Implementations' : 'Possible Types'}
     >
-      {schema.getPossibleTypes(type).map(possibleType => (
-        <div key={possibleType.name}>
-          <TypeLink type={possibleType} />
-        </div>
-      ))}
+      <VirtualList
+        items={possibleTypes}
+        estimateSize={() => 36}
+        renderItem={possibleType => <TypeLink type={possibleType} />}
+      />
     </ExplorerSection>
   );
 };

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
@@ -17,7 +17,6 @@ import { DeprecationReason } from './deprecation-reason';
 import { FieldLink } from './field-link';
 import { ExplorerSection } from './section';
 import { TypeLink } from './type-link';
-import { VirtualList } from './virtual-list';
 import './type-documentation.css';
 
 type TypeDocumentationProps = {
@@ -89,21 +88,17 @@ const Fields: FC<{ type: GraphQLNamedType }> = ({ type }) => {
     <>
       {fields.length > 0 ? (
         <ExplorerSection title="Fields">
-          <VirtualList
-            items={fields}
-            estimateSize={() => 64}
-            renderItem={field => <Field field={field} />}
-          />
+          {fields.map(field => (
+            <Field key={field.name} field={field} />
+          ))}
         </ExplorerSection>
       ) : null}
       {deprecatedFields.length > 0 ? (
         showDeprecated || fields.length === 0 ? (
           <ExplorerSection title="Deprecated Fields">
-            <VirtualList
-              items={deprecatedFields}
-              estimateSize={() => 64}
-              renderItem={field => <Field field={field} />}
-            />
+            {deprecatedFields.map(field => (
+              <Field key={field.name} field={field} />
+            ))}
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
@@ -180,21 +175,17 @@ const EnumValues: FC<{ type: GraphQLNamedType }> = ({ type }) => {
     <>
       {values.length > 0 && (
         <ExplorerSection title="Enum Values">
-          <VirtualList
-            items={values}
-            estimateSize={() => 40}
-            renderItem={value => <EnumValue value={value} />}
-          />
+          {values.map(value => (
+            <EnumValue key={value.name} value={value} />
+          ))}
         </ExplorerSection>
       )}
       {deprecatedValues.length > 0 &&
         (showDeprecated || !values.length ? (
           <ExplorerSection title="Deprecated Enum Values">
-            <VirtualList
-              items={deprecatedValues}
-              estimateSize={() => 40}
-              renderItem={value => <EnumValue value={value} />}
-            />
+            {deprecatedValues.map(value => (
+              <EnumValue key={value.name} value={value} />
+            ))}
           </ExplorerSection>
         ) : (
           <Button type="button" onClick={handleShowDeprecated}>
@@ -233,11 +224,11 @@ const PossibleTypes: FC<{ type: GraphQLNamedType }> = ({ type }) => {
     <ExplorerSection
       title={isInterfaceType(type) ? 'Implementations' : 'Possible Types'}
     >
-      <VirtualList
-        items={possibleTypes}
-        estimateSize={() => 36}
-        renderItem={possibleType => <TypeLink type={possibleType} />}
-      />
+      {possibleTypes.map(possibleType => (
+        <div key={possibleType.name}>
+          <TypeLink type={possibleType} />
+        </div>
+      ))}
     </ExplorerSection>
   );
 };

--- a/packages/graphiql-plugin-doc-explorer/src/components/virtual-list.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/virtual-list.tsx
@@ -1,0 +1,67 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+type VirtualListProps<T> = {
+  items: readonly T[];
+  estimateSize: (index: number) => number;
+  renderItem: (item: T, index: number) => ReactNode;
+};
+
+export function VirtualList<T>({
+  items,
+  estimateSize,
+  renderItem,
+}: VirtualListProps<T>) {
+  // React Compiler memoizes this component's output. Because `virtualizer` is a
+  // stable instance, the compiler treats the render as cacheable and skips the
+  // re-renders that TanStack Virtual's internal useReducer dispatch triggers
+  // on scroll/resize. Disabling memoization here keeps scroll-driven updates working.
+  'use no memo';
+
+  const [scrollEl, setScrollEl] = useState<HTMLDivElement | null>(null);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollEl,
+    estimateSize,
+    overscan: 5,
+    initialRect: { width: 0, height: 800 },
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div ref={setScrollEl} style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}>
+      {virtualItems.length > 0 ? (
+        <div
+          style={{ height: virtualizer.getTotalSize(), position: 'relative' }}
+        >
+          {virtualItems.map(virtualRow => (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+                paddingBottom: 'var(--px-16)',
+              }}
+            >
+              {renderItem(items[virtualRow.index]!, virtualRow.index)}
+            </div>
+          ))}
+        </div>
+      ) : (
+        items.map((item, index) => (
+          <div key={index} style={{ paddingBottom: 'var(--px-16)' }}>
+            {renderItem(item, index)}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/virtual-list.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/virtual-list.tsx
@@ -48,7 +48,6 @@ export function VirtualList<T>({
                 left: 0,
                 width: '100%',
                 transform: `translateY(${virtualRow.start}px)`,
-                paddingBottom: 'var(--px-16)',
               }}
             >
               {renderItem(items[virtualRow.index]!, virtualRow.index)}

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -42,9 +42,11 @@ bobbybobby
 borggreve
 bram
 browserslistrc
+cacheable
 calar
 chainable
 changesets
+classname
 clsx
 codebases
 codegen
@@ -140,7 +142,6 @@ multipass
 nauroze
 newhope
 nextjs
-nodenext
 nishchit
 nocheck
 nocursor
@@ -159,6 +160,7 @@ orche
 orta
 outdir
 outlineable
+overscan
 ovsx
 oxfmt
 oxlint
@@ -214,6 +216,7 @@ svgo
 svgr
 tanay
 tanaypratap
+tanstack
 testid
 testonly
 therox
@@ -231,6 +234,7 @@ unfocus
 unnormalized
 unparsable
 unsubscribable
+unvirtualized
 urigo
 urql
 usememo

--- a/yarn.lock
+++ b/yarn.lock
@@ -6019,7 +6019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:^3.13.24":
+"@tanstack/react-virtual@npm:^3.13.24, @tanstack/react-virtual@npm:^3.13.6":
   version: 3.13.24
   resolution: "@tanstack/react-virtual@npm:3.13.24"
   dependencies:
@@ -6028,25 +6028,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/f409b2bb67965a513b75a1403e622c0b86c88c67419f757c79f670615979e38dc7ad5569a02c924741697df3d4301a0f45208fd4b9f935a5d58dd83e1db5622a
-  languageName: node
-  linkType: hard
-
-"@tanstack/react-virtual@npm:^3.13.6":
-  version: 3.13.6
-  resolution: "@tanstack/react-virtual@npm:3.13.6"
-  dependencies:
-    "@tanstack/virtual-core": "npm:3.13.6"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/3d2fdf024cb9189981cc015518a34a771a57cd698ca775022ad481431e6f26e596309f57d2238ef15f3b53b805879edaed6394e4cad1bb550ee92259e4d52633
-  languageName: node
-  linkType: hard
-
-"@tanstack/virtual-core@npm:3.13.6":
-  version: 3.13.6
-  resolution: "@tanstack/virtual-core@npm:3.13.6"
-  checksum: 10c0/9c40af4deccf0fadc5c371f4e659f1aff221db0ede9664ee7cf3642a2d05f6f1c9494605f3606f70d7c8948dc22e50c48519a8435d0e845f1b1f34c9353722c8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,7 @@ __metadata:
   dependencies:
     "@graphiql/react": "npm:^0.37.4"
     "@headlessui/react": "npm:^2.2"
+    "@tanstack/react-virtual": "npm:^3.13.24"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
@@ -6018,6 +6019,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.13.24":
+  version: 3.13.24
+  resolution: "@tanstack/react-virtual@npm:3.13.24"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.14.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/f409b2bb67965a513b75a1403e622c0b86c88c67419f757c79f670615979e38dc7ad5569a02c924741697df3d4301a0f45208fd4b9f935a5d58dd83e1db5622a
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-virtual@npm:^3.13.6":
   version: 3.13.6
   resolution: "@tanstack/react-virtual@npm:3.13.6"
@@ -6034,6 +6047,13 @@ __metadata:
   version: 3.13.6
   resolution: "@tanstack/virtual-core@npm:3.13.6"
   checksum: 10c0/9c40af4deccf0fadc5c371f4e659f1aff221db0ede9664ee7cf3642a2d05f6f1c9494605f3606f70d7c8948dc22e50c48519a8435d0e845f1b1f34c9353722c8
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.14.0":
+  version: 3.14.0
+  resolution: "@tanstack/virtual-core@npm:3.14.0"
+  checksum: 10c0/9e07e7f74f5e02dfc47b358f7b5089e680d8b14b9c5b90e9497be6f57c76ca98d185fbe5008795b89919346bfc3676ebe1c61b34980eefe6674c88ec6ff4b136
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds virtualization for the top-level list of the Docs pane, keeping things performant for huge schemas.

The new `<VirtualList />` component (employing `@tanstack/react-virtual`) is used for the "All Types" list in the Docs pane when there are more than 1000 elements. With 1000 or fewer, that list is simply rendered into the DOM as before.

(I'm currently working with a schema that results in a list of more than 42,000 schema elements, and all of those items getting rendered directly into the DOM results in buggy/crashy behavior in the Docs pane.)