### PR TITLE
v6: Restyle `Button` and `ToolbarButton`

### DIFF
--- a/.changeset/restyle-button-iconbutton.md
+++ b/.changeset/restyle-button-iconbutton.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Restyle `Button` and `ToolbarButton` to the v6 OKLCH design tokens. Adds a `primary` variant to `Button` for the Run-button style. Storybook stories added for each variant. Props and behavior unchanged.

--- a/packages/graphiql-react/src/components/button/button.stories.tsx
+++ b/packages/graphiql-react/src/components/button/button.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './';
+
+const meta: Meta<typeof Button> = {
+  title: 'Primitives/Button',
+  component: Button,
+  tags: ['autodocs'],
+  args: { children: 'Button' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Primary: Story = {
+  args: { variant: 'primary', children: 'Run' },
+};
+
+export const Success: Story = {
+  args: { state: 'success', children: 'Copied!' },
+};
+
+export const Error: Story = {
+  args: { state: 'error', children: 'Failed' },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};

--- a/packages/graphiql-react/src/components/button/button.stories.tsx
+++ b/packages/graphiql-react/src/components/button/button.stories.tsx
@@ -5,27 +5,28 @@ const meta: Meta<typeof Button> = {
   title: 'Primitives/Button',
   component: Button,
   tags: ['autodocs'],
-  args: { children: 'Button' },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof Button>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: () => <Button>Button</Button>,
+};
 
 export const Primary: Story = {
-  args: { variant: 'primary', children: 'Run' },
+  render: () => <Button variant="primary">Run</Button>,
 };
 
 export const Success: Story = {
-  args: { state: 'success', children: 'Copied!' },
+  render: () => <Button state="success">Copied!</Button>,
 };
 
 export const Error: Story = {
-  args: { state: 'error', children: 'Failed' },
+  render: () => <Button state="error">Failed</Button>,
 };
 
 export const Disabled: Story = {
-  args: { disabled: true },
+  render: () => <Button disabled>Button</Button>,
 };

--- a/packages/graphiql-react/src/components/button/index.css
+++ b/packages/graphiql-react/src/components/button/index.css
@@ -54,9 +54,13 @@ button.graphiql-button {
   }
 
   &.graphiql-button-success {
-    background-color: oklch(var(--accent-green) / 0.15);
+    background-color: oklch(var(--accent-green));
+    border-color: oklch(var(--accent-green));
+    color: #fff;
   }
   &.graphiql-button-error {
-    background-color: oklch(var(--accent-red) / 0.15);
+    background-color: oklch(var(--accent-red));
+    border-color: oklch(var(--accent-red));
+    color: #fff;
   }
 }

--- a/packages/graphiql-react/src/components/button/index.css
+++ b/packages/graphiql-react/src/components/button/index.css
@@ -56,11 +56,11 @@ button.graphiql-button {
   &.graphiql-button-success {
     background-color: oklch(var(--accent-green));
     border-color: oklch(var(--accent-green));
-    color: #fff;
+    color: #000;
   }
   &.graphiql-button-error {
     background-color: oklch(var(--accent-red));
     border-color: oklch(var(--accent-red));
-    color: #fff;
+    color: #000;
   }
 }

--- a/packages/graphiql-react/src/components/button/index.css
+++ b/packages/graphiql-react/src/components/button/index.css
@@ -1,50 +1,62 @@
 .graphiql-un-styled {
   all: unset;
-  border-radius: var(--border-radius-4);
+  border-radius: var(--radius-sm);
   cursor: pointer;
 
   &:hover {
-    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
+    background-color: oklch(var(--bg-overlay));
   }
 
   &:active {
-    background-color: hsla(
-      var(--color-neutral),
-      var(--alpha-background-medium)
-    );
+    background-color: oklch(var(--bg-overlay) / 0.8);
   }
 
-  &:focus {
-    outline: hsla(var(--color-neutral), var(--alpha-background-heavy)) auto 1px;
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: 1px;
   }
 }
 
 .graphiql-button,
 button.graphiql-button {
-  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
-  border: none;
-  border-radius: var(--border-radius-4);
-  color: hsl(var(--color-neutral));
+  background-color: oklch(var(--bg-subtle));
+  border: 1px solid oklch(var(--border-strong));
+  border-radius: var(--radius-sm);
+  color: oklch(var(--fg-default));
   cursor: pointer;
   font-size: var(--font-size-body);
-  padding: var(--px-8) var(--px-12);
+  padding: var(--px-4) var(--px-12);
 
   &:hover,
   &:active {
-    background-color: hsla(
-      var(--color-neutral),
-      var(--alpha-background-medium)
-    );
+    background-color: oklch(var(--bg-overlay));
   }
 
-  &:focus {
-    outline: hsla(var(--color-neutral), var(--alpha-background-heavy)) auto 1px;
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: 1px;
+  }
+
+  &.graphiql-button-primary {
+    background-color: oklch(var(--btn-primary));
+    border-color: oklch(var(--btn-primary-border));
+    color: #fff;
+    font-weight: 600;
+
+    &:hover {
+      background-color: oklch(var(--btn-primary-border));
+    }
+
+    &:active {
+      background-color: oklch(var(--btn-primary));
+      opacity: 0.85;
+    }
   }
 
   &.graphiql-button-success {
-    background-color: hsla(var(--color-success), var(--alpha-background-heavy));
+    background-color: oklch(var(--accent-green) / 0.15);
   }
   &.graphiql-button-error {
-    background-color: hsla(var(--color-error), var(--alpha-background-heavy));
+    background-color: oklch(var(--accent-red) / 0.15);
   }
 }

--- a/packages/graphiql-react/src/components/button/index.tsx
+++ b/packages/graphiql-react/src/components/button/index.tsx
@@ -1,5 +1,5 @@
 import { ComponentPropsWithoutRef, forwardRef } from 'react';
-import { cn } from '../../utility';
+import { clsx as cn } from 'clsx';
 import './index.css';
 
 type UnStyledButtonProps = ComponentPropsWithoutRef<'button'>;
@@ -18,6 +18,7 @@ UnStyledButton.displayName = 'UnStyledButton';
 
 interface ButtonProps extends UnStyledButtonProps {
   state?: 'success' | 'error';
+  variant?: 'default' | 'primary';
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -27,6 +28,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       ref={ref}
       className={cn(
         'graphiql-button',
+        props.variant === 'primary' && 'graphiql-button-primary',
         {
           success: 'graphiql-button-success',
           error: 'graphiql-button-error',

--- a/packages/graphiql-react/src/components/execute-button/index.css
+++ b/packages/graphiql-react/src/components/execute-button/index.css
@@ -1,26 +1,28 @@
 button.graphiql-execute-button {
-  background-color: hsl(var(--color-primary));
-  border: none;
-  border-radius: var(--border-radius-8);
+  background-color: oklch(var(--btn-primary));
+  border: 1px solid oklch(var(--btn-primary-border));
+  border-radius: var(--radius-md);
   cursor: pointer;
   height: var(--toolbar-width);
   padding: 0;
   width: var(--toolbar-width);
 
   &:hover {
-    background-color: hsla(var(--color-primary), 0.9);
+    background-color: oklch(var(--btn-primary-border));
   }
 
   &:active {
-    background-color: hsla(var(--color-primary), 0.8);
+    background-color: oklch(var(--btn-primary));
+    opacity: 0.85;
   }
 
-  &:focus {
-    outline: hsla(var(--color-primary), 0.8) auto 1px;
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: 1px;
   }
 
   & > svg {
-    color: white;
+    color: #fff;
     display: block;
     height: var(--px-16);
     margin: auto;

--- a/packages/graphiql-react/src/components/toolbar-button/index.css
+++ b/packages/graphiql-react/src/components/toolbar-button/index.css
@@ -4,8 +4,21 @@ button.graphiql-toolbar-button {
   justify-content: center;
   height: var(--toolbar-width);
   width: var(--toolbar-width);
+  color: oklch(var(--fg-subtle));
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    background-color: oklch(var(--bg-overlay));
+    color: oklch(var(--fg-default));
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: 1px;
+  }
 
   &.error {
-    background: hsla(var(--color-error), var(--alpha-background-heavy));
+    background-color: oklch(var(--accent-red) / 0.15);
+    color: oklch(var(--accent-red));
   }
 }

--- a/packages/graphiql-react/src/components/toolbar-button/index.tsx
+++ b/packages/graphiql-react/src/components/toolbar-button/index.tsx
@@ -4,7 +4,7 @@ import {
   useState,
   ComponentPropsWithoutRef,
 } from 'react';
-import { cn } from '../../utility';
+import { clsx as cn } from 'clsx';
 import { Tooltip } from '../tooltip';
 import { UnStyledButton } from '../button';
 import './index.css';

--- a/packages/graphiql-react/src/components/toolbar-button/toolbar-button.stories.tsx
+++ b/packages/graphiql-react/src/components/toolbar-button/toolbar-button.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import * as T from '@radix-ui/react-tooltip';
+import { ToolbarButton } from './';
+
+const meta: Meta<typeof ToolbarButton> = {
+  title: 'Primitives/ToolbarButton',
+  component: ToolbarButton,
+  tags: ['autodocs'],
+  args: {
+    label: 'Prettify query',
+    children: '✦',
+  },
+  decorators: [
+    Story => (
+      <T.Provider>
+        <Story />
+      </T.Provider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToolbarButton>;
+
+export const Default: Story = {};

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -32,6 +32,7 @@ arthurgeron
 asiandrummer
 astro
 astrojs
+autodocs
 aumy
 Autopurge
 behaviour


### PR DESCRIPTION
## Summary

- Migrate `Button`, `UnStyledButton`, `ToolbarButton`, and `ExecuteButton` CSS to v6 OKLCH tokens.
- Add `variant?: 'default' | 'primary'` to `Button`; `primary` renders the Run-button style.
- Switch `:focus` to `:focus-visible` on interactive states so the focus ring no longer fires on mouse click. Aligns with [MDN `:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) and WCAG 2.4.7 (Focus Visible).
- Import `clsx` directly in `button` and `toolbar-button`, following the leaf-module pattern from #4272. A follow-up PR will convert remaining callers and remove the `cn` re-export.
- Add Storybook stories: `Primitives/Button` (Default, Primary, Success, Error, Disabled) and `Primitives/ToolbarButton` (Default).

## Test plan

- [x] Open Storybook `Primitives/Button` and verify each variant matches the design.
- [x] Tab into the buttons, then mouse-click them. Focus ring appears on Tab only, not on click.
- [x] Open `Primitives/ToolbarButton`. Hover the icon button; a v6 tooltip appears.
- [x] Run `yarn dev:graphiql`. The Run button and toolbar buttons match the new design.

Refs: graphql/graphiql#4219
