### PR TITLE
Rename `BUILD-CACHE-LIST` to `BUILD_CACHE_LIST` so it parses as one identifier

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
 
   cspell:
     name: CSpell
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
       - run: yarn test
 
   lint:
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
       - run: yarn oxlint
 
   types-check:
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
       - run: yarn types:check
 
   types-check-tsgo:
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
       - uses: actions/cache@v5
         with:
           path: |
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/cache@v5
         with:
           key: build-${{ github.sha }}
-          path: ${{ env.BUILD-CACHE-LIST }}
+          path: ${{ env.BUILD_CACHE_LIST }}
       - name: Setup NPM credentials
         run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
         env:
@@ -236,7 +236,7 @@ jobs:
         run: yarn license-check
 
 env:
-  BUILD-CACHE-LIST: |
+  BUILD_CACHE_LIST: |
     packages/**/dist/**/*
     packages/**/cjs/**/*
     packages/**/esm/**/*


### PR DESCRIPTION
## Summary

`${{ env.BUILD-CACHE-LIST }}` parses as subtraction in the GitHub Actions expression language, not as an identifier. The cache step ended up with `path: packages/**/dist/**/*` — just the first line of the 11-line multi-line value. The other 10 patterns, including the `!**/node_modules` negation, were never cached.

Proof in a recent passing run: [Build · actions/cache@v5 step][log] shows `path: packages/**/dist/**/*` rather than the full list.

Underscores fix it. Verified locally with `actionlint`. CI will show `path:` now resolving to the full list.

[log]: https://github.com/graphql/graphiql/actions/runs/25846653731/job/75943304738#step:6:4