### PR TITLE
v6: Add `MethodPill` primitive

### DIFF
--- a/.changeset/method-pill.md
+++ b/.changeset/method-pill.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a `MethodPill` primitive: a small colored pill labeling an operation as QRY (query), MUT (mutation), or SUB (subscription).

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -27,3 +27,5 @@ export type {
   SegmentedControlProps,
   SegmentedControlOption,
 } from './segmented-control';
+export { MethodPill } from './method-pill';
+export type { MethodPillProps, Operation } from './method-pill';

--- a/packages/graphiql-react/src/components/method-pill/index.css
+++ b/packages/graphiql-react/src/components/method-pill/index.css
@@ -1,0 +1,32 @@
+.graphiql-method-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+}
+
+/*
+ * Pills use solid backgrounds rather than alpha tints so they read the
+ * same regardless of what surface they're stacked on, and contrast against
+ * the pill text stays well above WCAG AA in both themes.
+ */
+.graphiql-method-pill-query {
+  color: oklch(98% 0 0);
+  background: oklch(50% 0.15 146);
+}
+
+.graphiql-method-pill-mutation {
+  color: oklch(15% 0 0);
+  background: oklch(85% 0.13 90);
+}
+
+.graphiql-method-pill-subscription {
+  color: oklch(98% 0 0);
+  background: oklch(45% 0.18 295);
+}

--- a/packages/graphiql-react/src/components/method-pill/index.tsx
+++ b/packages/graphiql-react/src/components/method-pill/index.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+import './index.css';
+
+export type Operation = 'query' | 'mutation' | 'subscription';
+
+const LABELS: Record<Operation, string> = {
+  query: 'QRY',
+  mutation: 'MUT',
+  subscription: 'SUB',
+};
+
+export type MethodPillProps = {
+  operation: Operation;
+  'aria-hidden'?: boolean;
+};
+
+export const MethodPill: FC<MethodPillProps> = ({ operation, ...rest }) => (
+  <span
+    className={`graphiql-method-pill graphiql-method-pill-${operation}`}
+    {...rest}
+  >
+    {LABELS[operation]}
+  </span>
+);

--- a/packages/graphiql-react/src/components/method-pill/method-pill.stories.tsx
+++ b/packages/graphiql-react/src/components/method-pill/method-pill.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MethodPill } from './';
+
+const meta: Meta<typeof MethodPill> = {
+  title: 'Primitives/MethodPill',
+  component: MethodPill,
+  tags: ['autodocs'],
+};
+export default meta;
+
+type Story = StoryObj<typeof MethodPill>;
+
+export const Query: Story = {
+  render: () => <MethodPill operation="query" />,
+};
+
+export const Mutation: Story = {
+  render: () => <MethodPill operation="mutation" />,
+};
+
+export const Subscription: Story = {
+  render: () => <MethodPill operation="subscription" />,
+};

--- a/packages/graphiql-react/src/components/method-pill/method-pill.test.tsx
+++ b/packages/graphiql-react/src/components/method-pill/method-pill.test.tsx
@@ -1,0 +1,22 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MethodPill } from './';
+
+describe('MethodPill', () => {
+  it('renders QRY for query operations', () => {
+    render(<MethodPill operation="query" />);
+    expect(screen.getByText('QRY')).toBeInTheDocument();
+  });
+
+  it('renders MUT for mutations', () => {
+    render(<MethodPill operation="mutation" />);
+    expect(screen.getByText('MUT')).toBeInTheDocument();
+  });
+
+  it('renders SUB for subscriptions', () => {
+    render(<MethodPill operation="subscription" />);
+    expect(screen.getByText('SUB')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- New primitive `MethodPill` labeling operation types: QRY (green), MUT (yellow), SUB (purple).
- Three Storybook stories covering each operation.

## Test plan

- [x] Open `Primitives/MethodPill` and confirm each variant's color and label.
- [x] Pill renders as decorative; consumers pair it with the operation name for the accessible name.

Refs: graphql/graphiql#4219
