### PR TITLE
v6: Add `SegmentedControl` primitive

### DIFF
--- a/.changeset/segmented-control.md
+++ b/.changeset/segmented-control.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a `SegmentedControl` primitive for selecting one option from a small set inline. Used by the new top-bar response view toggle and several settings controls.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -20,3 +20,8 @@ export { Tooltip } from './tooltip';
 export { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 export { KeycapHint } from './keycap-hint';
 export type { KeycapHintProps } from './keycap-hint';
+export { SegmentedControl } from './segmented-control';
+export type {
+  SegmentedControlProps,
+  SegmentedControlOption,
+} from './segmented-control';

--- a/packages/graphiql-react/src/components/segmented-control/index.css
+++ b/packages/graphiql-react/src/components/segmented-control/index.css
@@ -1,0 +1,42 @@
+.graphiql-segmented-control {
+  display: inline-flex;
+  padding: 1px;
+  background: oklch(var(--bg-subtle));
+  border: 1px solid oklch(var(--border-muted));
+  border-radius: var(--radius-md);
+  gap: 1px;
+}
+
+.graphiql-segmented-control-option {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: 3px var(--px-8);
+  border: 0;
+  background: transparent;
+  color: oklch(var(--fg-subtle));
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  font-weight: 500;
+  cursor: pointer;
+  letter-spacing: var(--letter-spacing-ui);
+}
+
+.graphiql-segmented-control-option:hover:not(.active):not(:disabled) {
+  color: oklch(var(--fg-default));
+}
+
+.graphiql-segmented-control-option.active {
+  background: oklch(var(--bg-overlay));
+  color: oklch(var(--fg-strong));
+}
+
+.graphiql-segmented-control-option:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.graphiql-segmented-control-icon {
+  display: inline-flex;
+}

--- a/packages/graphiql-react/src/components/segmented-control/index.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/index.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import './index.css';
+
+export type SegmentedControlOption<T extends string = string> = {
+  value: T;
+  label: ReactNode;
+  icon?: ReactNode;
+  disabled?: boolean;
+};
+
+export type SegmentedControlProps<T extends string = string> = {
+  value: T;
+  onChange: (value: T) => void;
+  options: SegmentedControlOption<T>[];
+  ariaLabel?: string;
+};
+
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}: SegmentedControlProps<T>) {
+  return (
+    <div
+      className="graphiql-segmented-control"
+      role="group"
+      aria-label={ariaLabel}
+    >
+      {options.map(opt => (
+        <button
+          key={opt.value}
+          type="button"
+          className={`graphiql-segmented-control-option${opt.value === value ? ' active' : ''}`}
+          onClick={() => onChange(opt.value)}
+          disabled={opt.disabled}
+          aria-pressed={opt.value === value}
+        >
+          {opt.icon && (
+            <span className="graphiql-segmented-control-icon">{opt.icon}</span>
+          )}
+          <span>{opt.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/graphiql-react/src/components/segmented-control/segmented-control.stories.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/segmented-control.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { SegmentedControl } from './';
+
+const meta: Meta = {
+  title: 'Primitives/SegmentedControl',
+  component: SegmentedControl,
+  tags: ['autodocs'],
+};
+export default meta;
+
+export const ResponseView: StoryObj = {
+  render() {
+    const [v, setV] = useState('json');
+    return (
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        ariaLabel="Response view"
+        options={[
+          { value: 'json', label: 'JSON' },
+          { value: 'tree', label: 'Tree' },
+          { value: 'table', label: 'Table' },
+        ]}
+      />
+    );
+  },
+};
+
+export const Density: StoryObj = {
+  render() {
+    const [v, setV] = useState('comfortable');
+    return (
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        ariaLabel="Density"
+        options={[
+          { value: 'compact', label: 'Compact' },
+          { value: 'comfortable', label: 'Comfortable' },
+          { value: 'spacious', label: 'Spacious' },
+        ]}
+      />
+    );
+  },
+};
+
+export const WithDisabledOption: StoryObj = {
+  render() {
+    const [v, setV] = useState('list');
+    return (
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        ariaLabel="View mode"
+        options={[
+          { value: 'list', label: 'List' },
+          { value: 'grid', label: 'Grid' },
+          { value: 'map', label: 'Map', disabled: true },
+        ]}
+      />
+    );
+  },
+};

--- a/packages/graphiql-react/src/components/segmented-control/segmented-control.test.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/segmented-control.test.tsx
@@ -1,0 +1,84 @@
+'use no memo';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { SegmentedControl } from './';
+
+describe('SegmentedControl', () => {
+  it('renders all options', () => {
+    render(
+      <SegmentedControl
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+          { value: 'c', label: 'Gamma' },
+        ]}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Beta' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Gamma' })).toBeInTheDocument();
+  });
+
+  it('marks the selected option with aria-pressed', () => {
+    render(
+      <SegmentedControl
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta' },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Alpha', pressed: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Beta', pressed: false }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange when a non-selected option is clicked', async () => {
+    const user = userEvent.setup();
+    function Wrapper() {
+      const [v, setV] = useState('a');
+      return (
+        <SegmentedControl
+          value={v}
+          onChange={setV}
+          options={[
+            { value: 'a', label: 'Alpha' },
+            { value: 'b', label: 'Beta' },
+          ]}
+        />
+      );
+    }
+    render(<Wrapper />);
+    await user.click(screen.getByRole('button', { name: 'Beta' }));
+    expect(
+      screen.getByRole('button', { name: 'Beta', pressed: true }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not call onChange for a disabled option', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        value="a"
+        onChange={onChange}
+        options={[
+          { value: 'a', label: 'Alpha' },
+          { value: 'b', label: 'Beta', disabled: true },
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Beta' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- New primitive `SegmentedControl<T extends string>`.
- Props: `value`, `onChange`, `options`, optional `ariaLabel`. Each option supports an icon and `disabled` flag.
- Storybook stories: ResponseView and Density.

## Test plan

- [x] Open `Primitives/SegmentedControl`; click between options to confirm selection updates.
- [x] `aria-pressed` reflects the active option (check DOM or screen reader).
- [x] Disabled options don't fire `onChange`.

Refs: graphql/graphiql#4219
