### PR TITLE
v6: Restyle `Tooltip`

### DIFF
--- a/.changeset/restyle-tooltip.md
+++ b/.changeset/restyle-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Restyle `Tooltip` to the v6 design: `--bg-elevated` surface, simplified border and shadow.

--- a/packages/graphiql-react/src/components/tooltip/index.css
+++ b/packages/graphiql-react/src/components/tooltip/index.css
@@ -1,10 +1,10 @@
 .graphiql-tooltip {
-  background: hsl(var(--color-base));
-  border: var(--popover-border);
-  border-radius: var(--border-radius-4);
-  box-shadow: var(--popover-box-shadow);
-  color: hsl(var(--color-neutral));
-  font-size: inherit;
-  padding: var(--px-4) var(--px-6);
+  background: oklch(var(--bg-elevated));
+  border: 1px solid oklch(var(--border-default));
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+  color: oklch(var(--fg-default));
   font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  padding: var(--px-6) var(--px-8);
 }

--- a/packages/graphiql-react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/graphiql-react/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tooltip } from './';
+
+const meta: Meta = {
+  title: 'Primitives/Tooltip',
+  decorators: [
+    Story => (
+      <Tooltip.Provider>
+        <Story />
+      </Tooltip.Provider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <Tooltip label="Tooltip text">
+      <button style={{ padding: '6px 12px' }}>Hover me</button>
+    </Tooltip>
+  ),
+};
+
+export const TopPlacement: Story = {
+  render: () => (
+    <Tooltip label="Appears above" side="top">
+      <button style={{ padding: '6px 12px' }}>Hover me</button>
+    </Tooltip>
+  ),
+};

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -78,6 +78,11 @@
   --radius-sm: 4px;
   --radius-md: 6px;
   --radius-lg: 8px;
+
+  /* Shadows */
+  --shadow-popover:
+    0 4px 12px oklch(0% 0 0 / 0.3),
+    0 1px 3px oklch(0% 0 0 / 0.15);
 }
 
 [data-theme='light'] {
@@ -114,6 +119,11 @@
   --btn-primary: 51% 0.15 145;
   --btn-primary-border: 45% 0.17 145;
 
+  /* Shadows — lighter to read on light surfaces */
+  --shadow-popover:
+    0 4px 12px oklch(0% 0 0 / 0.08),
+    0 1px 3px oklch(0% 0 0 / 0.04);
+
   /* Typography, spacing, dimensions, and radii are inherited from :root. */
 }
 
@@ -148,5 +158,8 @@
     --accent-pink: 58% 0.22 17;
     --btn-primary: 51% 0.15 145;
     --btn-primary-border: 45% 0.17 145;
+    --shadow-popover:
+      0 4px 12px oklch(0% 0 0 / 0.08),
+      0 1px 3px oklch(0% 0 0 / 0.04);
   }
 }

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -81,8 +81,7 @@
 
   /* Shadows */
   --shadow-popover:
-    0 4px 12px oklch(0% 0 0 / 0.3),
-    0 1px 3px oklch(0% 0 0 / 0.15);
+    0 4px 12px oklch(0% 0 0 / 0.3), 0 1px 3px oklch(0% 0 0 / 0.15);
 }
 
 [data-theme='light'] {
@@ -121,8 +120,7 @@
 
   /* Shadows — lighter to read on light surfaces */
   --shadow-popover:
-    0 4px 12px oklch(0% 0 0 / 0.08),
-    0 1px 3px oklch(0% 0 0 / 0.04);
+    0 4px 12px oklch(0% 0 0 / 0.08), 0 1px 3px oklch(0% 0 0 / 0.04);
 
   /* Typography, spacing, dimensions, and radii are inherited from :root. */
 }
@@ -159,7 +157,6 @@
     --btn-primary: 51% 0.15 145;
     --btn-primary-border: 45% 0.17 145;
     --shadow-popover:
-      0 4px 12px oklch(0% 0 0 / 0.08),
-      0 1px 3px oklch(0% 0 0 / 0.04);
+      0 4px 12px oklch(0% 0 0 / 0.08), 0 1px 3px oklch(0% 0 0 / 0.04);
   }
 }


### PR DESCRIPTION
## Summary

- Migrate `Tooltip` CSS to v6 OKLCH tokens (`--bg-elevated`, `--border-default`, `--fg-default`).
- Add `--shadow-popover` to `tokens.css` (dark + light variants) and use it in `Tooltip`. Future Dialog and DropdownMenu PRs reuse this token.
- Pin tooltip `font-size` to `--font-size-small` (11px) rather than `inherit`: tooltips are floating UI primitives and should render at a consistent size regardless of where they're anchored.
- Add Storybook stories: `Primitives/Tooltip` (Default + TopPlacement).

## Test plan

- [x] Open Storybook `Primitives/Tooltip` and verify both Default and TopPlacement render correctly.
- [x] Toggle to light theme (system preference or set `data-theme="light"` on the Storybook root). Shadow should soften for the lighter surface.
- [x] Hover any toolbar button in the example app. Tooltip should match the design.

Refs: graphql/graphiql#4219
