### PR TITLE
v6: Add `StatusBar` layout component

### DIFF
--- a/.changeset/status-bar.md
+++ b/.changeset/status-bar.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a `StatusBar` layout component: a 24px-tall footer at the bottom of the app showing connection status, schema type count, active plugin count, cursor position, and document metadata (encoding, indent, language label).

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -29,10 +29,7 @@ export type {
 } from './segmented-control';
 export { MethodPill } from './method-pill';
 export type { MethodPillProps, Operation } from './method-pill';
-<<<<<<< HEAD
 export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
-=======
 export { StatusBar, StatusBarView } from './status-bar';
 export type { StatusBarProps, StatusBarViewProps } from './status-bar';
->>>>>>> 03408f29 (Add `StatusBar` layout component)

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -29,5 +29,10 @@ export type {
 } from './segmented-control';
 export { MethodPill } from './method-pill';
 export type { MethodPillProps, Operation } from './method-pill';
+<<<<<<< HEAD
 export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
+=======
+export { StatusBar, StatusBarView } from './status-bar';
+export type { StatusBarProps, StatusBarViewProps } from './status-bar';
+>>>>>>> 03408f29 (Add `StatusBar` layout component)

--- a/packages/graphiql-react/src/components/status-bar/index.css
+++ b/packages/graphiql-react/src/components/status-bar/index.css
@@ -7,7 +7,7 @@
   padding: 0 var(--px-12);
   background: oklch(var(--bg-elevated));
   border-top: 1px solid oklch(var(--border-default));
-  color: oklch(var(--fg-disabled));
+  color: oklch(var(--fg-subtle));
   font-family: var(--font-family-mono);
   font-size: var(--font-size-eyebrow);
 }

--- a/packages/graphiql-react/src/components/status-bar/index.css
+++ b/packages/graphiql-react/src/components/status-bar/index.css
@@ -17,15 +17,24 @@
 }
 
 .graphiql-status-bar-conn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-6);
   font-weight: 500;
 }
 
-.graphiql-status-bar-conn.connected {
-  color: oklch(var(--accent-green));
+.graphiql-status-bar-conn-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
 }
 
-.graphiql-status-bar-conn.disconnected {
-  color: oklch(var(--accent-red));
+.graphiql-status-bar-conn.connected .graphiql-status-bar-conn-dot {
+  background: oklch(var(--accent-green));
+}
+
+.graphiql-status-bar-conn.disconnected .graphiql-status-bar-conn-dot {
+  background: oklch(var(--accent-red));
 }
 
 .graphiql-status-bar-plugins {

--- a/packages/graphiql-react/src/components/status-bar/index.css
+++ b/packages/graphiql-react/src/components/status-bar/index.css
@@ -1,0 +1,33 @@
+.graphiql-status-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--px-14);
+  height: var(--status-bar-height);
+  flex-shrink: 0;
+  padding: 0 var(--px-12);
+  background: oklch(var(--bg-elevated));
+  border-top: 1px solid oklch(var(--border-default));
+  color: oklch(var(--fg-disabled));
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-eyebrow);
+}
+
+.graphiql-status-bar-spacer {
+  flex: 1;
+}
+
+.graphiql-status-bar-conn {
+  font-weight: 500;
+}
+
+.graphiql-status-bar-conn.connected {
+  color: oklch(var(--accent-green));
+}
+
+.graphiql-status-bar-conn.disconnected {
+  color: oklch(var(--accent-red));
+}
+
+.graphiql-status-bar-plugins {
+  color: oklch(var(--accent-purple));
+}

--- a/packages/graphiql-react/src/components/status-bar/index.tsx
+++ b/packages/graphiql-react/src/components/status-bar/index.tsx
@@ -1,0 +1,67 @@
+'use no memo';
+
+import type { FC } from 'react';
+import { useGraphiQL } from '../provider';
+import './index.css';
+
+export type StatusBarProps = {
+  cursorPosition?: { line: number; column: number };
+  encoding?: string;
+  indent?: string;
+};
+
+export type StatusBarViewProps = StatusBarProps & {
+  isConnected: boolean;
+  typeCount: number;
+  pluginCount: number;
+};
+
+export const StatusBarView: FC<StatusBarViewProps> = ({
+  isConnected,
+  typeCount,
+  pluginCount,
+  cursorPosition,
+  encoding = 'UTF-8',
+  indent = 'Spaces: 2',
+}) => (
+  <footer className="graphiql-status-bar" role="contentinfo">
+    <span
+      className={`graphiql-status-bar-conn${isConnected ? ' connected' : ' disconnected'}`}
+    >
+      {isConnected ? 'Connected' : 'Disconnected'}
+    </span>
+    {isConnected && (
+      <span className="graphiql-status-bar-types">{typeCount} types</span>
+    )}
+    {pluginCount > 0 && (
+      <span className="graphiql-status-bar-plugins">
+        {pluginCount} {pluginCount === 1 ? 'plugin' : 'plugins'}
+      </span>
+    )}
+    <span className="graphiql-status-bar-spacer" />
+    {cursorPosition && (
+      <span>
+        Ln {cursorPosition.line}, Col {cursorPosition.column}
+      </span>
+    )}
+    <span>{encoding}</span>
+    <span>{indent}</span>
+    <span>GraphQL</span>
+  </footer>
+);
+
+export const StatusBar: FC<StatusBarProps> = props => {
+  const schema = useGraphiQL(state => state.schema);
+  const plugins = useGraphiQL(state => state.plugins);
+  const isConnected = schema != null;
+  const typeCount = schema ? Object.keys(schema.getTypeMap()).length : 0;
+
+  return (
+    <StatusBarView
+      {...props}
+      isConnected={isConnected}
+      typeCount={typeCount}
+      pluginCount={plugins.length}
+    />
+  );
+};

--- a/packages/graphiql-react/src/components/status-bar/index.tsx
+++ b/packages/graphiql-react/src/components/status-bar/index.tsx
@@ -7,7 +7,6 @@ import './index.css';
 export type StatusBarProps = {
   cursorPosition?: { line: number; column: number };
   encoding?: string;
-  indent?: string;
 };
 
 export type StatusBarViewProps = StatusBarProps & {
@@ -22,12 +21,12 @@ export const StatusBarView: FC<StatusBarViewProps> = ({
   pluginCount,
   cursorPosition,
   encoding = 'UTF-8',
-  indent = 'Spaces: 2',
 }) => (
   <footer className="graphiql-status-bar" role="contentinfo">
     <span
       className={`graphiql-status-bar-conn${isConnected ? ' connected' : ' disconnected'}`}
     >
+      <span className="graphiql-status-bar-conn-dot" aria-hidden="true" />
       {isConnected ? 'Connected' : 'Disconnected'}
     </span>
     {isConnected && (
@@ -45,7 +44,6 @@ export const StatusBarView: FC<StatusBarViewProps> = ({
       </span>
     )}
     <span>{encoding}</span>
-    <span>{indent}</span>
     <span>GraphQL</span>
   </footer>
 );

--- a/packages/graphiql-react/src/components/status-bar/index.tsx
+++ b/packages/graphiql-react/src/components/status-bar/index.tsx
@@ -5,7 +5,6 @@ import { useGraphiQL } from '../provider';
 import './index.css';
 
 export type StatusBarProps = {
-  cursorPosition?: { line: number; column: number };
   encoding?: string;
 };
 
@@ -19,7 +18,6 @@ export const StatusBarView: FC<StatusBarViewProps> = ({
   isConnected,
   typeCount,
   pluginCount,
-  cursorPosition,
   encoding = 'UTF-8',
 }) => (
   <footer className="graphiql-status-bar" role="contentinfo">
@@ -38,11 +36,6 @@ export const StatusBarView: FC<StatusBarViewProps> = ({
       </span>
     )}
     <span className="graphiql-status-bar-spacer" />
-    {cursorPosition && (
-      <span>
-        Ln {cursorPosition.line}, Col {cursorPosition.column}
-      </span>
-    )}
     <span>{encoding}</span>
     <span>GraphQL</span>
   </footer>

--- a/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { buildSchema } from 'graphql';
+import { StatusBarView } from './';
+
+const SCHEMA = buildSchema(`
+  type Query {
+    hero: Character
+    heroes: [Character]
+    search(text: String): [SearchResult]
+  }
+
+  union SearchResult = Human | Droid
+
+  interface Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+  }
+
+  enum Episode { NEWHOPE EMPIRE JEDI }
+
+  type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    homePlanet: String
+    height(unit: LengthUnit = METER): Float
+    mass: Float
+    starships: [Starship]
+  }
+
+  type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+  }
+
+  type Starship { id: ID! name: String! }
+
+  enum LengthUnit { METER FOOT }
+`);
+
+const typeCount = Object.keys(SCHEMA.getTypeMap()).length;
+
+const meta: Meta<typeof StatusBarView> = {
+  title: 'Layout/StatusBar',
+  component: StatusBarView,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div style={{ position: 'relative' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusBarView>;
+
+export const Disconnected: Story = {
+  args: {
+    isConnected: false,
+    typeCount: 0,
+    pluginCount: 0,
+  },
+};
+
+export const Connected: Story = {
+  args: {
+    isConnected: true,
+    typeCount,
+    pluginCount: 0,
+  },
+};
+
+export const WithPlugins: Story = {
+  args: {
+    isConnected: true,
+    typeCount,
+    pluginCount: 2,
+  },
+};
+
+export const WithCursorPosition: Story = {
+  args: {
+    isConnected: true,
+    typeCount,
+    pluginCount: 2,
+    cursorPosition: { line: 12, column: 5 },
+  },
+};
+
+export const CustomMetadata: Story = {
+  args: {
+    isConnected: false,
+    typeCount: 0,
+    pluginCount: 0,
+    encoding: 'UTF-16',
+    indent: 'Tabs: 4',
+    cursorPosition: { line: 1, column: 1 },
+  },
+};

--- a/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
@@ -86,21 +86,11 @@ export const WithPlugins: Story = {
   },
 };
 
-export const WithCursorPosition: Story = {
-  args: {
-    isConnected: true,
-    typeCount,
-    pluginCount: 2,
-    cursorPosition: { line: 12, column: 5 },
-  },
-};
-
-export const CustomMetadata: Story = {
+export const CustomEncoding: Story = {
   args: {
     isConnected: false,
     typeCount: 0,
     pluginCount: 0,
     encoding: 'UTF-16',
-    cursorPosition: { line: 1, column: 1 },
   },
 };

--- a/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
@@ -101,7 +101,6 @@ export const CustomMetadata: Story = {
     typeCount: 0,
     pluginCount: 0,
     encoding: 'UTF-16',
-    indent: 'Tabs: 4',
     cursorPosition: { line: 1, column: 1 },
   },
 };

--- a/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
@@ -1,0 +1,102 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { buildSchema } from 'graphql';
+import { StatusBarView } from './';
+
+const SCHEMA = buildSchema(`type Query { hello: String }`);
+
+const CONNECTED_DEFAULTS = {
+  isConnected: true,
+  typeCount: Object.keys(SCHEMA.getTypeMap()).length,
+  pluginCount: 0,
+};
+
+const DISCONNECTED_DEFAULTS = {
+  isConnected: false,
+  typeCount: 0,
+  pluginCount: 0,
+};
+
+describe('StatusBarView', () => {
+  it('shows "Disconnected" when not connected', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('shows "Connected" when connected', () => {
+    render(<StatusBarView {...CONNECTED_DEFAULTS} />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('shows type count when connected', () => {
+    render(<StatusBarView {...CONNECTED_DEFAULTS} />);
+    expect(
+      screen.getByText(`${CONNECTED_DEFAULTS.typeCount} types`),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show type count when disconnected', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.queryByText(/types/)).toBeNull();
+  });
+
+  it('shows plugin count when plugins are registered', () => {
+    render(<StatusBarView {...CONNECTED_DEFAULTS} pluginCount={2} />);
+    expect(screen.getByText('2 plugins')).toBeInTheDocument();
+  });
+
+  it('uses singular "plugin" for one plugin', () => {
+    render(<StatusBarView {...CONNECTED_DEFAULTS} pluginCount={1} />);
+    expect(screen.getByText('1 plugin')).toBeInTheDocument();
+  });
+
+  it('does not show plugin count when no plugins are registered', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.queryByText(/plugin/)).toBeNull();
+  });
+
+  it('shows cursor position when provided', () => {
+    render(
+      <StatusBarView
+        {...DISCONNECTED_DEFAULTS}
+        cursorPosition={{ line: 4, column: 12 }}
+      />,
+    );
+    expect(screen.getByText('Ln 4, Col 12')).toBeInTheDocument();
+  });
+
+  it('does not show cursor position when omitted', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.queryByText(/Ln/)).toBeNull();
+  });
+
+  it('shows default encoding and indent', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.getByText('UTF-8')).toBeInTheDocument();
+    expect(screen.getByText('Spaces: 2')).toBeInTheDocument();
+  });
+
+  it('shows custom encoding and indent', () => {
+    render(
+      <StatusBarView
+        {...DISCONNECTED_DEFAULTS}
+        encoding="UTF-16"
+        indent="Tabs: 4"
+      />,
+    );
+    expect(screen.getByText('UTF-16')).toBeInTheDocument();
+    expect(screen.getByText('Tabs: 4')).toBeInTheDocument();
+  });
+
+  it('always shows the GraphQL language label', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.getByText('GraphQL')).toBeInTheDocument();
+  });
+
+  it('renders as a footer with role contentinfo', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+});

--- a/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
@@ -57,21 +57,6 @@ describe('StatusBarView', () => {
     expect(screen.queryByText(/plugin/)).toBeNull();
   });
 
-  it('shows cursor position when provided', () => {
-    render(
-      <StatusBarView
-        {...DISCONNECTED_DEFAULTS}
-        cursorPosition={{ line: 4, column: 12 }}
-      />,
-    );
-    expect(screen.getByText('Ln 4, Col 12')).toBeInTheDocument();
-  });
-
-  it('does not show cursor position when omitted', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.queryByText(/Ln/)).toBeNull();
-  });
-
   it('shows default encoding', () => {
     render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
     expect(screen.getByText('UTF-8')).toBeInTheDocument();

--- a/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
@@ -72,22 +72,23 @@ describe('StatusBarView', () => {
     expect(screen.queryByText(/Ln/)).toBeNull();
   });
 
-  it('shows default encoding and indent', () => {
+  it('shows default encoding', () => {
     render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
     expect(screen.getByText('UTF-8')).toBeInTheDocument();
-    expect(screen.getByText('Spaces: 2')).toBeInTheDocument();
   });
 
-  it('shows custom encoding and indent', () => {
-    render(
-      <StatusBarView
-        {...DISCONNECTED_DEFAULTS}
-        encoding="UTF-16"
-        indent="Tabs: 4"
-      />,
-    );
+  it('shows custom encoding', () => {
+    render(<StatusBarView {...DISCONNECTED_DEFAULTS} encoding="UTF-16" />);
     expect(screen.getByText('UTF-16')).toBeInTheDocument();
-    expect(screen.getByText('Tabs: 4')).toBeInTheDocument();
+  });
+
+  it('renders a status dot inside the connection label', () => {
+    const { container } = render(<StatusBarView {...CONNECTED_DEFAULTS} />);
+    expect(
+      container.querySelector(
+        '.graphiql-status-bar-conn.connected .graphiql-status-bar-conn-dot',
+      ),
+    ).not.toBeNull();
   });
 
   it('always shows the GraphQL language label', () => {

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -21,6 +21,7 @@ import {
   QueryEditor,
   ResponseEditor,
   Spinner,
+  StatusBar,
   Tab,
   Tabs,
   Tooltip,
@@ -531,6 +532,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
             </div>
           </div>
         </div>
+        <StatusBar />
       </div>
       {children}
     </Tooltip.Provider>

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -9,7 +9,7 @@
   width: 100%;
 }
 
-/* Sidebar + main content row (below the top bar) */
+/* Sidebar + main content row (below the top bar and above the status bar) */
 .graphiql-container .graphiql-body {
   display: flex;
   flex: 1;
@@ -201,7 +201,7 @@ button.graphiql-tab-add {
 
 /* The response view */
 .graphiql-container .graphiql-response {
-  /* Add some padding so it doesn’t touch the tabs */
+  /* Add some padding so it doesn't touch the tabs */
   padding-top: var(--px-16);
   display: flex;
   width: 100%;

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -211,6 +211,7 @@ sonarjs
 sorare
 spawndamnit
 squirrelly
+starships
 stonexer
 streamable
 subword


### PR DESCRIPTION
## Summary

This PR adds a 24px footer pinned to the bottom of the GraphiQL app. It shows the connection status (with a small dot indicator), schema type count, plugin count, the document encoding, and the language label. The outer container becomes a flex column with a new `graphiql-body` wrapper for the sidebar-plus-main row, which keeps the status bar fixed beneath a scrolling content area.

## Test plan

- [x] Open the [deploy preview](https://deploy-preview-4289--graphiql-test.netlify.app). Confirm the status bar appears at the bottom of the app and reads "Disconnected" with a red dot before any schema loads.
- [x] In the deploy preview, the default endpoint should load a schema; confirm the status flips to "Connected" with a green dot, and a schema type count appears.
- [x] Resize the browser window narrow; confirm the status bar stays pinned at the bottom and the content area above scrolls independently.
- [x] Open the settings dialog and toggle dark/light theme; confirm the bar's chrome follows the active theme.

Refs: graphql/graphiql#4219
