### PR TITLE
v6: Restyle `DropdownMenu`

### DIFF
--- a/.changeset/restyle-dropdown-menu.md
+++ b/.changeset/restyle-dropdown-menu.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Restyle `DropdownMenu` to the v6 design. Behavior and API unchanged.

--- a/packages/graphiql-react/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/packages/graphiql-react/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DropdownMenu } from './';
+
+const meta: Meta = {
+  title: 'Primitives/DropdownMenu',
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Button>Open menu</DropdownMenu.Button>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Item 1</DropdownMenu.Item>
+        <DropdownMenu.Item>Item 2</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item disabled>Disabled</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+export const WithManyItems: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Button>Open menu</DropdownMenu.Button>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Schema</DropdownMenu.Item>
+        <DropdownMenu.Item>Explorer</DropdownMenu.Item>
+        <DropdownMenu.Item>History</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>Settings</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Unavailable</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};

--- a/packages/graphiql-react/src/components/dropdown-menu/index.css
+++ b/packages/graphiql-react/src/components/dropdown-menu/index.css
@@ -1,13 +1,13 @@
 .graphiql-dropdown-content {
-  background-color: hsl(var(--color-base));
-  border: var(--popover-border);
-  border-radius: var(--border-radius-8);
-  box-shadow: var(--popover-box-shadow);
-  font-size: inherit;
+  background: oklch(var(--bg-elevated));
+  border: 1px solid oklch(var(--border-default));
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+  color: oklch(var(--fg-default));
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
   max-width: 250px;
   padding: var(--px-4);
-  font-family: var(--font-family);
-  color: hsl(var(--color-neutral));
   max-height: min(
     calc(var(--radix-dropdown-menu-content-available-height) - 10px),
     400px
@@ -16,25 +16,37 @@
 }
 
 .graphiql-dropdown-item {
-  border-radius: var(--border-radius-4);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
   font-size: inherit;
+  line-height: var(--line-height-body);
   margin: var(--px-4);
+  outline: none;
   overflow: hidden;
   padding: var(--px-6) var(--px-8);
   text-overflow: ellipsis;
   white-space: nowrap;
-  outline: none;
-  cursor: pointer;
-  line-height: var(--line-height);
 
-  &[data-selected],
-  &[data-current-nav],
+  &[data-highlighted],
   &:hover {
-    background-color: hsla(var(--color-neutral), var(--alpha-background-light));
-    color: inherit;
+    background: oklch(var(--bg-overlay));
+    color: oklch(var(--fg-strong));
+    outline: none;
+  }
+
+  &[data-disabled] {
+    color: oklch(var(--fg-disabled));
+    cursor: default;
+    pointer-events: none;
   }
 
   &:not(:first-child) {
     margin-top: 0;
   }
+}
+
+.graphiql-dropdown-separator {
+  border: none;
+  border-top: 1px solid oklch(var(--border-muted));
+  margin: var(--px-4) 0;
 }

--- a/packages/graphiql-react/src/components/dropdown-menu/index.tsx
+++ b/packages/graphiql-react/src/components/dropdown-menu/index.tsx
@@ -5,20 +5,18 @@ import {
   Portal,
   Content as RadixContent,
   Item as RadixItem,
+  Separator as RadixSeparator,
   DropdownMenuContentProps,
   DropdownMenuItemProps,
   Root,
 } from '@radix-ui/react-dropdown-menu';
+import { UnStyledButton } from '../button';
 import './index.css';
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(
   (props, ref) => (
     <Trigger asChild>
-      <button
-        {...props}
-        ref={ref}
-        className={cn('graphiql-un-styled', props.className)}
-      />
+      <UnStyledButton {...props} ref={ref} />
     </Trigger>
   ),
 );
@@ -51,8 +49,16 @@ const Item: FC<DropdownMenuItemProps> = ({ className, children, ...props }) => (
   </RadixItem>
 );
 
+const Separator: FC<ComponentProps<'div'>> = ({ className, ...props }) => (
+  <RadixSeparator
+    className={cn('graphiql-dropdown-separator', className)}
+    {...props}
+  />
+);
+
 export const DropdownMenu = Object.assign(Root, {
   Button,
   Item,
   Content,
+  Separator,
 });


### PR DESCRIPTION
## Summary

- DropdownMenu styling moves to v6 OKLCH tokens (surface, item hover, separator).
- Adds a `Separator` subcomponent wrapping the Radix primitive.
- Adds Storybook stories.

## Test plan

- [x] Open `Primitives/DropdownMenu`; check default and separator-bearing variants.
- [x] Keyboard nav: arrow keys cycle items, Enter activates, Escape closes.
- [x] Disabled items render with reduced contrast and don't activate.

Refs: graphql/graphiql#4219
