### PR TITLE
Run release workflow on `release/*` branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Add `release/*` to the Release workflow's branch list so the
changesets action runs on pushes to short-lived release branches. This
lets us enter changesets pre-mode on a temporary `release/*` branch and
cut prereleases (alpha, beta, rc) without flipping `main` into pre-mode.

The immediate use case: validating a `@graphiql/react` fix on esm.sh's
`?standalone` build before it lands on `latest`. The mechanism is
reusable for future prerelease lines.