### PR TITLE
v6: Restyle `Spinner`

### DIFF
--- a/.changeset/restyle-spinner.md
+++ b/.changeset/restyle-spinner.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Restyle `Spinner` to the v6 design. Default stroke uses the muted foreground token.

--- a/packages/graphiql-react/src/components/spinner/index.css
+++ b/packages/graphiql-react/src/components/spinner/index.css
@@ -8,7 +8,7 @@
     animation: rotation 0.8s linear 0s infinite;
     border: 4px solid transparent;
     border-radius: 100%;
-    border-top: 4px solid hsla(var(--color-neutral), var(--alpha-tertiary));
+    border-top: 4px solid oklch(var(--fg-muted));
     content: '';
     display: inline-block;
     height: 46px;


### PR DESCRIPTION
## Summary

Spinner stroke now uses `oklch(var(--fg-muted))`.

## Test plan

- [x] Open the Spinner story and confirm it renders.
- [x] Trigger a fetch in the app; verify spinner appearance.

Refs: graphql/graphiql#4219
