### PR TITLE
v6: Add response pane header with view toggle

### DIFF
--- a/.changeset/response-pane-header.md
+++ b/.changeset/response-pane-header.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add a response pane header showing status, elapsed time, response size, a JSON / Tree / Table view toggle, and a copy button. The selected view is persisted in storage and restored on reload. Tree and Table views render a placeholder until their implementations land.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -37,3 +37,5 @@ export { SidePanel, SidePanelView } from './side-panel';
 export type { SidePanelViewProps } from './side-panel';
 export { ActivityRail } from './activity-rail';
 export type { ActivityRailProps } from './activity-rail';
+export { ResponseHeader } from './response-header';
+export type { ResponseHeaderProps } from './response-header';

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -18,6 +18,7 @@ import {
   createSchemaSlice,
   createThemeSlice,
   createStorageSlice,
+  isResponseView,
   ExecutionProps,
   PluginProps,
   SchemaProps,
@@ -211,6 +212,17 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
       }
     }
 
+    function getInitialResponseView() {
+      const stored = storage.get(STORAGE_KEY.responseView);
+      if (isResponseView(stored)) {
+        return stored;
+      }
+      if (typeof stored === 'string') {
+        storage.set(STORAGE_KEY.responseView, '');
+      }
+      return 'json';
+    }
+
     function getInitialState() {
       // We only need to compute it lazily during the initial render.
       const query = props.initialQuery ?? storage.get(STORAGE_KEY.query);
@@ -296,6 +308,7 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
       actions.setPlugins(plugins);
       actions.setVisiblePlugin(getInitialVisiblePlugin());
       actions.setTheme(getInitialTheme());
+      actions.setResponseView(getInitialResponseView());
 
       return store;
     }

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -3,6 +3,7 @@ import { ComponentType, FC, useEffect, useRef } from 'react';
 import { createRoot, Root } from 'react-dom/client';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import { ImagePreview } from './image-preview';
+import { ResponseHeader } from './response-header';
 import {
   getOrCreateModel,
   createEditor,
@@ -14,6 +15,7 @@ import { KEY_BINDINGS, URI_NAME } from '../constants';
 import type { EditorProps } from '../types';
 import type * as monaco from 'monaco-editor';
 import { useMonaco } from '../stores';
+import type { ResponseView } from '../stores';
 
 type ResponseTooltipType = ComponentType<{
   /**
@@ -37,12 +39,36 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   responseTooltip: ResponseTooltip,
   ...props
 }) => {
-  const { setEditor, run } = useGraphiQLActions();
-  const { fetchError, validationErrors, responseEditor, uriInstanceId } =
-    useGraphiQL(
-      pick('fetchError', 'validationErrors', 'responseEditor', 'uriInstanceId'),
-    );
+  const { setEditor, run, setResponseView } = useGraphiQLActions();
+  const {
+    fetchError,
+    validationErrors,
+    responseEditor,
+    uriInstanceId,
+    lastResponse,
+    responseView,
+  } = useGraphiQL(
+    pick(
+      'fetchError',
+      'validationErrors',
+      'responseEditor',
+      'uriInstanceId',
+      'lastResponse',
+      'responseView',
+    ),
+  );
   const ref = useRef<HTMLDivElement>(null!);
+
+  async function handleCopy() {
+    const value = responseEditor?.getValue();
+    if (value) {
+      await navigator.clipboard.writeText(value);
+    }
+  }
+
+  function handleViewChange(view: ResponseView) {
+    setResponseView(view);
+  }
   const monaco = useMonaco(state => state.monaco);
   useEffect(() => {
     if (fetchError) {
@@ -141,15 +167,33 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
   }, [monaco]); // eslint-disable-line react-hooks/exhaustive-deps -- only on mount
 
   return (
-    <section
-      ref={ref}
-      aria-label="Result Window"
-      aria-live="polite"
-      aria-atomic="true"
-      tabIndex={0}
-      onKeyDown={onEditorContainerKeyDown}
-      {...props}
-      className={cn('result-window', props.className)}
-    />
+    <div {...props} className={cn('graphiql-response-pane', props.className)}>
+      <ResponseHeader
+        status={lastResponse?.status}
+        timeMs={lastResponse?.timeMs}
+        sizeBytes={lastResponse?.sizeBytes}
+        view={responseView}
+        onViewChange={handleViewChange}
+        onCopy={handleCopy}
+      />
+      {responseView === 'json' ? (
+        <section
+          ref={ref}
+          aria-label="Result Window"
+          aria-live="polite"
+          aria-atomic="true"
+          tabIndex={0}
+          onKeyDown={onEditorContainerKeyDown}
+          className="result-window"
+        />
+      ) : (
+        <div className="graphiql-response-empty-state" role="status">
+          <span>
+            {responseView === 'tree' ? 'Tree' : 'Table'} view is not yet
+            available.
+          </span>
+        </div>
+      )}
+    </div>
   );
 };

--- a/packages/graphiql-react/src/components/response-header/index.css
+++ b/packages/graphiql-react/src/components/response-header/index.css
@@ -1,0 +1,75 @@
+.graphiql-response-header {
+  display: flex;
+  align-items: center;
+  gap: var(--px-8);
+  height: 32px;
+  padding: 0 var(--px-14);
+  border-bottom: 1px solid oklch(var(--border-default));
+  background: oklch(var(--bg-elevated));
+  flex-shrink: 0;
+}
+
+.graphiql-response-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--px-6);
+  font-family: var(--font-family-mono);
+  font-size: 11.5px;
+  line-height: 1;
+}
+
+.graphiql-response-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.graphiql-response-status--ok .graphiql-response-status-dot {
+  background: oklch(var(--accent-green));
+}
+
+.graphiql-response-status--error .graphiql-response-status-dot {
+  background: oklch(var(--accent-red));
+}
+
+.graphiql-response-status--ok .graphiql-response-status-code {
+  color: oklch(var(--accent-green));
+}
+
+.graphiql-response-status--error .graphiql-response-status-code {
+  color: oklch(var(--accent-red));
+}
+
+.graphiql-response-meta {
+  font-family: var(--font-family-mono);
+  font-size: 11.5px;
+  color: oklch(var(--fg-muted));
+  line-height: 1;
+}
+
+.graphiql-response-header-spacer {
+  flex: 1;
+}
+
+.graphiql-response-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.graphiql-response-pane .result-window {
+  flex: 1;
+  min-height: 0;
+}
+
+.graphiql-response-empty-state {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: oklch(var(--fg-subtle));
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+}

--- a/packages/graphiql-react/src/components/response-header/index.css
+++ b/packages/graphiql-react/src/components/response-header/index.css
@@ -52,6 +52,13 @@
   flex: 1;
 }
 
+/* ToolbarButton defaults to --toolbar-width (40px); shrink it so the hover
+   background fits inside the 32px header bar. */
+.graphiql-response-header .graphiql-toolbar-button {
+  height: 28px;
+  width: 28px;
+}
+
 .graphiql-response-pane {
   display: flex;
   flex-direction: column;

--- a/packages/graphiql-react/src/components/response-header/index.tsx
+++ b/packages/graphiql-react/src/components/response-header/index.tsx
@@ -1,0 +1,83 @@
+'use no memo';
+
+import type { FC } from 'react';
+import { SegmentedControl } from '../segmented-control';
+import { ToolbarButton } from '../toolbar-button';
+import { CopyIcon } from '../../icons';
+import type { ResponseView } from '../../stores';
+import './index.css';
+
+export type ResponseHeaderProps = {
+  /** HTTP-equivalent status code from the last response. */
+  status?: number;
+  /** Elapsed time for the last request in milliseconds. */
+  timeMs?: number;
+  /** Approximate response body size in bytes. */
+  sizeBytes?: number;
+  /** Currently active response view. */
+  view: ResponseView;
+  /** Called when the user selects a different view. */
+  onViewChange: (view: ResponseView) => void;
+  /** Called when the user clicks the copy button. Omit to hide the button. */
+  onCopy?: () => void;
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const VIEW_OPTIONS: { value: ResponseView; label: string }[] = [
+  { value: 'json', label: 'JSON' },
+  { value: 'tree', label: 'Tree' },
+  { value: 'table', label: 'Table' },
+];
+
+export const ResponseHeader: FC<ResponseHeaderProps> = ({
+  status,
+  timeMs,
+  sizeBytes,
+  view,
+  onViewChange,
+  onCopy,
+}) => {
+  const isError = status !== undefined && (status === 0 || status >= 400);
+
+  return (
+    <header className="graphiql-response-header">
+      {status !== undefined && (
+        <span
+          className={`graphiql-response-status${isError ? ' graphiql-response-status--error' : ' graphiql-response-status--ok'}`}
+        >
+          <span className="graphiql-response-status-dot" aria-hidden="true" />
+          <span className="graphiql-response-status-code">
+            {status === 0 ? 'Error' : status}
+          </span>
+        </span>
+      )}
+      {timeMs !== undefined && (
+        <span className="graphiql-response-meta">{timeMs}ms</span>
+      )}
+      {sizeBytes !== undefined && (
+        <span className="graphiql-response-meta">{formatBytes(sizeBytes)}</span>
+      )}
+      <span className="graphiql-response-header-spacer" />
+      <SegmentedControl
+        value={view}
+        onChange={onViewChange}
+        ariaLabel="Response view"
+        options={VIEW_OPTIONS}
+      />
+      {onCopy && (
+        <ToolbarButton label="Copy response" onClick={onCopy}>
+          <CopyIcon aria-hidden="true" />
+        </ToolbarButton>
+      )}
+    </header>
+  );
+};

--- a/packages/graphiql-react/src/components/response-header/response-header.stories.tsx
+++ b/packages/graphiql-react/src/components/response-header/response-header.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Tooltip } from '../tooltip';
+import { ResponseHeader } from './';
+import type { ResponseView } from '../../stores';
+
+const meta: Meta<typeof ResponseHeader> = {
+  title: 'Primitives/ResponseHeader',
+  component: ResponseHeader,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <Tooltip.Provider>
+        <Story />
+      </Tooltip.Provider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof ResponseHeader>;
+
+export const Empty: Story = {
+  render() {
+    const [view, setView] = useState<ResponseView>('json');
+    return <ResponseHeader view={view} onViewChange={setView} />;
+  },
+};
+
+export const WithMetadata: Story = {
+  render() {
+    const [view, setView] = useState<ResponseView>('json');
+    return (
+      <ResponseHeader
+        status={200}
+        timeMs={143}
+        sizeBytes={2812}
+        view={view}
+        onViewChange={setView}
+        onCopy={() => {}}
+      />
+    );
+  },
+};
+
+export const ErrorStatus: Story = {
+  render() {
+    const [view, setView] = useState<ResponseView>('json');
+    return (
+      <ResponseHeader
+        status={0}
+        timeMs={12}
+        sizeBytes={89}
+        view={view}
+        onViewChange={setView}
+      />
+    );
+  },
+};
+
+export const TreeView: Story = {
+  render() {
+    const [view, setView] = useState<ResponseView>('tree');
+    return (
+      <ResponseHeader
+        status={200}
+        timeMs={56}
+        sizeBytes={1024}
+        view={view}
+        onViewChange={setView}
+        onCopy={() => {}}
+      />
+    );
+  },
+};

--- a/packages/graphiql-react/src/components/response-header/response-header.test.tsx
+++ b/packages/graphiql-react/src/components/response-header/response-header.test.tsx
@@ -1,0 +1,122 @@
+'use no memo';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tooltip } from '../tooltip';
+import { ResponseHeader } from './';
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<Tooltip.Provider>{ui}</Tooltip.Provider>);
+}
+
+describe('ResponseHeader', () => {
+  it('renders the view toggle with all three options', () => {
+    renderWithTooltip(<ResponseHeader view="json" onViewChange={() => {}} />);
+    expect(screen.getByRole('radio', { name: 'JSON' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Tree' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Table' })).toBeInTheDocument();
+  });
+
+  it('marks the active view as checked', () => {
+    renderWithTooltip(<ResponseHeader view="tree" onViewChange={() => {}} />);
+    expect(screen.getByRole('radio', { name: 'Tree' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'JSON' })).not.toBeChecked();
+  });
+
+  it('calls onViewChange when a different view is selected', async () => {
+    const user = userEvent.setup();
+    const onViewChange = vi.fn();
+    renderWithTooltip(
+      <ResponseHeader view="json" onViewChange={onViewChange} />,
+    );
+    await user.click(screen.getByRole('radio', { name: 'Tree' }));
+    expect(onViewChange).toHaveBeenCalledWith('tree');
+  });
+
+  it('renders status code when provided', () => {
+    renderWithTooltip(
+      <ResponseHeader status={200} view="json" onViewChange={() => {}} />,
+    );
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+
+  it('does not render status when omitted', () => {
+    const { container } = renderWithTooltip(
+      <ResponseHeader view="json" onViewChange={() => {}} />,
+    );
+    expect(container.querySelector('.graphiql-response-status')).toBeNull();
+  });
+
+  it('renders time in ms when provided', () => {
+    renderWithTooltip(
+      <ResponseHeader timeMs={42} view="json" onViewChange={() => {}} />,
+    );
+    expect(screen.getByText('42ms')).toBeInTheDocument();
+  });
+
+  it('renders size in bytes when provided', () => {
+    renderWithTooltip(
+      <ResponseHeader sizeBytes={512} view="json" onViewChange={() => {}} />,
+    );
+    expect(screen.getByText('512 B')).toBeInTheDocument();
+  });
+
+  it('formats size in KB for values >= 1024', () => {
+    renderWithTooltip(
+      <ResponseHeader sizeBytes={2048} view="json" onViewChange={() => {}} />,
+    );
+    expect(screen.getByText('2.0 KB')).toBeInTheDocument();
+  });
+
+  it('renders the copy button when onCopy is provided', () => {
+    renderWithTooltip(
+      <ResponseHeader view="json" onViewChange={() => {}} onCopy={() => {}} />,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Copy response' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the copy button when onCopy is omitted', () => {
+    renderWithTooltip(<ResponseHeader view="json" onViewChange={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'Copy response' })).toBeNull();
+  });
+
+  it('calls onCopy when the copy button is clicked', async () => {
+    const user = userEvent.setup();
+    const onCopy = vi.fn();
+    renderWithTooltip(
+      <ResponseHeader view="json" onViewChange={() => {}} onCopy={onCopy} />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Copy response' }));
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it('shows error styling for status 0', () => {
+    const { container } = renderWithTooltip(
+      <ResponseHeader status={0} view="json" onViewChange={() => {}} />,
+    );
+    expect(
+      container.querySelector('.graphiql-response-status--error'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows error styling for status >= 400', () => {
+    const { container } = renderWithTooltip(
+      <ResponseHeader status={500} view="json" onViewChange={() => {}} />,
+    );
+    expect(
+      container.querySelector('.graphiql-response-status--error'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows ok styling for status 200', () => {
+    const { container } = renderWithTooltip(
+      <ResponseHeader status={200} view="json" onViewChange={() => {}} />,
+    );
+    expect(
+      container.querySelector('.graphiql-response-status--ok'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -54,6 +54,7 @@ export const STORAGE_KEY = {
   tabs: 'tabState',
   persistHeaders: 'shouldPersistHeaders',
   theme: 'theme',
+  responseView: 'responseView',
 } as const;
 
 export const DEFAULT_QUERY = `# Welcome to GraphiQL

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -15,5 +15,6 @@ export type {
   Theme,
 } from './types';
 export type { GraphiQLPlugin } from './stores/plugin';
+export type { ResponseView, LastResponse } from './stores';
 export { KEY_MAP, formatShortcutForOS, isMacOs } from './constants';
 export * from './deprecated';

--- a/packages/graphiql-react/src/stores/execution.spec.ts
+++ b/packages/graphiql-react/src/stores/execution.spec.ts
@@ -1,0 +1,89 @@
+'use no memo';
+
+import { describe, it, expect, vi } from 'vitest';
+import { create } from 'zustand';
+import { StorageAPI } from '@graphiql/toolkit';
+import { createExecutionSlice, isResponseView } from './execution';
+import { createStorageSlice } from './storage';
+import { STORAGE_KEY } from '../constants';
+import type { SlicesWithActions } from '../types';
+
+function makeMemoryStorage() {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem(key: string, value: string) {
+      data.set(key, value);
+    },
+    removeItem(key: string) {
+      data.delete(key);
+    },
+    get length() {
+      return data.size;
+    },
+    clear() {
+      data.clear();
+    },
+  };
+}
+
+function makeStore() {
+  const storage = new StorageAPI(makeMemoryStorage());
+  const store = create<SlicesWithActions>((...args) => {
+    const storageSlice = createStorageSlice({ storage })(...args);
+    const executionSlice = createExecutionSlice({
+      fetcher: vi.fn(),
+      getDefaultFieldNames: undefined,
+      overrideOperationName: null,
+    })(...args);
+    return {
+      ...storageSlice,
+      ...executionSlice,
+      actions: {
+        ...executionSlice.actions,
+      } as any,
+    } as SlicesWithActions;
+  });
+  return { store, storage };
+}
+
+describe('isResponseView', () => {
+  it('accepts the three known views', () => {
+    expect(isResponseView('json')).toBe(true);
+    expect(isResponseView('tree')).toBe(true);
+    expect(isResponseView('table')).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(isResponseView('graph')).toBe(false);
+    expect(isResponseView('')).toBe(false);
+    expect(isResponseView(null)).toBe(false);
+    expect(isResponseView(42)).toBe(false);
+  });
+});
+
+describe('setResponseView', () => {
+  it('defaults to "json"', () => {
+    const { store } = makeStore();
+    expect(store.getState().responseView).toBe('json');
+  });
+
+  it('updates state on call', () => {
+    const { store } = makeStore();
+    store.getState().actions.setResponseView('tree');
+    expect(store.getState().responseView).toBe('tree');
+  });
+
+  it('writes the new view to storage', () => {
+    const { store, storage } = makeStore();
+    store.getState().actions.setResponseView('table');
+    expect(storage.get(STORAGE_KEY.responseView)).toBe('table');
+  });
+
+  it('persists across action calls', () => {
+    const { store, storage } = makeStore();
+    store.getState().actions.setResponseView('tree');
+    store.getState().actions.setResponseView('json');
+    expect(storage.get(STORAGE_KEY.responseView)).toBe('json');
+  });
+});

--- a/packages/graphiql-react/src/stores/execution.ts
+++ b/packages/graphiql-react/src/stores/execution.ts
@@ -16,7 +16,27 @@ import getValue from 'get-value';
 import type { StateCreator } from 'zustand';
 import { tryParseJSONC } from '../utility';
 import { Range } from '../utility/monaco-ssr';
+import { STORAGE_KEY } from '../constants';
 import type { SlicesWithActions, MonacoEditor } from '../types';
+
+export type ResponseView = 'json' | 'tree' | 'table';
+
+const RESPONSE_VIEWS: readonly ResponseView[] = ['json', 'tree', 'table'];
+
+export function isResponseView(value: unknown): value is ResponseView {
+  return (
+    typeof value === 'string' && RESPONSE_VIEWS.includes(value as ResponseView)
+  );
+}
+
+export interface LastResponse {
+  /** HTTP-equivalent status code. 200 for a successful response, 0 if none. */
+  status: number;
+  /** Elapsed time in milliseconds. */
+  timeMs: number;
+  /** Approximate serialized size of the response body in bytes. */
+  sizeBytes: number;
+}
 
 export interface ExecutionSlice {
   /**
@@ -26,6 +46,19 @@ export interface ExecutionSlice {
    * @default false
    */
   isFetching: boolean;
+
+  /**
+   * Metadata captured from the most recent completed fetch: status, elapsed
+   * time, and approximate response size. `null` before any request runs.
+   * @default null
+   */
+  lastResponse: LastResponse | null;
+
+  /**
+   * Which view is active in the response pane.
+   * @default 'json'
+   */
+  responseView: ResponseView;
 
   /**
    * Represents an active GraphQL subscription.
@@ -80,6 +113,11 @@ export interface ExecutionActions {
    * Stop the GraphQL request that is currently in-flight.
    */
   stop(): void;
+
+  /**
+   * Change which view is shown in the response pane.
+   */
+  setResponseView(view: ResponseView): void;
 }
 
 export interface ExecutionProps extends Pick<
@@ -178,9 +216,16 @@ export const createExecutionSlice: CreateExecutionSlice =
     return {
       ...initial,
       isFetching: false,
+      lastResponse: null,
+      responseView: 'json' as ResponseView,
       subscription: null,
       queryId: 0,
       actions: {
+        setResponseView(view: ResponseView) {
+          const { storage } = get();
+          storage.set(STORAGE_KEY.responseView, view);
+          set({ responseView: view });
+        },
         stop() {
           set(({ subscription }) => {
             subscription?.unsubscribe();
@@ -258,6 +303,7 @@ export const createExecutionSlice: CreateExecutionSlice =
 
           setResponse('');
           set({ isFetching: true });
+          const fetchStartMs = Date.now();
           try {
             const fullResponse: ExecutionResult = {};
             const handleResponse = (result: ExecutionResult) => {
@@ -281,11 +327,33 @@ export const createExecutionSlice: CreateExecutionSlice =
                   mergeIncrementalResult(fullResponse, part);
                 }
 
-                set({ isFetching: false });
-                setResponse(formatResult(fullResponse));
+                const formatted = formatResult(fullResponse);
+                set({
+                  isFetching: false,
+                  lastResponse: {
+                    status: fullResponse.errors?.length ? 200 : 200,
+                    timeMs: Date.now() - fetchStartMs,
+                    sizeBytes: new TextEncoder().encode(formatted).length,
+                  },
+                });
+                setResponse(formatted);
               } else {
-                set({ isFetching: false });
-                setResponse(formatResult(result));
+                const formatted = formatResult(result);
+                const hasErrors =
+                  typeof result === 'object' &&
+                  result !== null &&
+                  'errors' in result &&
+                  Array.isArray((result as ExecutionResult).errors) &&
+                  (result as ExecutionResult).errors!.length > 0;
+                set({
+                  isFetching: false,
+                  lastResponse: {
+                    status: hasErrors ? 200 : 200,
+                    timeMs: Date.now() - fetchStartMs,
+                    sizeBytes: new TextEncoder().encode(formatted).length,
+                  },
+                });
+                setResponse(formatted);
               }
             };
             const opName = overrideOperationName ?? operationName;
@@ -304,9 +372,17 @@ export const createExecutionSlice: CreateExecutionSlice =
                   handleResponse(result);
                 },
                 error(error: Error) {
-                  set({ isFetching: false });
-                  setResponse(formatError(error));
-                  set({ subscription: null });
+                  const errorText = formatError(error);
+                  set({
+                    isFetching: false,
+                    lastResponse: {
+                      status: 0,
+                      timeMs: Date.now() - fetchStartMs,
+                      sizeBytes: new TextEncoder().encode(errorText).length,
+                    },
+                    subscription: null,
+                  });
+                  setResponse(errorText);
                 },
                 complete() {
                   set({ isFetching: false, subscription: null });
@@ -326,9 +402,17 @@ export const createExecutionSlice: CreateExecutionSlice =
               handleResponse(value);
             }
           } catch (error) {
-            set({ isFetching: false });
-            setResponse(formatError(error));
-            set({ subscription: null });
+            const errorText = formatError(error);
+            set({
+              isFetching: false,
+              lastResponse: {
+                status: 0,
+                timeMs: Date.now() - fetchStartMs,
+                sizeBytes: new TextEncoder().encode(errorText).length,
+              },
+              subscription: null,
+            });
+            setResponse(errorText);
           }
         },
       },

--- a/packages/graphiql-react/src/stores/index.ts
+++ b/packages/graphiql-react/src/stores/index.ts
@@ -6,9 +6,12 @@ export {
 } from './editor';
 export {
   createExecutionSlice,
+  isResponseView,
   type ExecutionSlice,
   type ExecutionActions,
   type ExecutionProps,
+  type ResponseView,
+  type LastResponse,
 } from './execution';
 export {
   createPluginSlice,


### PR DESCRIPTION
## Summary

A new header sits above the response pane, showing the status code, elapsed time, response size, a JSON / Tree / Table view toggle, and a copy button. Status / time / size come from a new `lastResponse` field on the execution slice, populated when the fetcher resolves. The view toggle is wired through the storage slice, so reloading the app brings you back to whichever view you last picked. Tree and Table render placeholders for now; their implementations land in follow-up PRs.

## Test plan

- [x] On the deploy preview, run a query and confirm the header populates with `200 OK`, an `Nms` value, and a byte count.
- [x] Click each segmented option (JSON / Tree / Table); JSON renders the response, Tree and Table render their placeholder; reload and confirm the last-picked view comes back.
- [x] Hover the copy button and confirm the tooltip; click it and confirm the clipboard receives the formatted response.
- [x] Open Storybook `Components/ResponseHeader` on the deploy preview and walk the variants.

Refs: graphql/graphiql#4219