### PR TITLE
Revert "chore(cdn-example): update dependencies to latest versions"

### DIFF
--- a/examples/graphiql-cdn/index.html
+++ b/examples/graphiql-cdn/index.html
@@ -30,13 +30,13 @@
     </style>
     <link
       rel="stylesheet"
-      href="https://esm.sh/graphiql@5.2.3/dist/style.css"
-      integrity="sha384-TFpQQKp325U5sd3PddH4cS0KOB3Gz/aqdEe12Mqkkq3wm2MGcDhRX5WhWf+o8akh"
+      href="https://esm.sh/graphiql@5.2.2/dist/style.css"
+      integrity="sha384-f6GHLfCwoa4MFYUMd3rieGOsIVAte/evKbJhMigNdzUf52U9bV2JQBMQLke0ua+2"
       crossorigin="anonymous"
     />
     <link
       rel="stylesheet"
-      href="https://esm.sh/@graphiql/plugin-explorer@5.1.2/dist/style.css"
+      href="https://esm.sh/@graphiql/plugin-explorer@5.1.1/dist/style.css"
       integrity="sha384-vTFGj0krVqwFXLB7kq/VHR0/j2+cCT/B63rge2mULaqnib2OX7DVLUVksTlqvMab"
       crossorigin="anonymous"
     />
@@ -48,27 +48,27 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "https://esm.sh/react@19.2.6",
-          "react/": "https://esm.sh/react@19.2.6/",
-          "react-dom": "https://esm.sh/react-dom@19.2.6",
-          "react-dom/": "https://esm.sh/react-dom@19.2.6/",
-          "graphiql": "https://esm.sh/graphiql@5.2.3?standalone&external=react,react-dom,@graphiql/react,graphql",
-          "graphiql/": "https://esm.sh/graphiql@5.2.3/",
-          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer@5.1.2?standalone&external=react,@graphiql/react,graphql",
-          "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.5?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
-          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit@0.12.0?standalone&external=graphql",
-          "graphql": "https://esm.sh/graphql@16.14.0",
+          "react": "https://esm.sh/react@19.2.5",
+          "react/": "https://esm.sh/react@19.2.5/",
+          "react-dom": "https://esm.sh/react-dom@19.2.5",
+          "react-dom/": "https://esm.sh/react-dom@19.2.5/",
+          "graphiql": "https://esm.sh/graphiql@5.2.2?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "graphiql/": "https://esm.sh/graphiql@5.2.2/",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer@5.1.1?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react@0.37.3?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid",
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit@0.11.3?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.13.2",
           "@emotion/is-prop-valid": "data:text/javascript,"
         },
         "integrity": {
-          "https://esm.sh/react@19.2.6": "sha384-cULQr/uUHnGWJTu+mMitrsp8U68hnawvW+WKOfrKWimkxs2Ro7FPDDOR/AifqLA+",
-          "https://esm.sh/react-dom@19.2.6": "sha384-P0E4fscwP/KjngFh/I4mdUbuvPooaN8nXl9kUohx30r8a/q3HE7erwThGp6+slgE",
-          "https://esm.sh/graphiql@5.2.3": "sha384-0PwvdQK9J/s8o/8I0HVWMc8fAO8CM+6izUvBK2hn9yra9km+DwEz66IFNhYS5s9F",
-          "https://esm.sh/graphiql@5.2.3?standalone&external=react,react-dom,@graphiql/react,graphql": "sha384-pumDMAiSNzyidT/jWu2dyWDEBh3wpnQD0GlhkL+ia5vkznkEZlU7yFbDMNc9/RgD",
-          "https://esm.sh/@graphiql/plugin-explorer@5.1.2": "sha384-SkIde/TO5zMZTCZyjXZ7Y4YcWQWSqkoGu2koIU9+TyoYaM6DlNIh/v17UH+b2/A8",
-          "https://esm.sh/@graphiql/react@0.37.5?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid": "sha384-DGOGn5hIz3iKo3VcBXoVWJyE6RB6dVrHSO8bcjPSii/nJZHeV1PSI7kLXu65TFXs",
-          "https://esm.sh/@graphiql/toolkit@0.12.0?standalone&external=graphql": "sha384-g/QXS1WWddfNDQI+qvjLSeaJ0XLV7a8/Q+uY2+NVBfyiEmXu7F4zif760Ux5jhhq",
-          "https://esm.sh/graphql@16.14.0": "sha384-eUWg26UKdPQB05LGm6vm//PmrgaaY3wXONfQPX/1QXSpo78YaUHZ6F7w5/v5DDim"
+          "https://esm.sh/react@19.2.5": "sha384-ZNmUQ9QQgyl95nnD/FJTBQn2ZEPTbWtMuWCXTKWNuF6Si7nC+6bvSgk5LWu+ELHn",
+          "https://esm.sh/react-dom@19.2.5": "sha384-qtNxBzn9gBs3CmJItMuvIVyjW3VIU0/rzGhCm9MippVU1BpR/c4VgaFYDIg/FrY2",
+          "https://esm.sh/graphiql@5.2.2": "sha384-MBVZMq1pmz8DwpwIWPWLk2tmS6tGiSi6WwbXvy9NhuDYASAAWd2m96xbxLqszig9",
+          "https://esm.sh/graphiql@5.2.2?standalone&external=react,react-dom,@graphiql/react,graphql": "sha384-SzHBEbcQfhvmwqh5Vtat9k7b/kIzmdVO3KMzQiAYwcxCA9x7vZwFRUgjzN1AeV3q",
+          "https://esm.sh/@graphiql/plugin-explorer@5.1.1": "sha384-83REbLb9KtIhL/6J1n91SLoP0648KOKZLIDdHRx/a0E7T3ajq6PzKz+815SCfN52",
+          "https://esm.sh/@graphiql/react@0.37.3?standalone&external=react,react-dom,graphql,@graphiql/toolkit,@emotion/is-prop-valid": "sha384-iZsbTy9B0VcX2BOTdqMuX0uJ9Hff5GbG2QeOt4OeMp0GHza76dwQaYQYNYkZkIVq",
+          "https://esm.sh/@graphiql/toolkit@0.11.3?standalone&external=graphql": "sha384-ZsnupyYmzpNjF1Z/81zwi4nV352n4P7vm0JOFKiYnAwVGOf9twnEMnnxmxabMBXe",
+          "https://esm.sh/graphql@16.13.2": "sha384-TQg9alwG3P9fzBErDW011vKuyTnrwpBZsl3SdMAh6DwBcv9ezFOl0djGI/68VOyy"
         }
       }
     </script>


### PR DESCRIPTION
Reverts graphql/graphiql#4300

The latest releases are causing issues for folks who use the CDN example with unpinned versions (or latest). The most recent example (updated by #4300) is broken, but the previous example is not, so we'll at least restore that for now while we investigate the issue.

If you're here because your versions are unpinned and currently broken, the fix should be to just copy the updated (reverted) example within this PR. Sorry for the trouble!

Ref: https://github.com/graphql/graphiql/issues/4303