### PR TITLE
Add missing `concurrently` dev dependency

### DIFF
--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -68,6 +68,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/web-worker": "^4.1.6",
     "babel-plugin-react-compiler": "19.1.0-rc.1",
+    "concurrently": "^7.0.0",
     "cross-env": "^7.0.2",
     "cypress": "^13.13.2",
     "graphql": "^16.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12970,6 +12970,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.4.1"
     "@vitest/web-worker": "npm:^4.1.6"
     babel-plugin-react-compiler: "npm:19.1.0-rc.1"
+    concurrently: "npm:^7.0.0"
     cross-env: "npm:^7.0.2"
     cypress: "npm:^13.13.2"
     graphql: "npm:^16.11.0"


### PR DESCRIPTION
Running `yarn workspace graphiql dev` fails due to missing dependency. Adding it as a dev dependency of the package itself resolves this. This most likely worked pre-Yarn 4 and broke after upgrading.