### PR TITLE
v6: Add `SidePanel` component

### DIFF
--- a/.changeset/side-panel.md
+++ b/.changeset/side-panel.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add `SidePanel` component that hosts the active plugin's content next to the activity rail. Default width 340px, resizable.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -33,4 +33,5 @@ export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
 export { StatusBar, StatusBarView } from './status-bar';
 export type { StatusBarProps, StatusBarViewProps } from './status-bar';
-export { SidePanel } from './side-panel';
+export { SidePanel, SidePanelView } from './side-panel';
+export type { SidePanelViewProps } from './side-panel';

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -33,3 +33,4 @@ export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
 export { StatusBar, StatusBarView } from './status-bar';
 export type { StatusBarProps, StatusBarViewProps } from './status-bar';
+export { SidePanel } from './side-panel';

--- a/packages/graphiql-react/src/components/side-panel/index.css
+++ b/packages/graphiql-react/src/components/side-panel/index.css
@@ -1,0 +1,13 @@
+/*
+ * SidePanel fills its resize-controlled parent. The parent div (`.graphiql-plugin`)
+ * owns the flex/width; SidePanel just stretches to fill it and adds its own chrome.
+ */
+.graphiql-side-panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: oklch(var(--bg-canvas));
+  border-right: 1px solid oklch(var(--border-default));
+  overflow: auto;
+}

--- a/packages/graphiql-react/src/components/side-panel/index.tsx
+++ b/packages/graphiql-react/src/components/side-panel/index.tsx
@@ -1,15 +1,28 @@
-import type { FC } from 'react';
+import type { ComponentType, FC } from 'react';
 import { useGraphiQL } from '../provider';
 import './index.css';
+
+type Plugin = {
+  title: string;
+  content: ComponentType;
+};
 
 export const SidePanel: FC = () => {
   const visiblePlugin = useGraphiQL(state => state.visiblePlugin);
   if (!visiblePlugin) {
     return null;
   }
-  const Content = visiblePlugin.content;
+  return <SidePanelView plugin={visiblePlugin} />;
+};
+
+export type SidePanelViewProps = {
+  plugin: Plugin;
+};
+
+export const SidePanelView: FC<SidePanelViewProps> = ({ plugin }) => {
+  const Content = plugin.content;
   return (
-    <aside className="graphiql-side-panel" aria-label={visiblePlugin.title}>
+    <aside className="graphiql-side-panel" aria-label={plugin.title}>
       <Content />
     </aside>
   );

--- a/packages/graphiql-react/src/components/side-panel/index.tsx
+++ b/packages/graphiql-react/src/components/side-panel/index.tsx
@@ -1,0 +1,16 @@
+import type { FC } from 'react';
+import { useGraphiQL } from '../provider';
+import './index.css';
+
+export const SidePanel: FC = () => {
+  const visiblePlugin = useGraphiQL(state => state.visiblePlugin);
+  if (!visiblePlugin) {
+    return null;
+  }
+  const Content = visiblePlugin.content;
+  return (
+    <aside className="graphiql-side-panel" aria-label={visiblePlugin.title}>
+      <Content />
+    </aside>
+  );
+};

--- a/packages/graphiql-react/src/components/side-panel/side-panel.stories.tsx
+++ b/packages/graphiql-react/src/components/side-panel/side-panel.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import { GraphiQLProvider, useGraphiQLActions } from '../provider';
+import { DocsIcon, HistoryIcon } from '../../icons';
+import { SidePanel } from './';
+
+const mockFetcher = () => ({ data: null });
+
+const DOCS_PLUGIN = {
+  title: 'Documentation Explorer',
+  icon: DocsIcon,
+  content: () => (
+    <div style={{ padding: 16 }}>
+      <p style={{ margin: 0, color: 'oklch(var(--fg-muted))' }}>
+        Documentation content
+      </p>
+    </div>
+  ),
+};
+
+const HISTORY_PLUGIN = {
+  title: 'History',
+  icon: HistoryIcon,
+  content: () => (
+    <div style={{ padding: 16 }}>
+      <p style={{ margin: 0, color: 'oklch(var(--fg-muted))' }}>
+        History content
+      </p>
+    </div>
+  ),
+};
+
+function ActivatePlugin({ title }: { title: string }) {
+  const { setVisiblePlugin } = useGraphiQLActions();
+  useEffect(() => {
+    setVisiblePlugin(title);
+  }, [setVisiblePlugin, title]);
+  return null;
+}
+
+const meta: Meta<typeof SidePanel> = {
+  title: 'Components/SidePanel',
+  component: SidePanel,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <GraphiQLProvider
+        fetcher={mockFetcher}
+        plugins={[DOCS_PLUGIN, HISTORY_PLUGIN]}
+      >
+        <Story />
+      </GraphiQLProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof SidePanel>;
+
+export const Hidden: Story = {
+  name: 'No active plugin (hidden)',
+};
+
+export const DocsPanel: Story = {
+  name: 'Documentation Explorer active',
+  decorators: [
+    Story => (
+      <>
+        <ActivatePlugin title="Documentation Explorer" />
+        <Story />
+      </>
+    ),
+  ],
+};
+
+export const HistoryPanel: Story = {
+  name: 'History active',
+  decorators: [
+    Story => (
+      <>
+        <ActivatePlugin title="History" />
+        <Story />
+      </>
+    ),
+  ],
+};

--- a/packages/graphiql-react/src/components/side-panel/side-panel.test.tsx
+++ b/packages/graphiql-react/src/components/side-panel/side-panel.test.tsx
@@ -1,95 +1,38 @@
 'use no memo';
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { GraphiQLProvider, useGraphiQLActions } from '../provider';
-import { useEffect } from 'react';
-import { SidePanel } from './';
-
-// jsdom does not implement window.matchMedia; stub it for GraphiQLProvider's theme slice.
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', {
-    writable: true,
-    value: (query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener() {},
-      removeListener() {},
-      addEventListener() {},
-      removeEventListener() {},
-      dispatchEvent() {
-        return false;
-      },
-    }),
-  });
-});
-
-const mockFetcher = () => ({ data: null });
+import { SidePanelView } from './';
 
 const MOCK_PLUGIN = {
   title: 'Test Plugin',
-  icon: () => null,
   content: () => <div>Plugin content</div>,
 };
 
-function ActivatePlugin({ title }: { title: string }) {
-  const { setVisiblePlugin } = useGraphiQLActions();
-  useEffect(() => {
-    setVisiblePlugin(title);
-  }, [setVisiblePlugin, title]);
-  return null;
-}
-
-describe('SidePanel', () => {
-  it('renders nothing when no plugin is active', () => {
-    const { container } = render(
-      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
-        <SidePanel />
-      </GraphiQLProvider>,
-    );
-    expect(container.querySelector('.graphiql-side-panel')).toBeNull();
-  });
-
-  it('renders plugin content when a plugin is active', () => {
-    render(
-      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
-        <ActivatePlugin title="Test Plugin" />
-        <SidePanel />
-      </GraphiQLProvider>,
-    );
+describe('SidePanelView', () => {
+  it('renders the plugin content inside the panel', () => {
+    render(<SidePanelView plugin={MOCK_PLUGIN} />);
     expect(screen.getByText('Plugin content')).toBeInTheDocument();
   });
 
   it('renders as an aside element with aria-label matching the plugin title', () => {
-    const { container } = render(
-      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
-        <ActivatePlugin title="Test Plugin" />
-        <SidePanel />
-      </GraphiQLProvider>,
-    );
+    const { container } = render(<SidePanelView plugin={MOCK_PLUGIN} />);
     const aside = container.querySelector('aside.graphiql-side-panel');
     expect(aside).not.toBeNull();
     expect(aside).toHaveAttribute('aria-label', 'Test Plugin');
   });
 
-  it('does not render .graphiql-side-panel when plugin is cleared', () => {
-    function ActivateThenClear() {
-      const { setVisiblePlugin } = useGraphiQLActions();
-      // First render: activate
-      useEffect(() => {
-        setVisiblePlugin('Test Plugin');
-        // Then immediately clear
-        setVisiblePlugin(null);
-      }, [setVisiblePlugin]);
-      return null;
-    }
-    const { container } = render(
-      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
-        <ActivateThenClear />
-        <SidePanel />
-      </GraphiQLProvider>,
+  it('renders a different aria-label when the plugin title changes', () => {
+    const { container, rerender } = render(
+      <SidePanelView plugin={MOCK_PLUGIN} />,
     );
-    expect(container.querySelector('.graphiql-side-panel')).toBeNull();
+    rerender(
+      <SidePanelView
+        plugin={{ title: 'Other', content: () => <div>Other</div> }}
+      />,
+    );
+    expect(
+      container.querySelector('aside.graphiql-side-panel'),
+    ).toHaveAttribute('aria-label', 'Other');
   });
 });

--- a/packages/graphiql-react/src/components/side-panel/side-panel.test.tsx
+++ b/packages/graphiql-react/src/components/side-panel/side-panel.test.tsx
@@ -1,0 +1,95 @@
+'use no memo';
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GraphiQLProvider, useGraphiQLActions } from '../provider';
+import { useEffect } from 'react';
+import { SidePanel } from './';
+
+// jsdom does not implement window.matchMedia; stub it for GraphiQLProvider's theme slice.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    }),
+  });
+});
+
+const mockFetcher = () => ({ data: null });
+
+const MOCK_PLUGIN = {
+  title: 'Test Plugin',
+  icon: () => null,
+  content: () => <div>Plugin content</div>,
+};
+
+function ActivatePlugin({ title }: { title: string }) {
+  const { setVisiblePlugin } = useGraphiQLActions();
+  useEffect(() => {
+    setVisiblePlugin(title);
+  }, [setVisiblePlugin, title]);
+  return null;
+}
+
+describe('SidePanel', () => {
+  it('renders nothing when no plugin is active', () => {
+    const { container } = render(
+      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
+        <SidePanel />
+      </GraphiQLProvider>,
+    );
+    expect(container.querySelector('.graphiql-side-panel')).toBeNull();
+  });
+
+  it('renders plugin content when a plugin is active', () => {
+    render(
+      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
+        <ActivatePlugin title="Test Plugin" />
+        <SidePanel />
+      </GraphiQLProvider>,
+    );
+    expect(screen.getByText('Plugin content')).toBeInTheDocument();
+  });
+
+  it('renders as an aside element with aria-label matching the plugin title', () => {
+    const { container } = render(
+      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
+        <ActivatePlugin title="Test Plugin" />
+        <SidePanel />
+      </GraphiQLProvider>,
+    );
+    const aside = container.querySelector('aside.graphiql-side-panel');
+    expect(aside).not.toBeNull();
+    expect(aside).toHaveAttribute('aria-label', 'Test Plugin');
+  });
+
+  it('does not render .graphiql-side-panel when plugin is cleared', () => {
+    function ActivateThenClear() {
+      const { setVisiblePlugin } = useGraphiQLActions();
+      // First render: activate
+      useEffect(() => {
+        setVisiblePlugin('Test Plugin');
+        // Then immediately clear
+        setVisiblePlugin(null);
+      }, [setVisiblePlugin]);
+      return null;
+    }
+    const { container } = render(
+      <GraphiQLProvider fetcher={mockFetcher} plugins={[MOCK_PLUGIN]}>
+        <ActivateThenClear />
+        <SidePanel />
+      </GraphiQLProvider>,
+    );
+    expect(container.querySelector('.graphiql-side-panel')).toBeNull();
+  });
+});

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -20,6 +20,7 @@ import {
   PlusIcon,
   QueryEditor,
   ResponseEditor,
+  SidePanel,
   Spinner,
   StatusBar,
   Tab,
@@ -227,8 +228,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     ),
   );
   const hasMonaco = useMonaco(state => Boolean(state.monaco));
-
-  const PluginContent = visiblePlugin?.content;
 
   const pluginResize = useDragResize({
     defaultSizeRelation: 1 / 3,
@@ -455,16 +454,8 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
             setHiddenElement={pluginResize.setHiddenElement}
           />
           <div className="graphiql-main">
-            <div
-              ref={pluginResize.firstRef}
-              className="graphiql-plugin"
-              style={{
-                // Make sure the container shrinks when containing long
-                // non-breaking texts
-                minWidth: '200px',
-              }}
-            >
-              {PluginContent && <PluginContent />}
+            <div ref={pluginResize.firstRef} className="graphiql-plugin">
+              <SidePanel />
             </div>
             {visiblePlugin && (
               <div

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -220,13 +220,12 @@ button.graphiql-tab-add {
     hsla(var(--color-neutral), var(--alpha-background-heavy));
 }
 
-/* The plugin container */
+/* The plugin container — sizing controlled by useDragResize; chrome handled by <SidePanel> */
 .graphiql-container .graphiql-plugin {
-  border-left: 1px solid
-    hsla(var(--color-neutral), var(--alpha-background-heavy));
+  display: flex;
   flex: 1;
-  overflow-y: auto;
-  padding: var(--px-16);
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Generic drag bar for horizontal resizing */


### PR DESCRIPTION
## Summary

This PR adds a `SidePanel` that hosts the active plugin's content next to the new activity rail. The panel renders nothing when no plugin is active, and remains user-resizable via the existing drag handle. Together with the activity rail change, it completes the left-side navigation chrome for the v6 layout.

## Test plan

- [x] Open the [deploy preview](https://deploy-preview-4291--graphiql-test.netlify.app). With no plugin active, confirm the side panel area is collapsed and the editor takes the full width.
- [x] Click a plugin icon in the activity rail; confirm the side panel opens with that plugin's content.
- [x] Drag the divider between the panel and the editor; confirm the panel resizes smoothly and the width persists when you switch between plugins.
- [x] Click the active plugin's icon a second time; confirm the panel closes.
- [x] Toggle dark/light theme via the settings dialog; confirm the panel chrome reads from the active tokens.

Refs: graphql/graphiql#4219
