### PR TITLE
v6: History `⌥`-click opens a diff against the current query

### DIFF
--- a/.changeset/history-alt-click-diff.md
+++ b/.changeset/history-alt-click-diff.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/react': patch
+'@graphiql/plugin-history': patch
+'graphiql': patch
+---
+
+History panel: hold `⌥` (or `Alt` on non-Mac) and click a row to open a side-by-side diff of the current query against the row's query. `Apply` loads the row into the editors; `Cancel` or `ESC` dismisses without changes. `@graphiql/react` exports a new `OperationDiffEditor` component and a `diffOverlay` slice on the editor store, which any consumer can populate to render a diff in the operation editor area.

--- a/packages/graphiql-plugin-history/src/__tests__/components.spec.tsx
+++ b/packages/graphiql-plugin-history/src/__tests__/components.spec.tsx
@@ -10,6 +10,7 @@ vi.mock('@graphiql/react', async () => {
   const mockedSetQueryEditor = vi.fn();
   const mockedSetVariableEditor = vi.fn();
   const mockedSetHeaderEditor = vi.fn();
+  const mockedSetDiffOverlay = vi.fn();
   return {
     ...originalModule,
     useGraphiQL() {
@@ -21,6 +22,12 @@ vi.mock('@graphiql/react', async () => {
         storage: {
           get() {},
         },
+        setDiffOverlay: mockedSetDiffOverlay,
+      };
+    },
+    useGraphiQLActions() {
+      return {
+        setDiffOverlay: mockedSetDiffOverlay,
       };
     },
   };
@@ -74,17 +81,23 @@ function getMockProps(
 }
 
 describe('QueryHistoryItem', () => {
-  const { queryEditor, variableEditor, headerEditor } = useGraphiQL(
-    state => state,
-  );
-  const mockedSetQueryEditor = queryEditor!.setValue as Mock;
-  const mockedSetVariableEditor = variableEditor!.setValue as Mock;
-  const mockedSetHeaderEditor = headerEditor!.setValue as Mock;
+  const state = useGraphiQL(s => s) as unknown as {
+    queryEditor: { setValue: Mock };
+    variableEditor: { setValue: Mock };
+    headerEditor: { setValue: Mock };
+    setDiffOverlay: Mock;
+  };
+  const { queryEditor, variableEditor, headerEditor } = state;
+  const mockedSetQueryEditor = queryEditor.setValue;
+  const mockedSetVariableEditor = variableEditor.setValue;
+  const mockedSetHeaderEditor = headerEditor.setValue;
+  const mockedSetDiffOverlay = state.setDiffOverlay;
 
   beforeEach(() => {
     mockedSetQueryEditor.mockClear();
     mockedSetVariableEditor.mockClear();
     mockedSetHeaderEditor.mockClear();
+    mockedSetDiffOverlay.mockClear();
   });
 
   it('renders operationName if label is not provided', () => {
@@ -124,6 +137,58 @@ describe('QueryHistoryItem', () => {
     );
     expect(mockedSetHeaderEditor).toHaveBeenCalledTimes(1);
     expect(mockedSetHeaderEditor).toHaveBeenCalledWith(mockProps.item.headers);
+  });
+
+  it('opens a diff overlay on alt-click and does not load the editors', () => {
+    const otherMockProps = { item: { operationName: mockOperationName } };
+    const mockProps = getMockProps(otherMockProps);
+    const { container } = render(
+      <QueryHistoryItemWithContext {...mockProps} />,
+    );
+    fireEvent.click(
+      container.querySelector('button.graphiql-history-item-label')!,
+      { altKey: true },
+    );
+    expect(mockedSetDiffOverlay).toHaveBeenCalledTimes(1);
+    const overlay = mockedSetDiffOverlay.mock.calls[0]![0];
+    expect(overlay.modifiedQuery).toBe(mockProps.item.query);
+    expect(overlay.label).toBe(mockOperationName);
+    expect(typeof overlay.onApply).toBe('function');
+    expect(mockedSetQueryEditor).not.toHaveBeenCalled();
+    expect(mockedSetVariableEditor).not.toHaveBeenCalled();
+    expect(mockedSetHeaderEditor).not.toHaveBeenCalled();
+  });
+
+  it('the diff overlay onApply loads the row into the editors', () => {
+    const otherMockProps = { item: { operationName: mockOperationName } };
+    const mockProps = getMockProps(otherMockProps);
+    const { container } = render(
+      <QueryHistoryItemWithContext {...mockProps} />,
+    );
+    fireEvent.click(
+      container.querySelector('button.graphiql-history-item-label')!,
+      { altKey: true },
+    );
+    const overlay = mockedSetDiffOverlay.mock.calls[0]![0];
+    overlay.onApply();
+    expect(mockedSetQueryEditor).toHaveBeenCalledWith(mockProps.item.query);
+    expect(mockedSetVariableEditor).toHaveBeenCalledWith(
+      mockProps.item.variables,
+    );
+    expect(mockedSetHeaderEditor).toHaveBeenCalledWith(mockProps.item.headers);
+  });
+
+  it('plain-click still loads the editors and does not open a diff overlay', () => {
+    const otherMockProps = { item: { operationName: mockOperationName } };
+    const mockProps = getMockProps(otherMockProps);
+    const { container } = render(
+      <QueryHistoryItemWithContext {...mockProps} />,
+    );
+    fireEvent.click(
+      container.querySelector('button.graphiql-history-item-label')!,
+    );
+    expect(mockedSetDiffOverlay).not.toHaveBeenCalled();
+    expect(mockedSetQueryEditor).toHaveBeenCalledWith(mockProps.item.query);
   });
 
   it('renders label input if the edit label button is clicked', () => {

--- a/packages/graphiql-plugin-history/src/components.tsx
+++ b/packages/graphiql-plugin-history/src/components.tsx
@@ -8,6 +8,7 @@ import {
   StarIcon,
   TrashIcon,
   useGraphiQL,
+  useGraphiQLActions,
   pick,
   Button,
   MethodPill,
@@ -50,7 +51,7 @@ export const History: FC = () => {
     <section aria-label="History" className="graphiql-history">
       <PanelHeader
         title="History"
-        subtitle="Last 20 runs."
+        subtitle="Last 20 runs. ⌥-click a row to diff."
         actions={clearButton}
       />
 
@@ -87,6 +88,7 @@ export const HistoryItem: FC<QueryHistoryItemProps> = props => {
   const { headerEditor, queryEditor, variableEditor } = useGraphiQL(
     pick('headerEditor', 'queryEditor', 'variableEditor'),
   );
+  const { setDiffOverlay } = useGraphiQLActions();
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const [isEditable, setIsEditable] = useState(false);
@@ -117,12 +119,23 @@ export const HistoryItem: FC<QueryHistoryItemProps> = props => {
     setIsEditable(true);
   };
 
-  const handleHistoryItemClick: MouseEventHandler<HTMLButtonElement> = () => {
-    const { query, variables, headers } = props.item;
-    queryEditor?.setValue(query ?? '');
-    variableEditor?.setValue(variables ?? '');
-    headerEditor?.setValue(headers ?? '');
-    setActive(props.item);
+  const applyItem = (item: QueryStoreItem) => {
+    queryEditor?.setValue(item.query ?? '');
+    variableEditor?.setValue(item.variables ?? '');
+    headerEditor?.setValue(item.headers ?? '');
+    setActive(item);
+  };
+
+  const handleHistoryItemClick: MouseEventHandler<HTMLButtonElement> = e => {
+    if (e.altKey) {
+      setDiffOverlay({
+        modifiedQuery: props.item.query ?? '',
+        label: displayName ?? '',
+        onApply: () => applyItem(props.item),
+      });
+      return;
+    }
+    applyItem(props.item);
   };
 
   const handleDeleteItemFromHistory: MouseEventHandler<

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -6,6 +6,7 @@ export { RequestHeadersEditor as HeaderEditor } from './request-headers-editor';
 export { ImagePreview } from './image-preview';
 export { GraphiQLProvider, useGraphiQL, useGraphiQLActions } from './provider';
 export { OperationEditor as QueryEditor } from './operation-editor';
+export { OperationDiffEditor } from './operation-diff-editor';
 export { ResponseEditor } from './response-editor';
 export { VariablesEditor as VariableEditor } from './variables-editor';
 

--- a/packages/graphiql-react/src/components/operation-diff-editor.css
+++ b/packages/graphiql-react/src/components/operation-diff-editor.css
@@ -1,0 +1,36 @@
+.graphiql-diff-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.graphiql-diff-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--px-8) var(--px-12);
+  border-bottom: 1px solid oklch(var(--border-default));
+  background: oklch(var(--bg-elevated));
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  color: oklch(var(--fg-subtle));
+}
+
+.graphiql-diff-editor-label strong {
+  margin-left: var(--px-4);
+  color: oklch(var(--fg-strong));
+  font-family: var(--font-family-mono);
+  font-weight: 500;
+}
+
+.graphiql-diff-editor-actions {
+  display: flex;
+  gap: var(--px-8);
+}
+
+.graphiql-diff-editor-monaco {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}

--- a/packages/graphiql-react/src/components/operation-diff-editor.stories.tsx
+++ b/packages/graphiql-react/src/components/operation-diff-editor.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect } from 'react';
+import { GraphiQLProvider, useGraphiQLActions } from './provider';
+import { OperationDiffEditor } from './operation-diff-editor';
+
+const mockFetcher = () => ({ data: null });
+
+const SAMPLE_QUERY = `query GetUser($id: ID!) {
+  user(id: $id) {
+    id
+    name
+    email
+  }
+}`;
+
+function SeedOverlay({ label }: { label: string }) {
+  const { setDiffOverlay } = useGraphiQLActions();
+  useEffect(() => {
+    setDiffOverlay({
+      modifiedQuery: SAMPLE_QUERY,
+      label,
+      // eslint-disable-next-line no-console
+      onApply: () => console.log('Apply clicked'),
+    });
+    return () => setDiffOverlay(null);
+  }, [setDiffOverlay, label]);
+  return null;
+}
+
+const meta: Meta<typeof OperationDiffEditor> = {
+  title: 'Components/OperationDiffEditor',
+  component: OperationDiffEditor,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <GraphiQLProvider fetcher={mockFetcher}>
+        <div style={{ height: 400 }}>
+          <Story />
+        </div>
+      </GraphiQLProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof OperationDiffEditor>;
+
+/**
+ * Header strip rendered with a primed overlay. The Monaco diff itself does not
+ * mount in Storybook (Monaco is initialized at runtime in the main app), so
+ * this story is for visual review of the label and the Apply/Cancel buttons.
+ */
+export const HeaderStrip: Story = {
+  render: () => (
+    <>
+      <SeedOverlay label="GetUser" />
+      <OperationDiffEditor />
+    </>
+  ),
+};
+
+export const LongLabel: Story = {
+  render: () => (
+    <>
+      <SeedOverlay label="GetUserWithAReallyLongOperationNameThatMightWrap" />
+      <OperationDiffEditor />
+    </>
+  ),
+};

--- a/packages/graphiql-react/src/components/operation-diff-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-diff-editor.tsx
@@ -1,0 +1,106 @@
+import { FC, useEffect, useRef } from 'react';
+import { useMonaco } from '../stores';
+import { useGraphiQL, useGraphiQLActions } from './provider';
+import { getOrCreateModel } from '../utility/create-editor';
+import { cleanupDisposables, cn, pick } from '../utility';
+import { Button } from './button';
+import './operation-diff-editor.css';
+
+const ORIGINAL_URI = (id: string) => `${id}diff-original.graphql`;
+const MODIFIED_URI = (id: string) => `${id}diff-modified.graphql`;
+
+export const OperationDiffEditor: FC<{ className?: string }> = ({
+  className,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { setDiffOverlay } = useGraphiQLActions();
+  const { diffOverlay, queryEditor, monacoTheme, uriInstanceId } = useGraphiQL(
+    pick('diffOverlay', 'queryEditor', 'monacoTheme', 'uriInstanceId'),
+  );
+  const { monaco } = useMonaco();
+
+  useEffect(() => {
+    if (!monaco || !diffOverlay || !containerRef.current) {
+      return;
+    }
+    const original = getOrCreateModel({
+      uri: ORIGINAL_URI(uriInstanceId),
+      value: '',
+    });
+    const modified = getOrCreateModel({
+      uri: MODIFIED_URI(uriInstanceId),
+      value: '',
+    });
+    original.setValue(queryEditor?.getValue() ?? '');
+    modified.setValue(diffOverlay.modifiedQuery);
+
+    const editor = monaco.editor.createDiffEditor(containerRef.current, {
+      theme: monacoTheme,
+      readOnly: true,
+      originalEditable: false,
+      renderSideBySide: true,
+      automaticLayout: true,
+      minimap: { enabled: false },
+      scrollBeyondLastLine: false,
+      fontFamily: '"Fira Code"',
+      fontLigatures: true,
+      fontSize: 15,
+    });
+    editor.setModel({ original, modified });
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setDiffOverlay(null);
+      }
+    };
+    const node = containerRef.current;
+    node.addEventListener('keydown', onKeyDown);
+
+    return cleanupDisposables([
+      editor,
+      { dispose: () => node.removeEventListener('keydown', onKeyDown) },
+    ]);
+    // Models are intentionally NOT disposed — they're reused on the next open.
+  }, [
+    monaco,
+    diffOverlay,
+    monacoTheme,
+    uriInstanceId,
+    queryEditor,
+    setDiffOverlay,
+  ]);
+
+  if (!diffOverlay) {
+    return null;
+  }
+
+  return (
+    <div className={cn('graphiql-diff-editor', className)}>
+      <div className="graphiql-diff-editor-header">
+        <span className="graphiql-diff-editor-label">
+          Compare with <strong>{diffOverlay.label}</strong>
+        </span>
+        <div className="graphiql-diff-editor-actions">
+          <Button type="button" onClick={() => setDiffOverlay(null)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => {
+              diffOverlay.onApply();
+              setDiffOverlay(null);
+            }}
+          >
+            Apply
+          </Button>
+        </div>
+      </div>
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        className="graphiql-diff-editor-monaco"
+      />
+    </div>
+  );
+};

--- a/packages/graphiql-react/src/stores/editor.ts
+++ b/packages/graphiql-react/src/stores/editor.ts
@@ -20,6 +20,20 @@ import type { SlicesWithActions, MonacoEditor } from '../types';
 import { debounce, formatJSONC } from '../utility';
 import { STORAGE_KEY } from '../constants';
 
+/**
+ * A read-only diff to render in place of the operation editor. While set, the
+ * editor area shows a side-by-side comparison of the current query (left)
+ * against `modifiedQuery` (right). Cleared by `setDiffOverlay(null)`.
+ */
+export interface DiffOverlay {
+  /** Query content rendered on the right (modified) side of the diff. */
+  modifiedQuery: string;
+  /** Display label shown in the diff header strip. */
+  label: string;
+  /** Invoked when the user clicks Apply. The overlay is cleared automatically afterwards. */
+  onApply: () => void;
+}
+
 export interface EditorSlice extends TabsState {
   /**
    * Unique ID of the GraphiQL instance, which will be suffixed to the URIs for operations,
@@ -47,6 +61,12 @@ export interface EditorSlice extends TabsState {
    * The Monaco Editor instance used in the variables editor.
    */
   variableEditor?: MonacoEditor;
+
+  /**
+   * When set, the editor area renders a Monaco diff editor in place of the
+   * regular operation editor. Used by the history plugin to preview a row.
+   */
+  diffOverlay: DiffOverlay | null;
 
   /**
    * The contents of the request headers editor when initially rendering the provider
@@ -194,6 +214,12 @@ export interface EditorActions {
       'headerEditor' | 'queryEditor' | 'responseEditor' | 'variableEditor'
     >,
   ): void;
+
+  /**
+   * Set or clear the diff overlay rendered in the operation editor area.
+   * Pass `null` to dismiss.
+   */
+  setDiffOverlay(overlay: DiffOverlay | null): void;
 
   /**
    * Changes the operation name and invokes the `onEditOperationName` callback.
@@ -428,6 +454,9 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
       const newState = Object.fromEntries(entries);
       set(newState);
     },
+    setDiffOverlay(diffOverlay) {
+      set({ diffOverlay });
+    },
     setOperationName(operationName) {
       set(({ onEditOperationName, actions }) => {
         actions.updateActiveTabValues({ operationName });
@@ -556,6 +585,7 @@ export const createEditorSlice: CreateEditorSlice = initial => (set, get) => {
   };
   return {
     ...initial,
+    diffOverlay: null,
     actions: $actions,
   };
 };

--- a/packages/graphiql/cypress/e2e/history.cy.ts
+++ b/packages/graphiql/cypress/e2e/history.cy.ts
@@ -99,6 +99,34 @@ describe('history', () => {
     cy.get('.graphiql-history-item').should('have.length', 0);
   });
 
+  it('alt-clicking a row opens a diff overlay, Apply dismisses it', () => {
+    cy.visit(`?query=${mockQuery1}&headers=${mockHeaders1}`);
+    cy.clickExecuteQuery();
+    cy.visit(`?query=${mockQuery2}&headers=${mockHeaders1}`);
+    cy.get('button[aria-label="Show History"]').click();
+    cy.get('.graphiql-history-item').should('have.length', 1);
+
+    cy.get('.graphiql-history-item-label').first().click({ altKey: true });
+    cy.get('.graphiql-diff-editor').should('be.visible');
+    cy.get('.graphiql-diff-editor').contains('Compare with');
+
+    cy.get('.graphiql-diff-editor').contains('button', 'Apply').click();
+    cy.get('.graphiql-diff-editor').should('not.exist');
+  });
+
+  it('alt-clicking a row opens a diff overlay, Cancel dismisses it', () => {
+    cy.visit(`?query=${mockQuery1}&headers=${mockHeaders1}`);
+    cy.clickExecuteQuery();
+    cy.visit(`?query=${mockQuery2}&headers=${mockHeaders1}`);
+    cy.get('button[aria-label="Show History"]').click();
+
+    cy.get('.graphiql-history-item-label').first().click({ altKey: true });
+    cy.get('.graphiql-diff-editor').should('be.visible');
+
+    cy.get('.graphiql-diff-editor').contains('button', 'Cancel').click();
+    cy.get('.graphiql-diff-editor').should('not.exist');
+  });
+
   it('should add/remove item to favorite', () => {
     cy.visit(`?query=${mockQuery1}&headers=${mockHeaders1}`);
     cy.clickExecuteQuery();

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -21,6 +21,7 @@ import {
   PlusIcon,
   PrettifyIcon,
   QueryEditor,
+  OperationDiffEditor,
   ResponseEditor,
   SaveIcon,
   SidePanel,
@@ -236,6 +237,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     activeTabIndex,
     isFetching,
     visiblePlugin,
+    diffOverlay,
   } = useGraphiQL(
     pick(
       'initialVariables',
@@ -244,6 +246,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       'activeTabIndex',
       'isFetching',
       'visiblePlugin',
+      'diffOverlay',
     ),
   );
   const hasMonaco = useMonaco(state => Boolean(state.monaco));
@@ -378,10 +381,14 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
         ref={editorToolsResize.firstRef}
       >
         {hasMonaco ? (
-          <QueryEditor
-            onClickReference={onClickReference}
-            onEdit={onEditQuery}
-          />
+          <>
+            <QueryEditor
+              onClickReference={onClickReference}
+              onEdit={onEditQuery}
+              className={cn(diffOverlay && 'hidden')}
+            />
+            {diffOverlay && <OperationDiffEditor />}
+          </>
         ) : (
           <Spinner />
         )}


### PR DESCRIPTION
## Summary

- Hold `⌥` (or `Alt` on non-Mac) and click a history row to open a side-by-side Monaco diff of the current query against the row's query.
- `Apply` loads the row into the editors (matching the existing plain-click behavior). `Cancel` or `ESC` dismisses with no changes.
- New `OperationDiffEditor` component and `diffOverlay` slice in `@graphiql/react` are generic: any caller can prime them to render a diff in the operation editor area.
- History panel subtitle updated to advertise the gesture.

## Test plan

- [ ] Run a query so a history row exists. Edit the query.
- [ ] `⌥`-click the row. Verify the side-by-side diff appears with "Compare with <row name>" in the header.
- [ ] Click `Apply`. Editor swaps to the row's query.
- [ ] Repeat the setup, `⌥`-click again, then `Cancel` (or `ESC`). Editor stays as you left it.

Refs: graphql/graphiql#4219