### PR TITLE
v6: Rewrite `SegmentedControl` on native radio inputs

### DIFF
--- a/.changeset/segmented-control-radio.md
+++ b/.changeset/segmented-control-radio.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Rewrite `SegmentedControl` on top of native radio inputs. Public props are unchanged. Keyboard navigation (arrow keys, Home / End) and screen-reader semantics now come from the browser; the group is a single tab stop instead of one per option.

--- a/packages/graphiql-react/src/components/segmented-control/index.css
+++ b/packages/graphiql-react/src/components/segmented-control/index.css
@@ -1,10 +1,29 @@
 .graphiql-segmented-control {
   display: inline-flex;
   padding: 1px;
-  background: oklch(var(--bg-subtle));
+  margin: 0;
   border: 1px solid oklch(var(--border-muted));
   border-radius: var(--radius-md);
+  background: oklch(var(--bg-subtle));
   gap: 1px;
+}
+
+.graphiql-segmented-control-legend {
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.graphiql-segmented-control-input {
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  opacity: 0;
 }
 
 .graphiql-segmented-control-option {
@@ -12,29 +31,36 @@
   align-items: center;
   gap: var(--px-6);
   padding: 3px var(--px-8);
-  border: 0;
-  background: transparent;
-  color: oklch(var(--fg-subtle));
   border-radius: var(--radius-sm);
+  color: oklch(var(--fg-subtle));
   font-family: var(--font-family);
   font-size: var(--font-size-small);
   font-weight: 500;
-  cursor: pointer;
   letter-spacing: var(--letter-spacing-ui);
+  cursor: pointer;
 }
 
-.graphiql-segmented-control-option:hover:not(.active):not(:disabled) {
+.graphiql-segmented-control-option:hover:not([data-checked]):not(
+    [data-disabled]
+  ) {
   color: oklch(var(--fg-default));
 }
 
-.graphiql-segmented-control-option.active {
+.graphiql-segmented-control-option[data-checked] {
   background: oklch(var(--bg-overlay));
   color: oklch(var(--fg-strong));
 }
 
-.graphiql-segmented-control-option:disabled {
+.graphiql-segmented-control-option[data-disabled] {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.graphiql-segmented-control-option:has(
+  .graphiql-segmented-control-input:focus-visible
+) {
+  outline: 2px solid oklch(var(--accent-blue));
+  outline-offset: 1px;
 }
 
 .graphiql-segmented-control-icon {

--- a/packages/graphiql-react/src/components/segmented-control/index.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/index.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+'use no memo';
+
+import { useId, type ReactNode } from 'react';
 import './index.css';
 
 export type SegmentedControlOption<T extends string = string> = {
@@ -21,27 +23,36 @@ export function SegmentedControl<T extends string>({
   options,
   ariaLabel,
 }: SegmentedControlProps<T>) {
+  const name = useId();
   return (
-    <div
-      className="graphiql-segmented-control"
-      role="group"
-      aria-label={ariaLabel}
-    >
+    <fieldset className="graphiql-segmented-control">
+      {ariaLabel && (
+        <legend className="graphiql-segmented-control-legend">
+          {ariaLabel}
+        </legend>
+      )}
       {options.map(opt => (
-        <button
+        <label
           key={opt.value}
-          type="button"
-          className={`graphiql-segmented-control-option${opt.value === value ? ' active' : ''}`}
-          onClick={() => onChange(opt.value)}
-          disabled={opt.disabled}
-          aria-pressed={opt.value === value}
+          className="graphiql-segmented-control-option"
+          data-checked={opt.value === value || undefined}
+          data-disabled={opt.disabled || undefined}
         >
+          <input
+            className="graphiql-segmented-control-input"
+            type="radio"
+            name={name}
+            value={opt.value}
+            checked={opt.value === value}
+            disabled={opt.disabled}
+            onChange={() => onChange(opt.value)}
+          />
           {opt.icon && (
             <span className="graphiql-segmented-control-icon">{opt.icon}</span>
           )}
           <span>{opt.label}</span>
-        </button>
+        </label>
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/packages/graphiql-react/src/components/segmented-control/segmented-control.stories.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/segmented-control.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SegmentedControl } from './';
+import { PrettifyIcon, DocsIcon, MergeIcon } from '../../icons';
 
 const meta: Meta = {
   title: 'Primitives/SegmentedControl',
@@ -57,6 +58,36 @@ export const WithDisabledOption: StoryObj = {
           { value: 'list', label: 'List' },
           { value: 'grid', label: 'Grid' },
           { value: 'map', label: 'Map', disabled: true },
+        ]}
+      />
+    );
+  },
+};
+
+export const Icons: StoryObj = {
+  render() {
+    const [v, setV] = useState('pretty');
+    return (
+      <SegmentedControl
+        value={v}
+        onChange={setV}
+        ariaLabel="Response view"
+        options={[
+          {
+            value: 'pretty',
+            label: 'Pretty',
+            icon: <PrettifyIcon aria-hidden="true" />,
+          },
+          {
+            value: 'docs',
+            label: 'Docs',
+            icon: <DocsIcon aria-hidden="true" />,
+          },
+          {
+            value: 'merged',
+            label: 'Merged',
+            icon: <MergeIcon aria-hidden="true" />,
+          },
         ]}
       />
     );

--- a/packages/graphiql-react/src/components/segmented-control/segmented-control.test.tsx
+++ b/packages/graphiql-react/src/components/segmented-control/segmented-control.test.tsx
@@ -19,12 +19,12 @@ describe('SegmentedControl', () => {
         ]}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Alpha' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Beta' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Gamma' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Beta' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Gamma' })).toBeInTheDocument();
   });
 
-  it('marks the selected option with aria-pressed', () => {
+  it('marks the selected option as checked', () => {
     render(
       <SegmentedControl
         value="a"
@@ -35,12 +35,8 @@ describe('SegmentedControl', () => {
         ]}
       />,
     );
-    expect(
-      screen.getByRole('button', { name: 'Alpha', pressed: true }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Beta', pressed: false }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Alpha' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Beta' })).not.toBeChecked();
   });
 
   it('calls onChange when a non-selected option is clicked', async () => {
@@ -59,10 +55,8 @@ describe('SegmentedControl', () => {
       );
     }
     render(<Wrapper />);
-    await user.click(screen.getByRole('button', { name: 'Beta' }));
-    expect(
-      screen.getByRole('button', { name: 'Beta', pressed: true }),
-    ).toBeInTheDocument();
+    await user.click(screen.getByRole('radio', { name: 'Beta' }));
+    expect(screen.getByRole('radio', { name: 'Beta' })).toBeChecked();
   });
 
   it('does not call onChange for a disabled option', async () => {
@@ -78,7 +72,28 @@ describe('SegmentedControl', () => {
         ]}
       />,
     );
-    await user.click(screen.getByRole('button', { name: 'Beta' }));
+    await user.click(screen.getByRole('radio', { name: 'Beta' }));
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('moves selection with ArrowRight keyboard navigation', async () => {
+    const user = userEvent.setup();
+    function Wrapper() {
+      const [v, setV] = useState('a');
+      return (
+        <SegmentedControl
+          value={v}
+          onChange={setV}
+          options={[
+            { value: 'a', label: 'Alpha' },
+            { value: 'b', label: 'Beta' },
+          ]}
+        />
+      );
+    }
+    render(<Wrapper />);
+    screen.getByRole('radio', { name: 'Alpha' }).focus();
+    await user.keyboard('{ArrowRight}');
+    expect(screen.getByRole('radio', { name: 'Beta' })).toBeChecked();
   });
 });


### PR DESCRIPTION
## Summary

- Rewrites `SegmentedControl` to render `<fieldset>` + hidden `<input type="radio">` per option, with a visible `<label>` doing the visual work. Public props (`value`, `onChange`, `options`, `ariaLabel`) stay the same.
- Browser handles ArrowLeft / Right / Up / Down / Home / End across the group, and the whole control is a single tab stop.
- Adds an `Icons` story using real icons from `~/icons`; `options[].icon` was always supported but had no demo.

## Test plan

- [x] Open `Primitives/SegmentedControl`; tab into the group, press ArrowRight, watch selection move across options.
- [x] Try the `WithDisabledOption` story; arrow nav skips the disabled option.
- [x] Screen-reader spot-check: the group announces as `radiogroup` with the provided label; each option announces its checked state.

Refs: graphql/graphiql#4219
