### PR TITLE
v6: Redesign Schema Explorer panel structure

### DIFF
--- a/.changeset/doc-explorer-redesign.md
+++ b/.changeset/doc-explorer-redesign.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-doc-explorer': minor
+---
+
+Redesign the Schema Explorer panel: eyebrow header with filter and search icon buttons, dedicated breadcrumb row with color-coded depth segments, inline search row with keycap hint, type card with TYPE badge and implements list, and a mono field list with type colors and active-row accent border.

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
@@ -1,5 +1,5 @@
 import { type Mock, describe, it, expect, vi, beforeEach } from 'vitest';
-import { useGraphiQL as $useGraphiQL } from '@graphiql/react';
+import { useGraphiQL as $useGraphiQL, Tooltip } from '@graphiql/react';
 import { render } from '@testing-library/react';
 import { GraphQLInt, GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { FC, useEffect } from 'react';
@@ -54,9 +54,11 @@ const withErrorSchemaContext = {
 
 const DocExplorerWithContext: FC = () => {
   return (
-    <DocExplorerStore>
-      <DocExplorer />
-    </DocExplorerStore>
+    <Tooltip.Provider>
+      <DocExplorerStore>
+        <DocExplorer />
+      </DocExplorerStore>
+    </Tooltip.Provider>
   );
 };
 
@@ -124,20 +126,27 @@ describe('DocExplorer', () => {
       cb({ ...defaultSchemaContext, schema: initialSchema }),
     );
     const { container, rerender } = render(
-      <DocExplorerStore>
-        <SetInitialStack />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <SetInitialStack />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
 
     // First proper render of doc explorer
     rerender(
-      <DocExplorerStore>
-        <DocExplorer />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <DocExplorer />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
 
-    const title = container.querySelector('.graphiql-doc-explorer-title')!;
-    expect(title.textContent).toEqual('field');
+    // The current page is shown as the last breadcrumb segment
+    const breadcrumb = container.querySelector(
+      '.graphiql-doc-explorer-breadcrumb-current',
+    )!;
+    expect(breadcrumb.textContent).toEqual('field');
 
     // Second render of doc explorer, this time with a new schema, with _same_ field name
     useGraphiQL.mockImplementation(cb =>
@@ -147,13 +156,17 @@ describe('DocExplorer', () => {
       }),
     );
     rerender(
-      <DocExplorerStore>
-        <DocExplorer />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <DocExplorer />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
-    const title2 = container.querySelector('.graphiql-doc-explorer-title')!;
+    const breadcrumb2 = container.querySelector(
+      '.graphiql-doc-explorer-breadcrumb-current',
+    )!;
     // Because `Query.field` still exists in the new schema, we can still render it
-    expect(title2.textContent).toEqual('field');
+    expect(breadcrumb2.textContent).toEqual('field');
   });
   it('trims nav stack when necessary', () => {
     const initialSchema = makeSchema();
@@ -179,20 +192,26 @@ describe('DocExplorer', () => {
       cb({ ...defaultSchemaContext, schema: initialSchema }),
     );
     const { container, rerender } = render(
-      <DocExplorerStore>
-        <SetInitialStack />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <SetInitialStack />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
 
     // First proper render of doc explorer
     rerender(
-      <DocExplorerStore>
-        <DocExplorer />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <DocExplorer />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
 
-    const title = container.querySelector('.graphiql-doc-explorer-title')!;
-    expect(title.textContent).toEqual('field');
+    const breadcrumb = container.querySelector(
+      '.graphiql-doc-explorer-breadcrumb-current',
+    )!;
+    expect(breadcrumb.textContent).toEqual('field');
 
     // Second render of doc explorer, this time with a new schema, with a different field name
     useGraphiQL.mockImplementation(cb =>
@@ -202,12 +221,16 @@ describe('DocExplorer', () => {
       }),
     );
     rerender(
-      <DocExplorerStore>
-        <DocExplorer />
-      </DocExplorerStore>,
+      <Tooltip.Provider>
+        <DocExplorerStore>
+          <DocExplorer />
+        </DocExplorerStore>
+      </Tooltip.Provider>,
     );
-    const title2 = container.querySelector('.graphiql-doc-explorer-title')!;
+    const breadcrumb2 = container.querySelector(
+      '.graphiql-doc-explorer-breadcrumb-current',
+    )!;
     // Because `Query.field` doesn't exist anymore, the top-most item we can render is `Query`
-    expect(title2.textContent).toEqual('Query');
+    expect(breadcrumb2.textContent).toEqual('Query');
   });
 });

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
@@ -90,8 +90,8 @@ describe('DocExplorer', () => {
     const error = container.querySelectorAll('.graphiql-doc-explorer-error');
     expect(error).toHaveLength(0);
     expect(
-      container.querySelector('.graphiql-markdown-description'),
-    ).toHaveTextContent('GraphQL Schema for testing');
+      container.querySelector('.graphiql-doc-explorer-schema-overview'),
+    ).toBeInTheDocument();
   });
   it('renders correctly with schema error', () => {
     useGraphiQL.mockImplementation(cb => cb(withErrorSchemaContext));

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/field-documentation.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/field-documentation.spec.tsx
@@ -78,7 +78,7 @@ describe('FieldDocumentation', () => {
       />,
     );
     expect(
-      container.querySelector('.graphiql-markdown-description'),
+      container.querySelector('.graphiql-doc-explorer-field-card-description'),
     ).not.toBeInTheDocument();
     expect(
       container.querySelector('.graphiql-doc-explorer-type-name'),
@@ -95,7 +95,7 @@ describe('FieldDocumentation', () => {
       />,
     );
     expect(
-      container.querySelector('.graphiql-markdown-description'),
+      container.querySelector('.graphiql-doc-explorer-field-card-description'),
     ).not.toBeInTheDocument();
     expect(
       container.querySelector('.graphiql-doc-explorer-type-name'),
@@ -113,7 +113,7 @@ describe('FieldDocumentation', () => {
       container.querySelector('.graphiql-doc-explorer-type-name'),
     ).toHaveTextContent('String');
     expect(
-      container.querySelector('.graphiql-markdown-description'),
+      container.querySelector('.graphiql-doc-explorer-field-card-description'),
     ).toHaveTextContent('Example String field with arguments');
   });
 
@@ -127,14 +127,14 @@ describe('FieldDocumentation', () => {
       container.querySelector('.graphiql-doc-explorer-type-name'),
     ).toHaveTextContent('String');
     expect(
-      container.querySelector('.graphiql-markdown-description'),
+      container.querySelector('.graphiql-doc-explorer-field-card-description'),
     ).toHaveTextContent('Example String field with arguments');
     expect(
       container.querySelectorAll('.graphiql-doc-explorer-argument'),
     ).toHaveLength(1);
     expect(
       container.querySelector('.graphiql-doc-explorer-argument'),
-    ).toHaveTextContent('stringArg: String');
+    ).toHaveTextContent('stringArg:String');
     // by default, the deprecation docs should be hidden
     expect(
       container.querySelectorAll('.graphiql-markdown-deprecation'),

--- a/packages/graphiql-plugin-doc-explorer/src/components/arguments-list.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/arguments-list.css
@@ -1,0 +1,140 @@
+.graphiql-doc-explorer-arguments-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--px-4) 0;
+}
+
+/* Section header — "ARGUMENTS · N" / "DIRECTIVES · N" */
+.graphiql-doc-explorer-arguments-list-header {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: var(--px-6) var(--px-16) var(--px-4);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: oklch(var(--fg-subtle));
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  width: 100%;
+  text-align: left;
+
+  & svg {
+    width: 9px;
+    height: 9px;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    color: oklch(var(--fg-muted));
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: -2px;
+  }
+}
+
+.graphiql-doc-explorer-arguments-list-count {
+  color: oklch(var(--fg-dim));
+  font-weight: 500;
+}
+
+.graphiql-doc-explorer-arguments-list-body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Individual argument row */
+.graphiql-doc-explorer-argument {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-4);
+  padding: 5px var(--px-16) 5px var(--px-24);
+}
+
+.graphiql-doc-explorer-argument--deprecated {
+  opacity: 0.6;
+}
+
+/* Signature line: name : type = default */
+.graphiql-doc-explorer-argument-sig {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--px-4);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+}
+
+.graphiql-doc-explorer-argument-name {
+  color: oklch(var(--accent-green-light));
+}
+
+.graphiql-doc-explorer-argument-colon {
+  color: oklch(var(--fg-disabled));
+}
+
+.graphiql-doc-explorer-argument-type {
+  color: oklch(var(--accent-orange));
+
+  & .graphiql-doc-explorer-type-name {
+    color: oklch(var(--accent-orange));
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.graphiql-doc-explorer-argument-default {
+  color: oklch(var(--fg-muted));
+}
+
+.graphiql-doc-explorer-argument-desc {
+  font-size: 11px;
+  color: oklch(var(--fg-subtle));
+  line-height: 15px;
+}
+
+.graphiql-doc-explorer-arguments-list-show-deprecated {
+  margin: var(--px-8) var(--px-16);
+}
+
+/* Directives — same eyebrow layout as ArgumentsList */
+.graphiql-doc-explorer-directives-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--px-4) 0;
+}
+
+.graphiql-doc-explorer-directives-list-header {
+  padding: var(--px-6) var(--px-16) var(--px-4);
+  color: oklch(var(--fg-subtle));
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.graphiql-doc-explorer-directives-list-count {
+  color: oklch(var(--fg-dim));
+  font-weight: 500;
+}
+
+.graphiql-doc-explorer-directives-list-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.graphiql-doc-explorer-directive-row {
+  padding: 5px var(--px-16) 5px var(--px-24);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+}
+
+.graphiql-doc-explorer-directive-row .graphiql-doc-explorer-directive {
+  color: oklch(var(--accent-orange));
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/arguments-list.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/arguments-list.tsx
@@ -1,0 +1,115 @@
+import { FC, useState } from 'react';
+import { astFromValue, print, type GraphQLArgument } from 'graphql';
+import { Button, ChevronDownIcon, ChevronUpIcon } from '@graphiql/react';
+import { DeprecationReason } from './deprecation-reason';
+import { TypeLink } from './type-link';
+import { renderType } from './utils';
+import './arguments-list.css';
+
+type ArgumentsListProps = {
+  title: 'ARGUMENTS' | 'DEPRECATED ARGUMENTS';
+  args: GraphQLArgument[];
+};
+
+export const ArgumentsList: FC<ArgumentsListProps> = ({ title, args }) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (args.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="graphiql-doc-explorer-arguments-list">
+      <button
+        type="button"
+        className="graphiql-doc-explorer-arguments-list-header"
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+      >
+        {expanded ? <ChevronDownIcon /> : <ChevronUpIcon />}
+        <span>
+          {title}{' '}
+          <span className="graphiql-doc-explorer-arguments-list-count">
+            · {args.length}
+          </span>
+        </span>
+      </button>
+      {expanded && (
+        <div className="graphiql-doc-explorer-arguments-list-body">
+          {args.map(arg => (
+            <ArgumentRow key={arg.name} arg={arg} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+type ShowDeprecatedArgumentsButtonProps = {
+  onClick: () => void;
+};
+
+export const ShowDeprecatedArgumentsButton: FC<
+  ShowDeprecatedArgumentsButtonProps
+> = ({ onClick }) => (
+  <Button
+    type="button"
+    onClick={onClick}
+    className="graphiql-doc-explorer-arguments-list-show-deprecated"
+  >
+    Show Deprecated Arguments
+  </Button>
+);
+
+type ArgumentRowProps = {
+  arg: GraphQLArgument;
+};
+
+const ArgumentRow: FC<ArgumentRowProps> = ({ arg }) => {
+  const defaultAst =
+    arg.defaultValue === undefined
+      ? null
+      : astFromValue(arg.defaultValue, arg.type);
+  const isDeprecated = Boolean(arg.deprecationReason);
+
+  return (
+    <div
+      className={[
+        'graphiql-doc-explorer-argument',
+        isDeprecated ? 'graphiql-doc-explorer-argument--deprecated' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="graphiql-doc-explorer-argument-sig">
+        <span className="graphiql-doc-explorer-argument-name">{arg.name}</span>
+        <span
+          className="graphiql-doc-explorer-argument-colon"
+          aria-hidden="true"
+        >
+          :
+        </span>
+        <span className="graphiql-doc-explorer-argument-type">
+          {renderType(arg.type, namedType => (
+            <TypeLink type={namedType} />
+          ))}
+        </span>
+        {defaultAst && (
+          <span className="graphiql-doc-explorer-argument-default">
+            = {print(defaultAst)}
+          </span>
+        )}
+      </div>
+      {arg.description && (
+        <div className="graphiql-doc-explorer-argument-desc">
+          {arg.description}
+        </div>
+      )}
+      {arg.deprecationReason ? (
+        <DeprecationReason preview={false}>
+          {arg.deprecationReason}
+        </DeprecationReason>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.css
@@ -3,7 +3,7 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 0;
-  padding: var(--px-6) var(--px-14) 0;
+  padding: var(--px-6) var(--px-16) 0;
   font-family: var(--font-family-mono);
   font-size: 11.5px;
   line-height: 1.4;

--- a/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.css
@@ -1,0 +1,50 @@
+.graphiql-doc-explorer-breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0;
+  padding: var(--px-6) var(--px-14) 0;
+  font-family: var(--font-family-mono);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.graphiql-doc-explorer-breadcrumb-segment {
+  display: flex;
+  align-items: center;
+  gap: var(--px-4);
+}
+
+.graphiql-doc-explorer-breadcrumb-sep {
+  color: oklch(var(--fg-dim));
+  margin: 0 var(--px-4);
+  font-family: var(--font-family);
+  font-size: 13px;
+}
+
+/* Query root — accent blue */
+a.graphiql-doc-explorer-breadcrumb-root,
+span.graphiql-doc-explorer-breadcrumb-root {
+  color: oklch(var(--accent-blue));
+  text-decoration: none;
+}
+
+a.graphiql-doc-explorer-breadcrumb-root:hover {
+  text-decoration: underline;
+}
+
+/* Intermediate types — green */
+a.graphiql-doc-explorer-breadcrumb-intermediate,
+span.graphiql-doc-explorer-breadcrumb-intermediate {
+  color: oklch(var(--accent-green-light));
+  text-decoration: none;
+}
+
+a.graphiql-doc-explorer-breadcrumb-intermediate:hover {
+  text-decoration: underline;
+}
+
+/* Current (last) segment — strong foreground */
+span.graphiql-doc-explorer-breadcrumb-current {
+  color: oklch(var(--fg-strong));
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.tsx
@@ -27,7 +27,10 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ navStack, onNavigateTo }) => {
               : 'graphiql-doc-explorer-breadcrumb-intermediate';
 
         return (
-          <span key={index} className="graphiql-doc-explorer-breadcrumb-segment">
+          <span
+            key={index}
+            className="graphiql-doc-explorer-breadcrumb-segment"
+          >
             {index > 0 && (
               <span
                 className="graphiql-doc-explorer-breadcrumb-sep"

--- a/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/breadcrumb.tsx
@@ -1,0 +1,59 @@
+import type { FC } from 'react';
+import type { DocExplorerNavStack } from '../context';
+import './breadcrumb.css';
+
+type BreadcrumbProps = {
+  navStack: DocExplorerNavStack;
+  onNavigateTo: (index: number) => void;
+};
+
+export const Breadcrumb: FC<BreadcrumbProps> = ({ navStack, onNavigateTo }) => {
+  if (navStack.length <= 1) {
+    return null;
+  }
+
+  return (
+    <nav
+      className="graphiql-doc-explorer-breadcrumb"
+      aria-label="Schema navigation path"
+    >
+      {navStack.map((item, index) => {
+        const isLast = index === navStack.length - 1;
+        const depthClass =
+          index === 0
+            ? 'graphiql-doc-explorer-breadcrumb-root'
+            : isLast
+              ? 'graphiql-doc-explorer-breadcrumb-current'
+              : 'graphiql-doc-explorer-breadcrumb-intermediate';
+
+        return (
+          <span key={index} className="graphiql-doc-explorer-breadcrumb-segment">
+            {index > 0 && (
+              <span
+                className="graphiql-doc-explorer-breadcrumb-sep"
+                aria-hidden="true"
+              >
+                ›
+              </span>
+            )}
+            {isLast ? (
+              <span className={depthClass}>{item.name}</span>
+            ) : (
+              <a
+                href="#"
+                className={depthClass}
+                onClick={event => {
+                  event.preventDefault();
+                  onNavigateTo(index);
+                }}
+                aria-label={`Go back to ${item.name}`}
+              >
+                {item.name}
+              </a>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -1,102 +1,68 @@
-/* The header wrapper — positions PanelHeader as a containing block for search overlay */
-.graphiql-doc-explorer-header {
-  & .graphiql-panel-header {
-    position: relative;
-
-    &:focus-within {
-      & .graphiql-doc-explorer-title {
-        /* Hide the title when the search input is focused */
-        visibility: hidden;
-      }
-
-      & .graphiql-doc-explorer-back:not(:focus) {
-        /**
-          * Make the back link invisible when focussing the search input. Hiding
-          * it in any other way makes it impossible to focus the link by pressing
-          * Shift-Tab while the input is focussed.
-          */
-        color: transparent;
-      }
-    }
-  }
+/* Eyebrow title in PanelHeader */
+.graphiql-panel-header-title {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--font-size-eyebrow);
 }
 
-.graphiql-doc-explorer-header-content {
+/* Small action buttons in the panel header */
+.graphiql-doc-explorer-action-btn {
+  width: 20px;
+  height: 20px;
   display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-/* The search input in the header of the doc explorer */
-.graphiql-doc-explorer-search {
-  position: absolute;
-  right: var(--px-14);
-  top: var(--px-4);
-  bottom: var(--px-4);
-  display: flex;
-  min-width: 11rem;
-
-  &:focus-within {
-    left: var(--px-14);
-  }
-}
-
-/* The back-button in the doc explorer */
-a.graphiql-doc-explorer-back {
   align-items: center;
-  color: oklch(var(--fg-muted));
-  display: flex;
-  text-decoration: none;
+  justify-content: center;
 
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:focus {
-    outline: oklch(var(--fg-muted)) auto 1px;
-
-    & + .graphiql-doc-explorer-title {
-      /* Don't hide the header when focussing the back link */
-      visibility: unset;
-    }
-  }
-
-  & > svg {
-    height: var(--px-8);
-    margin-right: var(--px-8);
-    width: var(--px-8);
+  & svg {
+    width: 12px;
+    height: 12px;
   }
 }
 
-/* The title of the currently active page in the doc explorer */
-.graphiql-doc-explorer-title {
-  color: oklch(var(--fg-strong));
-  font-weight: 600;
-  font-size: 12px;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  &:not(:first-child) {
-    margin-top: var(--px-4);
-  }
-}
-
-/* The contents of the currently active page in the doc explorer */
+/* Main content area */
 .graphiql-doc-explorer-content {
-  padding: 0 var(--px-14) var(--px-14);
+  overflow-y: auto;
+  flex: 1;
 }
 
+/* Schema overview and field-documentation padding */
 .graphiql-doc-explorer-content > * {
   color: oklch(var(--fg-muted));
-  margin-top: var(--px-20);
+  padding: 0 var(--px-14) var(--px-14);
+  margin-top: var(--px-16);
+}
+
+/* TypeCard and FieldsList are direct children too but handle their own padding */
+.graphiql-doc-explorer-content .graphiql-doc-explorer-type-card,
+.graphiql-doc-explorer-content .graphiql-doc-explorer-fields-list {
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+/* Wrap for enum/union/interface extra sections */
+.graphiql-doc-explorer-type-extra {
+  padding: 0 var(--px-14) var(--px-14);
+  margin-top: var(--px-16);
+  color: oklch(var(--fg-muted));
 }
 
 /* Error message */
 .graphiql-doc-explorer-error {
   background-color: oklch(var(--accent-red) / 0.15);
   border: 1px solid oklch(var(--accent-red));
-  border-radius: var(--border-radius-8);
+  border-radius: var(--radius-sm);
   color: oklch(var(--accent-red));
   padding: var(--px-8) var(--px-12);
+  margin: var(--px-14);
+}
+
+/* Old back-button and title selectors kept for Cypress compatibility */
+a.graphiql-doc-explorer-back {
+  display: none;
+}
+
+.graphiql-doc-explorer-title {
+  display: none;
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -14,7 +14,7 @@
 /* Schema overview and field-documentation padding */
 .graphiql-doc-explorer-content > * {
   color: oklch(var(--fg-muted));
-  padding: 0 var(--px-14) var(--px-14);
+  padding: 0 var(--px-16) var(--px-16);
   margin-top: var(--px-16);
 }
 
@@ -29,7 +29,7 @@
 
 /* Wrap for enum/union/interface extra sections */
 .graphiql-doc-explorer-type-extra {
-  padding: 0 var(--px-14) var(--px-14);
+  padding: 0 var(--px-16) var(--px-16);
   margin-top: var(--px-16);
   color: oklch(var(--fg-muted));
 }
@@ -41,7 +41,7 @@
   border-radius: var(--radius-sm);
   color: oklch(var(--accent-red));
   padding: var(--px-8) var(--px-12);
-  margin: var(--px-14);
+  margin: var(--px-16);
 }
 
 /* Old back-button and title selectors kept for Cypress compatibility */

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -31,19 +31,13 @@
 .graphiql-doc-explorer-search {
   position: absolute;
   right: var(--px-14);
-  top: var(--px-10);
+  top: var(--px-4);
+  bottom: var(--px-4);
+  display: flex;
+  min-width: 11rem;
 
   &:focus-within {
     left: var(--px-14);
-  }
-
-  &:not(:focus-within) [role='combobox'] {
-    height: 24px;
-    width: 6.5ch;
-  }
-
-  & [role='combobox']:focus {
-    width: 100%;
   }
 }
 

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -18,8 +18,13 @@
   margin-top: var(--px-16);
 }
 
-/* TypeCard and FieldsList are direct children too but handle their own padding */
-.graphiql-doc-explorer-content .graphiql-doc-explorer-type-card,
+/* TypeCard keeps its own horizontal padding */
+.graphiql-doc-explorer-content .graphiql-doc-explorer-type-card {
+  padding: var(--px-10) var(--px-16);
+  margin-top: 0;
+}
+
+/* FieldsList rows span full width, so zero out container padding */
 .graphiql-doc-explorer-content .graphiql-doc-explorer-fields-list {
   padding-left: 0;
   padding-right: 0;

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -18,14 +18,16 @@
   margin-top: var(--px-16);
 }
 
-/* TypeCard keeps its own horizontal padding */
-.graphiql-doc-explorer-content .graphiql-doc-explorer-type-card {
+/* TypeCard and FieldCard keep their own horizontal padding */
+.graphiql-doc-explorer-content .graphiql-doc-explorer-type-card,
+.graphiql-doc-explorer-content .graphiql-doc-explorer-field-card {
   padding: var(--px-10) var(--px-16);
   margin-top: 0;
 }
 
-/* FieldsList rows span full width, so zero out container padding */
-.graphiql-doc-explorer-content .graphiql-doc-explorer-fields-list {
+/* FieldsList and ArgumentsList rows span full width, so zero out container padding */
+.graphiql-doc-explorer-content .graphiql-doc-explorer-fields-list,
+.graphiql-doc-explorer-content .graphiql-doc-explorer-arguments-list {
   padding-left: 0;
   padding-right: 0;
   padding-top: 0;

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.css
@@ -5,20 +5,6 @@
   font-size: var(--font-size-eyebrow);
 }
 
-/* Small action buttons in the panel header */
-.graphiql-doc-explorer-action-btn {
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  & svg {
-    width: 12px;
-    height: 12px;
-  }
-}
-
 /* Main content area */
 .graphiql-doc-explorer-content {
   overflow-y: auto;

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
@@ -1,16 +1,29 @@
-import { isType } from 'graphql';
+import {
+  GraphQLNamedType,
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isObjectType,
+  isType,
+  isUnionType,
+} from 'graphql';
 import type { FC, ReactNode } from 'react';
 import {
-  ChevronLeftIcon,
+  MagnifyingGlassIcon,
   PanelHeader,
+  SettingsIcon,
   Spinner,
+  ToolbarButton,
   useGraphiQL,
   pick,
 } from '@graphiql/react';
 import { useDocExplorer, useDocExplorerActions } from '../context';
+import { Breadcrumb } from './breadcrumb';
 import { FieldDocumentation } from './field-documentation';
+import { FieldsList } from './fields-list';
 import { SchemaDocumentation } from './schema-documentation';
-import { Search } from './search';
+import { SearchRow } from './search-row';
+import { TypeCard } from './type-card';
 import { TypeDocumentation } from './type-documentation';
 import './doc-explorer.css';
 
@@ -21,6 +34,13 @@ export const DocExplorer: FC = () => {
   const explorerNavStack = useDocExplorer();
   const { pop } = useDocExplorerActions();
   const navItem = explorerNavStack.at(-1)!;
+
+  const navigateToIndex = (index: number) => {
+    const stepsBack = explorerNavStack.length - 1 - index;
+    for (let i = 0; i < stepsBack; i++) {
+      pop();
+    }
+  };
 
   let content: ReactNode = null;
   if (fetchError) {
@@ -34,11 +54,8 @@ export const DocExplorer: FC = () => {
       </div>
     );
   } else if (isIntrospecting) {
-    // Schema is undefined when it is being loaded via introspection.
     content = <Spinner />;
   } else if (!schema) {
-    // Schema is null when it explicitly does not exist, typically due to
-    // an error during introspection.
     content = (
       <div className="graphiql-doc-explorer-error">
         No GraphQL schema available
@@ -47,48 +64,66 @@ export const DocExplorer: FC = () => {
   } else if (explorerNavStack.length === 1) {
     content = <SchemaDocumentation schema={schema} />;
   } else if (isType(navItem.def)) {
-    content = <TypeDocumentation type={navItem.def} />;
+    content = <TypeView type={navItem.def} />;
   } else if (navItem.def) {
     content = <FieldDocumentation field={navItem.def} />;
   }
 
-  let prevName;
-  if (explorerNavStack.length > 1) {
-    prevName = explorerNavStack.at(-2)!.name;
-  }
-
-  const headerTitle = (
-    <div className="graphiql-doc-explorer-header-content">
-      {prevName && (
-        <a
-          href="#"
-          className="graphiql-doc-explorer-back"
-          onClick={event => {
-            event.preventDefault();
-            pop();
-          }}
-          aria-label={`Go back to ${prevName}`}
-        >
-          <ChevronLeftIcon />
-          {prevName}
-        </a>
-      )}
-      <div className="graphiql-doc-explorer-title">{navItem.name}</div>
-    </div>
-  );
+  const isTypeOrFieldView = explorerNavStack.length > 1;
 
   return (
     <section
       className="graphiql-doc-explorer"
       aria-label="Documentation Explorer"
     >
-      <div className="graphiql-doc-explorer-header">
-        <PanelHeader
-          title={headerTitle}
-          actions={<Search key={navItem.name} />}
+      <PanelHeader
+        title="Schema Explorer"
+        actions={
+          <>
+            <ToolbarButton
+              label="Filter fields"
+              className="graphiql-doc-explorer-action-btn"
+            >
+              <SettingsIcon />
+            </ToolbarButton>
+            <ToolbarButton
+              label="Search schema"
+              className="graphiql-doc-explorer-action-btn"
+            >
+              <MagnifyingGlassIcon />
+            </ToolbarButton>
+          </>
+        }
+      />
+      {isTypeOrFieldView && (
+        <Breadcrumb
+          navStack={explorerNavStack}
+          onNavigateTo={navigateToIndex}
         />
-      </div>
+      )}
+      {isTypeOrFieldView && <SearchRow key={navItem.name} />}
       <div className="graphiql-doc-explorer-content">{content}</div>
     </section>
+  );
+};
+
+const TypeView: FC<{ type: GraphQLNamedType }> = ({ type }) => {
+  const hasNewFieldsList =
+    isObjectType(type) || isInterfaceType(type) || isInputObjectType(type);
+  // Enum/union/scalar still need the TypeDocumentation for enum values and
+  // possible-type sections; interface needs it for Implementations.
+  const needsTypeDocs =
+    isEnumType(type) || isUnionType(type) || isInterfaceType(type);
+
+  return (
+    <>
+      <TypeCard type={type} />
+      {hasNewFieldsList && <FieldsList type={type} />}
+      {needsTypeDocs && (
+        <div className="graphiql-doc-explorer-type-extra">
+          <TypeDocumentation type={type} hideHeader />
+        </div>
+      )}
+    </>
   );
 };

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
@@ -8,15 +8,7 @@ import {
   isUnionType,
 } from 'graphql';
 import type { FC, ReactNode } from 'react';
-import {
-  MagnifyingGlassIcon,
-  PanelHeader,
-  SettingsIcon,
-  Spinner,
-  ToolbarButton,
-  useGraphiQL,
-  pick,
-} from '@graphiql/react';
+import { PanelHeader, Spinner, useGraphiQL, pick } from '@graphiql/react';
 import { useDocExplorer, useDocExplorerActions } from '../context';
 import { Breadcrumb } from './breadcrumb';
 import { FieldDocumentation } from './field-documentation';
@@ -76,25 +68,7 @@ export const DocExplorer: FC = () => {
       className="graphiql-doc-explorer"
       aria-label="Documentation Explorer"
     >
-      <PanelHeader
-        title="Schema Explorer"
-        actions={
-          <>
-            <ToolbarButton
-              label="Filter fields"
-              className="graphiql-doc-explorer-action-btn"
-            >
-              <SettingsIcon />
-            </ToolbarButton>
-            <ToolbarButton
-              label="Search schema"
-              className="graphiql-doc-explorer-action-btn"
-            >
-              <MagnifyingGlassIcon />
-            </ToolbarButton>
-          </>
-        }
-      />
+      <PanelHeader title="Schema Explorer" />
       {isTypeOrFieldView && (
         <Breadcrumb
           navStack={explorerNavStack}

--- a/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/doc-explorer.tsx
@@ -75,7 +75,7 @@ export const DocExplorer: FC = () => {
           onNavigateTo={navigateToIndex}
         />
       )}
-      {isTypeOrFieldView && <SearchRow key={navItem.name} />}
+      <SearchRow key={navItem.name} />
       <div className="graphiql-doc-explorer-content">{content}</div>
     </section>
   );

--- a/packages/graphiql-plugin-doc-explorer/src/components/field-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/field-card.css
@@ -1,0 +1,45 @@
+.graphiql-doc-explorer-field-card {
+  border-top: 1px solid oklch(var(--border-default));
+}
+
+.graphiql-doc-explorer-field-card-header {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--px-6);
+  margin-bottom: var(--px-4);
+}
+
+.graphiql-doc-explorer-field-card-name {
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: oklch(var(--accent-green-light));
+}
+
+.graphiql-doc-explorer-field-card-colon {
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  color: oklch(var(--fg-muted));
+}
+
+.graphiql-doc-explorer-field-card-type {
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  color: oklch(var(--accent-orange));
+
+  & .graphiql-doc-explorer-type-name {
+    color: oklch(var(--accent-orange));
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.graphiql-doc-explorer-field-card-description {
+  margin: 0 0 var(--px-6);
+  font-size: 12px;
+  color: oklch(var(--fg-muted));
+  line-height: 17px;
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/field-card.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/field-card.tsx
@@ -1,0 +1,44 @@
+import type { FC } from 'react';
+import type { DocExplorerFieldDef } from '../context';
+import { DeprecationReason } from './deprecation-reason';
+import { TypeLink } from './type-link';
+import { renderType } from './utils';
+import './field-card.css';
+
+type FieldCardProps = {
+  field: DocExplorerFieldDef;
+};
+
+export const FieldCard: FC<FieldCardProps> = ({ field }) => {
+  return (
+    <div className="graphiql-doc-explorer-field-card">
+      <div className="graphiql-doc-explorer-field-card-header">
+        <span className="graphiql-doc-explorer-type-badge">FIELD</span>
+        <span className="graphiql-doc-explorer-field-card-name">
+          {field.name}
+        </span>
+        <span
+          className="graphiql-doc-explorer-field-card-colon"
+          aria-hidden="true"
+        >
+          :
+        </span>
+        <span className="graphiql-doc-explorer-field-card-type">
+          {renderType(field.type, namedType => (
+            <TypeLink type={namedType} />
+          ))}
+        </span>
+      </div>
+      {field.description && (
+        <p className="graphiql-doc-explorer-field-card-description">
+          {field.description}
+        </p>
+      )}
+      {'deprecationReason' in field && field.deprecationReason ? (
+        <DeprecationReason preview={false}>
+          {field.deprecationReason}
+        </DeprecationReason>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/field-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/field-documentation.tsx
@@ -1,12 +1,9 @@
-import type { GraphQLArgument } from 'graphql';
+import type { ConstDirectiveNode, GraphQLArgument } from 'graphql';
 import { FC, useState } from 'react';
-import { Button, MarkdownContent } from '@graphiql/react';
 import type { DocExplorerFieldDef } from '../context';
-import { Argument } from './argument';
-import { DeprecationReason } from './deprecation-reason';
+import { ArgumentsList, ShowDeprecatedArgumentsButton } from './arguments-list';
 import { Directive } from './directive';
-import { ExplorerSection } from './section';
-import { TypeLink } from './type-link';
+import { FieldCard } from './field-card';
 
 type FieldDocumentationProps = {
   /**
@@ -18,17 +15,7 @@ type FieldDocumentationProps = {
 export const FieldDocumentation: FC<FieldDocumentationProps> = ({ field }) => {
   return (
     <>
-      {field.description ? (
-        <MarkdownContent type="description">
-          {field.description}
-        </MarkdownContent>
-      ) : null}
-      <DeprecationReason preview={false}>
-        {field.deprecationReason}
-      </DeprecationReason>
-      <ExplorerSection title="Type">
-        <TypeLink type={field.type} />
-      </ExplorerSection>
+      <FieldCard field={field} />
       <Arguments field={field} />
       <Directives field={field} />
     </>
@@ -37,9 +24,6 @@ export const FieldDocumentation: FC<FieldDocumentationProps> = ({ field }) => {
 
 const Arguments: FC<{ field: DocExplorerFieldDef }> = ({ field }) => {
   const [showDeprecated, setShowDeprecated] = useState(false);
-  const handleShowDeprecated = () => {
-    setShowDeprecated(true);
-  };
 
   if (!('args' in field)) {
     return null;
@@ -57,42 +41,44 @@ const Arguments: FC<{ field: DocExplorerFieldDef }> = ({ field }) => {
 
   return (
     <>
-      {args.length > 0 ? (
-        <ExplorerSection title="Arguments">
-          {args.map(arg => (
-            <Argument key={arg.name} arg={arg} />
-          ))}
-        </ExplorerSection>
-      ) : null}
-      {deprecatedArgs.length > 0 ? (
-        showDeprecated || args.length === 0 ? (
-          <ExplorerSection title="Deprecated Arguments">
-            {deprecatedArgs.map(arg => (
-              <Argument key={arg.name} arg={arg} />
-            ))}
-          </ExplorerSection>
+      <ArgumentsList title="ARGUMENTS" args={args} />
+      {deprecatedArgs.length > 0 &&
+        (showDeprecated || args.length === 0 ? (
+          <ArgumentsList title="DEPRECATED ARGUMENTS" args={deprecatedArgs} />
         ) : (
-          <Button type="button" onClick={handleShowDeprecated}>
-            Show Deprecated Arguments
-          </Button>
-        )
-      ) : null}
+          <ShowDeprecatedArgumentsButton
+            onClick={() => setShowDeprecated(true)}
+          />
+        ))}
     </>
   );
 };
 
 const Directives: FC<{ field: DocExplorerFieldDef }> = ({ field }) => {
-  const directives = field.astNode?.directives;
+  const directives = field.astNode?.directives as
+    | readonly ConstDirectiveNode[]
+    | undefined;
   if (!directives?.length) {
     return null;
   }
   return (
-    <ExplorerSection title="Directives">
-      {directives.map(directive => (
-        <div key={directive.name.value}>
-          <Directive directive={directive} />
-        </div>
-      ))}
-    </ExplorerSection>
+    <div className="graphiql-doc-explorer-directives-list">
+      <div className="graphiql-doc-explorer-directives-list-header">
+        DIRECTIVES{' '}
+        <span className="graphiql-doc-explorer-directives-list-count">
+          · {directives.length}
+        </span>
+      </div>
+      <div className="graphiql-doc-explorer-directives-list-body">
+        {directives.map(directive => (
+          <div
+            key={directive.name.value}
+            className="graphiql-doc-explorer-directive-row"
+          >
+            <Directive directive={directive} />
+          </div>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
@@ -11,7 +11,7 @@
   display: flex;
   align-items: center;
   gap: var(--px-6);
-  padding: var(--px-6) var(--px-14) var(--px-4);
+  padding: var(--px-6) var(--px-16) var(--px-4);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -126,5 +126,5 @@
 }
 
 .graphiql-doc-explorer-fields-list-show-deprecated {
-  margin: var(--px-8) var(--px-14);
+  margin: var(--px-8) var(--px-16);
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
@@ -1,0 +1,130 @@
+.graphiql-doc-explorer-fields-list {
+  flex: 1;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  padding: var(--px-4) 0;
+}
+
+/* Section header — "FIELDS · N" */
+.graphiql-doc-explorer-fields-list-header {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: var(--px-6) var(--px-14) var(--px-4);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: oklch(var(--fg-subtle));
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  width: 100%;
+  text-align: left;
+
+  & svg {
+    width: 9px;
+    height: 9px;
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    color: oklch(var(--fg-muted));
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: -2px;
+  }
+}
+
+.graphiql-doc-explorer-fields-list-count {
+  color: oklch(var(--fg-dim));
+  font-weight: 500;
+}
+
+.graphiql-doc-explorer-fields-list-body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Individual field row */
+.graphiql-doc-explorer-field-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-4);
+  padding: 5px var(--px-12) 5px var(--px-24);
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: oklch(var(--fg-default) / 0.04);
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: -2px;
+  }
+}
+
+/* Active row — blue accent */
+.graphiql-doc-explorer-field-row--active {
+  background: oklch(var(--accent-blue) / 0.08);
+  border-left-color: oklch(var(--accent-blue));
+  margin-left: -2px;
+
+  &:hover {
+    background: oklch(var(--accent-blue) / 0.12);
+  }
+}
+
+.graphiql-doc-explorer-field-row--deprecated {
+  opacity: 0.6;
+}
+
+/* Signature line: name : type */
+.graphiql-doc-explorer-field-row-sig {
+  display: flex;
+  align-items: baseline;
+  gap: var(--px-6);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+}
+
+.graphiql-doc-explorer-field-row-name {
+  color: oklch(var(--accent-green-light));
+}
+
+.graphiql-doc-explorer-field-row-colon {
+  color: oklch(var(--fg-disabled));
+}
+
+/* Return type color — inherits from TypeLink */
+.graphiql-doc-explorer-field-row-type {
+  color: oklch(var(--accent-orange));
+
+  /* TypeLink anchors inside a field row get orange color */
+  & .graphiql-doc-explorer-type-name {
+    color: oklch(var(--accent-orange));
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+/* Optional description */
+.graphiql-doc-explorer-field-row-desc {
+  font-size: 11px;
+  color: oklch(var(--fg-subtle));
+  line-height: 15px;
+}
+
+.graphiql-doc-explorer-fields-list-show-deprecated {
+  margin: var(--px-8) var(--px-14);
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.tsx
@@ -1,0 +1,134 @@
+import { FC, useState } from 'react';
+import {
+  GraphQLNamedType,
+  isObjectType,
+  isInterfaceType,
+  isInputObjectType,
+} from 'graphql';
+import { Button, ChevronDownIcon, ChevronUpIcon } from '@graphiql/react';
+import type { DocExplorerFieldDef } from '../context';
+import { useDocExplorerActions } from '../context';
+import { TypeLink } from './type-link';
+import { renderType } from './utils';
+import './fields-list.css';
+
+type FieldsListProps = {
+  type: GraphQLNamedType;
+  activeFieldName?: string;
+};
+
+export const FieldsList: FC<FieldsListProps> = ({ type, activeFieldName }) => {
+  const [expanded, setExpanded] = useState(true);
+  const [showDeprecated, setShowDeprecated] = useState(false);
+
+  if (
+    !isObjectType(type) &&
+    !isInterfaceType(type) &&
+    !isInputObjectType(type)
+  ) {
+    return null;
+  }
+
+  const fieldMap = type.getFields();
+  const fields: DocExplorerFieldDef[] = [];
+  const deprecatedFields: DocExplorerFieldDef[] = [];
+
+  for (const field of Object.values(fieldMap)) {
+    if (field.deprecationReason) {
+      deprecatedFields.push(field);
+    } else {
+      fields.push(field);
+    }
+  }
+
+  const totalCount = fields.length + (showDeprecated ? deprecatedFields.length : 0);
+
+  return (
+    <div className="graphiql-doc-explorer-fields-list">
+      <button
+        type="button"
+        className="graphiql-doc-explorer-fields-list-header"
+        onClick={() => setExpanded(e => !e)}
+        aria-expanded={expanded}
+      >
+        {expanded ? <ChevronDownIcon /> : <ChevronUpIcon />}
+        <span>
+          FIELDS{' '}
+          <span className="graphiql-doc-explorer-fields-list-count">
+            · {totalCount}
+          </span>
+        </span>
+      </button>
+      {expanded && (
+        <div className="graphiql-doc-explorer-fields-list-body">
+          {fields.map(field => (
+            <FieldRow
+              key={field.name}
+              field={field}
+              isActive={field.name === activeFieldName}
+            />
+          ))}
+          {deprecatedFields.length > 0 &&
+            (showDeprecated || fields.length === 0 ? (
+              deprecatedFields.map(field => (
+                <FieldRow
+                  key={field.name}
+                  field={field}
+                  isActive={field.name === activeFieldName}
+                  deprecated
+                />
+              ))
+            ) : (
+              <Button
+                type="button"
+                onClick={() => setShowDeprecated(true)}
+                className="graphiql-doc-explorer-fields-list-show-deprecated"
+              >
+                Show Deprecated Fields
+              </Button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+type FieldRowProps = {
+  field: DocExplorerFieldDef;
+  isActive: boolean;
+  deprecated?: boolean;
+};
+
+const FieldRow: FC<FieldRowProps> = ({ field, isActive, deprecated }) => {
+  const { push } = useDocExplorerActions();
+
+  return (
+    <button
+      type="button"
+      className={[
+        'graphiql-doc-explorer-field-row',
+        isActive ? 'graphiql-doc-explorer-field-row--active' : '',
+        deprecated ? 'graphiql-doc-explorer-field-row--deprecated' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => push({ name: field.name, def: field })}
+      aria-current={isActive ? 'true' : undefined}
+    >
+      <div className="graphiql-doc-explorer-field-row-sig">
+        <span className="graphiql-doc-explorer-field-row-name">{field.name}</span>
+        <span className="graphiql-doc-explorer-field-row-colon">:</span>
+        <span className="graphiql-doc-explorer-field-row-type">
+          {renderType(field.type, namedType => (
+            <TypeLink type={namedType} />
+          ))}
+        </span>
+      </div>
+      {field.description && (
+        <div className="graphiql-doc-explorer-field-row-desc">
+          {field.description}
+        </div>
+      )}
+    </button>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.tsx
@@ -41,7 +41,8 @@ export const FieldsList: FC<FieldsListProps> = ({ type, activeFieldName }) => {
     }
   }
 
-  const totalCount = fields.length + (showDeprecated ? deprecatedFields.length : 0);
+  const totalCount =
+    fields.length + (showDeprecated ? deprecatedFields.length : 0);
 
   return (
     <div className="graphiql-doc-explorer-fields-list">
@@ -116,7 +117,9 @@ const FieldRow: FC<FieldRowProps> = ({ field, isActive, deprecated }) => {
       aria-current={isActive ? 'true' : undefined}
     >
       <div className="graphiql-doc-explorer-field-row-sig">
-        <span className="graphiql-doc-explorer-field-row-name">{field.name}</span>
+        <span className="graphiql-doc-explorer-field-row-name">
+          {field.name}
+        </span>
         <span className="graphiql-doc-explorer-field-row-colon">:</span>
         <span className="graphiql-doc-explorer-field-row-type">
           {renderType(field.type, namedType => (

--- a/packages/graphiql-plugin-doc-explorer/src/components/index.ts
+++ b/packages/graphiql-plugin-doc-explorer/src/components/index.ts
@@ -1,9 +1,11 @@
 export { Argument } from './argument';
+export { ArgumentsList } from './arguments-list';
 export { Breadcrumb } from './breadcrumb';
 export { DefaultValue } from './default-value';
 export { DeprecationReason } from './deprecation-reason';
 export { Directive } from './directive';
 export { DocExplorer } from './doc-explorer';
+export { FieldCard } from './field-card';
 export { FieldDocumentation } from './field-documentation';
 export { FieldLink } from './field-link';
 export { FieldsList } from './fields-list';

--- a/packages/graphiql-plugin-doc-explorer/src/components/index.ts
+++ b/packages/graphiql-plugin-doc-explorer/src/components/index.ts
@@ -1,12 +1,16 @@
 export { Argument } from './argument';
+export { Breadcrumb } from './breadcrumb';
 export { DefaultValue } from './default-value';
 export { DeprecationReason } from './deprecation-reason';
 export { Directive } from './directive';
 export { DocExplorer } from './doc-explorer';
 export { FieldDocumentation } from './field-documentation';
 export { FieldLink } from './field-link';
+export { FieldsList } from './fields-list';
 export { SchemaDocumentation } from './schema-documentation';
 export { Search } from './search';
+export { SearchRow } from './search-row';
 export { ExplorerSection } from './section';
+export { TypeCard } from './type-card';
 export { TypeDocumentation } from './type-documentation';
 export { TypeLink } from './type-link';

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.css
@@ -1,3 +1,89 @@
-.graphiql-doc-explorer-root-type {
+.graphiql-doc-explorer-schema-overview {
+  display: flex;
+  flex-direction: column;
+  padding: var(--px-8) 0;
+}
+
+/* Eyebrow section headers — matches FieldsList header style */
+.graphiql-doc-explorer-schema-section-header {
+  padding: var(--px-6) var(--px-16) var(--px-4);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: oklch(var(--fg-subtle));
+}
+
+.graphiql-doc-explorer-schema-section-header--types {
+  margin-top: var(--px-12);
+}
+
+.graphiql-doc-explorer-schema-type-count {
+  color: oklch(var(--fg-dim));
+  font-weight: 500;
+}
+
+/* Root type rows */
+.graphiql-doc-explorer-schema-root-row {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+  padding: 5px var(--px-16);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+
+  &:hover {
+    background: oklch(var(--fg-default) / 0.04);
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: -2px;
+  }
+}
+
+.graphiql-doc-explorer-schema-root-label {
+  color: oklch(var(--fg-default));
+}
+
+.graphiql-doc-explorer-schema-root-colon {
   color: oklch(var(--fg-muted));
+}
+
+/* Type name in root rows — orange like TypeLink */
+.graphiql-doc-explorer-schema-root-row .graphiql-doc-explorer-type-name {
+  color: oklch(var(--accent-orange));
+}
+
+/* All-types rows */
+.graphiql-doc-explorer-schema-type-row {
+  display: flex;
+  align-items: center;
+  gap: var(--px-8);
+  padding: 4px var(--px-16);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+
+  &:hover {
+    background: oklch(var(--fg-default) / 0.04);
+  }
+
+  &:focus-visible {
+    outline: 2px solid oklch(var(--accent-blue));
+    outline-offset: -2px;
+  }
+}
+
+.graphiql-doc-explorer-schema-type-name {
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  color: oklch(var(--fg-default));
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.tsx
@@ -1,8 +1,15 @@
 import type { FC } from 'react';
-import type { GraphQLSchema } from 'graphql';
-import { MarkdownContent } from '@graphiql/react';
-import { ExplorerSection } from './section';
-import { TypeLink } from './type-link';
+import type { GraphQLNamedType, GraphQLSchema } from 'graphql';
+import {
+  isObjectType,
+  isInterfaceType,
+  isInputObjectType,
+  isEnumType,
+  isScalarType,
+  isUnionType,
+} from 'graphql';
+import { MethodPill } from '@graphiql/react';
+import { useDocExplorerActions } from '../context';
 import './schema-documentation.css';
 
 type SchemaDocumentationProps = {
@@ -12,68 +19,129 @@ type SchemaDocumentationProps = {
   schema: GraphQLSchema;
 };
 
+function getTypeKindLabel(type: GraphQLNamedType): string {
+  if (isObjectType(type)) {
+    return 'TYPE';
+  }
+  if (isInterfaceType(type)) {
+    return 'INTERFACE';
+  }
+  if (isInputObjectType(type)) {
+    return 'INPUT';
+  }
+  if (isEnumType(type)) {
+    return 'ENUM';
+  }
+  if (isScalarType(type)) {
+    return 'SCALAR';
+  }
+  if (isUnionType(type)) {
+    return 'UNION';
+  }
+  return 'TYPE';
+}
+
 export const SchemaDocumentation: FC<SchemaDocumentationProps> = ({
   schema,
 }) => {
+  const { push } = useDocExplorerActions();
   const queryType = schema.getQueryType();
   const mutationType = schema.getMutationType();
   const subscriptionType = schema.getSubscriptionType();
-  const typeMap = schema.getTypeMap();
-  const ignoreTypesInAllSchema = [
-    queryType?.name,
-    mutationType?.name,
-    subscriptionType?.name,
-  ];
+  const rootTypeNames = new Set(
+    [queryType?.name, mutationType?.name, subscriptionType?.name].filter(
+      Boolean,
+    ),
+  );
+
+  const allTypes = Object.values(schema.getTypeMap()).filter(
+    type => !type.name.startsWith('__') && !rootTypeNames.has(type.name),
+  );
 
   return (
-    <>
-      <MarkdownContent type="description">
-        {schema.description ||
-          'A GraphQL schema provides a root type for each kind of operation.'}
-      </MarkdownContent>
-      <ExplorerSection title="Root Types">
-        {queryType ? (
-          <div>
-            <span className="graphiql-doc-explorer-root-type">query</span>
-            {': '}
-            <TypeLink type={queryType} />
-          </div>
-        ) : null}
+    <div className="graphiql-doc-explorer-schema-overview">
+      {/* Root types section */}
+      <div className="graphiql-doc-explorer-schema-section-header">
+        ROOT TYPES
+      </div>
+      <div className="graphiql-doc-explorer-schema-root-types">
+        {queryType && (
+          <button
+            type="button"
+            className="graphiql-doc-explorer-schema-root-row"
+            onClick={() => push({ name: queryType.name, def: queryType })}
+          >
+            <MethodPill operation="query" aria-hidden />
+            <span className="graphiql-doc-explorer-schema-root-label">
+              Query
+            </span>
+            <span className="graphiql-doc-explorer-schema-root-colon">:</span>
+            <span className="graphiql-doc-explorer-type-name">
+              {queryType.name}
+            </span>
+          </button>
+        )}
         {mutationType && (
-          <div>
-            <span className="graphiql-doc-explorer-root-type">mutation</span>
-            {': '}
-            <TypeLink type={mutationType} />
-          </div>
+          <button
+            type="button"
+            className="graphiql-doc-explorer-schema-root-row"
+            onClick={() => push({ name: mutationType.name, def: mutationType })}
+          >
+            <MethodPill operation="mutation" aria-hidden />
+            <span className="graphiql-doc-explorer-schema-root-label">
+              Mutation
+            </span>
+            <span className="graphiql-doc-explorer-schema-root-colon">:</span>
+            <span className="graphiql-doc-explorer-type-name">
+              {mutationType.name}
+            </span>
+          </button>
         )}
         {subscriptionType && (
-          <div>
-            <span className="graphiql-doc-explorer-root-type">
-              subscription
-            </span>
-            {': '}
-            <TypeLink type={subscriptionType} />
-          </div>
-        )}
-      </ExplorerSection>
-      <ExplorerSection title="All Schema Types">
-        <div>
-          {Object.values(typeMap).map(type => {
-            if (
-              ignoreTypesInAllSchema.includes(type.name) ||
-              type.name.startsWith('__')
-            ) {
-              return null;
+          <button
+            type="button"
+            className="graphiql-doc-explorer-schema-root-row"
+            onClick={() =>
+              push({ name: subscriptionType.name, def: subscriptionType })
             }
+          >
+            <MethodPill operation="subscription" aria-hidden />
+            <span className="graphiql-doc-explorer-schema-root-label">
+              Subscription
+            </span>
+            <span className="graphiql-doc-explorer-schema-root-colon">:</span>
+            <span className="graphiql-doc-explorer-type-name">
+              {subscriptionType.name}
+            </span>
+          </button>
+        )}
+      </div>
 
-            return (
-              <div key={type.name}>
-                <TypeLink type={type} />
-              </div>
-            );
-          })}
-        </div>
-      </ExplorerSection>
-    </>
+      {/* All schema types section */}
+      <div className="graphiql-doc-explorer-schema-section-header graphiql-doc-explorer-schema-section-header--types">
+        ALL SCHEMA TYPES
+        <span className="graphiql-doc-explorer-schema-type-count">
+          {' '}
+          · {allTypes.length}
+        </span>
+      </div>
+      <div className="graphiql-doc-explorer-schema-all-types">
+        {allTypes.map(type => (
+          <button
+            key={type.name}
+            type="button"
+            className="graphiql-doc-explorer-schema-type-row"
+            onClick={() => push({ name: type.name, def: type })}
+          >
+            <span className="graphiql-doc-explorer-type-badge">
+              {getTypeKindLabel(type)}
+            </span>
+            <span className="graphiql-doc-explorer-schema-type-name">
+              {type.name}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
@@ -1,0 +1,87 @@
+.graphiql-doc-explorer-search-row-wrapper {
+  padding: var(--px-8) var(--px-14);
+  position: relative;
+}
+
+.graphiql-doc-explorer-search-row {
+  position: relative;
+}
+
+.graphiql-doc-explorer-search-row-input {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+  background: oklch(var(--bg-subtle));
+  border: 1px solid oklch(var(--border-muted));
+  border-radius: var(--radius-sm);
+  padding: var(--px-4) var(--px-8);
+  cursor: text;
+
+  & svg {
+    width: 11px;
+    height: 11px;
+    color: oklch(var(--fg-disabled));
+    flex-shrink: 0;
+  }
+
+  & [role='combobox'] {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    font-family: var(--font-family-mono);
+    font-size: 11.5px;
+    color: oklch(var(--fg-default));
+
+    &::placeholder {
+      color: oklch(var(--fg-disabled));
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.graphiql-doc-explorer-search-row-listbox {
+  position: absolute;
+  top: calc(100% + var(--px-4));
+  left: 0;
+  right: 0;
+  z-index: 5;
+  background: oklch(var(--bg-canvas));
+  border: 1px solid oklch(var(--border-default));
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-popover);
+  max-height: 400px;
+  overflow-y: auto;
+  padding: var(--px-4);
+  font-size: var(--font-size-body);
+  margin: 0;
+
+  & [role='option'] {
+    border-radius: var(--radius-sm);
+    color: oklch(var(--fg-muted));
+    overflow-x: hidden;
+    padding: var(--px-8) var(--px-12);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+
+    &[data-headlessui-state='active'] {
+      background-color: oklch(var(--fg-default) / 0.08);
+    }
+
+    &:hover {
+      background-color: oklch(var(--fg-default) / 0.12);
+    }
+
+    &[data-headlessui-state='active']:hover {
+      background-color: oklch(var(--fg-default) / 0.16);
+    }
+
+    & + [role='option'] {
+      margin-top: var(--px-4);
+    }
+  }
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
@@ -1,5 +1,5 @@
 .graphiql-doc-explorer-search-row-wrapper {
-  padding: var(--px-8) var(--px-14);
+  padding: var(--px-8) var(--px-16);
   position: relative;
 }
 

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
@@ -94,7 +94,7 @@ export const SearchRow: FC = () => {
           <ComboboxInput
             autoComplete="off"
             onChange={event => setSearchValue(event.target.value)}
-            placeholder="Filter fields…"
+            placeholder="Search schema"
             ref={inputRef}
             value={searchValue}
             data-cy="doc-explorer-input"

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
@@ -151,10 +151,7 @@ export const SearchRow: FC = () => {
                 data-cy="doc-explorer-option"
               >
                 <SearchType type={result.type} />.
-                <SearchField
-                  field={result.field}
-                  argument={result.argument}
-                />
+                <SearchField field={result.field} argument={result.argument} />
               </ComboboxOption>
             ))}
           </ComboboxOptions>

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.tsx
@@ -1,0 +1,195 @@
+import { FC, useEffect, useRef, useState } from 'react';
+import {
+  GraphQLArgument,
+  GraphQLField,
+  GraphQLInputField,
+  GraphQLNamedType,
+  isInputObjectType,
+  isInterfaceType,
+  isObjectType,
+} from 'graphql';
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOptions,
+  ComboboxOption,
+} from '@headlessui/react';
+import {
+  formatShortcutForOS,
+  MagnifyingGlassIcon,
+  KeycapHint,
+  debounce,
+  KEY_MAP,
+} from '@graphiql/react';
+import { useDocExplorer, useDocExplorerActions } from '../context';
+import { useSearchResults } from './search';
+import { renderType } from './utils';
+import './search-row.css';
+
+type TypeMatch = { type: GraphQLNamedType };
+type FieldMatch = {
+  type: GraphQLNamedType;
+  field: GraphQLField<unknown, unknown> | GraphQLInputField;
+  argument?: GraphQLArgument;
+};
+
+export const SearchRow: FC = () => {
+  const explorerNavStack = useDocExplorer();
+  const { push } = useDocExplorerActions();
+
+  const inputRef = useRef<HTMLInputElement>(null!);
+  const getSearchResults = useSearchResults();
+  const [searchValue, setSearchValue] = useState('');
+  const [results, setResults] = useState(() => getSearchResults(searchValue));
+  const debouncedGetSearchResults = debounce(200, (search: string) => {
+    setResults(getSearchResults(search));
+  });
+  const [ref] = useState(inputRef);
+  const isFocused = ref.current === document.activeElement;
+
+  useEffect(() => {
+    debouncedGetSearchResults(searchValue);
+  }, [debouncedGetSearchResults, searchValue]);
+
+  const navItem = explorerNavStack.at(-1)!;
+
+  const onSelect = (def: TypeMatch | FieldMatch | null) => {
+    if (!def) {
+      return;
+    }
+    push(
+      'field' in def
+        ? { name: def.field.name, def: def.field }
+        : { name: def.type.name, def: def.type },
+    );
+  };
+
+  const shouldShow =
+    explorerNavStack.length === 1 ||
+    isObjectType(navItem.def) ||
+    isInterfaceType(navItem.def) ||
+    isInputObjectType(navItem.def);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const shortcutKeys = formatShortcutForOS(KEY_MAP.searchInDocs.key).split('-');
+
+  return (
+    <div className="graphiql-doc-explorer-search-row-wrapper">
+      <Combobox
+        as="div"
+        className="graphiql-doc-explorer-search-row"
+        onChange={onSelect}
+        aria-label={`Search ${navItem.name}...`}
+      >
+        <div
+          className="graphiql-doc-explorer-search-row-input"
+          onClick={() => {
+            inputRef.current.focus();
+          }}
+        >
+          <MagnifyingGlassIcon />
+          <ComboboxInput
+            autoComplete="off"
+            onChange={event => setSearchValue(event.target.value)}
+            placeholder="Filter fields…"
+            ref={inputRef}
+            value={searchValue}
+            data-cy="doc-explorer-input"
+          />
+          {!isFocused && !searchValue && (
+            <KeycapHint keys={shortcutKeys} ariaLabel="Search docs shortcut" />
+          )}
+        </div>
+        {isFocused && (
+          <ComboboxOptions
+            className="graphiql-doc-explorer-search-row-listbox"
+            data-cy="doc-explorer-list"
+          >
+            {results.within.length +
+              results.types.length +
+              results.fields.length ===
+            0 ? (
+              <div className="graphiql-doc-explorer-search-empty">
+                No results found
+              </div>
+            ) : (
+              results.within.map((result, i) => (
+                <ComboboxOption
+                  key={`within-${i}`}
+                  value={result}
+                  data-cy="doc-explorer-option"
+                >
+                  <SearchField
+                    field={result.field}
+                    argument={result.argument}
+                  />
+                </ComboboxOption>
+              ))
+            )}
+            {results.within.length > 0 &&
+            results.types.length + results.fields.length > 0 ? (
+              <div className="graphiql-doc-explorer-search-divider">
+                Other results
+              </div>
+            ) : null}
+            {results.types.map((result, i) => (
+              <ComboboxOption
+                key={`type-${i}`}
+                value={result}
+                data-cy="doc-explorer-option"
+              >
+                <SearchType type={result.type} />
+              </ComboboxOption>
+            ))}
+            {results.fields.map((result, i) => (
+              <ComboboxOption
+                key={`field-${i}`}
+                value={result}
+                data-cy="doc-explorer-option"
+              >
+                <SearchType type={result.type} />.
+                <SearchField
+                  field={result.field}
+                  argument={result.argument}
+                />
+              </ComboboxOption>
+            ))}
+          </ComboboxOptions>
+        )}
+      </Combobox>
+    </div>
+  );
+};
+
+const SearchType: FC<{ type: GraphQLNamedType }> = ({ type }) => (
+  <span className="graphiql-doc-explorer-search-type">{type.name}</span>
+);
+
+type SearchFieldProps = {
+  field: GraphQLField<unknown, unknown> | GraphQLInputField;
+  argument?: GraphQLArgument;
+};
+
+const SearchField: FC<SearchFieldProps> = ({ field, argument }) => {
+  return (
+    <>
+      <span className="graphiql-doc-explorer-search-field">{field.name}</span>
+      {argument ? (
+        <>
+          (
+          <span className="graphiql-doc-explorer-search-argument">
+            {argument.name}
+          </span>
+          :{' '}
+          {renderType(argument.type, namedType => (
+            <SearchType type={namedType} />
+          ))}
+          )
+        </>
+      ) : null}
+    </>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -17,18 +17,24 @@
   background-color: oklch(var(--fg-default) / 0.08);
   border-radius: var(--border-radius-4);
   display: flex;
-  padding: var(--px-8) var(--px-12);
+  flex: 1;
+  gap: var(--px-8);
+  padding: var(--px-4) var(--px-8);
 }
 
 .graphiql-doc-explorer-search [role='combobox'] {
   border: none;
   background-color: transparent;
-  margin-left: var(--px-4);
-  width: 100%;
+  flex: 1;
+  min-width: 0;
 
   &:focus {
     outline: none;
   }
+}
+
+.graphiql-doc-explorer-search:focus-within .graphiql-keycap-hint {
+  display: none;
 }
 
 .graphiql-doc-explorer-search [role='listbox'] {

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.tsx
@@ -17,6 +17,7 @@ import {
 import {
   formatShortcutForOS,
   useGraphiQL,
+  KeycapHint,
   MagnifyingGlassIcon,
   debounce,
   KEY_MAP,
@@ -58,6 +59,8 @@ export const Search: FC = () => {
         : { name: def.type.name, def: def.type },
     );
   };
+  const shortcutKeys = formatShortcutForOS(KEY_MAP.searchInDocs.key).split('-');
+
   const shouldSearchBoxAppear =
     explorerNavStack.length === 1 ||
     isObjectType(navItem.def) ||
@@ -85,13 +88,12 @@ export const Search: FC = () => {
         <ComboboxInput
           autoComplete="off"
           onChange={event => setSearchValue(event.target.value)}
-          placeholder={formatShortcutForOS(
-            formatShortcutForOS(KEY_MAP.searchInDocs.key).replaceAll('-', ' '),
-          )}
+          placeholder="Search Docs"
           ref={inputRef}
           value={searchValue}
           data-cy="doc-explorer-input"
         />
+        <KeycapHint keys={shortcutKeys} ariaLabel="Search docs shortcut" />
       </div>
       {isFocused && (
         <ComboboxOptions data-cy="doc-explorer-list">

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
@@ -1,5 +1,5 @@
 .graphiql-doc-explorer-type-card {
-  padding: var(--px-8) var(--px-14) var(--px-8);
+  padding: var(--px-10) var(--px-16) var(--px-10);
   border-top: 1px solid oklch(var(--border-default));
 }
 

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
@@ -1,5 +1,4 @@
 .graphiql-doc-explorer-type-card {
-  padding: var(--px-10) var(--px-16) var(--px-10);
   border-top: 1px solid oklch(var(--border-default));
 }
 

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
@@ -1,0 +1,77 @@
+.graphiql-doc-explorer-type-card {
+  padding: var(--px-8) var(--px-14) var(--px-8);
+  border-top: 1px solid oklch(var(--border-default));
+}
+
+.graphiql-doc-explorer-type-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+  margin-bottom: var(--px-4);
+}
+
+/* [TYPE] badge */
+.graphiql-doc-explorer-type-badge {
+  padding: 1px 6px;
+  background: oklch(var(--accent-blue) / 0.12);
+  color: oklch(var(--accent-blue));
+  font-family: var(--font-family-mono);
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.graphiql-doc-explorer-type-card-name {
+  font-family: var(--font-family-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: oklch(var(--fg-strong));
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.graphiql-doc-explorer-type-card-description {
+  margin: 0 0 var(--px-6);
+  font-size: 12px;
+  color: oklch(var(--fg-muted));
+  line-height: 17px;
+}
+
+/* implements row */
+.graphiql-doc-explorer-type-card-implements {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--px-6);
+  margin-top: var(--px-6);
+  font-size: 10.5px;
+  color: oklch(var(--fg-subtle));
+}
+
+.graphiql-doc-explorer-type-card-implements-keyword {
+  font-family: var(--font-family-mono);
+}
+
+.graphiql-doc-explorer-type-card-implements-item {
+  display: flex;
+  align-items: center;
+  gap: var(--px-6);
+}
+
+.graphiql-doc-explorer-type-card-implements-dot {
+  color: oklch(var(--fg-dim));
+}
+
+a.graphiql-doc-explorer-type-card-implements-link {
+  font-family: var(--font-family-mono);
+  color: oklch(var(--accent-orange));
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.tsx
@@ -1,0 +1,87 @@
+import type { FC } from 'react';
+import {
+  GraphQLNamedType,
+  isObjectType,
+  isInterfaceType,
+  isInputObjectType,
+  isEnumType,
+  isScalarType,
+  isUnionType,
+} from 'graphql';
+import { useDocExplorerActions } from '../context';
+import './type-card.css';
+
+function getTypeKind(type: GraphQLNamedType): string {
+  if (isObjectType(type)) {
+    return 'TYPE';
+  }
+  if (isInterfaceType(type)) {
+    return 'INTERFACE';
+  }
+  if (isInputObjectType(type)) {
+    return 'INPUT';
+  }
+  if (isEnumType(type)) {
+    return 'ENUM';
+  }
+  if (isScalarType(type)) {
+    return 'SCALAR';
+  }
+  if (isUnionType(type)) {
+    return 'UNION';
+  }
+  return 'TYPE';
+}
+
+type TypeCardProps = {
+  type: GraphQLNamedType;
+};
+
+export const TypeCard: FC<TypeCardProps> = ({ type }) => {
+  const { push } = useDocExplorerActions();
+  const kind = getTypeKind(type);
+  const interfaces = isObjectType(type) ? type.getInterfaces() : [];
+
+  return (
+    <div className="graphiql-doc-explorer-type-card">
+      <div className="graphiql-doc-explorer-type-card-header">
+        <span className="graphiql-doc-explorer-type-badge">{kind}</span>
+        <span className="graphiql-doc-explorer-type-card-name">{type.name}</span>
+      </div>
+      {type.description && (
+        <p className="graphiql-doc-explorer-type-card-description">
+          {type.description}
+        </p>
+      )}
+      {interfaces.length > 0 && (
+        <div className="graphiql-doc-explorer-type-card-implements">
+          <span className="graphiql-doc-explorer-type-card-implements-keyword">
+            implements
+          </span>
+          {interfaces.map((iface, i) => (
+            <span key={iface.name} className="graphiql-doc-explorer-type-card-implements-item">
+              {i > 0 && (
+                <span
+                  className="graphiql-doc-explorer-type-card-implements-dot"
+                  aria-hidden="true"
+                >
+                  ·
+                </span>
+              )}
+              <a
+                href="#"
+                className="graphiql-doc-explorer-type-card-implements-link"
+                onClick={event => {
+                  event.preventDefault();
+                  push({ name: iface.name, def: iface });
+                }}
+              >
+                {iface.name}
+              </a>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.tsx
@@ -46,7 +46,9 @@ export const TypeCard: FC<TypeCardProps> = ({ type }) => {
     <div className="graphiql-doc-explorer-type-card">
       <div className="graphiql-doc-explorer-type-card-header">
         <span className="graphiql-doc-explorer-type-badge">{kind}</span>
-        <span className="graphiql-doc-explorer-type-card-name">{type.name}</span>
+        <span className="graphiql-doc-explorer-type-card-name">
+          {type.name}
+        </span>
       </div>
       {type.description && (
         <p className="graphiql-doc-explorer-type-card-description">
@@ -59,7 +61,10 @@ export const TypeCard: FC<TypeCardProps> = ({ type }) => {
             implements
           </span>
           {interfaces.map((iface, i) => (
-            <span key={iface.name} className="graphiql-doc-explorer-type-card-implements-item">
+            <span
+              key={iface.name}
+              className="graphiql-doc-explorer-type-card-implements-item"
+            >
               {i > 0 && (
                 <span
                   className="graphiql-doc-explorer-type-card-implements-dot"

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-documentation.tsx
@@ -24,16 +24,25 @@ type TypeDocumentationProps = {
    * The type that should be rendered.
    */
   type: GraphQLNamedType;
+  /**
+   * When true, the description, implements-interfaces, and fields sections
+   * are omitted. Used when TypeCard + FieldsList are already rendering those
+   * above the type documentation.
+   */
+  hideHeader?: boolean;
 };
 
-export const TypeDocumentation: FC<TypeDocumentationProps> = ({ type }) => {
+export const TypeDocumentation: FC<TypeDocumentationProps> = ({
+  type,
+  hideHeader,
+}) => {
   return isNamedType(type) ? (
     <>
-      {type.description ? (
+      {!hideHeader && type.description ? (
         <MarkdownContent type="description">{type.description}</MarkdownContent>
       ) : null}
-      <ImplementsInterfaces type={type} />
-      <Fields type={type} />
+      {!hideHeader && <ImplementsInterfaces type={type} />}
+      {!hideHeader && <Fields type={type} />}
       <EnumValues type={type} />
       <PossibleTypes type={type} />
     </>

--- a/packages/graphiql-plugin-doc-explorer/src/context.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/context.tsx
@@ -96,7 +96,7 @@ export type DocExplorerStoreType = {
   };
 };
 
-const INITIAL_NAV_STACK: DocExplorerNavStack = [{ name: 'Docs' }];
+const INITIAL_NAV_STACK: DocExplorerNavStack = [{ name: 'Root' }];
 
 export const docExplorerStore = createStore<DocExplorerStoreType>(
   (set, get) => ({

--- a/packages/graphiql-plugin-doc-explorer/src/stories/doc-explorer.stories.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/stories/doc-explorer.stories.tsx
@@ -9,12 +9,16 @@ import {
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
+  GraphQLUnionType,
 } from 'graphql';
 import { Tooltip } from '@graphiql/react';
 import { DocExplorerStore } from '../context';
 import { TypeDocumentation } from '../components/type-documentation';
 import { FieldDocumentation } from '../components/field-documentation';
 import { SchemaDocumentation } from '../components/schema-documentation';
+import { TypeCard } from '../components/type-card';
+import { FieldsList } from '../components/fields-list';
+import { Breadcrumb } from '../components/breadcrumb';
 import { TypeLink } from '../components/type-link';
 import { FieldLink } from '../components/field-link';
 import { Argument } from '../components/argument';
@@ -87,6 +91,12 @@ const HumanType = new GraphQLObjectType({
   }),
 });
 
+const SearchResultUnion = new GraphQLUnionType({
+  name: 'SearchResult',
+  description: 'A result from a global search',
+  types: [HumanType],
+});
+
 const QueryType = new GraphQLObjectType({
   name: 'Query',
   description: 'The root query type for the Star Wars API',
@@ -116,6 +126,10 @@ const QueryType = new GraphQLObjectType({
       type: GraphQLBoolean,
       deprecationReason: 'Use `hero` with status field instead',
     },
+    search: {
+      type: SearchResultUnion,
+      description: 'Search across all types',
+    },
   },
 });
 
@@ -137,7 +151,13 @@ const StarWarsSchema = new GraphQLSchema({
   description: 'The Star Wars GraphQL API',
   query: QueryType,
   mutation: MutationType,
-  types: [HumanType, CharacterInterface, EpisodeEnum, ReviewInputType],
+  types: [
+    HumanType,
+    CharacterInterface,
+    EpisodeEnum,
+    ReviewInputType,
+    SearchResultUnion,
+  ],
 });
 
 function withDocExplorerStore(Story: React.FC) {
@@ -167,24 +187,51 @@ export const SchemaOverview: Story = {
   },
 };
 
-export const TypeDetail: Story = {
-  name: 'Type detail (Human)',
-  render: function TypeDetailStory() {
-    return <TypeDocumentation type={HumanType} />;
+export const TypeDetailObject: Story = {
+  name: 'Type detail — Object',
+  render: function TypeDetailObjectStory() {
+    return (
+      <>
+        <TypeCard type={HumanType} />
+        <FieldsList type={HumanType} />
+      </>
+    );
   },
 };
 
-export const EnumTypeDetail: Story = {
-  name: 'Type detail (Enum)',
-  render: function EnumTypeDetailStory() {
-    return <TypeDocumentation type={EpisodeEnum} />;
+export const TypeDetailInterface: Story = {
+  name: 'Type detail — Interface',
+  render: function TypeDetailInterfaceStory() {
+    return (
+      <>
+        <TypeCard type={CharacterInterface} />
+        <FieldsList type={CharacterInterface} />
+      </>
+    );
   },
 };
 
-export const InputTypeDetail: Story = {
-  name: 'Type detail (Input)',
-  render: function InputTypeDetailStory() {
-    return <TypeDocumentation type={ReviewInputType} />;
+export const TypeDetailInput: Story = {
+  name: 'Type detail — Input',
+  render: function TypeDetailInputStory() {
+    return (
+      <>
+        <TypeCard type={ReviewInputType} />
+        <FieldsList type={ReviewInputType} />
+      </>
+    );
+  },
+};
+
+export const TypeDetailEnum: Story = {
+  name: 'Type detail — Enum',
+  render: function TypeDetailEnumStory() {
+    return (
+      <>
+        <TypeCard type={EpisodeEnum} />
+        <TypeDocumentation type={EpisodeEnum} hideHeader />
+      </>
+    );
   },
 };
 
@@ -193,6 +240,18 @@ export const FieldDetail: Story = {
   render: function FieldDetailStory() {
     const heroField = QueryType.getFields()['hero']!;
     return <FieldDocumentation field={heroField} />;
+  },
+};
+
+export const BreadcrumbNav: Story = {
+  name: 'Breadcrumb navigation',
+  render: function BreadcrumbNavStory() {
+    const navStack: Parameters<typeof Breadcrumb>[0]['navStack'] = [
+      { name: 'Docs' },
+      { name: 'Query', def: QueryType },
+      { name: 'Human', def: HumanType },
+    ];
+    return <Breadcrumb navStack={navStack} onNavigateTo={() => {}} />;
   },
 };
 

--- a/packages/graphiql-plugin-doc-explorer/src/stories/doc-explorer.stories.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/stories/doc-explorer.stories.tsx
@@ -247,7 +247,7 @@ export const BreadcrumbNav: Story = {
   name: 'Breadcrumb navigation',
   render: function BreadcrumbNavStory() {
     const navStack: Parameters<typeof Breadcrumb>[0]['navStack'] = [
-      { name: 'Docs' },
+      { name: 'Root' },
       { name: 'Query', def: QueryType },
       { name: 'Human', def: HumanType },
     ];

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -121,8 +121,8 @@ describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
     cy.dataCy('doc-explorer-option').first().children().first().click();
 
     cy.contains('Show Deprecated Arguments').click();
-    cy.get('.graphiql-doc-explorer-section-title').contains(
-      'Deprecated Arguments',
+    cy.get('.graphiql-doc-explorer-arguments-list-header').contains(
+      'DEPRECATED ARGUMENTS',
     );
     cy.get('.graphiql-markdown-deprecation').should(
       'have.text',

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -31,12 +31,15 @@ describe('GraphiQL DocExplorer - search', () => {
 
   it('Navigates to a docs entry on selecting a search result', () => {
     cy.dataCy('doc-explorer-option').eq(4).children().click();
-    cy.get('.graphiql-doc-explorer-title').should('have.text', 'TestInput');
+    cy.get('.graphiql-doc-explorer-breadcrumb-current').should(
+      'have.text',
+      'TestInput',
+    );
   });
 
   it('Allows searching fields within a type', () => {
     cy.dataCy('doc-explorer-option').eq(4).children().click();
-    cy.dataCy('doc-explorer-input').type('list');
+    cy.dataCy('doc-explorer-input').clear().type('list');
     cy.dataCy('doc-explorer-option').should('have.length', 14);
     cy.get('.graphiql-doc-explorer-search-divider').should(
       'have.text',
@@ -54,13 +57,18 @@ describe('GraphiQL DocExplorer - search', () => {
 
   it('Navigates back', () => {
     cy.dataCy('doc-explorer-option').eq(4).children().click();
-    cy.get('.graphiql-doc-explorer-back').click();
-    cy.get('.graphiql-doc-explorer-title').should('have.text', 'Docs');
+    // Click the root breadcrumb segment (first link, at depth 0 = "Docs")
+    cy.get('.graphiql-doc-explorer-breadcrumb-root').click();
+    // After navigating back, breadcrumb disappears (at root level, no breadcrumb shown)
+    cy.get('.graphiql-doc-explorer-breadcrumb').should('not.exist');
   });
 
   it('Type fields link to their own docs entry', () => {
     cy.dataCy('doc-explorer-option').last().click();
-    cy.get('.graphiql-doc-explorer-title').should('have.text', 'isTest');
+    cy.get('.graphiql-doc-explorer-breadcrumb-current').should(
+      'have.text',
+      'isTest',
+    );
     cy.get('.graphiql-markdown-description').should(
       'have.text',
       'Is this a test schema? Sure it is.\n',

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -116,10 +116,10 @@ describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
     // Open doc explorer
     cy.get('.graphiql-activity-rail-item').eq(0).click();
 
-    // Select query type
-    cy.get('.graphiql-doc-explorer-type-name').first().click();
+    // Use search to navigate directly to hasArgs
+    cy.dataCy('doc-explorer-input').type('hasArgs');
+    cy.dataCy('doc-explorer-option').first().children().first().click();
 
-    cy.contains('button.graphiql-doc-explorer-field-row', 'hasArgs').click();
     cy.contains('Show Deprecated Arguments').click();
     cy.get('.graphiql-doc-explorer-section-title').contains(
       'Deprecated Arguments',

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -87,20 +87,21 @@ describe('GraphQL DocExplorer - deprecated fields', () => {
     // Show deprecated fields
     cy.contains('Show Deprecated Fields').click();
 
-    // Assert that title is shown
-    cy.get('.graphiql-doc-explorer-section-title').contains(
-      'Deprecated Fields',
-    );
+    // Click into the deprecated field to view its documentation
+    cy.contains(
+      'button.graphiql-doc-explorer-field-row--deprecated',
+      'deprecatedField',
+    ).click();
 
-    // Assert that the deprecated field is shown correctly
-    cy.get('.graphiql-doc-explorer-field-name')
-      .contains('deprecatedField')
-      .closest('.graphiql-doc-explorer-item')
-      .should('contain.text', 'This field is an example of a deprecated field')
-      .and(
-        'contain.html',
-        '<p>No longer in use, try <code>test</code> instead.</p>',
-      );
+    // Assert description and deprecation reason are shown
+    cy.get('.graphiql-markdown-description').should(
+      'contain.text',
+      'This field is an example of a deprecated field',
+    );
+    cy.get('.graphiql-markdown-deprecation').should(
+      'contain.html',
+      '<p>No longer in use, try <code>test</code> instead.</p>',
+    );
   });
 });
 
@@ -118,7 +119,7 @@ describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
     // Select query type
     cy.get('.graphiql-doc-explorer-type-name').first().click();
 
-    cy.get('.graphiql-doc-explorer-field-name').contains('hasArgs').click();
+    cy.contains('button.graphiql-doc-explorer-field-row', 'hasArgs').click();
     cy.contains('Show Deprecated Arguments').click();
     cy.get('.graphiql-doc-explorer-section-title').contains(
       'Deprecated Arguments',

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -69,9 +69,9 @@ describe('GraphiQL DocExplorer - search', () => {
       'have.text',
       'isTest',
     );
-    cy.get('.graphiql-markdown-description').should(
+    cy.get('.graphiql-doc-explorer-field-card-description').should(
       'have.text',
-      'Is this a test schema? Sure it is.\n',
+      'Is this a test schema? Sure it is.',
     );
   });
 });
@@ -94,7 +94,7 @@ describe('GraphQL DocExplorer - deprecated fields', () => {
     ).click();
 
     // Assert description and deprecation reason are shown
-    cy.get('.graphiql-markdown-description').should(
+    cy.get('.graphiql-doc-explorer-field-card-description').should(
       'contain.text',
       'This field is an example of a deprecated field',
     );

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -57,7 +57,7 @@ describe('GraphiQL DocExplorer - search', () => {
 
   it('Navigates back', () => {
     cy.dataCy('doc-explorer-option').eq(4).children().click();
-    // Click the root breadcrumb segment (first link, at depth 0 = "Docs")
+    // Click the root breadcrumb segment (first link, at depth 0 = "Root")
     cy.get('.graphiql-doc-explorer-breadcrumb-root').click();
     // After navigating back, breadcrumb disappears (at root level, no breadcrumb shown)
     cy.get('.graphiql-doc-explorer-breadcrumb').should('not.exist');


### PR DESCRIPTION
## Summary

- `PanelHeader` for the docs panel becomes a fixed eyebrow label, `Schema Explorer`. The type name moves into a new breadcrumb row below the header.
- New `SchemaDocumentation` root view: two eyebrow sections (`ROOT TYPES` and `ALL SCHEMA TYPES · N`) replace the old accordion. Root operation rows show a `MethodPill` and target type name. All-types rows show a kind badge (`TYPE`, `SCALAR`, `ENUM`, `INPUT`, `INTERFACE`, `UNION`) and type name in mono.
- New `Breadcrumb` row: mono font, depth segments color-coded as `--accent-blue` / `--accent-green-light` / `--fg-strong`, chevron separators; clicking a segment navigates back to that depth.
- New `SearchRow` content-area component: inline `Search schema` input with keycap hint; listbox renders as a floating popover in the content area, replacing the old absolutely-positioned search overlay.
- New `TypeCard`: `TYPE` badge (mono, uppercase, accent-blue tinted), type name in mono, description, and an `implements X · Y` row with `--accent-orange` links.
- New `FieldsList`: collapsible `FIELDS · N` header, mono rows with field name in `--accent-green-light`, colon in `--fg-muted`, return type in `--accent-orange`, optional description in `--fg-subtle`, and a 2px `--accent-blue` left border on the active row. Horizontal padding bumped to 16px across all content sections for breathing room.
- `TypeDocumentation` gains a `hideHeader` prop so it can suppress its own description / implements / fields block when `TypeCard` + `FieldsList` render those above.

## Test plan

- [ ] Open the Docs panel. Confirm the header shows `SCHEMA EXPLORER` with no extra buttons, a search input, and two eyebrow sections: `ROOT TYPES` and `ALL SCHEMA TYPES · N`.
- [ ] Confirm each root operation row shows its `MethodPill` (`QRY`/`MUT`/`SUB`), operation label, and target type name. Click a row and confirm it navigates into the type detail.
- [ ] In `ALL SCHEMA TYPES`, confirm each row shows a kind badge and mono type name. Click a row and confirm navigation.
- [ ] Confirm the breadcrumb row appears below the header when inside a type, with color-coded segments. Click an intermediate segment and confirm it navigates back.
- [ ] Confirm `TypeCard` shows the kind badge, name, description, and `implements` list for an object type that implements interfaces.
- [ ] Confirm `FieldsList` shows mono rows with green field names and orange return types; click a field row and confirm it navigates in.
- [ ] Type in the inline search row and confirm the listbox popover appears with results.
- [ ] Toggle light / dark theme; confirm root view and type-detail both render correctly.
- [ ] Navigate to an enum type and confirm enum values still render below.

Refs: graphql/graphiql#4219
