### PR TITLE
v6: Add `ActivityRail` and replace the previous sidebar

### DIFF
--- a/.changeset/activity-rail.md
+++ b/.changeset/activity-rail.md
@@ -1,0 +1,8 @@
+---
+'@graphiql/react': minor
+'graphiql': major
+---
+
+Replace the left-side plugin sidebar with `ActivityRail`. Plugins render as a flat list in registration order with a 2px blue left border on the active plugin. Settings gear at the bottom opens the settings dialog.
+
+The previous `graphiql-sidebar` DOM structure and CSS class names are removed. Custom CSS overrides targeting `.graphiql-sidebar` or its children will need updating. Only CSS variable names are part of the public API.

--- a/packages/graphiql-react/src/components/activity-rail/activity-rail.stories.tsx
+++ b/packages/graphiql-react/src/components/activity-rail/activity-rail.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import {
+  DocsIcon,
+  HistoryIcon,
+  StarIcon,
+  MagnifyingGlassIcon,
+  SettingsIcon,
+} from '../../icons';
+import { Tooltip } from '../tooltip';
+import './index.css';
+
+type Plugin = { title: string; icon: React.ComponentType };
+
+const SAMPLE_PLUGINS: Plugin[] = [
+  { title: 'Documentation Explorer', icon: DocsIcon },
+  { title: 'History', icon: HistoryIcon },
+  { title: 'Favorites', icon: StarIcon },
+  { title: 'Search', icon: MagnifyingGlassIcon },
+];
+
+function ActivityRailDemo({
+  initialActive,
+  showSettings = true,
+}: {
+  initialActive?: string;
+  showSettings?: boolean;
+}) {
+  const [active, setActive] = useState<string | null>(initialActive ?? null);
+
+  function toggle(title: string) {
+    setActive(prev => (prev === title ? null : title));
+  }
+
+  return (
+    <Tooltip.Provider>
+      <div style={{ display: 'flex', height: 400 }}>
+        <nav className="graphiql-activity-rail" aria-label="Plugins">
+          <ul className="graphiql-activity-rail-list">
+            {SAMPLE_PLUGINS.map(plugin => {
+              const Icon = plugin.icon;
+              const isActive = active === plugin.title;
+              const label = `${isActive ? 'Hide' : 'Show'} ${plugin.title}`;
+              return (
+                <li key={plugin.title}>
+                  <Tooltip label={label}>
+                    <button
+                      type="button"
+                      className={`graphiql-activity-rail-item${isActive ? ' active' : ''}`}
+                      aria-pressed={isActive}
+                      aria-label={label}
+                      onClick={() => toggle(plugin.title)}
+                    >
+                      <Icon aria-hidden="true" />
+                    </button>
+                  </Tooltip>
+                </li>
+              );
+            })}
+          </ul>
+          <div className="graphiql-activity-rail-spacer" />
+          {showSettings && (
+            <Tooltip label="Settings">
+              <button
+                type="button"
+                className="graphiql-activity-rail-settings"
+                aria-label="Settings"
+              >
+                <SettingsIcon aria-hidden="true" />
+              </button>
+            </Tooltip>
+          )}
+        </nav>
+        {active && (
+          <div
+            style={{
+              padding: 16,
+              borderRight: '1px solid oklch(var(--border-default))',
+            }}
+          >
+            <strong>{active}</strong> panel
+          </div>
+        )}
+      </div>
+    </Tooltip.Provider>
+  );
+}
+
+const meta: Meta = {
+  title: 'Components/ActivityRail',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+export const Default: StoryObj = {
+  render: () => <ActivityRailDemo />,
+};
+
+export const WithActivePlugin: StoryObj = {
+  render: () => <ActivityRailDemo initialActive="Documentation Explorer" />,
+};
+
+export const NoPluginsNoSettings: StoryObj = {
+  render: () => (
+    <Tooltip.Provider>
+      <div style={{ display: 'flex', height: 400 }}>
+        <nav className="graphiql-activity-rail" aria-label="Plugins">
+          <ul className="graphiql-activity-rail-list" />
+          <div className="graphiql-activity-rail-spacer" />
+        </nav>
+      </div>
+    </Tooltip.Provider>
+  ),
+};

--- a/packages/graphiql-react/src/components/activity-rail/activity-rail.test.tsx
+++ b/packages/graphiql-react/src/components/activity-rail/activity-rail.test.tsx
@@ -1,0 +1,132 @@
+'use no memo';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as T from '@radix-ui/react-tooltip';
+import type { ReactNode } from 'react';
+import type { GraphiQLPlugin } from '../../stores/plugin';
+import { ActivityRail } from './';
+
+const DocsIcon = () => <svg data-testid="docs-icon" />;
+const HistoryIcon = () => <svg data-testid="history-icon" />;
+
+const DOCS_PLUGIN: GraphiQLPlugin = {
+  title: 'Documentation Explorer',
+  icon: DocsIcon,
+  content: () => null,
+};
+
+const HISTORY_PLUGIN: GraphiQLPlugin = {
+  title: 'History',
+  icon: HistoryIcon,
+  content: () => null,
+};
+
+const mockSetVisiblePlugin = vi.fn();
+
+vi.mock('../provider', () => ({
+  useGraphiQL: vi.fn(),
+  useGraphiQLActions: vi.fn(),
+}));
+
+import { useGraphiQL, useGraphiQLActions } from '../provider';
+
+const mockUseGraphiQL = vi.mocked(useGraphiQL);
+const mockUseGraphiQLActions = vi.mocked(useGraphiQLActions);
+
+function renderWithProvider(ui: ReactNode) {
+  return render(<T.Provider>{ui}</T.Provider>);
+}
+
+function setup(visiblePlugin: GraphiQLPlugin | null = null) {
+  mockUseGraphiQL.mockImplementation((selector: (s: any) => any) => {
+    const state = {
+      plugins: [DOCS_PLUGIN, HISTORY_PLUGIN],
+      visiblePlugin,
+    };
+    return selector(state);
+  });
+  mockUseGraphiQLActions.mockReturnValue({
+    setVisiblePlugin: mockSetVisiblePlugin,
+  } as any);
+}
+
+describe('ActivityRail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a button for each plugin', () => {
+    setup();
+    renderWithProvider(<ActivityRail />);
+    expect(
+      screen.getByRole('button', { name: 'Show Documentation Explorer' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Show History' }),
+    ).toBeInTheDocument();
+  });
+
+  it('marks the active plugin with aria-pressed=true', () => {
+    setup(DOCS_PLUGIN);
+    renderWithProvider(<ActivityRail />);
+    expect(
+      screen.getByRole('button', { name: 'Hide Documentation Explorer' }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(
+      screen.getByRole('button', { name: 'Show History' }),
+    ).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('calls setVisiblePlugin with the plugin when an inactive button is clicked', async () => {
+    const user = userEvent.setup();
+    setup(null);
+    renderWithProvider(<ActivityRail />);
+    await user.click(
+      screen.getByRole('button', { name: 'Show Documentation Explorer' }),
+    );
+    expect(mockSetVisiblePlugin).toHaveBeenCalledWith(DOCS_PLUGIN);
+  });
+
+  it('calls setVisiblePlugin(null) when the active plugin button is clicked', async () => {
+    const user = userEvent.setup();
+    setup(DOCS_PLUGIN);
+    renderWithProvider(<ActivityRail />);
+    await user.click(
+      screen.getByRole('button', { name: 'Hide Documentation Explorer' }),
+    );
+    expect(mockSetVisiblePlugin).toHaveBeenCalledWith(null);
+  });
+
+  it('renders inside a <nav> with aria-label="Plugins"', () => {
+    setup();
+    renderWithProvider(<ActivityRail />);
+    expect(
+      screen.getByRole('navigation', { name: 'Plugins' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the settings button when onSettingsClick is provided', () => {
+    setup();
+    renderWithProvider(<ActivityRail onSettingsClick={vi.fn()} />);
+    expect(
+      screen.getByRole('button', { name: 'Settings' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the settings button without onSettingsClick', () => {
+    setup();
+    renderWithProvider(<ActivityRail />);
+    expect(screen.queryByRole('button', { name: 'Settings' })).toBeNull();
+  });
+
+  it('calls onSettingsClick when the settings button is clicked', async () => {
+    const user = userEvent.setup();
+    const onSettingsClick = vi.fn();
+    setup();
+    renderWithProvider(<ActivityRail onSettingsClick={onSettingsClick} />);
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(onSettingsClick).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/graphiql-react/src/components/activity-rail/index.css
+++ b/packages/graphiql-react/src/components/activity-rail/index.css
@@ -1,0 +1,97 @@
+.graphiql-activity-rail {
+  display: flex;
+  flex-direction: column;
+  width: var(--rail-width);
+  padding: var(--px-8) 0;
+  background: oklch(var(--bg-elevated));
+  border-right: 1px solid oklch(var(--border-default));
+  flex-shrink: 0;
+}
+
+.graphiql-activity-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-4);
+  align-items: center;
+}
+
+.graphiql-activity-rail-item {
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-left: 2px solid transparent;
+  margin-left: -2px;
+  background: transparent;
+  color: oklch(var(--fg-subtle));
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition:
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.graphiql-activity-rail-item:hover {
+  color: oklch(var(--fg-default));
+  background: oklch(var(--bg-subtle));
+}
+
+.graphiql-activity-rail-item:focus-visible {
+  outline: 2px solid oklch(var(--accent-blue));
+  outline-offset: 2px;
+}
+
+.graphiql-activity-rail-item.active {
+  background: oklch(var(--bg-subtle));
+  color: oklch(var(--fg-strong));
+  border-left-color: oklch(var(--accent-blue));
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.graphiql-activity-rail-item svg {
+  width: 16px;
+  height: 16px;
+}
+
+.graphiql-activity-rail-spacer {
+  flex: 1;
+}
+
+.graphiql-activity-rail-settings {
+  width: 32px;
+  height: 32px;
+  margin: 0 auto;
+  border: 0;
+  background: transparent;
+  color: oklch(var(--fg-subtle));
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: var(--radius-md);
+  transition:
+    color 120ms ease,
+    background 120ms ease;
+}
+
+.graphiql-activity-rail-settings:hover {
+  color: oklch(var(--fg-default));
+  background: oklch(var(--bg-subtle));
+}
+
+.graphiql-activity-rail-settings:focus-visible {
+  outline: 2px solid oklch(var(--accent-blue));
+  outline-offset: 2px;
+}
+
+.graphiql-activity-rail-settings svg {
+  width: 16px;
+  height: 16px;
+}

--- a/packages/graphiql-react/src/components/activity-rail/index.tsx
+++ b/packages/graphiql-react/src/components/activity-rail/index.tsx
@@ -1,0 +1,71 @@
+'use no memo';
+
+import type { FC } from 'react';
+import { useGraphiQL, useGraphiQLActions } from '../provider';
+import type { GraphiQLPlugin } from '../../stores/plugin';
+import { Tooltip } from '../tooltip';
+import { SettingsIcon } from '../../icons';
+import './index.css';
+
+export interface ActivityRailProps {
+  /**
+   * Called when a plugin button is clicked, after the store has been updated.
+   * Receives the plugin that is now visible, or `null` if the panel was closed.
+   */
+  onPluginToggle?: (nextPlugin: GraphiQLPlugin | null) => void;
+  /** Called when the settings gear button is clicked. */
+  onSettingsClick?: () => void;
+}
+
+export const ActivityRail: FC<ActivityRailProps> = ({
+  onPluginToggle,
+  onSettingsClick,
+}) => {
+  const plugins = useGraphiQL(state => state.plugins);
+  const visiblePlugin = useGraphiQL(state => state.visiblePlugin);
+  const { setVisiblePlugin } = useGraphiQLActions();
+
+  return (
+    <nav className="graphiql-activity-rail" aria-label="Plugins">
+      <ul className="graphiql-activity-rail-list">
+        {plugins.map(plugin => {
+          const Icon = plugin.icon;
+          const isActive = visiblePlugin?.title === plugin.title;
+          const label = `${isActive ? 'Hide' : 'Show'} ${plugin.title}`;
+          const nextPlugin = isActive ? null : plugin;
+          return (
+            <li key={plugin.title}>
+              <Tooltip label={label}>
+                <button
+                  type="button"
+                  className={`graphiql-activity-rail-item${isActive ? ' active' : ''}`}
+                  aria-pressed={isActive}
+                  aria-label={label}
+                  onClick={() => {
+                    setVisiblePlugin(nextPlugin);
+                    onPluginToggle?.(nextPlugin);
+                  }}
+                >
+                  <Icon aria-hidden="true" />
+                </button>
+              </Tooltip>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="graphiql-activity-rail-spacer" />
+      {onSettingsClick && (
+        <Tooltip label="Settings">
+          <button
+            type="button"
+            className="graphiql-activity-rail-settings"
+            aria-label="Settings"
+            onClick={onSettingsClick}
+          >
+            <SettingsIcon aria-hidden="true" />
+          </button>
+        </Tooltip>
+      )}
+    </nav>
+  );
+};

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -33,3 +33,5 @@ export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
 export { StatusBar, StatusBarView } from './status-bar';
 export type { StatusBarProps, StatusBarViewProps } from './status-bar';
+export { ActivityRail } from './activity-rail';
+export type { ActivityRailProps } from './activity-rail';

--- a/packages/graphiql/cypress/e2e/a11y.cy.ts
+++ b/packages/graphiql/cypress/e2e/a11y.cy.ts
@@ -88,7 +88,7 @@ describe('a11y baseline', () => {
 
   it('with docs panel open has no new violations', () => {
     // First sidebar button is the docs explorer toggle (confirmed in docs.cy.ts)
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
     cy.get('.graphiql-doc-explorer').should('be.visible');
     cy.injectAxe();
     checkOrCapture('docs-open');

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -6,21 +6,21 @@ beforeEach(() => {
 
 describe('GraphiQL DocExplorer - button', () => {
   beforeEach(() => {
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
   });
   it('Toggles doc pane on', () => {
     cy.get('.graphiql-doc-explorer').should('be.visible');
   });
 
   it('Toggles doc pane back off', () => {
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
     cy.get('.graphiql-doc-explorer').should('not.exist');
   });
 });
 
 describe('GraphiQL DocExplorer - search', () => {
   beforeEach(() => {
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
     cy.dataCy('doc-explorer-input').type('test');
     cy.dataCy('doc-explorer-option').should('have.length', 7);
   });
@@ -71,7 +71,7 @@ describe('GraphiQL DocExplorer - search', () => {
 describe('GraphQL DocExplorer - deprecated fields', () => {
   it('should show deprecated fields details when expanding', () => {
     // Open doc explorer
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
 
     // Select query type
     cy.get('.graphiql-doc-explorer-type-name').first().click();
@@ -105,7 +105,7 @@ if (!version.includes('15.5')) {
 describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
   it('should show deprecated arguments category title', () => {
     // Open doc explorer
-    cy.get('.graphiql-sidebar button').eq(0).click();
+    cy.get('.graphiql-activity-rail-item').eq(0).click();
 
     // Select query type
     cy.get('.graphiql-doc-explorer-type-name').first().click();

--- a/packages/graphiql/cypress/e2e/theme.cy.ts
+++ b/packages/graphiql/cypress/e2e/theme.cy.ts
@@ -12,7 +12,7 @@ describe('Theme', () => {
 
     it('Defaults to light theme when `forcedTheme` value is invalid', () => {
       cy.visit('?forcedTheme=invalid');
-      cy.get('[data-value=settings]').click();
+      cy.get('.graphiql-activity-rail-settings').click();
       cy.get('.graphiql-dialog-section-title')
         .eq(1)
         .should('have.text', 'Theme'); // Check for the presence of the theme dialog

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -390,9 +390,7 @@ describe('GraphiQL', () => {
     );
 
     act(() => {
-      fireEvent.click(
-        container.querySelector('[aria-label="Open settings dialog"]')!,
-      );
+      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
     });
 
     const element = await findByText('Persist headers');
@@ -405,9 +403,7 @@ describe('GraphiQL', () => {
     );
 
     act(() => {
-      fireEvent.click(
-        container.querySelector('[aria-label="Open settings dialog"]')!,
-      );
+      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
     });
 
     const element = await findByText('Persist headers');
@@ -420,9 +416,7 @@ describe('GraphiQL', () => {
     );
 
     act(() => {
-      fireEvent.click(
-        container.querySelector('[aria-label="Open settings dialog"]')!,
-      );
+      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
     });
 
     const callback = async () => {

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -41,7 +41,12 @@ import {
   DocExplorerStore,
   DOC_EXPLORER_PLUGIN,
 } from '@graphiql/plugin-doc-explorer';
-import { GraphiQLLogo, GraphiQLToolbar, GraphiQLFooter, Sidebar } from './ui';
+import {
+  ActivityBar,
+  GraphiQLLogo,
+  GraphiQLToolbar,
+  GraphiQLFooter,
+} from './ui';
 
 /**
  * API docs for this live here:
@@ -152,7 +157,7 @@ export interface GraphiQLInterfaceProps
     AddSuffix<Pick<HeaderEditorProps, 'onEdit'>, 'Headers'>,
     Pick<ResponseEditorProps, 'responseTooltip'>,
     Pick<
-      ComponentPropsWithoutRef<typeof Sidebar>,
+      ComponentPropsWithoutRef<typeof ActivityBar>,
       'forcedTheme' | 'showPersistHeadersSettings'
     > {
   children?: ReactNode;
@@ -449,7 +454,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       <div className={cn('graphiql-container', className)}>
         <TopBar />
         <div className="graphiql-body">
-          <Sidebar
+          <ActivityBar
             forcedTheme={forcedTheme}
             showPersistHeadersSettings={showPersistHeadersSettings}
             setHiddenElement={pluginResize.setHiddenElement}

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -17,36 +17,7 @@
   overflow: hidden;
 }
 
-/* The sidebar */
-.graphiql-container .graphiql-sidebar {
-  display: flex;
-  flex-direction: column;
-  padding: var(--px-8);
-  width: var(--sidebar-width);
-  gap: var(--px-8);
-  overflow-y: auto;
-}
-
-.graphiql-container .graphiql-sidebar > button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: hsla(var(--color-neutral), var(--alpha-secondary));
-  height: calc(var(--sidebar-width) - (2 * var(--px-8)));
-  width: calc(var(--sidebar-width) - (2 * var(--px-8)));
-  flex-shrink: 0;
-}
-
-.graphiql-container .graphiql-sidebar button.active {
-  color: hsl(var(--color-neutral));
-}
-
-.graphiql-container .graphiql-sidebar button > svg {
-  height: var(--px-20);
-  width: var(--px-20);
-}
-
-/* The main content, i.e. everything except the sidebar */
+/* The main content, i.e. everything except the activity rail */
 .graphiql-container .graphiql-main {
   display: flex;
   flex: 1;

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -9,7 +9,7 @@
   width: 100%;
 }
 
-/* Sidebar + main content row (below the top bar and above the status bar) */
+/* Activity rail + main content row (below the top bar and above the status bar) */
 .graphiql-container .graphiql-body {
   display: flex;
   flex: 1;

--- a/packages/graphiql/src/ui/activity-bar.tsx
+++ b/packages/graphiql/src/ui/activity-bar.tsx
@@ -85,7 +85,9 @@ export const ActivityBar: FC<ActivityBarProps> = ({
   }
 
   function handleOpenShortKeysDialog(isOpen: boolean) {
-    if (!isOpen) setShowDialog(null);
+    if (!isOpen) {
+      setShowDialog(null);
+    }
   }
 
   function handleClearData() {

--- a/packages/graphiql/src/ui/activity-bar.tsx
+++ b/packages/graphiql/src/ui/activity-bar.tsx
@@ -1,35 +1,23 @@
-import { FC, type MouseEventHandler, useEffect, useState } from 'react';
+import { type FC, type MouseEventHandler, useEffect, useState } from 'react';
 import {
+  ActivityRail,
   Button,
   ButtonGroup,
   cn,
   Dialog,
   isMacOs,
-  KEY_MAP,
-  KeyboardShortcutIcon,
   pick,
-  ReloadIcon,
-  SettingsIcon,
-  Tooltip,
-  UnStyledButton,
-  useDragResize,
   useGraphiQL,
   useGraphiQLActions,
+  useDragResize,
   VisuallyHidden,
+  type GraphiQLPlugin,
 } from '@graphiql/react';
 import { ShortKeys } from './short-keys';
 
-type ButtonHandler = MouseEventHandler<HTMLButtonElement>;
-
-const LABEL = {
-  refetchSchema: `Re-fetch GraphQL schema (${KEY_MAP.refetchSchema.key})`,
-  shortCutDialog: 'Open short keys dialog',
-  settingsDialogs: 'Open settings dialog',
-};
-
 const THEMES = ['light', 'dark', 'system'] as const;
 
-interface SidebarProps {
+export interface ActivityBarProps {
   /**
    * `forcedTheme` allows enforcement of a specific theme for GraphiQL.
    * This is useful when you want to make sure that GraphiQL is always
@@ -46,31 +34,19 @@ interface SidebarProps {
   setHiddenElement: ReturnType<typeof useDragResize>['setHiddenElement'];
 }
 
-export const Sidebar: FC<SidebarProps> = ({
+type ButtonHandler = MouseEventHandler<HTMLButtonElement>;
+
+export const ActivityBar: FC<ActivityBarProps> = ({
   forcedTheme: $forcedTheme,
   showPersistHeadersSettings,
   setHiddenElement,
 }) => {
   const forcedTheme =
     $forcedTheme && THEMES.includes($forcedTheme) ? $forcedTheme : undefined;
-  const { setShouldPersistHeaders, introspect, setVisiblePlugin, setTheme } =
-    useGraphiQLActions();
-  const {
-    shouldPersistHeaders,
-    isIntrospecting,
-    visiblePlugin,
-    plugins,
-    theme,
-    storage,
-  } = useGraphiQL(
-    pick(
-      'shouldPersistHeaders',
-      'isIntrospecting',
-      'visiblePlugin',
-      'plugins',
-      'theme',
-      'storage',
-    ),
+
+  const { setShouldPersistHeaders, setTheme } = useGraphiQLActions();
+  const { shouldPersistHeaders, theme, storage } = useGraphiQL(
+    pick('shouldPersistHeaders', 'theme', 'storage'),
   );
 
   useEffect(() => {
@@ -91,28 +67,25 @@ export const Sidebar: FC<SidebarProps> = ({
   useEffect(() => {
     function openSettings(event: KeyboardEvent) {
       if ((isMacOs ? event.metaKey : event.ctrlKey) && event.key === ',') {
-        event.preventDefault(); // prevent default browser settings dialog
+        event.preventDefault();
         setShowDialog(prev => (prev === 'settings' ? null : 'settings'));
       }
     }
-
     window.addEventListener('keydown', openSettings);
     return () => {
       window.removeEventListener('keydown', openSettings);
     };
   }, []);
 
-  function handleOpenShortKeysDialog(isOpen: boolean) {
-    if (!isOpen) {
-      setShowDialog(null);
-    }
-  }
-
   function handleOpenSettingsDialog(isOpen: boolean) {
     if (!isOpen) {
       setShowDialog(null);
       setClearStorageStatus(undefined);
     }
+  }
+
+  function handleOpenShortKeysDialog(isOpen: boolean) {
+    if (!isOpen) setShowDialog(null);
   }
 
   function handleClearData() {
@@ -136,78 +109,20 @@ export const Sidebar: FC<SidebarProps> = ({
     setTheme(selectedTheme || null);
   };
 
-  const handleShowDialog: ButtonHandler = event => {
-    setShowDialog(
-      event.currentTarget.dataset.value as 'short-keys' | 'settings',
-    );
-  };
-
-  const handlePluginClick: ButtonHandler = event => {
-    const pluginIndex = Number(event.currentTarget.dataset.index!);
-    const plugin = plugins.find((_, index) => pluginIndex === index)!;
-    const isVisible = plugin === visiblePlugin;
-    if (isVisible) {
-      setVisiblePlugin(null);
+  function handlePluginToggle(nextPlugin: GraphiQLPlugin | null) {
+    if (nextPlugin === null) {
       setHiddenElement('first');
     } else {
-      setVisiblePlugin(plugin);
       setHiddenElement(null);
     }
-  };
+  }
 
   return (
-    <div className="graphiql-sidebar">
-      {plugins.map((plugin, index) => {
-        const isVisible = plugin === visiblePlugin;
-        const label = `${isVisible ? 'Hide' : 'Show'} ${plugin.title}`;
-        return (
-          <Tooltip key={plugin.title} label={label}>
-            <UnStyledButton
-              type="button"
-              className={cn(isVisible && 'active')}
-              onClick={handlePluginClick}
-              data-index={index}
-              aria-label={label}
-            >
-              <plugin.icon aria-hidden="true" />
-            </UnStyledButton>
-          </Tooltip>
-        );
-      })}
-      <Tooltip label={LABEL.refetchSchema}>
-        <UnStyledButton
-          type="button"
-          disabled={isIntrospecting}
-          onClick={introspect}
-          aria-label={LABEL.refetchSchema}
-          style={{ marginTop: 'auto' }}
-        >
-          <ReloadIcon
-            className={cn(isIntrospecting && 'graphiql-spin')}
-            aria-hidden="true"
-          />
-        </UnStyledButton>
-      </Tooltip>
-      <Tooltip label={LABEL.shortCutDialog}>
-        <UnStyledButton
-          type="button"
-          data-value="short-keys"
-          onClick={handleShowDialog}
-          aria-label={LABEL.shortCutDialog}
-        >
-          <KeyboardShortcutIcon aria-hidden="true" />
-        </UnStyledButton>
-      </Tooltip>
-      <Tooltip label={LABEL.settingsDialogs}>
-        <UnStyledButton
-          type="button"
-          data-value="settings"
-          onClick={handleShowDialog}
-          aria-label={LABEL.settingsDialogs}
-        >
-          <SettingsIcon aria-hidden="true" />
-        </UnStyledButton>
-      </Tooltip>
+    <>
+      <ActivityRail
+        onPluginToggle={handlePluginToggle}
+        onSettingsClick={() => setShowDialog('settings')}
+      />
       <Dialog
         open={showDialog === 'short-keys'}
         onOpenChange={handleOpenShortKeysDialog}
@@ -217,7 +132,6 @@ export const Sidebar: FC<SidebarProps> = ({
             Short Keys
           </Dialog.Title>
           <VisuallyHidden>
-            {/* Fixes Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent} */}
             <Dialog.Description>
               This modal provides a list of available keyboard shortcuts and
               their functions.
@@ -238,7 +152,6 @@ export const Sidebar: FC<SidebarProps> = ({
             Settings
           </Dialog.Title>
           <VisuallyHidden>
-            {/* Fixes Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent} */}
             <Dialog.Description>
               This modal lets you adjust header persistence, interface theme,
               and clear local storage.
@@ -335,6 +248,6 @@ export const Sidebar: FC<SidebarProps> = ({
           </Button>
         </div>
       </Dialog>
-    </div>
+    </>
   );
 };

--- a/packages/graphiql/src/ui/index.ts
+++ b/packages/graphiql/src/ui/index.ts
@@ -1,5 +1,6 @@
+export { ActivityBar } from './activity-bar';
+export type { ActivityBarProps } from './activity-bar';
 export { GraphiQLFooter } from './footer';
 export { GraphiQLLogo } from './logo';
 export { ShortKeys } from './short-keys';
-export { Sidebar } from './sidebar';
 export { GraphiQLToolbar } from './toolbar';


### PR DESCRIPTION
## Summary

This PR replaces the v5 sidebar icon strip with a new `ActivityRail` that renders registered plugins as a flat list with the settings gear pinned at the bottom. An `ActivityBar` wrapper in the `graphiql` package owns the resize sync and the settings/theme dialogs that previously lived inside the old `Sidebar`. There are no plugin API changes; registered plugins continue to render through the existing `plugins` array.

## Test plan

- [x] Open the [deploy preview](https://deploy-preview-4290--graphiql-test.netlify.app). Confirm the activity rail renders along the left edge with each plugin's icon and the settings gear at the bottom.
- [x] Click between plugin icons; confirm the active plugin shows the accent indicator and the panel content swaps.
- [x] Click the settings gear; confirm the settings dialog opens.
- [x] Drag the divider between the panel and the editor area; confirm the rail stays put and the side panel resizes.
- [x] Toggle dark/light theme via the settings dialog; confirm the rail reads from the active tokens in both modes.

Refs: graphql/graphiql#4219
