### PR TITLE
v6: Restyle `Dialog`

### DIFF
--- a/.changeset/restyle-dialog.md
+++ b/.changeset/restyle-dialog.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Restyle `Dialog` to the v6 design: `--bg-elevated` surface, refined border, larger radius. Behavior and API unchanged.

--- a/packages/graphiql-react/.storybook/preview.tsx
+++ b/packages/graphiql-react/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { Preview } from '@storybook/react-vite';
 import '../src/style/root.css';
 
@@ -48,17 +49,20 @@ const preview: Preview = {
     },
   },
   decorators: [
-    (Story, ctx) => (
-      <div
-        className="graphiql-container"
-        data-theme={ctx.globals.theme}
-        data-density={ctx.globals.density}
-        data-font-size={ctx.globals.fontSize}
-        style={{ padding: 24 }}
-      >
-        <Story />
-      </div>
-    ),
+    (Story, ctx) => {
+      useEffect(() => {
+        const root = document.documentElement;
+        root.setAttribute('data-theme', ctx.globals.theme);
+        root.setAttribute('data-density', ctx.globals.density);
+        root.setAttribute('data-font-size', ctx.globals.fontSize);
+      }, [ctx.globals.theme, ctx.globals.density, ctx.globals.fontSize]);
+
+      return (
+        <div className="graphiql-container" style={{ padding: 24 }}>
+          <Story />
+        </div>
+      );
+    },
   ],
 };
 

--- a/packages/graphiql-react/src/components/dialog/dialog.stories.tsx
+++ b/packages/graphiql-react/src/components/dialog/dialog.stories.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../button';
+import { Dialog } from './';
+
+const meta: Meta = {
+  title: 'Primitives/Dialog',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+const headerStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: 'var(--px-4) var(--px-4) var(--px-4) var(--px-16)',
+  borderBottom: '1px solid oklch(var(--border-default))',
+} as const;
+
+const bodyStyle = {
+  padding: 'var(--px-16)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--px-12)',
+} as const;
+
+export const Default: Story = {
+  render: function DefaultStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open settings</Button>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <div style={{ minWidth: 360 }}>
+            <div style={headerStyle}>
+              <Dialog.Title style={{ margin: 0 }}>Settings</Dialog.Title>
+              <Dialog.Close />
+            </div>
+            <div style={bodyStyle}>
+              <Dialog.Description style={{ margin: 0 }}>
+                Update your preferences.
+              </Dialog.Description>
+            </div>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const ConfirmAction: Story = {
+  render: function ConfirmActionStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Discard changes</Button>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <div style={{ minWidth: 360 }}>
+            <div style={headerStyle}>
+              <Dialog.Title style={{ margin: 0 }}>
+                Discard changes?
+              </Dialog.Title>
+              <Dialog.Close />
+            </div>
+            <div style={bodyStyle}>
+              <Dialog.Description style={{ margin: 0 }}>
+                Your unsaved changes will be lost.
+              </Dialog.Description>
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 'var(--px-8)',
+                  justifyContent: 'flex-end',
+                }}
+              >
+                <Button onClick={() => setOpen(false)}>Cancel</Button>
+                <Button variant="primary" onClick={() => setOpen(false)}>
+                  Discard
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Dialog>
+      </>
+    );
+  },
+};

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -1,7 +1,7 @@
 .graphiql-dialog-overlay {
   position: fixed;
   inset: 0;
-  background-color: hsla(var(--color-neutral), var(--alpha-background-heavy));
+  background-color: oklch(0% 0 0 / 0.5);
   /**
    * CodeMirror has a `z-index` set for the container of the scrollbar of the
    * editor, so we have to add one here to make sure that the dialog is shown
@@ -11,10 +11,12 @@
 }
 
 .graphiql-dialog {
-  background-color: hsl(var(--color-base));
-  border: var(--popover-border);
-  border-radius: var(--border-radius-12);
-  box-shadow: var(--popover-box-shadow);
+  background: oklch(var(--bg-elevated));
+  border: 1px solid oklch(var(--border-default));
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
+  color: oklch(var(--fg-default));
+  font-family: var(--font-family);
   margin: 0;
   max-height: 80vh;
   max-width: 80vw;
@@ -29,7 +31,7 @@
 }
 
 .graphiql-dialog-close > svg {
-  color: hsla(var(--color-neutral), var(--alpha-secondary));
+  color: oklch(var(--fg-muted));
   display: block;
   height: var(--px-12);
   padding: var(--px-12);


### PR DESCRIPTION
## Summary

- Dialog styling moves to v6 OKLCH tokens.
- Adds Storybook stories: Default and ConfirmAction. Layout matches the real consumer pattern: title and close button in a header row, body below.
- Bundles a Storybook decorator fix so portaled components actually theme. Without it, `Dialog` (and any future portaled story) ignored the toolbar's Dark / Light toggle because Radix portals render to `document.body`, outside the wrapper div the decorator was setting attributes on. The fix moves `data-theme` / `data-density` / `data-font-size` to `document.documentElement` so the whole DOM inherits.

## Test plan

- [x] Open `Primitives/Dialog` in Storybook; both stories render with the new surface, border, and shadow. Close button sits in the header row at top right.
- [x] Toggle the theme between Dark and Light; surface and text colors should now actually differ (this was the symptom that prompted the decorator fix).
- [ ] In the example app, open the Settings dialog (gear icon). Visuals match the new look.

Refs: graphql/graphiql#4219

## Merge note

Two commits, intended for rebase-merge: dialog restyle and the storybook decorator fix are independently reviewable.
