### PR TITLE
v6: Add `KeycapHint` primitive

### DIFF
--- a/.changeset/keycap-hint.md
+++ b/.changeset/keycap-hint.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a `KeycapHint` primitive for displaying inline keyboard shortcuts (e.g. `⌘K`, `⌘⏎`). Used in the new top bar; available for general consumer use.

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -75,6 +75,8 @@
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-vitest": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/get-value": "^3.0.5",
     "@types/markdown-it": "^14.1.2",
     "@types/react-dom": "^19.1.2",

--- a/packages/graphiql-react/setup-files.ts
+++ b/packages/graphiql-react/setup-files.ts
@@ -1,6 +1,8 @@
-import { vi } from 'vitest';
+import { vi, afterEach } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(cleanup);
 
 // to make it works like Jest (auto-mocking)
 vi.mock('monaco-editor');
-
-export {};

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -18,3 +18,5 @@ export { Spinner } from './spinner';
 export { Tabs, Tab } from './tabs';
 export { Tooltip } from './tooltip';
 export { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
+export { KeycapHint } from './keycap-hint';
+export type { KeycapHintProps } from './keycap-hint';

--- a/packages/graphiql-react/src/components/keycap-hint/index.css
+++ b/packages/graphiql-react/src/components/keycap-hint/index.css
@@ -1,0 +1,22 @@
+.graphiql-keycap-hint {
+  display: inline-flex;
+  gap: var(--px-4);
+  align-items: center;
+}
+
+.graphiql-keycap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 var(--px-4);
+  border: 1px solid oklch(var(--border-strong));
+  border-radius: var(--radius-sm);
+  background: oklch(var(--bg-canvas));
+  color: oklch(var(--fg-muted));
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-eyebrow);
+  font-weight: 600;
+  line-height: 1;
+}

--- a/packages/graphiql-react/src/components/keycap-hint/index.tsx
+++ b/packages/graphiql-react/src/components/keycap-hint/index.tsx
@@ -1,0 +1,17 @@
+import type { FC } from 'react';
+import './index.css';
+
+export type KeycapHintProps = {
+  keys: string[];
+  ariaLabel: string;
+};
+
+export const KeycapHint: FC<KeycapHintProps> = ({ keys, ariaLabel }) => (
+  <span className="graphiql-keycap-hint" aria-label={ariaLabel}>
+    {keys.map((k, i) => (
+      <kbd key={`${k}-${i}`} className="graphiql-keycap">
+        {k}
+      </kbd>
+    ))}
+  </span>
+);

--- a/packages/graphiql-react/src/components/keycap-hint/keycap-hint.stories.tsx
+++ b/packages/graphiql-react/src/components/keycap-hint/keycap-hint.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { KeycapHint } from './';
+
+const meta: Meta<typeof KeycapHint> = {
+  title: 'Primitives/KeycapHint',
+  component: KeycapHint,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof KeycapHint>;
+
+export const Single: Story = {
+  args: { keys: ['K'], ariaLabel: 'Focus shortcut: K' },
+};
+export const ChordWithModifier: Story = {
+  args: { keys: ['⌘', 'K'], ariaLabel: 'Open command palette' },
+};
+export const RunShortcut: Story = {
+  args: { keys: ['⌘', '⏎'], ariaLabel: 'Run query' },
+};

--- a/packages/graphiql-react/src/components/keycap-hint/keycap-hint.stories.tsx
+++ b/packages/graphiql-react/src/components/keycap-hint/keycap-hint.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { KeycapHint } from './';
 
 const meta: Meta<typeof KeycapHint> = {
@@ -11,11 +11,15 @@ export default meta;
 type Story = StoryObj<typeof KeycapHint>;
 
 export const Single: Story = {
-  args: { keys: ['K'], ariaLabel: 'Focus shortcut: K' },
+  render: () => <KeycapHint keys={['K']} ariaLabel="Focus shortcut: K" />,
 };
+
 export const ChordWithModifier: Story = {
-  args: { keys: ['⌘', 'K'], ariaLabel: 'Open command palette' },
+  render: () => (
+    <KeycapHint keys={['⌘', 'K']} ariaLabel="Open command palette" />
+  ),
 };
+
 export const RunShortcut: Story = {
-  args: { keys: ['⌘', '⏎'], ariaLabel: 'Run query' },
+  render: () => <KeycapHint keys={['⌘', '⏎']} ariaLabel="Run query" />,
 };

--- a/packages/graphiql-react/src/components/keycap-hint/keycap-hint.test.tsx
+++ b/packages/graphiql-react/src/components/keycap-hint/keycap-hint.test.tsx
@@ -1,0 +1,25 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KeycapHint } from './';
+
+describe('KeycapHint', () => {
+  it('renders the provided keys', () => {
+    render(<KeycapHint keys={['⌘', 'K']} ariaLabel="Open command palette" />);
+    expect(screen.getByText('⌘')).toBeInTheDocument();
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+
+  it('exposes the shortcut as an accessible name', () => {
+    render(<KeycapHint keys={['⌘', 'Enter']} ariaLabel="Run query (Cmd+Enter)" />);
+    expect(screen.getByLabelText(/Run query/i)).toBeInTheDocument();
+  });
+
+  it('renders a <kbd> element for each key', () => {
+    const { container } = render(
+      <KeycapHint keys={['⌘', 'K']} ariaLabel="Open command palette" />,
+    );
+    expect(container.querySelectorAll('kbd')).toHaveLength(2);
+  });
+});

--- a/packages/graphiql-react/src/components/keycap-hint/keycap-hint.test.tsx
+++ b/packages/graphiql-react/src/components/keycap-hint/keycap-hint.test.tsx
@@ -12,7 +12,9 @@ describe('KeycapHint', () => {
   });
 
   it('exposes the shortcut as an accessible name', () => {
-    render(<KeycapHint keys={['⌘', 'Enter']} ariaLabel="Run query (Cmd+Enter)" />);
+    render(
+      <KeycapHint keys={['⌘', 'Enter']} ariaLabel="Run query (Cmd+Enter)" />,
+    );
     expect(screen.getByLabelText(/Run query/i)).toBeInTheDocument();
   });
 

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -32,6 +32,7 @@ arthurgeron
 asiandrummer
 astro
 astrojs
+autodocs
 aumy
 Autopurge
 behaviour

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -113,6 +113,7 @@ jiti
 jonathanawesome
 jsdelivr
 jsgl
+keycap
 kumar
 languageservice
 leebyron

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,6 +3329,8 @@ __metadata:
     "@storybook/addon-a11y": "npm:^10.3.6"
     "@storybook/addon-vitest": "npm:^10.3.6"
     "@storybook/react-vite": "npm:^10.3.6"
+    "@testing-library/jest-dom": "npm:^6.6.3"
+    "@testing-library/react": "npm:^16.3.0"
     "@types/get-value": "npm:^3.0.5"
     "@types/markdown-it": "npm:^14.1.2"
     "@types/react-dom": "npm:^19.1.2"


### PR DESCRIPTION
## Summary

- New primitive `KeycapHint` for inline keyboard-shortcut chips.
- Renders an array of keys as `<kbd>` elements with the v6 keycap visual.
- Required `ariaLabel` ensures every shortcut chip has a screen-reader-readable description.
- Storybook stories for single, chord-with-modifier, and Run-shortcut variants.
- Adds `@testing-library/react` + `@testing-library/jest-dom` as devDeps; these are the first component unit tests in `@graphiql/react`.

## Test plan

- [ ] Open Storybook `Primitives/KeycapHint`. Each variant renders with the v6 chip style.
- [ ] Inspect the `aria-label` on each story root; screen-reader spot-check is optional.

Refs: graphql/graphiql#4219
