### PR TITLE
Add `monaco-graphql/monaco-editor` to the exports map

### DIFF
--- a/.changeset/monaco-graphql-monaco-editor-export.md
+++ b/.changeset/monaco-graphql-monaco-editor-export.md
@@ -1,0 +1,9 @@
+---
+'monaco-graphql': minor
+---
+
+Add `./monaco-editor` to the `exports` map.
+
+`monaco-graphql/monaco-editor` re-exports `monaco-editor` with only the graphql and json languages, skipping the css, html, and typescript contributions that the default `monaco-editor` entry point bundles. Consumers can use it to share a single `monaco-editor` instance with `monaco-graphql` (for `editor`, `Uri`, `KeyMod`, `KeyCode`, `languages`, etc.) without paying for those extras. Until now you had to reach for the unstable `monaco-graphql/esm/monaco-editor` path, which only resolves under legacy `node10`-style module resolution.
+
+The legacy `monaco-graphql/esm/monaco-editor` path still works via the existing `./*` wildcard, so this change is purely additive.

--- a/.changeset/monaco-graphql-monaco-editor-export.md
+++ b/.changeset/monaco-graphql-monaco-editor-export.md
@@ -7,3 +7,5 @@ Add `./monaco-editor` to the `exports` map.
 `monaco-graphql/monaco-editor` re-exports `monaco-editor` with only the graphql and json languages, skipping the css, html, and typescript contributions that the default `monaco-editor` entry point bundles. Consumers can use it to share a single `monaco-editor` instance with `monaco-graphql` (for `editor`, `Uri`, `KeyMod`, `KeyCode`, `languages`, etc.) without paying for those extras. Until now you had to reach for the unstable `monaco-graphql/esm/monaco-editor` path, which only resolves under legacy `node10`-style module resolution.
 
 The legacy `monaco-graphql/esm/monaco-editor` path still works via the existing `./*` wildcard, so this change is purely additive.
+
+The `monaco-graphql/esm/*` import pattern is now considered deprecated. It will continue to work throughout the `1.x` line, but the wildcard `exports` entry that enables it is planned for removal in the next major version. New code should prefer the canonical paths: `monaco-graphql/monaco-editor`, `monaco-graphql/initializeMode`, `monaco-graphql/graphql.worker`, and `monaco-graphql/lite`.

--- a/examples/monaco-graphql-nextjs/package.json
+++ b/examples/monaco-graphql-nextjs/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/node": "^24",
     "@types/react": "^19",
-    "typescript": "^4"
+    "typescript": "^5"
   }
 }

--- a/examples/monaco-graphql-nextjs/src/constants.ts
+++ b/examples/monaco-graphql-nextjs/src/constants.ts
@@ -1,5 +1,5 @@
-import { editor, Uri, languages } from 'monaco-graphql/esm/monaco-editor';
-import { initializeMode } from 'monaco-graphql/esm/initializeMode';
+import { editor, Uri, languages } from 'monaco-graphql/monaco-editor';
+import { initializeMode } from 'monaco-graphql/initializeMode';
 import { parse, print } from 'graphql';
 
 type ModelType = 'operations' | 'variables' | 'response' | 'ts';

--- a/examples/monaco-graphql-nextjs/src/editor.tsx
+++ b/examples/monaco-graphql-nextjs/src/editor.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import { getIntrospectionQuery, IntrospectionQuery } from 'graphql';
-import { editor, KeyMod, KeyCode } from 'monaco-graphql/esm/monaco-editor';
+import { editor, KeyMod, KeyCode } from 'monaco-graphql/monaco-editor';
 
 // to get typescript mode working
 import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution';

--- a/examples/monaco-graphql-nextjs/tsconfig.json
+++ b/examples/monaco-graphql-nextjs/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -9,12 +9,11 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/examples/monaco-graphql-webpack/package.json
+++ b/examples/monaco-graphql-webpack/package.json
@@ -35,7 +35,7 @@
     "html-webpack-plugin": "^5",
     "monaco-editor-webpack-plugin": "^7",
     "style-loader": "^3",
-    "typescript": "^4",
+    "typescript": "^5",
     "webpack": "^5",
     "webpack-bundle-analyzer": "^3",
     "webpack-cli": "^5",

--- a/examples/monaco-graphql-webpack/src/editors.ts
+++ b/examples/monaco-graphql-webpack/src/editors.ts
@@ -1,4 +1,4 @@
-import { editor, Uri } from 'monaco-graphql/esm/monaco-editor';
+import { editor, Uri } from 'monaco-graphql/monaco-editor';
 
 const GRAPHQL_LANGUAGE_ID = 'graphql';
 

--- a/examples/monaco-graphql-webpack/src/index.ts
+++ b/examples/monaco-graphql-webpack/src/index.ts
@@ -1,8 +1,8 @@
 /* global netlify */
 
-import { editor, KeyMod, KeyCode } from 'monaco-graphql/esm/monaco-editor';
+import { editor, KeyMod, KeyCode } from 'monaco-graphql/monaco-editor';
 import * as JSONC from 'jsonc-parser';
-import { initializeMode } from 'monaco-graphql/esm/initializeMode';
+import { initializeMode } from 'monaco-graphql/initializeMode';
 
 import { createEditors } from './editors';
 import { schemaFetcher, schemaOptions } from './schema';

--- a/examples/monaco-graphql-webpack/src/schema.ts
+++ b/examples/monaco-graphql-webpack/src/schema.ts
@@ -6,7 +6,7 @@ import {
   buildASTSchema,
 } from 'graphql';
 import type { SchemaConfig } from 'monaco-graphql';
-import { Uri } from 'monaco-graphql/esm/monaco-editor';
+import { Uri } from 'monaco-graphql/monaco-editor';
 
 const SCHEMA_URL = 'https://api.github.com/graphql';
 const API_TOKEN = localStorage.getItem('ghapi') || null;

--- a/examples/monaco-graphql-webpack/tsconfig.json
+++ b/examples/monaco-graphql-webpack/tsconfig.json
@@ -10,7 +10,7 @@
     "types": ["node"],
     "typeRoots": ["../../node_modules/@types", "node_modules/@types"],
     "lib": ["dom", "ESNext"],
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "references": [{ "path": "../../packages/monaco-graphql" }],
   "include": ["src"],

--- a/packages/graphiql-react/src/env.d.ts
+++ b/packages/graphiql-react/src/env.d.ts
@@ -5,19 +5,19 @@ declare namespace globalThis {
 }
 
 declare module 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js' {
-  export { KeyCode } from 'monaco-graphql/esm/monaco-editor';
+  export { KeyCode } from 'monaco-graphql/monaco-editor';
 }
 
 declare module 'monaco-editor/esm/vs/editor/common/services/editorBaseApi.js' {
-  export { KeyMod } from 'monaco-graphql/esm/monaco-editor';
+  export { KeyMod } from 'monaco-graphql/monaco-editor';
 }
 
 declare module 'monaco-editor/esm/vs/base/common/uri.js' {
-  export { Uri as URI } from 'monaco-graphql/esm/monaco-editor';
+  export { Uri as URI } from 'monaco-graphql/monaco-editor';
 }
 
 declare module 'monaco-editor/esm/vs/editor/common/core/range.js' {
-  export { Range } from 'monaco-graphql/esm/monaco-editor';
+  export { Range } from 'monaco-graphql/monaco-editor';
 }
 
 declare module 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker&deps=monaco-editor@0.52.2' {

--- a/packages/monaco-graphql/README.md
+++ b/packages/monaco-graphql/README.md
@@ -53,7 +53,7 @@ yarn add monaco-graphql
 ```ts
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { initializeMode } from 'monaco-graphql/initializeMode'; // `monaco-graphql/esm/initializeMode` still works
+import { initializeMode } from 'monaco-graphql/initializeMode'; // `monaco-graphql/esm/initializeMode` is deprecated but still works
 
 // you can also configure these using the webpack or vite plugins for `monaco-editor`
 import GraphQLWorker from 'worker-loader!monaco-graphql/esm/graphql.worker';
@@ -589,6 +589,12 @@ only `graphql` and `json` languages, and skip loading unused languages.
 -import { ... } from 'monaco-editor'
 +import { ... } from 'monaco-graphql/monaco-editor'
 ```
+
+> The `monaco-graphql/esm/*` import pattern is deprecated. It is retained for
+> backwards compatibility but the wildcard export that enables it is planned
+> for removal in the next major version. New code should use the canonical
+> subpaths: `monaco-graphql/monaco-editor`, `monaco-graphql/initializeMode`,
+> `monaco-graphql/graphql.worker`, `monaco-graphql/lite`.
 
 ### Catch Future Import Mistakes with ESLint
 

--- a/packages/monaco-graphql/README.md
+++ b/packages/monaco-graphql/README.md
@@ -582,12 +582,12 @@ and
 
 For `monaco-graphql`, you need only 2 languages - `graphql` and `json`.
 In version `monaco-graphql@1.3.0` and later, you can replace all `monaco-editor`'s
-imports with `monaco-graphql/esm/monaco-editor` to improve performance, load
+imports with `monaco-graphql/monaco-editor` to improve performance, load
 only `graphql` and `json` languages, and skip loading unused languages.
 
 ```diff
 -import { ... } from 'monaco-editor'
-+import { ... } from 'monaco-graphql/esm/monaco-editor'
++import { ... } from 'monaco-graphql/monaco-editor'
 ```
 
 ### Catch Future Import Mistakes with ESLint
@@ -604,7 +604,7 @@ To prevent mis-importing of `monaco-editor`, you can set up default
       'error',
       {
         name: 'monaco-editor',
-        message: '`monaco-editor` imports all languages; use `monaco-graphql/esm/monaco-editor` instead to import only `json` and `graphql` languages',
+        message: '`monaco-editor` imports all languages; use `monaco-graphql/monaco-editor` instead to import only `json` and `graphql` languages',
       },
     ],
   },

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -51,6 +51,12 @@
       "import": "./esm/initializeMode.js",
       "require": "./dist/initializeMode.js",
       "default": "./dist/initializeMode.js"
+    },
+    "./monaco-editor": {
+      "types": "./esm/monaco-editor.d.ts",
+      "import": "./esm/monaco-editor.js",
+      "require": "./dist/monaco-editor.js",
+      "default": "./dist/monaco-editor.js"
     }
   },
   "repository": {

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -208,6 +208,8 @@ spawndamnit
 squirrelly
 stonexer
 streamable
+subpath
+subpaths
 subword
 suchanek
 svgo

--- a/yarn.lock
+++ b/yarn.lock
@@ -11402,7 +11402,7 @@ __metadata:
     next: "npm:^15"
     react: "npm:^19"
     react-dom: "npm:^19"
-    typescript: "npm:^4"
+    typescript: "npm:^5"
   languageName: unknown
   linkType: soft
 
@@ -11450,7 +11450,7 @@ __metadata:
     monaco-graphql: "npm:^1.7.4"
     prettier: "npm:^3"
     style-loader: "npm:^3"
-    typescript: "npm:^4"
+    typescript: "npm:^5"
     webpack: "npm:^5"
     webpack-bundle-analyzer: "npm:^3"
     webpack-cli: "npm:^5"
@@ -21025,7 +21025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4, typescript@npm:^4.2.3":
+"typescript@npm:^4.2.3":
   version: 4.9.5
   resolution: "typescript@npm:4.9.5"
   bin:
@@ -21055,7 +21055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.2.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^4.2.3#optional!builtin<compat/typescript>":
   version: 4.9.5
   resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
   bin:


### PR DESCRIPTION
## Summary

- Adds `./monaco-editor` to `monaco-graphql`'s `exports` map. It was previously only reachable via the unstable `monaco-graphql/esm/monaco-editor` path, which requires legacy `node10` resolution.
- Bumps the two `monaco-graphql` examples (`nextjs`, `webpack`) to TypeScript 5 and `bundler` resolution so they can adopt the canonical path.
- Soft-deprecates the `monaco-graphql/esm/*` pattern in the README and changeset. The wildcard `exports` entry stays for backwards compatibility; removal is queued for the next major.
- Unblocks adoption of the TypeScript Native Preview (`tsgo`): tsgo drops `moduleResolution: "node"`, so any code relying on the wildcard-only `monaco-graphql/esm/*` path stops resolving once tsgo replaces tsc. The canonical subpath works under every modern resolution mode.

## Validation Steps

- `yarn types:check`: `example-monaco-graphql-nextjs` resolves the new path under `bundler` resolution.
- `yarn workspace example-monaco-graphql-webpack build`: webpack resolves it through `exports` at runtime.