### PR TITLE
Drop deprecated `--frozen-lockfile` from release install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           node-version-file: '.node-version'
           cache: yarn
 
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -103,7 +103,7 @@ jobs:
           node-version-file: '.node-version'
           cache: yarn
 
-      - run: yarn install --frozen-lockfile --immutable
+      - run: yarn install --immutable
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Yarn Berry emits `YN0050: The --frozen-lockfile option is deprecated; use --immutable and/or --immutable-cache instead` on every release run. `--immutable` is already on the same command, so the flag is just noise.