### PR TITLE
Fix `vsix` download path in publish job

### DIFF
--- a/.changeset/vscode-publish-path-fix.md
+++ b/.changeset/vscode-publish-path-fix.md
@@ -1,0 +1,7 @@
+---
+'vscode-graphql-execution': patch
+'vscode-graphql-syntax': patch
+'vscode-graphql': patch
+---
+
+Burning patch version due to previous release failure.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: vscode-extensions
-          path: vsix
+          # `upload-artifact` strips the path prefix up to the first wildcard
+          # segment, so the artifact contains `vscode-graphql*/*.vsix` rather
+          # than `packages/vscode-graphql*/*.vsix`. Restore the `packages/`
+          # prefix here so the layout lines up with `vsixPath('vsix', …)` in
+          # the script.
+          path: vsix/packages
 
       - name: Publish
         env:


### PR DESCRIPTION
## Summary

The vsix publish jobs failed with `ENOENT` in the last release. `actions/upload-artifact@v4` strips the path prefix up to the first wildcard segment, so `packages/vscode-graphql*/*.vsix` only preserves `vscode-graphql*/<file>` in the artifact — but the publish script looks under `vsix/packages/<pkg>/`. Setting the download `path` to `vsix/packages` lines things back up.

A patch changeset re-bumps the three VSCode extensions so the next release exercises the publish path.

Failed run: https://github.com/graphql/graphiql/actions/runs/25878625719

## Test plan

Only exercisable by a real release. The previous run's `attach` step succeeded, so `0.13.4` / `1.3.10` / `0.3.4` can still be manually uploaded from the GitHub Release `.vsix` assets via `vsce publish` and `ovsx publish` if those versions are wanted on the marketplaces.