### PR TITLE
v6: Add `TopBar` layout component

### DIFF
--- a/.changeset/topbar-component.md
+++ b/.changeset/topbar-component.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+'graphiql': patch
+---
+
+Add a new `TopBar` layout component with brand, endpoint URL display, command palette button, and primary Run button. Endpoint method/URL are placeholders until the transport API lands. `TopBar` is now mounted at the top of the GraphiQL layout.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -29,3 +29,5 @@ export type {
 } from './segmented-control';
 export { MethodPill } from './method-pill';
 export type { MethodPillProps, Operation } from './method-pill';
+export { TopBar } from './top-bar';
+export type { TopBarProps } from './top-bar';

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -29,5 +29,5 @@ export type {
 } from './segmented-control';
 export { MethodPill } from './method-pill';
 export type { MethodPillProps, Operation } from './method-pill';
-export { TopBar } from './top-bar';
-export type { TopBarProps } from './top-bar';
+export { TopBar, TopBarView } from './top-bar';
+export type { TopBarProps, TopBarViewProps } from './top-bar';

--- a/packages/graphiql-react/src/components/top-bar/index.css
+++ b/packages/graphiql-react/src/components/top-bar/index.css
@@ -1,0 +1,122 @@
+.graphiql-top-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--px-12);
+  height: var(--top-bar-height);
+  padding: 0 var(--px-12);
+  background: oklch(var(--bg-elevated));
+  border-bottom: 1px solid oklch(var(--border-default));
+  color: oklch(var(--fg-default));
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
+}
+
+.graphiql-top-bar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--px-8);
+}
+
+.graphiql-top-bar-logo {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    135deg,
+    oklch(var(--accent-green-light)),
+    oklch(var(--accent-blue))
+  );
+  flex-shrink: 0;
+}
+
+.graphiql-top-bar-wordmark {
+  color: oklch(var(--fg-strong));
+  font-weight: 600;
+  font-size: var(--font-size-body);
+  white-space: nowrap;
+}
+
+.graphiql-top-bar-version {
+  color: oklch(var(--fg-subtle));
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  white-space: nowrap;
+}
+
+.graphiql-top-bar-divider {
+  width: 1px;
+  height: 18px;
+  background: oklch(var(--border-default));
+  flex-shrink: 0;
+}
+
+.graphiql-top-bar-cmd {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: 0 var(--px-10);
+  height: 24px;
+  background: oklch(var(--bg-subtle));
+  border: 1px solid oklch(var(--border-strong));
+  border-radius: var(--radius-md);
+  color: oklch(var(--fg-subtle));
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.graphiql-top-bar-endpoint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: 0 var(--px-10);
+  height: 24px;
+  flex: 1;
+  min-width: 0;
+  background: oklch(var(--bg-canvas));
+  border: 1px solid oklch(var(--border-muted));
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+}
+
+.graphiql-top-bar-endpoint-method {
+  color: oklch(var(--accent-green));
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.graphiql-top-bar-endpoint-url {
+  color: oklch(var(--fg-subtle));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graphiql-top-bar-run {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-8);
+  padding: 0 var(--px-10);
+  height: 28px;
+  background: oklch(var(--btn-primary));
+  border: 1px solid oklch(var(--btn-primary-border));
+  border-radius: var(--radius-md);
+  color: #fff;
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.graphiql-top-bar-run:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.graphiql-top-bar-run:not(:disabled):hover {
+  filter: brightness(1.1);
+}

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -17,6 +17,29 @@ export const TopBar: FC<TopBarProps> = ({ endpointUrl, version }) => {
   const isFetching = useGraphiQL(state => state.isFetching);
 
   return (
+    <TopBarView
+      endpointUrl={endpointUrl}
+      version={version}
+      isFetching={isFetching}
+      onRun={run}
+    />
+  );
+};
+
+export type TopBarViewProps = {
+  endpointUrl?: string;
+  version?: string;
+  isFetching: boolean;
+  onRun: () => void;
+};
+
+export const TopBarView: FC<TopBarViewProps> = ({
+  endpointUrl,
+  version,
+  isFetching,
+  onRun,
+}) => {
+  return (
     <header className="graphiql-top-bar" role="banner">
       <div className="graphiql-top-bar-brand">
         <span className="graphiql-top-bar-logo" aria-hidden="true" />
@@ -27,7 +50,6 @@ export const TopBar: FC<TopBarProps> = ({ endpointUrl, version }) => {
       <div className="graphiql-top-bar-divider" aria-hidden="true" />
 
       <div className="graphiql-top-bar-endpoint">
-        {/* Method/URL will be filled in once transport lands. */}
         <span className="graphiql-top-bar-endpoint-method">POST</span>
         <span className="graphiql-top-bar-endpoint-url">
           {endpointUrl ?? '/graphql'}
@@ -42,7 +64,7 @@ export const TopBar: FC<TopBarProps> = ({ endpointUrl, version }) => {
       <button
         type="button"
         className="graphiql-top-bar-run"
-        onClick={() => run()}
+        onClick={onRun}
         disabled={isFetching}
         aria-label="Run query"
       >

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -1,0 +1,57 @@
+'use no memo';
+
+import type { FC } from 'react';
+import { useGraphiQL, useGraphiQLActions } from '../provider';
+import { KeycapHint } from '../keycap-hint';
+import './index.css';
+
+export type TopBarProps = {
+  /** Endpoint URL to display (placeholder until transport lands). */
+  endpointUrl?: string;
+  /** Version string shown in the brand pill. */
+  version?: string;
+};
+
+export const TopBar: FC<TopBarProps> = ({
+  endpointUrl,
+  version,
+}) => {
+  const { run } = useGraphiQLActions();
+  const isFetching = useGraphiQL(state => state.isFetching);
+
+  return (
+    <header className="graphiql-top-bar" role="banner">
+      <div className="graphiql-top-bar-brand">
+        <span className="graphiql-top-bar-logo" aria-hidden="true" />
+        <span className="graphiql-top-bar-wordmark">GraphiQL</span>
+        {version && <span className="graphiql-top-bar-version">{version}</span>}
+      </div>
+
+      <div className="graphiql-top-bar-divider" aria-hidden="true" />
+
+      <div className="graphiql-top-bar-endpoint">
+        {/* Method/URL will be filled in once transport lands. */}
+        <span className="graphiql-top-bar-endpoint-method">POST</span>
+        <span className="graphiql-top-bar-endpoint-url">
+          {endpointUrl ?? '/graphql'}
+        </span>
+      </div>
+
+      <button type="button" className="graphiql-top-bar-cmd">
+        <span>Jump to schema</span>
+        <KeycapHint keys={['⌘', 'K']} ariaLabel="Open command palette" />
+      </button>
+
+      <button
+        type="button"
+        className="graphiql-top-bar-run"
+        onClick={() => run()}
+        disabled={isFetching}
+        aria-label="Run query"
+      >
+        Run
+        <KeycapHint keys={['⌘', '⏎']} ariaLabel="Run query shortcut" />
+      </button>
+    </header>
+  );
+};

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -1,3 +1,5 @@
+// React Compiler can stale-cache the references returned by zustand hooks;
+// opt this file out so `useGraphiQL` / `useGraphiQLActions` stay live.
 'use no memo';
 
 import type { FC } from 'react';

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -12,10 +12,7 @@ export type TopBarProps = {
   version?: string;
 };
 
-export const TopBar: FC<TopBarProps> = ({
-  endpointUrl,
-  version,
-}) => {
+export const TopBar: FC<TopBarProps> = ({ endpointUrl, version }) => {
   const { run } = useGraphiQLActions();
   const isFetching = useGraphiQL(state => state.isFetching);
 

--- a/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { GraphiQLProvider } from '../provider';
+import { TopBar } from './';
+
+const noOpFetcher = () => Promise.resolve({ data: {} });
+
+const meta: Meta<typeof TopBar> = {
+  title: 'Layout/TopBar',
+  component: TopBar,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <GraphiQLProvider fetcher={noOpFetcher}>
+        <Story />
+      </GraphiQLProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof TopBar>;
+
+export const Default: Story = {
+  args: {
+    endpointUrl: 'https://api.example.com/graphql',
+    version: 'v6.0.0-alpha.1',
+  },
+};
+
+export const NoVersion: Story = {
+  args: {
+    endpointUrl: '/graphql',
+  },
+};
+
+export const Minimal: Story = {
+  args: {},
+};

--- a/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
@@ -1,0 +1,91 @@
+'use no memo';
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GraphiQLProvider } from '../provider';
+import { TopBar } from './';
+
+// jsdom doesn't implement window.matchMedia; stub it so GraphiQLProvider
+// can resolve the initial theme without throwing.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+});
+
+const noOpFetcher = () => Promise.resolve({ data: {} });
+
+function renderInProvider(ui: React.ReactElement) {
+  return render(
+    <GraphiQLProvider fetcher={noOpFetcher}>{ui}</GraphiQLProvider>,
+  );
+}
+
+describe('TopBar', () => {
+  it('renders the Run button', () => {
+    renderInProvider(<TopBar />);
+    expect(
+      screen.getByRole('button', { name: /Run query/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the GraphiQL wordmark', () => {
+    renderInProvider(<TopBar />);
+    expect(screen.getByText('GraphiQL')).toBeInTheDocument();
+  });
+
+  it('renders the version pill when provided', () => {
+    renderInProvider(<TopBar version="v6.0.0-alpha.1" />);
+    expect(screen.getByText('v6.0.0-alpha.1')).toBeInTheDocument();
+  });
+
+  it('does not render the version pill when omitted', () => {
+    const { container } = renderInProvider(<TopBar />);
+    expect(container.querySelector('.graphiql-top-bar-version')).toBeNull();
+  });
+
+  it('renders the endpoint URL when provided', () => {
+    renderInProvider(<TopBar endpointUrl="https://api.example.com/graphql" />);
+    expect(
+      screen.getByText('https://api.example.com/graphql'),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to /graphql when endpointUrl is omitted', () => {
+    renderInProvider(<TopBar />);
+    expect(screen.getByText('/graphql')).toBeInTheDocument();
+  });
+
+  it('calls run when the Run button is clicked', async () => {
+    const user = userEvent.setup();
+    const fetcher = vi.fn(() => Promise.resolve({ data: {} }));
+    render(
+      <GraphiQLProvider fetcher={fetcher}>
+        <TopBar />
+      </GraphiQLProvider>,
+    );
+    await user.click(screen.getByRole('button', { name: /Run query/i }));
+    expect(fetcher).toHaveBeenCalled();
+  });
+
+  it('renders the command palette button', () => {
+    renderInProvider(<TopBar />);
+    expect(screen.getByText('Jump to schema')).toBeInTheDocument();
+  });
+
+  it('has role="banner" on the header element', () => {
+    const { container } = renderInProvider(<TopBar />);
+    expect(container.querySelector('header[role="banner"]')).not.toBeNull();
+  });
+});

--- a/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
@@ -1,91 +1,75 @@
 'use no memo';
 
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GraphiQLProvider } from '../provider';
-import { TopBar } from './';
+import { TopBarView } from './';
 
-// jsdom doesn't implement window.matchMedia; stub it so GraphiQLProvider
-// can resolve the initial theme without throwing.
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: (query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }),
-  });
-});
+const DEFAULTS = {
+  isFetching: false,
+  onRun: () => {},
+};
 
-const noOpFetcher = () => Promise.resolve({ data: {} });
-
-function renderInProvider(ui: React.ReactElement) {
-  return render(
-    <GraphiQLProvider fetcher={noOpFetcher}>{ui}</GraphiQLProvider>,
-  );
-}
-
-describe('TopBar', () => {
+describe('TopBarView', () => {
   it('renders the Run button', () => {
-    renderInProvider(<TopBar />);
+    render(<TopBarView {...DEFAULTS} />);
     expect(
       screen.getByRole('button', { name: /Run query/i }),
     ).toBeInTheDocument();
   });
 
   it('renders the GraphiQL wordmark', () => {
-    renderInProvider(<TopBar />);
+    render(<TopBarView {...DEFAULTS} />);
     expect(screen.getByText('GraphiQL')).toBeInTheDocument();
   });
 
   it('renders the version pill when provided', () => {
-    renderInProvider(<TopBar version="v6.0.0-alpha.1" />);
+    render(<TopBarView {...DEFAULTS} version="v6.0.0-alpha.1" />);
     expect(screen.getByText('v6.0.0-alpha.1')).toBeInTheDocument();
   });
 
   it('does not render the version pill when omitted', () => {
-    const { container } = renderInProvider(<TopBar />);
+    const { container } = render(<TopBarView {...DEFAULTS} />);
     expect(container.querySelector('.graphiql-top-bar-version')).toBeNull();
   });
 
   it('renders the endpoint URL when provided', () => {
-    renderInProvider(<TopBar endpointUrl="https://api.example.com/graphql" />);
+    render(
+      <TopBarView
+        {...DEFAULTS}
+        endpointUrl="https://api.example.com/graphql"
+      />,
+    );
     expect(
       screen.getByText('https://api.example.com/graphql'),
     ).toBeInTheDocument();
   });
 
   it('falls back to /graphql when endpointUrl is omitted', () => {
-    renderInProvider(<TopBar />);
+    render(<TopBarView {...DEFAULTS} />);
     expect(screen.getByText('/graphql')).toBeInTheDocument();
   });
 
-  it('calls run when the Run button is clicked', async () => {
+  it('calls onRun when the Run button is clicked', async () => {
     const user = userEvent.setup();
-    const fetcher = vi.fn(() => Promise.resolve({ data: {} }));
-    render(
-      <GraphiQLProvider fetcher={fetcher}>
-        <TopBar />
-      </GraphiQLProvider>,
-    );
+    const onRun = vi.fn();
+    render(<TopBarView {...DEFAULTS} onRun={onRun} />);
     await user.click(screen.getByRole('button', { name: /Run query/i }));
-    expect(fetcher).toHaveBeenCalled();
+    expect(onRun).toHaveBeenCalled();
+  });
+
+  it('disables the Run button while fetching', () => {
+    render(<TopBarView {...DEFAULTS} isFetching />);
+    expect(screen.getByRole('button', { name: /Run query/i })).toBeDisabled();
   });
 
   it('renders the command palette button', () => {
-    renderInProvider(<TopBar />);
+    render(<TopBarView {...DEFAULTS} />);
     expect(screen.getByText('Jump to schema')).toBeInTheDocument();
   });
 
   it('has role="banner" on the header element', () => {
-    const { container } = renderInProvider(<TopBar />);
+    const { container } = render(<TopBarView {...DEFAULTS} />);
     expect(container.querySelector('header[role="banner"]')).not.toBeNull();
   });
 });

--- a/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
@@ -7,7 +7,7 @@ import { TopBarView } from './';
 
 const DEFAULTS = {
   isFetching: false,
-  onRun: () => {},
+  onRun() {},
 };
 
 describe('TopBarView', () => {

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -181,9 +181,9 @@ describe('GraphiQL', () => {
           expect(queryEditor).toBeVisible();
           expect(queryEditor!.textContent).toBe('# Welcome to GraphiQL');
         },
-        { timeout: 15_000 },
+        { timeout: 25_000 },
       );
-    }, 20000);
+    }, 30000);
 
     it('accepts a custom default query', async () => {
       const { container } = render(

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -24,6 +24,7 @@ import {
   Tab,
   Tabs,
   Tooltip,
+  TopBar,
   UnStyledButton,
   useDragResize,
   useGraphiQL,
@@ -445,84 +446,87 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
   return (
     <Tooltip.Provider>
       <div className={cn('graphiql-container', className)}>
-        <Sidebar
-          forcedTheme={forcedTheme}
-          showPersistHeadersSettings={showPersistHeadersSettings}
-          setHiddenElement={pluginResize.setHiddenElement}
-        />
-        <div className="graphiql-main">
-          <div
-            ref={pluginResize.firstRef}
-            className="graphiql-plugin"
-            style={{
-              // Make sure the container shrinks when containing long
-              // non-breaking texts
-              minWidth: '200px',
-            }}
-          >
-            {PluginContent && <PluginContent />}
-          </div>
-          {visiblePlugin && (
+        <TopBar />
+        <div className="graphiql-body">
+          <Sidebar
+            forcedTheme={forcedTheme}
+            showPersistHeadersSettings={showPersistHeadersSettings}
+            setHiddenElement={pluginResize.setHiddenElement}
+          />
+          <div className="graphiql-main">
             <div
-              className="graphiql-horizontal-drag-bar"
-              ref={pluginResize.dragBarRef}
-            />
-          )}
-          <div ref={pluginResize.secondRef} className="graphiql-sessions">
-            <div className="graphiql-session-header">
-              <Tabs
-                ref={tabContainerRef}
-                values={tabs}
-                onReorder={moveTab}
-                aria-label="Select active operation"
-                className="no-scrollbar"
-              >
-                {tabs.map((tab, index, arr) => (
-                  <Tab
-                    key={tab.id}
-                    // Prevent overscroll over container
-                    dragConstraints={tabContainerRef}
-                    value={tab}
-                    isActive={index === activeTabIndex}
-                  >
-                    <Tab.Button
-                      aria-controls="graphiql-session"
-                      id={`graphiql-session-tab-${index}`}
-                      title={tab.title}
-                      onClick={handleTabClick}
-                    >
-                      {tab.title}
-                    </Tab.Button>
-                    {arr.length > 1 && <Tab.Close onClick={handleTabClose} />}
-                  </Tab>
-                ))}
-              </Tabs>
-              <Tooltip label={LABEL.newTab}>
-                <UnStyledButton
-                  type="button"
-                  className="graphiql-tab-add"
-                  onClick={addTab}
-                  aria-label={LABEL.newTab}
-                >
-                  <PlusIcon aria-hidden="true" />
-                </UnStyledButton>
-              </Tooltip>
-              {logo}
-            </div>
-            <div
-              role="tabpanel"
-              id="graphiql-session" // used by aria-controls="graphiql-session"
-              aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
+              ref={pluginResize.firstRef}
+              className="graphiql-plugin"
+              style={{
+                // Make sure the container shrinks when containing long
+                // non-breaking texts
+                minWidth: '200px',
+              }}
             >
-              {editors}
+              {PluginContent && <PluginContent />}
+            </div>
+            {visiblePlugin && (
               <div
                 className="graphiql-horizontal-drag-bar"
-                ref={editorResize.dragBarRef}
+                ref={pluginResize.dragBarRef}
               />
-              <div className="graphiql-response" ref={editorResize.secondRef}>
-                {isFetching && <Spinner />}
-                <ResponseEditor responseTooltip={responseTooltip} />
-                {footer}
+            )}
+            <div ref={pluginResize.secondRef} className="graphiql-sessions">
+              <div className="graphiql-session-header">
+                <Tabs
+                  ref={tabContainerRef}
+                  values={tabs}
+                  onReorder={moveTab}
+                  aria-label="Select active operation"
+                  className="no-scrollbar"
+                >
+                  {tabs.map((tab, index, arr) => (
+                    <Tab
+                      key={tab.id}
+                      // Prevent overscroll over container
+                      dragConstraints={tabContainerRef}
+                      value={tab}
+                      isActive={index === activeTabIndex}
+                    >
+                      <Tab.Button
+                        aria-controls="graphiql-session"
+                        id={`graphiql-session-tab-${index}`}
+                        title={tab.title}
+                        onClick={handleTabClick}
+                      >
+                        {tab.title}
+                      </Tab.Button>
+                      {arr.length > 1 && <Tab.Close onClick={handleTabClose} />}
+                    </Tab>
+                  ))}
+                </Tabs>
+                <Tooltip label={LABEL.newTab}>
+                  <UnStyledButton
+                    type="button"
+                    className="graphiql-tab-add"
+                    onClick={addTab}
+                    aria-label={LABEL.newTab}
+                  >
+                    <PlusIcon aria-hidden="true" />
+                  </UnStyledButton>
+                </Tooltip>
+                {logo}
+              </div>
+              <div
+                role="tabpanel"
+                id="graphiql-session" // used by aria-controls="graphiql-session"
+                aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
+              >
+                {editors}
+                <div
+                  className="graphiql-horizontal-drag-bar"
+                  ref={editorResize.dragBarRef}
+                />
+                <div className="graphiql-response" ref={editorResize.secondRef}>
+                  {isFetching && <Spinner />}
+                  <ResponseEditor responseTooltip={responseTooltip} />
+                  {footer}
+                </div>
               </div>
             </div>
           </div>

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -2,10 +2,19 @@
 .graphiql-container {
   background-color: hsl(var(--color-base));
   display: flex;
+  flex-direction: column;
   height: 100%;
   margin: 0;
   overflow: hidden;
   width: 100%;
+}
+
+/* Sidebar + main content row (below the top bar) */
+.graphiql-container .graphiql-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* The sidebar */

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -251,6 +251,7 @@ websockets
 wgutils
 wincent
 wonka
+wordmark
 yoshiakis
 zdravo
 zustand


### PR DESCRIPTION
## Summary

This PR introduces the top bar that anchors the new GraphiQL v6 layout. It renders the brand, an endpoint URL display, a command palette button, and a primary Run button across the top of the app. The endpoint URL and command palette are intentional placeholders; their behavior will fill in once the transport and command palette work land.

## Test plan

- [x] Open the [deploy preview](https://deploy-preview-4288--graphiql-test.netlify.app). Confirm the top bar spans the full width above the editor/sidebar split, showing the brand, endpoint URL placeholder, command palette button, and Run button.
- [x] In the deploy preview, type a query and click Run. Confirm the button disables for the duration of the fetch and re-enables once results arrive.
- [x] In the deploy preview, open the settings dialog and toggle dark/light theme. Confirm the top bar reads from the active tokens in both modes.
- [x] Tab through the bar with the keyboard. Confirm the Run button is reachable and activates with Space or Enter.

Refs: graphql/graphiql#4219
