### PR TITLE
Also bump the `waitFor` timeout — `testTimeout` alone isn't enough

### DIFF
--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -167,17 +167,22 @@ describe('GraphiQL', () => {
   }); // schema
 
   describe('default query', () => {
-    // First test to boot Monaco's editor worker; cold start needs extra time under Vitest 4's forks pool.
+    // First test to boot Monaco's editor worker; cold start needs extra time under
+    // Vitest 4's forks pool. Both the it() testTimeout and the waitFor()
+    // asyncUtilTimeout (configured at 9s in setup-files.ts) must be bumped.
     it('defaults to the built-in default query', async () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
-      await waitFor(() => {
-        const queryEditor = container.querySelector<HTMLDivElement>(
-          '.graphiql-editor .monaco-scrollable-element',
-        );
-        expect(queryEditor).toBeVisible();
-        expect(queryEditor!.textContent).toBe('# Welcome to GraphiQL');
-      });
+      await waitFor(
+        () => {
+          const queryEditor = container.querySelector<HTMLDivElement>(
+            '.graphiql-editor .monaco-scrollable-element',
+          );
+          expect(queryEditor).toBeVisible();
+          expect(queryEditor!.textContent).toBe('# Welcome to GraphiQL');
+        },
+        { timeout: 15_000 },
+      );
     }, 20000);
 
     it('accepts a custom default query', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #4268. That PR bumped `testTimeout` to 20s for this test but missed the second 9s ceiling: `configure({ asyncUtilTimeout: 9_000 })` in `packages/graphiql/setup-files.ts`. RTL's `waitFor` gives up at the asyncUtilTimeout regardless of how big the `it()` timeout is — its final assertion then runs against a `null` `queryEditor` and fails with `expect(...).toBeVisible()` instead of the original "Test timed out" message.

Evidence the previous fix was luck-of-the-draw: #4268 passed because Monaco cold-booted at 7927ms — 73ms under the 9s cliff. #4266 failed at 9066ms on the same fix because Monaco took longer that run.

This PR adds `{ timeout: 15_000 }` to the `waitFor(...)` call so the polling window matches the test's 20s ceiling. Keeps `it(..., 20000)` so the two timeouts don't race in the other direction.