### PR TITLE
Avoid two monaco-editor instances on CDN bundlers

### DIFF
--- a/.changeset/fix-cdn-monaco-instance.md
+++ b/.changeset/fix-cdn-monaco-instance.md
@@ -1,0 +1,9 @@
+---
+'@graphiql/react': patch
+---
+
+Fix syntax highlighting and autocompletion when GraphiQL is loaded from a CDN such as esm.sh.
+
+The monaco store previously imported `monaco-graphql/esm/monaco-editor.js`, a re-export module that both registers monaco-editor language contributions and re-exports the lean monaco-editor namespace. Some CDN bundlers (esm.sh's `?standalone` mode in particular) split that file in a way that leaves the consumer with two monaco-editor instances: one with the `graphql` and `json` languages registered, and one without. The lazily-loaded json/graphql tokenization runs against the unregistered instance and throws `Cannot set tokens provider for unknown language json`, breaking syntax highlighting and completion.
+
+The store now imports the language contribution side effects and the lean monaco-editor entry directly, so there is no re-export module for the bundler to split. Behavior is unchanged for npm-installed consumers using a bundler (Vite, webpack, Rollup, Next.js); module deduplication already produced a single instance there.

--- a/.changeset/fix-language-service-server-types.md
+++ b/.changeset/fix-language-service-server-types.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Point the package's `types` field at `dist/index.d.ts`, matching the CJS build output. The previous `typings: esm/index.d.ts` referenced the ESM build's output, which is emitted by a separate tsgo invocation that doesn't coordinate with the CJS project reference graph dependents rely on. `tsc` tolerated the misaligned path by falling back to `dist/index.d.ts` next to `main`; `tsgo` resolves project references more strictly and surfaced the misalignment as a "Could not find a declaration file" error during cold builds.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -25,5 +25,5 @@
     "vscode-graphql-execution": "0.3.5",
     "vscode-graphql-syntax": "1.3.11"
   },
-  "changesets": []
+  "changesets": ["fix-cdn-monaco-instance", "fix-language-service-server-types"]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,29 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "example-graphiql-vite": "0.0.0",
+    "example-graphiql-vite-react-router": "1.0.0",
+    "example-graphiql-webpack": "0.0.0",
+    "example-monaco-graphql-nextjs": "0.0.0",
+    "example-monaco-graphql-react-vite": "0.0.0",
+    "example-monaco-graphql-webpack": "0.0.0",
+    "cm6-graphql": "0.2.1",
+    "codemirror-graphql": "2.2.6",
+    "graphiql": "5.2.3",
+    "@graphiql/plugin-code-exporter": "5.1.2",
+    "@graphiql/plugin-doc-explorer": "0.4.2",
+    "@graphiql/plugin-explorer": "5.1.2",
+    "@graphiql/plugin-history": "0.4.2",
+    "@graphiql/react": "0.37.5",
+    "@graphiql/toolkit": "0.12.0",
+    "graphql-language-service": "5.5.1",
+    "graphql-language-service-cli": "3.5.0",
+    "graphql-language-service-server": "2.14.9",
+    "monaco-graphql": "1.8.0",
+    "vscode-graphql": "0.13.5",
+    "vscode-graphql-execution": "0.3.5",
+    "vscode-graphql-syntax": "1.3.11"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -25,5 +25,9 @@
     "vscode-graphql-execution": "0.3.5",
     "vscode-graphql-syntax": "1.3.11"
   },
-  "changesets": ["fix-cdn-monaco-instance", "fix-language-service-server-types"]
+  "changesets": [
+    "fix-cdn-monaco-instance",
+    "fix-language-service-server-types",
+    "revert-css-side-effect"
+  ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -28,6 +28,7 @@
   "changesets": [
     "fix-cdn-monaco-instance",
     "fix-language-service-server-types",
-    "revert-css-side-effect"
+    "revert-css-side-effect",
+    "revert-react-compiler-runtime-peer"
   ]
 }

--- a/.changeset/revert-css-side-effect.md
+++ b/.changeset/revert-css-side-effect.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Revert the `*.css` entry from `sideEffects` (added in #4211). The unbounded glob landed in the same release where esm.sh's `?standalone` builder started emitting a much larger preload stub that fragments `monaco-editor` into two instances and breaks syntax highlighting on CDN consumers (#4303). Removing it narrows the package.json delta between the last working version (0.37.3) and the first broken one (0.37.4). A more narrowly-scoped form may return in a follow-up if the webpack tree-shaking issue from #4211 recurs.

--- a/.changeset/revert-react-compiler-runtime-peer.md
+++ b/.changeset/revert-react-compiler-runtime-peer.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/plugin-doc-explorer': patch
+'@graphiql/plugin-history': patch
+'@graphiql/react': patch
+---
+
+Move `react-compiler-runtime` back to `peerDependencies` (revert of #4140). The earlier move to `dependencies` landed in 0.37.4 alongside esm.sh's `?standalone` builder starting to emit a 115-line preload stub that fragments `monaco-editor` into two instances on CDN consumers (#4303). Putting the dependency back in `peerDependencies` narrows the package.json delta between the last-working `0.37.3` and the first-broken `0.37.4`.

--- a/examples/graphiql-vite-react-router/package.json
+++ b/examples/graphiql-vite-react-router/package.json
@@ -11,7 +11,7 @@
     "start": "react-router-serve dist/server/index.js"
   },
   "dependencies": {
-    "@graphiql/react": "^0.37.6-alpha.1",
+    "@graphiql/react": "^0.37.6-alpha.2",
     "@react-router/fs-routes": "^7",
     "@react-router/node": "^7",
     "@react-router/serve": "^7",

--- a/examples/graphiql-vite-react-router/package.json
+++ b/examples/graphiql-vite-react-router/package.json
@@ -11,7 +11,7 @@
     "start": "react-router-serve dist/server/index.js"
   },
   "dependencies": {
-    "@graphiql/react": "^0.37.6-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.1",
     "@react-router/fs-routes": "^7",
     "@react-router/node": "^7",
     "@react-router/serve": "^7",

--- a/examples/graphiql-vite-react-router/package.json
+++ b/examples/graphiql-vite-react-router/package.json
@@ -11,11 +11,11 @@
     "start": "react-router-serve dist/server/index.js"
   },
   "dependencies": {
-    "@graphiql/react": "^0.37.5",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@react-router/fs-routes": "^7",
     "@react-router/node": "^7",
     "@react-router/serve": "^7",
-    "graphiql": "^5.2.3",
+    "graphiql": "^5.2.4-alpha.0",
     "isbot": "^5",
     "react": "^19",
     "react-dom": "^19",

--- a/examples/graphiql-vite/package.json
+++ b/examples/graphiql-vite/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "graphiql": "^5.2.3",
+    "graphiql": "^5.2.4-alpha.0",
     "graphql": "^16",
     "react": "^19",
     "react-dom": "^19"

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@graphiql/plugin-code-exporter": "^5.1.3-alpha.0",
     "@graphiql/plugin-explorer": "^5.1.3-alpha.0",
-    "@graphiql/react": "^0.37.6-alpha.1",
+    "@graphiql/react": "^0.37.6-alpha.2",
     "@graphiql/toolkit": "^0.12.0",
     "graphiql": "^5.2.4-alpha.0",
     "graphql": "^16",

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@graphiql/plugin-code-exporter": "^5.1.3-alpha.0",
     "@graphiql/plugin-explorer": "^5.1.3-alpha.0",
-    "@graphiql/react": "^0.37.6-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.1",
     "@graphiql/toolkit": "^0.12.0",
     "graphiql": "^5.2.4-alpha.0",
     "graphql": "^16",

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -9,11 +9,11 @@
     "start": "NODE_ENV=development webpack-cli serve"
   },
   "dependencies": {
-    "@graphiql/plugin-code-exporter": "^5.1.2",
-    "@graphiql/plugin-explorer": "^5.1.2",
-    "@graphiql/react": "^0.37.5",
+    "@graphiql/plugin-code-exporter": "^5.1.3-alpha.0",
+    "@graphiql/plugin-explorer": "^5.1.3-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@graphiql/toolkit": "^0.12.0",
-    "graphiql": "^5.2.3",
+    "graphiql": "^5.2.4-alpha.0",
     "graphql": "^16",
     "graphql-ws": "^5",
     "react": "^19",

--- a/packages/graphiql-plugin-code-exporter/CHANGELOG.md
+++ b/packages/graphiql-plugin-code-exporter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphiql/plugin-code-exporter
 
+## 5.1.3-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89)]:
+  - @graphiql/react@0.37.6-alpha.0
+
 ## 5.1.2
 
 ### Patch Changes

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-code-exporter",
-  "version": "5.1.2",
+  "version": "5.1.3-alpha.0",
   "sideEffects": [
     "*.css"
   ],
@@ -38,13 +38,13 @@
     "graphiql-code-exporter": "^3.0.3"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.37.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.4",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@vitejs/plugin-react": "^4.4.1",
     "graphql": "^16.9.0",
     "react": "^19.1.0",

--- a/packages/graphiql-plugin-doc-explorer/CHANGELOG.md
+++ b/packages/graphiql-plugin-doc-explorer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphiql/plugin-doc-explorer
 
+## 0.4.3-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89)]:
+  - @graphiql/react@0.37.6-alpha.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/graphiql-plugin-doc-explorer/CHANGELOG.md
+++ b/packages/graphiql-plugin-doc-explorer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphiql/plugin-doc-explorer
 
+## 0.4.3-alpha.1
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`598ffa3`](https://github.com/graphql/graphiql/commit/598ffa3de00f28fe66edc25527a3fc65e119c2d1) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Move `react-compiler-runtime` back to `peerDependencies` (revert of #4140). The earlier move to `dependencies` landed in 0.37.4 alongside esm.sh's `?standalone` builder starting to emit a 115-line preload stub that fragments `monaco-editor` into two instances on CDN consumers (#4303). Putting the dependency back in `peerDependencies` narrows the package.json delta between the last-working `0.37.3` and the first-broken `0.37.4`.
+
 ## 0.4.3-alpha.0
 
 ### Patch Changes

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-doc-explorer",
-  "version": "0.4.3-alpha.0",
+  "version": "0.4.3-alpha.1",
   "sideEffects": [
     "*.css"
   ],
@@ -49,7 +49,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.6-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-doc-explorer",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "sideEffects": [
     "*.css"
   ],
@@ -38,7 +38,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.37.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
@@ -49,7 +49,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.4",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -41,11 +41,11 @@
     "@graphiql/react": "^0.37.6-alpha.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
     "@headlessui/react": "^2.2",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/packages/graphiql-plugin-explorer/CHANGELOG.md
+++ b/packages/graphiql-plugin-explorer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphiql/plugin-explorer
 
+## 5.1.3-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89)]:
+  - @graphiql/react@0.37.6-alpha.0
+
 ## 5.1.2
 
 ### Patch Changes

--- a/packages/graphiql-plugin-explorer/package.json
+++ b/packages/graphiql-plugin-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-explorer",
-  "version": "5.1.2",
+  "version": "5.1.3-alpha.0",
   "sideEffects": [
     "*.css"
   ],
@@ -37,13 +37,13 @@
     "graphiql-explorer": "^0.9.0"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.37.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.4",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@vitejs/plugin-react": "^4.4.1",
     "graphql": "^16.9.0",
     "react": "^19.1.0",

--- a/packages/graphiql-plugin-history/CHANGELOG.md
+++ b/packages/graphiql-plugin-history/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphiql/plugin-history
 
+## 0.4.3-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89)]:
+  - @graphiql/react@0.37.6-alpha.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/graphiql-plugin-history/CHANGELOG.md
+++ b/packages/graphiql-plugin-history/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphiql/plugin-history
 
+## 0.4.3-alpha.1
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`598ffa3`](https://github.com/graphql/graphiql/commit/598ffa3de00f28fe66edc25527a3fc65e119c2d1) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Move `react-compiler-runtime` back to `peerDependencies` (revert of #4140). The earlier move to `dependencies` landed in 0.37.4 alongside esm.sh's `?standalone` builder starting to emit a 115-line preload stub that fragments `monaco-editor` into two instances on CDN consumers (#4303). Putting the dependency back in `peerDependencies` narrows the package.json delta between the last-working `0.37.3` and the first-broken `0.37.4`.
+
 ## 0.4.3-alpha.0
 
 ### Patch Changes

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-history",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "sideEffects": [
     "*.css"
   ],
@@ -37,7 +37,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@graphiql/react": "^0.37.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -47,7 +47,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.4",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.1",

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -39,11 +39,11 @@
   "peerDependencies": {
     "@graphiql/react": "^0.37.6-alpha.0",
     "react": "^18 || ^19",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
     "@graphiql/toolkit": "^0.12.0",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/plugin-history",
-  "version": "0.4.3-alpha.0",
+  "version": "0.4.3-alpha.1",
   "sideEffects": [
     "*.css"
   ],
@@ -47,7 +47,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "^0.37.6-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.2",
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.1",

--- a/packages/graphiql-react/CHANGELOG.md
+++ b/packages/graphiql-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @graphiql/react
 
+## 0.37.6-alpha.0
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Fix syntax highlighting and autocompletion when GraphiQL is loaded from a CDN such as esm.sh.
+
+  The monaco store previously imported `monaco-graphql/esm/monaco-editor.js`, a re-export module that both registers monaco-editor language contributions and re-exports the lean monaco-editor namespace. Some CDN bundlers (esm.sh's `?standalone` mode in particular) split that file in a way that leaves the consumer with two monaco-editor instances: one with the `graphql` and `json` languages registered, and one without. The lazily-loaded json/graphql tokenization runs against the unregistered instance and throws `Cannot set tokens provider for unknown language json`, breaking syntax highlighting and completion.
+
+  The store now imports the language contribution side effects and the lean monaco-editor entry directly, so there is no re-export module for the bundler to split. Behavior is unchanged for npm-installed consumers using a bundler (Vite, webpack, Rollup, Next.js); module deduplication already produced a single instance there.
+
 ## 0.37.5
 
 ### Patch Changes

--- a/packages/graphiql-react/CHANGELOG.md
+++ b/packages/graphiql-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphiql/react
 
+## 0.37.6-alpha.2
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`598ffa3`](https://github.com/graphql/graphiql/commit/598ffa3de00f28fe66edc25527a3fc65e119c2d1) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Move `react-compiler-runtime` back to `peerDependencies` (revert of #4140). The earlier move to `dependencies` landed in 0.37.4 alongside esm.sh's `?standalone` builder starting to emit a 115-line preload stub that fragments `monaco-editor` into two instances on CDN consumers (#4303). Putting the dependency back in `peerDependencies` narrows the package.json delta between the last-working `0.37.3` and the first-broken `0.37.4`.
+
 ## 0.37.6-alpha.1
 
 ### Patch Changes

--- a/packages/graphiql-react/CHANGELOG.md
+++ b/packages/graphiql-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphiql/react
 
+## 0.37.6-alpha.1
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`8ac17d1`](https://github.com/graphql/graphiql/commit/8ac17d13f8d82537d4f8c4b5539448d6515d5daf) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Revert the `*.css` entry from `sideEffects` (added in #4211). The unbounded glob landed in the same release where esm.sh's `?standalone` builder started emitting a much larger preload stub that fragments `monaco-editor` into two instances and breaks syntax highlighting on CDN consumers (#4303). Removing it narrows the package.json delta between the last working version (0.37.3) and the first broken one (0.37.4). A more narrowly-scoped form may return in a follow-up if the webpack tree-shaking issue from #4211 recurs.
+
 ## 0.37.6-alpha.0
 
 ### Patch Changes

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -46,6 +46,7 @@
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
+    "react-compiler-runtime": "19.1.0-rc.1",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
@@ -63,7 +64,6 @@
     "monaco-editor": "0.52.2",
     "monaco-graphql": "^1.8.0",
     "prettier": "^3.5.3",
-    "react-compiler-runtime": "19.1.0-rc.1",
     "set-value": "^4.1.0",
     "zustand": "^5"
   },

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/react",
-  "version": "0.37.5",
+  "version": "0.37.6-alpha.0",
   "sideEffects": [
     "dist/setup-workers/*",
     "*.css"

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/react",
-  "version": "0.37.6-alpha.0",
+  "version": "0.37.6-alpha.1",
   "sideEffects": [
     "dist/setup-workers/*"
   ],

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphiql/react",
-  "version": "0.37.6-alpha.1",
+  "version": "0.37.6-alpha.2",
   "sideEffects": [
     "dist/setup-workers/*"
   ],

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -2,8 +2,7 @@
   "name": "@graphiql/react",
   "version": "0.37.6-alpha.0",
   "sideEffects": [
-    "dist/setup-workers/*",
-    "*.css"
+    "dist/setup-workers/*"
   ],
   "repository": {
     "type": "git",

--- a/packages/graphiql-react/src/env.d.ts
+++ b/packages/graphiql-react/src/env.d.ts
@@ -4,6 +4,10 @@ declare namespace globalThis {
   var __MONACO: typeof monaco;
 }
 
+declare module 'monaco-editor/esm/vs/editor/edcore.main.js' {
+  export * from 'monaco-editor';
+}
+
 declare module 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js' {
   export { KeyCode } from 'monaco-graphql/monaco-editor';
 }

--- a/packages/graphiql-react/src/stores/monaco.ts
+++ b/packages/graphiql-react/src/stores/monaco.ts
@@ -70,8 +70,18 @@ export const monacoStore = createStore<MonacoStoreType>((set, get) => ({
       if (isInitialized) {
         return;
       }
-      const [monaco, { initializeMode }] = await Promise.all([
-        import('monaco-graphql/esm/monaco-editor.js'),
+      // Import monaco-editor's `graphql` and `json` contributions directly
+      // rather than via `monaco-graphql/esm/monaco-editor.js`. That re-export
+      // module trips up esm.sh's standalone bundler into emitting two monaco
+      // instances (one bundled, one lazily fetched), which produces
+      // "Cannot set tokens provider for unknown language json" at runtime on
+      // CDN setups. See https://github.com/graphql/graphiql/issues/4303.
+      const [, , monaco, { initializeMode }] = await Promise.all([
+        import('monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution.js'),
+        import('monaco-editor/esm/vs/language/json/monaco.contribution.js'),
+        import('monaco-editor/esm/vs/editor/edcore.main.js') as Promise<
+          typeof import('monaco-editor')
+        >,
         import('monaco-graphql/esm/lite.js'),
       ]);
       globalThis.__MONACO = monaco;

--- a/packages/graphiql/CHANGELOG.md
+++ b/packages/graphiql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 5.2.4-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`5f44a27`](https://github.com/graphql/graphiql/commit/5f44a27ae0ff370b4f9eaffe8f92975091bfeb89)]:
+  - @graphiql/react@0.37.6-alpha.0
+  - @graphiql/plugin-doc-explorer@0.4.3-alpha.0
+  - @graphiql/plugin-history@0.4.3-alpha.0
+
 ## 5.2.3
 
 ### Patch Changes

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphiql",
-  "version": "5.2.3",
+  "version": "5.2.4-alpha.0",
   "sideEffects": [
     "dist/setup-workers/*",
     "*.css"
@@ -50,9 +50,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@graphiql/plugin-doc-explorer": "^0.4.2",
-    "@graphiql/plugin-history": "^0.4.2",
-    "@graphiql/react": "^0.37.4",
+    "@graphiql/plugin-doc-explorer": "^0.4.3-alpha.0",
+    "@graphiql/plugin-history": "^0.4.3-alpha.0",
+    "@graphiql/react": "^0.37.6-alpha.0",
     "react-compiler-runtime": "19.1.0-rc.1"
   },
   "peerDependencies": {

--- a/packages/graphql-language-service-cli/CHANGELOG.md
+++ b/packages/graphql-language-service-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # graphql-language-service-cli
 
+## 3.5.1-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`e46fc55`](https://github.com/graphql/graphiql/commit/e46fc55ad40c4c0bae4d7a32bdc5168701f1932f)]:
+  - graphql-language-service-server@2.14.10-alpha.0
+
 ## 3.5.0
 
 ### Minor Changes
@@ -31,7 +38,6 @@
   note that `schemaCacheTTL` can only be set in extension settings or graphql config at the top level - it will be ignored if configured per-project in the graphql config
 
   **Code Improvements**
-
   - Fixes flaky tests, and `schemaCacheTTL` setting not being passed to the cache
   - Adds a test to validate network schema changes are reflected in the cache
 
@@ -57,7 +63,6 @@
   This fixes multiple cacheing bugs, upon addomg some in-depth integration test coverage for the LSP server. It also solves several bugs regarding loading config types, and properly restarts the server and invalidates schema when there are config changes.
 
   ### Bugfix Summary
-
   - configurable polling updates for network and other code first schema configuration, set to a 30s interval by default. powered by `schemaCacheTTL` which can be configured in the IDE settings (vscode, nvim) or in the graphql config file. (1)
   - jump to definition in embedded files offset bug, for both fragments and code files with SDL strings
   - cache invalidation for fragments (fragment lookup/autcoomplete data is more accurate, but incomplete/invalid fragments still do not autocomplete or validate, and remember fragment options always filter/validate by the `on` type!)
@@ -65,11 +70,9 @@
   - schema definition lookups & autocomplete crossing over into the wrong project
 
   **Notes**
-
   1. If possible, configuring for your locally running framework or a schema registry client to handle schema updates and output to a `schema.graphql` or `introspection.json` will always provide a better experience. many graphql frameworks have this built in! Otherwise, we must use this new lazy polling approach if you provide a url schema (this includes both introspection URLs and remote file URLs, and the combination of these).
 
   ### Known Bugs Fixed
-
   - #3318
   - #2357
   - #3469
@@ -78,7 +81,6 @@
   - many more!
 
   ### Test Improvements
-
   - new, high level integration spec suite for the LSP with a matching test utility
   - more unit test coverage
   - **total increased test coverage of about 25% in the LSP server codebase.**
@@ -94,7 +96,6 @@
 ### Patch Changes
 
 - [#3521](https://github.com/graphql/graphiql/pull/3521) [`aa6dbbb4`](https://github.com/graphql/graphiql/commit/aa6dbbb45bf51c1966537640fbe5c4f375735c8d) Thanks [@acao](https://github.com/acao)! - Fixes several issues with Type System (SDL) completion across the ecosystem:
-
   - restores completion for object and input type fields when the document context is not detectable or parseable
   - correct top-level completions for either of the unknown, type system or executable definitions. this leads to mixed top level completions when the document is unparseable, but now you are not seemingly restricted to only executable top level definitions
   - `.graphqls` ad-hoc standard functionality remains, but is not required, as it is not part of the official spec, and the spec also allows mixed mode documents in theory, and this concept is required when the type is unknown
@@ -111,7 +112,7 @@
 
   ```ts
   // import it
-  import { locateCommand } from './graphql/tooling/lsp/locate.js';
+  import { locateCommand } from "./graphql/tooling/lsp/locate.js";
   export default {
     languageService: {
       locateCommand,
@@ -119,12 +120,12 @@
 
     projects: {
       a: {
-        schema: 'https://localhost:8000/graphql',
-        documents: './a/**/*.{ts,tsx,jsx,js,graphql}',
+        schema: "https://localhost:8000/graphql",
+        documents: "./a/**/*.{ts,tsx,jsx,js,graphql}",
       },
       b: {
-        schema: './schema/ascode.ts',
-        documents: './b/**/*.{ts,tsx,jsx,js,graphql}',
+        schema: "./schema/ascode.ts",
+        documents: "./b/**/*.{ts,tsx,jsx,js,graphql}",
       },
     },
   };
@@ -133,7 +134,7 @@
   ```ts
   // or define it inline
 
-  import { type LocateCommand } from 'graphql-language-service-server';
+  import { type LocateCommand } from "graphql-language-service-server";
 
   // relay LSP style
   const locateCommand = (projectName: string, typePath: string) => {
@@ -159,8 +160,8 @@
     languageService: {
       locateCommand,
     },
-    schema: 'https://localhost:8000/graphql',
-    documents: './**/*.{ts,tsx,jsx,js,graphql}',
+    schema: "https://localhost:8000/graphql",
+    documents: "./**/*.{ts,tsx,jsx,js,graphql}",
   };
   ```
 

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-cli",
-  "version": "3.5.0",
+  "version": "3.5.1-alpha.0",
   "description": "An interface for building GraphQL language services for IDEs",
   "contributors": [
     "Hyohyeon Jeong <asiandrummer@fb.com>",
@@ -42,7 +42,7 @@
     "@babel/polyfill": "^7.12.1",
     "@types/yargs": "16.0.5",
     "graphql-language-service": "^5.3.0",
-    "graphql-language-service-server": "^2.14.0",
+    "graphql-language-service-server": "^2.14.10-alpha.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/packages/graphql-language-service-server/CHANGELOG.md
+++ b/packages/graphql-language-service-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # graphql-language-service-server
 
+## 2.14.10-alpha.0
+
+### Patch Changes
+
+- [#4308](https://github.com/graphql/graphiql/pull/4308) [`e46fc55`](https://github.com/graphql/graphiql/commit/e46fc55ad40c4c0bae4d7a32bdc5168701f1932f) Thanks [@trevor-scheer](https://github.com/trevor-scheer)! - Point the package's `types` field at `dist/index.d.ts`, matching the CJS build output. The previous `typings: esm/index.d.ts` referenced the ESM build's output, which is emitted by a separate tsgo invocation that doesn't coordinate with the CJS project reference graph dependents rely on. `tsc` tolerated the misaligned path by falling back to `dist/index.d.ts` next to `main`; `tsgo` resolves project references more strictly and surfaced the misalignment as a "Could not find a declaration file" error during cold builds.
+
 ## 2.14.9
 
 ### Patch Changes

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-language-service-server",
-  "version": "2.14.9",
+  "version": "2.14.10-alpha.0",
   "description": "Server process backing the GraphQL Language Service",
   "contributors": [
     "Greg Hurrell <greg@hurrell.net> (https://greg.hurrell.net)",

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -36,7 +36,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "typings": "esm/index.d.ts",
+  "types": "dist/index.d.ts",
   "peerDependencies": {
     "graphql": "^16.0.0"
   },

--- a/packages/vscode-graphql/CHANGELOG.md
+++ b/packages/vscode-graphql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.13.6-alpha.0
+
+### Patch Changes
+
+- Updated dependencies [[`e46fc55`](https://github.com/graphql/graphiql/commit/e46fc55ad40c4c0bae4d7a32bdc5168701f1932f)]:
+  - graphql-language-service-server@2.14.10-alpha.0
+
 ## 0.13.5
 
 ### Patch Changes

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-graphql",
-  "version": "0.13.5",
+  "version": "0.13.6-alpha.0",
   "private": true,
   "license": "MIT",
   "displayName": "GraphQL: Language Feature Support",
@@ -187,7 +187,7 @@
   },
   "dependencies": {
     "graphql": "^16.9.0 || ^17.0.0-alpha.2",
-    "graphql-language-service-server": "^2.14.9",
+    "graphql-language-service-server": "^2.14.10-alpha.0",
     "typescript": "^5.8.0",
     "vscode-languageclient": "8.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,7 +3099,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphiql/react@npm:^0.37.6-alpha.0, @graphiql/react@workspace:packages/graphiql-react":
+"@graphiql/react@npm:^0.37.6-alpha.0, @graphiql/react@npm:^0.37.6-alpha.1, @graphiql/react@workspace:packages/graphiql-react":
   version: 0.0.0-use.local
   resolution: "@graphiql/react@workspace:packages/graphiql-react"
   dependencies:
@@ -11321,7 +11321,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-graphiql-vite-react-router@workspace:examples/graphiql-vite-react-router"
   dependencies:
-    "@graphiql/react": "npm:^0.37.6-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.1"
     "@react-router/dev": "npm:^7"
     "@react-router/fs-routes": "npm:^7"
     "@react-router/node": "npm:^7"
@@ -11362,7 +11362,7 @@ __metadata:
     "@babel/preset-react": "npm:^7"
     "@graphiql/plugin-code-exporter": "npm:^5.1.3-alpha.0"
     "@graphiql/plugin-explorer": "npm:^5.1.3-alpha.0"
-    "@graphiql/react": "npm:^0.37.6-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.1"
     "@graphiql/toolkit": "npm:^0.12.0"
     ajv-formats: "npm:^3"
     babel-loader: "npm:^9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,11 +3008,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphiql/plugin-code-exporter@npm:^5.1.2, @graphiql/plugin-code-exporter@workspace:packages/graphiql-plugin-code-exporter":
+"@graphiql/plugin-code-exporter@npm:^5.1.3-alpha.0, @graphiql/plugin-code-exporter@workspace:packages/graphiql-plugin-code-exporter":
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-code-exporter@workspace:packages/graphiql-plugin-code-exporter"
   dependencies:
-    "@graphiql/react": "npm:^0.37.4"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
     graphiql-code-exporter: "npm:^3.0.3"
     graphql: "npm:^16.9.0"
@@ -3022,18 +3022,18 @@ __metadata:
     vite: "npm:^6.3.4"
     vite-plugin-dts: "npm:^4.0.1"
   peerDependencies:
-    "@graphiql/react": ^0.37.0
+    "@graphiql/react": ^0.37.6-alpha.0
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
 
-"@graphiql/plugin-doc-explorer@npm:^0.4.2, @graphiql/plugin-doc-explorer@workspace:packages/graphiql-plugin-doc-explorer":
+"@graphiql/plugin-doc-explorer@npm:^0.4.3-alpha.0, @graphiql/plugin-doc-explorer@workspace:packages/graphiql-plugin-doc-explorer":
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-doc-explorer@workspace:packages/graphiql-plugin-doc-explorer"
   dependencies:
-    "@graphiql/react": "npm:^0.37.4"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@headlessui/react": "npm:^2.2"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -3048,18 +3048,18 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.3"
     zustand: "npm:^5"
   peerDependencies:
-    "@graphiql/react": ^0.37.0
+    "@graphiql/react": ^0.37.6-alpha.0
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
 
-"@graphiql/plugin-explorer@npm:^5.1.2, @graphiql/plugin-explorer@workspace:packages/graphiql-plugin-explorer":
+"@graphiql/plugin-explorer@npm:^5.1.3-alpha.0, @graphiql/plugin-explorer@workspace:packages/graphiql-plugin-explorer":
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-explorer@workspace:packages/graphiql-plugin-explorer"
   dependencies:
-    "@graphiql/react": "npm:^0.37.4"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
     graphiql-explorer: "npm:^0.9.0"
     graphql: "npm:^16.9.0"
@@ -3070,18 +3070,18 @@ __metadata:
     vite-plugin-dts: "npm:^4.0.1"
     vite-plugin-svgr: "npm:^4.3.0"
   peerDependencies:
-    "@graphiql/react": ^0.37.0
+    "@graphiql/react": ^0.37.6-alpha.0
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
 
-"@graphiql/plugin-history@npm:^0.4.2, @graphiql/plugin-history@workspace:packages/graphiql-plugin-history":
+"@graphiql/plugin-history@npm:^0.4.3-alpha.0, @graphiql/plugin-history@workspace:packages/graphiql-plugin-history":
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-history@workspace:packages/graphiql-plugin-history"
   dependencies:
-    "@graphiql/react": "npm:^0.37.4"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@graphiql/toolkit": "npm:^0.12.0"
     "@testing-library/react": "npm:^16.1.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
@@ -3093,13 +3093,13 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.3"
     zustand: "npm:^5"
   peerDependencies:
-    "@graphiql/react": ^0.37.0
+    "@graphiql/react": ^0.37.6-alpha.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
 
-"@graphiql/react@npm:^0.37.4, @graphiql/react@npm:^0.37.5, @graphiql/react@workspace:packages/graphiql-react":
+"@graphiql/react@npm:^0.37.6-alpha.0, @graphiql/react@workspace:packages/graphiql-react":
   version: 0.0.0-use.local
   resolution: "@graphiql/react@workspace:packages/graphiql-react"
   dependencies:
@@ -11321,14 +11321,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-graphiql-vite-react-router@workspace:examples/graphiql-vite-react-router"
   dependencies:
-    "@graphiql/react": "npm:^0.37.5"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@react-router/dev": "npm:^7"
     "@react-router/fs-routes": "npm:^7"
     "@react-router/node": "npm:^7"
     "@react-router/serve": "npm:^7"
     "@types/node": "npm:^24"
     "@types/react": "npm:^19"
-    graphiql: "npm:^5.2.3"
+    graphiql: "npm:^5.2.4-alpha.0"
     isbot: "npm:^5"
     react: "npm:^19"
     react-dom: "npm:^19"
@@ -11343,7 +11343,7 @@ __metadata:
   resolution: "example-graphiql-vite@workspace:examples/graphiql-vite"
   dependencies:
     "@vitejs/plugin-react": "npm:^4"
-    graphiql: "npm:^5.2.3"
+    graphiql: "npm:^5.2.4-alpha.0"
     graphql: "npm:^16"
     react: "npm:^19"
     react-dom: "npm:^19"
@@ -11360,9 +11360,9 @@ __metadata:
     "@babel/plugin-syntax-dynamic-import": "npm:^7"
     "@babel/preset-env": "npm:^7"
     "@babel/preset-react": "npm:^7"
-    "@graphiql/plugin-code-exporter": "npm:^5.1.2"
-    "@graphiql/plugin-explorer": "npm:^5.1.2"
-    "@graphiql/react": "npm:^0.37.5"
+    "@graphiql/plugin-code-exporter": "npm:^5.1.3-alpha.0"
+    "@graphiql/plugin-explorer": "npm:^5.1.3-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@graphiql/toolkit": "npm:^0.12.0"
     ajv-formats: "npm:^3"
     babel-loader: "npm:^9"
@@ -11370,7 +11370,7 @@ __metadata:
     cross-env: "npm:^7"
     css-loader: "npm:^6"
     file-loader: "npm:^6"
-    graphiql: "npm:^5.2.3"
+    graphiql: "npm:^5.2.4-alpha.0"
     graphql: "npm:^16"
     graphql-ws: "npm:^5"
     html-webpack-plugin: "npm:^5"
@@ -12950,13 +12950,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"graphiql@npm:^5.2.3, graphiql@workspace:packages/graphiql":
+"graphiql@npm:^5.2.4-alpha.0, graphiql@workspace:packages/graphiql":
   version: 0.0.0-use.local
   resolution: "graphiql@workspace:packages/graphiql"
   dependencies:
-    "@graphiql/plugin-doc-explorer": "npm:^0.4.2"
-    "@graphiql/plugin-history": "npm:^0.4.2"
-    "@graphiql/react": "npm:^0.37.4"
+    "@graphiql/plugin-doc-explorer": "npm:^0.4.3-alpha.0"
+    "@graphiql/plugin-history": "npm:^0.4.3-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.0"
     "@graphiql/toolkit": "npm:^0.12.0"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -13035,7 +13035,7 @@ __metadata:
     "@types/yargs": "npm:16.0.5"
     graphql: "npm:^16.9.0"
     graphql-language-service: "npm:^5.3.0"
-    graphql-language-service-server: "npm:^2.14.0"
+    graphql-language-service-server: "npm:^2.14.10-alpha.0"
     yargs: "npm:^16.2.0"
   peerDependencies:
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
@@ -13044,7 +13044,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"graphql-language-service-server@npm:^2.14.0, graphql-language-service-server@npm:^2.14.9, graphql-language-service-server@workspace:packages/graphql-language-service-server":
+"graphql-language-service-server@npm:^2.14.10-alpha.0, graphql-language-service-server@workspace:packages/graphql-language-service-server":
   version: 0.0.0-use.local
   resolution: "graphql-language-service-server@workspace:packages/graphql-language-service-server"
   dependencies:
@@ -21681,7 +21681,7 @@ __metadata:
     "@vscode/vsce": "npm:^2.22.1-2"
     esbuild: "npm:0.18.10"
     graphql: "npm:^16.9.0 || ^17.0.0-alpha.2"
-    graphql-language-service-server: "npm:^2.14.9"
+    graphql-language-service-server: "npm:^2.14.10-alpha.0"
     ovsx: "npm:0.8.3"
     typescript: "npm:^5.8.0"
     vscode-languageclient: "npm:8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,7 +3042,6 @@ __metadata:
     babel-plugin-react-compiler: "npm:19.1.0-rc.1"
     graphql: "npm:^16.9.0"
     react: "npm:^19.1.0"
-    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     vite: "npm:^6.3.4"
     vite-plugin-dts: "npm:^4.5.3"
@@ -3051,6 +3050,7 @@ __metadata:
     "@graphiql/react": ^0.37.6-alpha.0
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
     react: ^18 || ^19
+    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
@@ -3087,7 +3087,6 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.4.1"
     babel-plugin-react-compiler: "npm:19.1.0-rc.1"
     react: "npm:^19.1.0"
-    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     vite: "npm:^6.3.4"
     vite-plugin-dts: "npm:^4.5.3"
@@ -3095,6 +3094,7 @@ __metadata:
   peerDependencies:
     "@graphiql/react": ^0.37.6-alpha.0
     react: ^18 || ^19
+    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft
@@ -3126,7 +3126,6 @@ __metadata:
     monaco-graphql: "npm:^1.8.0"
     prettier: "npm:^3.5.3"
     react: "npm:^19.1.0"
-    react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
     set-value: "npm:^4.1.0"
     typescript: "npm:^5.8.0"
@@ -3137,6 +3136,7 @@ __metadata:
   peerDependencies:
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
     react: ^18 || ^19
+    react-compiler-runtime: 19.1.0-rc.1
     react-dom: ^18 || ^19
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,7 +3033,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-doc-explorer@workspace:packages/graphiql-plugin-doc-explorer"
   dependencies:
-    "@graphiql/react": "npm:^0.37.6-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.2"
     "@headlessui/react": "npm:^2.2"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -3081,7 +3081,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@graphiql/plugin-history@workspace:packages/graphiql-plugin-history"
   dependencies:
-    "@graphiql/react": "npm:^0.37.6-alpha.0"
+    "@graphiql/react": "npm:^0.37.6-alpha.2"
     "@graphiql/toolkit": "npm:^0.12.0"
     "@testing-library/react": "npm:^16.1.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
@@ -3099,7 +3099,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@graphiql/react@npm:^0.37.6-alpha.0, @graphiql/react@npm:^0.37.6-alpha.1, @graphiql/react@workspace:packages/graphiql-react":
+"@graphiql/react@npm:^0.37.6-alpha.0, @graphiql/react@npm:^0.37.6-alpha.2, @graphiql/react@workspace:packages/graphiql-react":
   version: 0.0.0-use.local
   resolution: "@graphiql/react@workspace:packages/graphiql-react"
   dependencies:
@@ -11321,7 +11321,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-graphiql-vite-react-router@workspace:examples/graphiql-vite-react-router"
   dependencies:
-    "@graphiql/react": "npm:^0.37.6-alpha.1"
+    "@graphiql/react": "npm:^0.37.6-alpha.2"
     "@react-router/dev": "npm:^7"
     "@react-router/fs-routes": "npm:^7"
     "@react-router/node": "npm:^7"
@@ -11362,7 +11362,7 @@ __metadata:
     "@babel/preset-react": "npm:^7"
     "@graphiql/plugin-code-exporter": "npm:^5.1.3-alpha.0"
     "@graphiql/plugin-explorer": "npm:^5.1.3-alpha.0"
-    "@graphiql/react": "npm:^0.37.6-alpha.1"
+    "@graphiql/react": "npm:^0.37.6-alpha.2"
     "@graphiql/toolkit": "npm:^0.12.0"
     ajv-formats: "npm:^3"
     babel-loader: "npm:^9"


### PR DESCRIPTION
## Summary

Alpha release branch for the `@graphiql/react` monaco fix. In changesets
pre-mode under the `alpha` dist-tag so the fix publishes as
`0.37.6-alpha.N` for esm.sh validation before landing on `main` under
`latest`. Substantive change is in the second commit; see its body and
#4303.

## Plan

- [ ] Merge the auto-opened "Version Packages (alpha)" PR (will appear
      against this branch once the Release workflow finishes) to
      publish `@graphiql/react@0.37.6-alpha.0`.
- [ ] Pin the alpha in a copy of `examples/graphiql-cdn/index.html` and
      load in a browser: no `Cannot set tokens provider for unknown
      language json` exception, GraphQL syntax colors render, and
      completion fires.
- [ ] On success: exit pre-mode and land the fix on `main` via a clean
      PR for the final `0.37.6` release.