### PR TITLE
v6: Add `PanelHeader` primitive

### DIFF
--- a/.changeset/panel-header.md
+++ b/.changeset/panel-header.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a `PanelHeader` primitive for side panels. Renders a title, optional subtitle, and optional action-icon row.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -20,3 +20,5 @@ export { Tooltip } from './tooltip';
 export { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 export { KeycapHint } from './keycap-hint';
 export type { KeycapHintProps } from './keycap-hint';
+export { PanelHeader } from './panel-header';
+export type { PanelHeaderProps } from './panel-header';

--- a/packages/graphiql-react/src/components/panel-header/index.css
+++ b/packages/graphiql-react/src/components/panel-header/index.css
@@ -1,0 +1,42 @@
+.graphiql-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: var(--px-12) var(--px-14) var(--px-10);
+  border-bottom: 1px solid oklch(var(--border-default));
+  background: oklch(var(--bg-elevated));
+}
+
+.graphiql-panel-header-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.graphiql-panel-header-title {
+  margin: 0;
+  color: oklch(var(--fg-strong));
+  font-family: var(--font-family);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.graphiql-panel-header-subtitle {
+  margin: 0;
+  color: oklch(var(--fg-subtle));
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-body);
+}
+
+.graphiql-panel-header-actions {
+  display: flex;
+  gap: var(--px-4);
+  color: oklch(var(--fg-subtle));
+}
+
+.graphiql-panel-header-actions svg {
+  width: 12px;
+  height: 12px;
+}

--- a/packages/graphiql-react/src/components/panel-header/index.tsx
+++ b/packages/graphiql-react/src/components/panel-header/index.tsx
@@ -1,0 +1,22 @@
+import type { FC, ReactNode } from 'react';
+import './index.css';
+
+export type PanelHeaderProps = {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+};
+
+export const PanelHeader: FC<PanelHeaderProps> = ({
+  title,
+  subtitle,
+  actions,
+}) => (
+  <header className="graphiql-panel-header">
+    <div className="graphiql-panel-header-titles">
+      <h2 className="graphiql-panel-header-title">{title}</h2>
+      {subtitle && <p className="graphiql-panel-header-subtitle">{subtitle}</p>}
+    </div>
+    {actions && <div className="graphiql-panel-header-actions">{actions}</div>}
+  </header>
+);

--- a/packages/graphiql-react/src/components/panel-header/panel-header.stories.tsx
+++ b/packages/graphiql-react/src/components/panel-header/panel-header.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MagnifyingGlassIcon, SettingsIcon } from '../../icons';
+import { ToolbarButton } from '../toolbar-button';
+import { Tooltip } from '../tooltip';
+import { PanelHeader } from './';
+
+const meta: Meta<typeof PanelHeader> = {
+  title: 'Primitives/PanelHeader',
+  component: PanelHeader,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <Tooltip.Provider>
+        <Story />
+      </Tooltip.Provider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof PanelHeader>;
+
+export const TitleOnly: Story = {
+  args: { title: 'Schema' },
+};
+
+export const WithSubtitle: Story = {
+  args: { title: 'Schema', subtitle: 'Pokemon API' },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: 'History',
+    subtitle: 'Last 500 runs, searchable.',
+    actions: (
+      <>
+        <ToolbarButton label="Search">
+          <MagnifyingGlassIcon aria-hidden="true" />
+        </ToolbarButton>
+        <ToolbarButton label="Settings">
+          <SettingsIcon aria-hidden="true" />
+        </ToolbarButton>
+      </>
+    ),
+  },
+};

--- a/packages/graphiql-react/src/components/panel-header/panel-header.test.tsx
+++ b/packages/graphiql-react/src/components/panel-header/panel-header.test.tsx
@@ -1,0 +1,46 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PanelHeader } from './';
+
+describe('PanelHeader', () => {
+  it('renders the title', () => {
+    render(<PanelHeader title="Schema" />);
+    expect(screen.getByText('Schema')).toBeInTheDocument();
+  });
+
+  it('renders the subtitle when provided', () => {
+    render(<PanelHeader title="Schema" subtitle="Pokemon API" />);
+    expect(screen.getByText('Pokemon API')).toBeInTheDocument();
+  });
+
+  it('does not render a subtitle element when omitted', () => {
+    const { container } = render(<PanelHeader title="Schema" />);
+    expect(
+      container.querySelector('.graphiql-panel-header-subtitle'),
+    ).toBeNull();
+  });
+
+  it('renders action icons when provided', () => {
+    render(
+      <PanelHeader
+        title="Schema"
+        actions={<button aria-label="Refresh">↻</button>}
+      />,
+    );
+    expect(screen.getByLabelText('Refresh')).toBeInTheDocument();
+  });
+
+  it('does not render the actions container when omitted', () => {
+    const { container } = render(<PanelHeader title="Schema" />);
+    expect(
+      container.querySelector('.graphiql-panel-header-actions'),
+    ).toBeNull();
+  });
+
+  it('renders the title in an h2', () => {
+    const { container } = render(<PanelHeader title="History" />);
+    expect(container.querySelector('h2')).toHaveTextContent('History');
+  });
+});


### PR DESCRIPTION
## Summary

- New primitive `PanelHeader` for side-panel content areas.
- Props: `title` (`<h2>`), `subtitle?`, `actions?`.

## Test plan

- [x] Open `Primitives/PanelHeader` in Storybook; check TitleOnly, WithSubtitle, and WithActions render correctly.
- [x] Confirm the title is an `<h2>` in the DOM.
- [x] Confirm action buttons are keyboard-focusable and carry their aria-labels.

Refs: graphql/graphiql#4219
