### PR TITLE
v6: Replace Monaco editor themes with v6 token palette

### DIFF
--- a/.changeset/monaco-theme-v6.md
+++ b/.changeset/monaco-theme-v6.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Replace the Monaco editor theme with v6-aligned token colors. Both `graphiql-DARK` and `graphiql-LIGHT` now cover all GraphQL token types (keywords, type names, field identifiers, variables, annotations, strings, numbers, comments) using the v6 design's accent palette. UI chrome colors (suggest widget, hover widget, quick input) are updated to match.

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -174,60 +174,110 @@ export const MONACO_THEME_NAME = {
   light: 'graphiql-LIGHT',
 } as const;
 
-const colors = {
-  transparent: '#ffffff00',
-  bg: {
-    dark: '#212a3b',
-    light: '#ffffffff',
+// v6 design token hex values, keyed for Monaco theme rules (no # prefix).
+const TOKEN_COLORS = {
+  dark: {
+    // Foreground
+    fgDefault: 'C9D1D9', // --fg-default
+    fgMuted: '8B949E', // --fg-muted
+    fgDisabled: '6E7681', // --fg-disabled
+    // Accents
+    accentBlue: '79C0FF', // --accent-blue
+    accentGreenLight: '7EE787', // --accent-green-light
+    accentOrange: 'FFA657', // --accent-orange
+    accentPurple: 'D2A8FF', // --accent-purple
+    accentPink: 'FF7B72', // --accent-pink
+    // UI
+    bgCanvas: '0D1117', // --bg-canvas
+    bgOverlay: '21262D', // --bg-overlay
+    accentGreen: '3FB950', // --accent-green (focus/primary)
+    accentGreenBg: '3FB95019',
   },
-  primary: {
-    dark: '#ff5794',
-    light: '#d60590',
+  light: {
+    // Foreground
+    fgDefault: '1F2328', // --fg-default
+    fgMuted: '636E7B', // --fg-muted (~40% oklch)
+    fgDisabled: '9AA3AD', // --fg-disabled (~65% oklch)
+    // Accents — tuned for AA contrast on white
+    accentBlue: '0969DA', // --accent-blue light
+    accentGreenLight: '1A7F37', // --accent-green-light light
+    accentOrange: 'BC4C00', // --accent-orange light
+    accentPurple: '8250DF', // --accent-purple light
+    accentPink: 'CF222E', // --accent-pink light
+    // UI
+    bgCanvas: 'FFFFFF', // --bg-canvas
+    bgOverlay: 'EAEEF2', // --bg-overlay
+    accentGreen: '1A7F37', // --accent-green (focus/primary)
+    accentGreenBg: '1A7F3719',
   },
-  primaryBg: {
-    dark: '#ff579419',
-    light: '#d6059019',
-  },
-  secondary: {
-    dark: '#b7c2d711',
-    light: '#3b4b6811',
-  },
-};
+} as const;
 
 const getBaseColors = (
   theme: 'dark' | 'light',
-): monaco.editor.IStandaloneThemeData['colors'] => ({
-  'editor.background': colors.transparent, // white with a 00 alpha value
-  'scrollbar.shadow': colors.transparent, // Scrollbar shadow to indicate that the view is scrolled
-  'textLink.foreground': colors.primary[theme], // Foreground color for links in text
-  'textLink.activeForeground': colors.primary[theme], // Foreground color for active links in text
-  'editorLink.activeForeground': colors.primary[theme], // Color of active links
-  'editorHoverWidget.background': colors.bg[theme], // Background color of the editor hover
-  'list.hoverBackground': colors.primaryBg[theme], // List/Tree background when hovering over items using the mouse
-  'list.highlightForeground': colors.primary[theme],
-  'list.focusHighlightForeground': colors.primary[theme],
-  'menu.background': colors.bg[theme], // Background color of the context menu
+): monaco.editor.IStandaloneThemeData['colors'] => {
+  const t = TOKEN_COLORS[theme];
+  return {
+    'editor.background': '#ffffff00', // transparent — editor inherits container bg
+    'scrollbar.shadow': '#ffffff00',
+    'textLink.foreground': `#${t.accentGreen}`,
+    'textLink.activeForeground': `#${t.accentGreen}`,
+    'editorLink.activeForeground': `#${t.accentGreen}`,
+    'editorHoverWidget.background': `#${t.bgCanvas}`,
+    'list.hoverBackground': `#${t.accentGreenBg}`,
+    'list.highlightForeground': `#${t.accentGreen}`,
+    'list.focusHighlightForeground': `#${t.accentGreen}`,
+    'menu.background': `#${t.bgCanvas}`,
+    'editorSuggestWidget.background': `#${t.bgCanvas}`,
+    'editorSuggestWidget.selectedBackground': `#${t.accentGreenBg}`,
+    'editorSuggestWidget.selectedForeground': `#${t.accentGreen}`,
+    'quickInput.background': `#${t.bgCanvas}`,
+    'quickInputList.focusForeground': theme === 'dark' ? '#ffffff' : '#444444',
+    'editorWidget.background': `#${t.bgCanvas}`,
+    'input.background': `#${t.bgOverlay}`,
+    focusBorder: `#${t.accentGreen}`,
+    'toolbar.hoverBackground': `#${t.accentGreenBg}`,
+    'inputOption.hoverBackground': `#${t.accentGreenBg}`,
+    'quickInputList.focusBackground': `#${t.accentGreenBg}`,
+    'editorWidget.resizeBorder': `#${t.accentGreen}`,
+    'pickerGroup.foreground': `#${t.accentGreen}`,
+    'menu.selectionBackground': `#${t.accentGreenBg}`,
+    'menu.selectionForeground': `#${t.accentGreen}`,
+  };
+};
 
-  'editorSuggestWidget.background': colors.bg[theme], // Background color of the suggest widget
-  'editorSuggestWidget.selectedBackground': colors.primaryBg[theme], // Background color of the selected entry in the suggest widget
-  'editorSuggestWidget.selectedForeground': colors.primary[theme], // Foreground color of the selected entry in the suggest widget
-  'quickInput.background': colors.bg[theme],
-  'quickInputList.focusForeground': theme === 'dark' ? '#ffffff' : '#444444',
-  'highlighted.label': colors.primary[theme],
-  'quickInput.widget': colors.primary[theme],
-  highlight: colors.primary[theme],
-  'editorWidget.background': colors.bg[theme], // Background color of editor widgets, such as find/replace
-  'input.background': colors.secondary[theme], // Input box background
-  focusBorder: colors.primary[theme], // Overall border color for focused elements. This color is only used if not overridden by a component
-  'toolbar.hoverBackground': colors.primaryBg[theme],
-  'inputOption.hoverBackground': colors.primaryBg[theme],
-  'quickInputList.focusBackground': colors.primaryBg[theme],
-  'editorWidget.resizeBorder': colors.primary[theme],
-  'pickerGroup.foreground': colors.primary[theme], // Quick picker color for grouping labels
-
-  'menu.selectionBackground': colors.primaryBg[theme], // hover background
-  'menu.selectionForeground': colors.primary[theme], // hover text color
-});
+const getTokenRules = (
+  theme: 'dark' | 'light',
+): monaco.editor.ITokenThemeRule[] => {
+  const t = TOKEN_COLORS[theme];
+  return [
+    // keywords: query, mutation, subscription, fragment, on, type, scalar, …
+    { token: 'keyword.gql', foreground: t.accentPink },
+    // field / argument names (lowercase identifiers)
+    { token: 'key.identifier.gql', foreground: t.fgDefault },
+    // $variable input variables
+    { token: 'argument.identifier.gql', foreground: t.accentBlue },
+    // TypeName (uppercase identifiers)
+    { token: 'type.identifier.gql', foreground: t.accentOrange },
+    // @directives
+    { token: 'annotation.gql', foreground: t.accentPurple },
+    // string literals
+    { token: 'string.gql', foreground: t.accentBlue },
+    { token: 'string.quote.gql', foreground: t.accentBlue },
+    { token: 'string.escape.gql', foreground: t.accentBlue },
+    // numbers
+    { token: 'number.gql', foreground: t.accentBlue },
+    { token: 'number.float.gql', foreground: t.accentBlue },
+    // operators and delimiters use muted foreground
+    { token: 'operator.gql', foreground: t.fgMuted },
+    { token: 'delimiter.gql', foreground: t.fgMuted },
+    // comments
+    { token: 'comment.gql', foreground: t.fgDisabled, fontStyle: 'italic' },
+    // definition names (identifiers following 'fragment'/'query'/etc.)
+    // are caught by key.identifier.gql above, but named fragments benefit
+    // from the green-light accent to mirror the design's "name" slot.
+    { token: 'identifier.gql', foreground: t.accentGreenLight },
+  ];
+};
 
 export const MONACO_THEME_DATA: Record<
   'dark' | 'light',
@@ -237,22 +287,12 @@ export const MONACO_THEME_DATA: Record<
     base: 'vs-dark',
     inherit: true,
     colors: getBaseColors('dark'),
-    rules: [
-      {
-        token: 'argument.identifier.gql',
-        foreground: '#908aff',
-      },
-    ],
+    rules: getTokenRules('dark'),
   },
   light: {
     base: 'vs',
     inherit: true,
     colors: getBaseColors('light'),
-    rules: [
-      {
-        token: 'argument.identifier.gql',
-        foreground: '#6c69ce',
-      },
-    ],
+    rules: getTokenRules('light'),
   },
 };

--- a/packages/graphiql-react/src/stores/monaco-themes.test.ts
+++ b/packages/graphiql-react/src/stores/monaco-themes.test.ts
@@ -1,0 +1,90 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { MONACO_THEME_DATA, MONACO_THEME_NAME } from '../constants';
+
+describe('MONACO_THEME_NAME', () => {
+  it('exports stable theme name constants', () => {
+    expect(MONACO_THEME_NAME.dark).toBe('graphiql-DARK');
+    expect(MONACO_THEME_NAME.light).toBe('graphiql-LIGHT');
+  });
+});
+
+describe('MONACO_THEME_DATA dark', () => {
+  const { dark } = MONACO_THEME_DATA;
+
+  it('uses vs-dark as base', () => {
+    expect(dark.base).toBe('vs-dark');
+    expect(dark.inherit).toBe(true);
+  });
+
+  it('has a transparent editor background', () => {
+    expect(dark.colors?.['editor.background']).toBe('#ffffff00');
+  });
+
+  it('colors keyword tokens with accent-pink', () => {
+    const rule = dark.rules.find(r => r.token === 'keyword.gql');
+    expect(rule?.foreground).toBe('FF7B72');
+  });
+
+  it('colors type identifiers with accent-orange', () => {
+    const rule = dark.rules.find(r => r.token === 'type.identifier.gql');
+    expect(rule?.foreground).toBe('FFA657');
+  });
+
+  it('colors variable arguments with accent-blue', () => {
+    const rule = dark.rules.find(r => r.token === 'argument.identifier.gql');
+    expect(rule?.foreground).toBe('79C0FF');
+  });
+
+  it('colors annotations with accent-purple', () => {
+    const rule = dark.rules.find(r => r.token === 'annotation.gql');
+    expect(rule?.foreground).toBe('D2A8FF');
+  });
+
+  it('italicizes comments', () => {
+    const rule = dark.rules.find(r => r.token === 'comment.gql');
+    expect(rule?.fontStyle).toBe('italic');
+  });
+});
+
+describe('MONACO_THEME_DATA light', () => {
+  const { light } = MONACO_THEME_DATA;
+
+  it('uses vs as base', () => {
+    expect(light.base).toBe('vs');
+    expect(light.inherit).toBe(true);
+  });
+
+  it('has a transparent editor background', () => {
+    expect(light.colors?.['editor.background']).toBe('#ffffff00');
+  });
+
+  it('colors keyword tokens with accent-pink light variant', () => {
+    const rule = light.rules.find(r => r.token === 'keyword.gql');
+    expect(rule?.foreground).toBe('CF222E');
+  });
+
+  it('colors type identifiers with accent-orange light variant', () => {
+    const rule = light.rules.find(r => r.token === 'type.identifier.gql');
+    expect(rule?.foreground).toBe('BC4C00');
+  });
+
+  it('colors variable arguments with accent-blue light variant', () => {
+    const rule = light.rules.find(r => r.token === 'argument.identifier.gql');
+    expect(rule?.foreground).toBe('0969DA');
+  });
+
+  it('italicizes comments', () => {
+    const rule = light.rules.find(r => r.token === 'comment.gql');
+    expect(rule?.fontStyle).toBe('italic');
+  });
+});
+
+describe('MONACO_THEME_DATA symmetry', () => {
+  it('dark and light themes cover the same token types', () => {
+    const darkTokens = MONACO_THEME_DATA.dark.rules.map(r => r.token).sort();
+    const lightTokens = MONACO_THEME_DATA.light.rules.map(r => r.token).sort();
+    expect(darkTokens).toEqual(lightTokens);
+  });
+});

--- a/packages/graphiql-react/src/style/editor.css
+++ b/packages/graphiql-react/src/style/editor.css
@@ -17,11 +17,11 @@
   outline-width: 0 !important;
 
   .highlight {
-    color: hsl(var(--color-primary)) !important;
+    color: oklch(var(--accent-green)) !important;
   }
 
   input:focus-visible {
-    outline-color: hsl(var(--color-primary));
+    outline-color: oklch(var(--accent-green));
   }
 
   /* Command pallet F1 styles */

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -70,6 +70,7 @@ dotan
 dotansimha
 edcore
 envrc
+EAEEF
 esbuild
 estree
 execa


### PR DESCRIPTION
## Summary

- Rewrite `MONACO_THEME_DATA` in `constants.ts`: both `graphiql-DARK` and `graphiql-LIGHT` now cover all GraphQL token types (keywords, types, fields, `$variables`, `@directives`, strings, numbers, operators, comments) using the v6 accent palette.
- Editor surface colors (suggest widget, hover widget, quick input) move from the old pink `--color-primary` to `--accent-green`.
- `editor.css`: swaps `hsl(var(--color-primary))` for `oklch(var(--accent-green))` in the `.highlight` and `input:focus-visible` rules.
- Adds `monaco-themes.test.ts` to pin token rule shapes for both themes.

## Test plan

- [x] Open the editor, write a query with keywords, type names, variables, directives, strings, and a comment; confirm syntax colors match the v6 palette (see the changeset for the token reference).
- [x] Toggle the theme via the settings dropdown; confirm Monaco switches from dark to light and back, with distinct and correct syntax colors in each.
- [x] Verify the autocomplete suggestion widget, hover widget, and quick-input palette use the green accent instead of pink.
- [x] Open the editor with the system set to light mode and no pinned theme; confirm Monaco uses the light palette.

Refs: graphql/graphiql#4219
