### PR TITLE
v6: Mirror the active theme to `data-theme` on `<html>`

### DIFF
--- a/.changeset/theme-data-attribute.md
+++ b/.changeset/theme-data-attribute.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+`setTheme` now mirrors the chosen theme onto `document.documentElement` as a `data-theme` attribute. The v6 OKLCH token cascade in `tokens.css` is gated on `[data-theme='light']` / `[data-theme='dark']` selectors and was previously never matched, so v6 components fell back to the OS `prefers-color-scheme` regardless of the GraphiQL theme toggle. The existing `body.graphiql-light` / `body.graphiql-dark` classes are preserved for backwards compatibility with custom CSS.

--- a/packages/graphiql-react/src/stores/theme.ts
+++ b/packages/graphiql-react/src/stores/theme.ts
@@ -60,6 +60,9 @@ export const createThemeSlice: CreateThemeSlice =
         document.body.classList.remove('graphiql-light', 'graphiql-dark');
         if (theme) {
           document.body.classList.add(`graphiql-${theme}`);
+          document.documentElement.setAttribute('data-theme', theme);
+        } else {
+          document.documentElement.removeAttribute('data-theme');
         }
         const { monaco } = monacoStore.getState();
         const resolvedTheme = theme ?? getSystemTheme();


### PR DESCRIPTION
## Summary

`tokens.css` scopes the v6 OKLCH cascade to `[data-theme='light']` / `[data-theme='dark']` selectors, but `setTheme` was only writing `graphiql-light` / `graphiql-dark` classes onto `<body>`. With no `data-theme` attribute set, v6 components fell through to the OS `prefers-color-scheme` media-query fallback regardless of the in-app toggle. This PR mirrors the active theme onto `document.documentElement` as `data-theme` so the selectors actually match; the existing body classes are preserved for any consumer CSS that depends on them.

## Test plan

- [ ] Open the [deploy preview](https://deploy-preview-4293--graphiql-test.netlify.app). With the GraphiQL theme dropdown set to System, confirm `<html>` has no `data-theme` attribute and v6 chrome follows your OS preference.
- [ ] Toggle the theme to Light; confirm `<html>` gains `data-theme="light"` and v6 components (`TopBar`, `StatusBar`, `ActivityRail`, etc., once those PRs land) all switch to light tokens.
- [ ] Toggle the theme to Dark; confirm `<html>` gains `data-theme="dark"` and v6 components switch to dark tokens.
- [ ] Toggle back to System; confirm `data-theme` is removed and the v6 components revert to following the OS preference.

Refs: graphql/graphiql#4219
