### PR TITLE
Give `defaults to the built-in default query` test a 20s timeout

### DIFF
--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -167,6 +167,7 @@ describe('GraphiQL', () => {
   }); // schema
 
   describe('default query', () => {
+    // First test to boot Monaco's editor worker; cold start needs extra time under Vitest 4's forks pool.
     it('defaults to the built-in default query', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
@@ -177,7 +178,7 @@ describe('GraphiQL', () => {
         expect(queryEditor).toBeVisible();
         expect(queryEditor!.textContent).toBe('# Welcome to GraphiQL');
       });
-    });
+    }, 20000);
 
     it('accepts a custom default query', async () => {
       const { container } = render(


### PR DESCRIPTION
## Summary

Times out at the default 9s on every CI run since Vitest 4 landed (#4260). It's the only test in `GraphiQL.spec.tsx` that boots Monaco's `editorWorkerService` from a cold start; the rest get a warm worker. Vitest 4's pool switch from `threads` to `forks` pushed cold-boot just past 9s.

Bumped to 20s on this one test, with an inline comment explaining why for the next person.

Failed on two back-to-back runs of an unrelated PR:
- https://github.com/graphql/graphiql/actions/runs/25878177678/job/76051305013
- https://github.com/graphql/graphiql/actions/runs/25878177678/job/76052552437