### PR TITLE
Bump `cypress-io/github-action` to `v7` for Node 24 support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -147,7 +147,7 @@ jobs:
             ~/.cache/Cypress
           key: cypress-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           command: yarn e2e


### PR DESCRIPTION
## Summary

GitHub now warns that `cypress-io/github-action@v6` runs on Node.js 20, which will be forced off the runners on 2026-06-02 and removed on 2026-09-16. `v7.0.0` is the [migration release](https://github.com/cypress-io/github-action/releases/tag/v7.0.0): same action, just on Node 24.