### PR TITLE
fix: correct validation diagnostic highlight range

### DIFF
--- a/.changeset/loud-fields-dance.md
+++ b/.changeset/loud-fields-dance.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Fix validation diagnostic ranges so highlights stop at the invalid token instead of including the following character.

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
@@ -44,6 +44,19 @@ describe('getDiagnostics', () => {
     );
     expect(error.severity).toEqual(DIAGNOSTIC_SEVERITY.Error);
     expect(error.source).toEqual('GraphQL: Validation');
+    expect(error.range).toMatchObject({
+      start: { line: 0, character: 18 },
+      end: { line: 0, character: 23 },
+    });
+  });
+
+  it('does not include trailing whitespace in validation highlights', () => {
+    const error = validateQuery(parse('query {\n  title \n}'), schema)[0];
+
+    expect(error.range).toMatchObject({
+      start: { line: 1, character: 2 },
+      end: { line: 1, character: 7 },
+    });
   });
 
   it('catches with multiple highlighted nodes', () => {
@@ -55,7 +68,7 @@ describe('getDiagnostics', () => {
       {
         range: {
           end: {
-            character: 20,
+            character: 19,
             line: 0,
           },
           start: {
@@ -67,7 +80,7 @@ describe('getDiagnostics', () => {
       {
         range: {
           end: {
-            character: 32,
+            character: 31,
             line: 0,
           },
           start: {

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -154,15 +154,16 @@ function annotations(
       // https://github.com/microsoft/TypeScript/pull/32695
       const loc = error.locations[i];
       const highlightLoc = getLocation(highlightNode);
-      const end = loc.column + (highlightLoc.end - highlightLoc.start);
+      const start = new Position(loc.line - 1, loc.column - 1);
+      const end = new Position(
+        start.line,
+        start.character + highlightLoc.end - highlightLoc.start,
+      );
       highlightedNodes.push({
         source: `GraphQL: ${type}`,
         message: error.message,
         severity,
-        range: new Range(
-          new Position(loc.line - 1, loc.column - 1),
-          new Position(loc.line - 1, end),
-        ),
+        range: new Range(start, end),
       });
     }
   }


### PR DESCRIPTION
## Issue

The GraphQL language service reports validation diagnostics with a range that is one character too long. In VS Code / LSP clients this makes an invalid field underline include the following whitespace, instead of stopping at the invalid field name. This reproduces the screenshot and report in #4234.

## Why this fixes it

`graphql-js` locations are 1-based, while LSP ranges are 0-based and end-exclusive. The previous code converted the start column to 0-based but computed the end column from the original 1-based column, so the diagnostic end position was shifted one character too far.

This PR computes the LSP start position first, then adds the highlighted AST node length to that zero-based start character. The resulting end position stops exactly after the invalid token and no longer includes trailing whitespace.

## Manual verification steps

1. Use the GraphQL language service with a schema that does not contain a `title` field at the queried location.
2. Open this query:

   ```graphql
   query {
     title 
   }
   ```

3. Trigger validation diagnostics in the editor / LSP client.
4. Confirm the validation underline starts at the `t` in `title` and ends immediately after `title`; the following space before the newline is not highlighted.

## Automated verification

- `yarn vitest run packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts`
- `yarn tsgo --build packages/graphql-language-service/tsconfig.json`
- `yarn vitest run packages/graphql-language-service/src`
- `yarn turbo run test --filter=graphql-language-service`
- `yarn turbo run types:check --filter=graphql-language-service`
- `yarn oxfmt --check packages/graphql-language-service/src/interface/getDiagnostics.ts packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts .changeset/loud-fields-dance.md`
- `git diff --check`

Fixes #4234.
