### PR TITLE
fix(graphql-language-service-server): move debounce-promise to dependencies

### DIFF
--- a/.changeset/lsp-server-debounce-promise-dependency.md
+++ b/.changeset/lsp-server-debounce-promise-dependency.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Move `debounce-promise` from `devDependencies` to `dependencies`. It is imported at runtime in `MessageProcessor.ts`, so it must be a regular dependency. Previously the package only resolved it via hoisting, which fails under strict installs (e.g. `pnpm` v11), causing `graphql-lsp` to crash with `Cannot find module 'debounce-promise'`.

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -47,6 +47,7 @@
     "@babel/types": "^7.23.5",
     "@graphql-tools/code-file-loader": "8.0.3",
     "cosmiconfig-toml-loader": "^1.0.0",
+    "debounce-promise": "^3.1.2",
     "dotenv": "10.0.0",
     "fast-glob": "^3.2.7",
     "glob": "^7.2.0",
@@ -67,9 +68,9 @@
     "vue": "^3.2.0"
   },
   "devDependencies": {
+    "@types/debounce-promise": "^3.1.9",
     "@types/glob": "^8.1.0",
     "@types/mkdirp": "^1.0.1",
-    "debounce-promise": "^3.1.2",
     "graphql": "^16.9.0",
     "msw": "^2.13.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13094,6 +13094,7 @@ __metadata:
     "@babel/parser": "npm:^7.23.6"
     "@babel/types": "npm:^7.23.5"
     "@graphql-tools/code-file-loader": "npm:8.0.3"
+    "@types/debounce-promise": "npm:^3.1.9"
     "@types/glob": "npm:^8.1.0"
     "@types/mkdirp": "npm:^1.0.1"
     cosmiconfig-toml-loader: "npm:^1.0.0"


### PR DESCRIPTION
## Summary

`graphql-language-service-server` imports `debounce-promise` at runtime in `MessageProcessor.ts`, but it was declared as a `devDependency`. It previously resolved only through dependency hoisting (the sibling `graphql-language-service` package lists it as a real dependency), which breaks under strict, isolated installs such as `pnpm` v11. There, `graphql-lsp` crashes on startup with `Cannot find module 'debounce-promise'`.

This moves `debounce-promise` into `dependencies` so it is always available at runtime, and adds `@types/debounce-promise` to `devDependencies` so type-checking no longer relies on hoisting either.

Fixes #4324.

## Changes

- Move `debounce-promise` from `devDependencies` to `dependencies`.
- Add `@types/debounce-promise` to `devDependencies`.
- Add a patch changeset.

## Verification

- Scanned the package source for bare (non-relative) runtime imports; `debounce-promise` was the only genuinely mis-declared runtime dependency (`@graphql-tools/load` is a type-only import and is erased at build time).
- `tsgo --build` and `tsgo --noEmit` on `graphql-language-service-server` pass; the `debounce-promise` import and its types resolve correctly.

## Credit

Thanks to @dylanarmstrong for the report and for correctly diagnosing the root cause in the issue.
