### PR TITLE
fix(graphql-language-service): allow optional field blocks in SDL type definitions

### DIFF
--- a/.changeset/schema-kitchen-sink-optional-fields.md
+++ b/.changeset/schema-kitchen-sink-optional-fields.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Make the fields block optional when parsing object, interface, input, and enum type definitions (and their extensions) in the online parser. Per the GraphQL spec these blocks are optional, so spec-valid SDL such as `extend type Foo @onType` or `type Foo @onType` (directives only, no body) no longer reports `invalidchar` during syntax highlighting.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,11 +6,7 @@
   "proseWrap": "never",
   "printWidth": 80,
   "sortPackageJson": false,
-  "ignorePatterns": [
-    "packages/codemirror-graphql/src/__tests__/schema-kitchen-sink.graphql",
-    "**/CHANGELOG.md",
-    "working-group/agendas/**"
-  ],
+  "ignorePatterns": ["**/CHANGELOG.md", "working-group/agendas/**"],
   "overrides": [
     {
       "files": ["*.md", "*.mdx"],

--- a/packages/codemirror-graphql/src/__tests__/mode.test.ts
+++ b/packages/codemirror-graphql/src/__tests__/mode.test.ts
@@ -91,6 +91,24 @@ describe('graphql-mode', () => {
     });
   });
 
+  it('parses type system definitions without a body without invalidchar', () => {
+    const schema = `
+      type EmptyType @onType
+      interface EmptyInterface @onInterface
+      enum EmptyEnum @onEnum
+      input EmptyInput @onInputObject
+
+      extend type Foo @onType
+      extend interface Bar @onInterface
+      extend enum Site @onEnum
+      extend input InputType @onInputObject
+    `;
+
+    CodeMirror.runMode(schema, 'graphql', (_token, style) => {
+      expect(style).not.toBe('invalidchar');
+    });
+  });
+
   it('parses anonymous operations without invalidchar', () => {
     CodeMirror.runMode('{ id }', 'graphql', (_token, style) => {
       expect(style).not.toBe('invalidchar');

--- a/packages/codemirror-graphql/src/__tests__/schema-kitchen-sink.graphql
+++ b/packages/codemirror-graphql/src/__tests__/schema-kitchen-sink.graphql
@@ -16,7 +16,7 @@ type Foo implements Bar {
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
-  six(argument: InputType = {key: "value"}): Type
+  six(argument: InputType = { key: "value" }): Type
 }
 
 type AnnotatedObject @onObject(arg: "value") {
@@ -63,13 +63,8 @@ extend type Foo {
   seven(argument: [[String!]!]!): Type
 }
 
-extend type Foo @onType {}
-
-type NoFields {}
+extend type Foo @onType
 
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-directive @include(if: Boolean!)
-  on FIELD
-   | FRAGMENT_SPREAD
-   | INLINE_FRAGMENT
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -232,9 +232,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
     name('atom'),
     opt('Implements'),
     list('Directive'),
-    p('{'),
-    list('FieldDef'),
-    p('}'),
+    opt('FieldsDef'),
   ],
   Implements: [word('implements'), list('NamedType', p('&'))],
   DirectiveLocation: [name('string-2')],
@@ -254,10 +252,13 @@ export const ParseRules: { [name: string]: ParseRule } = {
     name('atom'),
     opt('Implements'),
     list('Directive'),
-    p('{'),
-    list('FieldDef'),
-    p('}'),
+    opt('FieldsDef'),
   ],
+
+  // The fields block is optional per spec (e.g. `type Foo @directive` or a
+  // type extension that only adds directives/interfaces). When present it must
+  // contain at least one field, but the online parser tolerates an empty body.
+  FieldsDef: [p('{'), list('FieldDef'), p('}')],
 
   FieldDef: [
     name('property'),
@@ -289,20 +290,21 @@ export const ParseRules: { [name: string]: ParseRule } = {
     word('enum'),
     name('atom'),
     list('Directive'),
-    p('{'),
-    list('EnumValueDef'),
-    p('}'),
+    opt('EnumValuesDef'),
   ],
 
+  // Optional per spec, see `FieldsDef`.
+  EnumValuesDef: [p('{'), list('EnumValueDef'), p('}')],
   EnumValueDef: [name('string-2'), list('Directive')],
   InputDef: [
     word('input'),
     name('atom'),
     list('Directive'),
-    p('{'),
-    list('InputValueDef'),
-    p('}'),
+    opt('InputFieldsDef'),
   ],
+
+  // Optional per spec, see `FieldsDef`.
+  InputFieldsDef: [p('{'), list('InputValueDef'), p('}')],
   ExtendDef: [word('extend'), 'ExtensionDefinition'],
   ExtensionDefinition(token: Token): RuleKind | void {
     switch (token.value) {

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
@@ -1372,5 +1372,80 @@ describe('onlineParser', () => {
         t.eol();
       });
     });
+
+    // The fields/values block is optional per spec. A definition without a body
+    // must not break parsing of the definitions that follow it.
+    describe('parses type system definitions without a body', () => {
+      it('object type definition followed by another definition', () => {
+        const { t } = getUtils('type SomeType\nscalar SomeScalar');
+
+        t.keyword('type', { kind: 'ObjectTypeDef' });
+        t.name('SomeType');
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+
+      it('interface definition followed by another definition', () => {
+        const { t } = getUtils('interface SomeInterface\nscalar SomeScalar');
+
+        t.keyword('interface', { kind: 'InterfaceDef' });
+        t.name('SomeInterface');
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+
+      it('enum definition followed by another definition', () => {
+        const { t } = getUtils('enum SomeEnum\nscalar SomeScalar');
+
+        t.keyword('enum', { kind: 'EnumDef' });
+        t.name('SomeEnum');
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+
+      it('input object definition followed by another definition', () => {
+        const { t } = getUtils('input SomeInput\nscalar SomeScalar');
+
+        t.keyword('input', { kind: 'InputDef' });
+        t.name('SomeInput');
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+
+      it('definition with only a directive and no body', () => {
+        const { t } = getUtils('type SomeType @onType\nscalar SomeScalar');
+
+        t.keyword('type', { kind: 'ObjectTypeDef' });
+        t.name('SomeType');
+        expectDirective({ t }, { name: 'onType' });
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+
+      it('type extension with only a directive and no body', () => {
+        const { t } = getUtils(
+          'extend type SomeType @onType\nscalar SomeScalar',
+        );
+
+        t.keyword('extend', { kind: 'ExtendDef' });
+        t.keyword('type', { kind: 'ObjectTypeDef' });
+        t.name('SomeType');
+        expectDirective({ t }, { name: 'onType' });
+        t.keyword('scalar', { kind: 'ScalarDef' });
+        t.name('SomeScalar');
+
+        t.eol();
+      });
+    });
   });
 });

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
@@ -908,7 +908,7 @@ describe('onlineParser', () => {
         `);
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -987,7 +987,7 @@ describe('onlineParser', () => {
         `);
         t.keyword('interface', { kind: 'InterfaceDef' });
         t.name('SomeInterface');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1055,7 +1055,7 @@ describe('onlineParser', () => {
         `);
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1075,7 +1075,7 @@ describe('onlineParser', () => {
         `);
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(/\(/, { kind: 'ArgumentsDef' });
@@ -1104,7 +1104,7 @@ describe('onlineParser', () => {
 
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1125,7 +1125,7 @@ describe('onlineParser', () => {
 
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1148,7 +1148,7 @@ describe('onlineParser', () => {
           it(`with a directive having arguments of type ${fill.type}`, () => {
             t.keyword('type', { kind: 'ObjectTypeDef' });
             t.name('SomeType');
-            t.punctuation('{');
+            t.punctuation('{', { kind: 'FieldsDef' });
 
             t.property('someField', { kind: 'FieldDef' });
             t.punctuation(':');
@@ -1181,7 +1181,7 @@ describe('onlineParser', () => {
         t.keyword('extend', { kind: 'ExtendDef' });
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1202,7 +1202,7 @@ describe('onlineParser', () => {
         t.keyword('extend', { kind: 'ExtendDef' });
         t.keyword('type', { kind: 'ObjectTypeDef' });
         t.name('SomeType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'FieldsDef' });
 
         t.property('someField', { kind: 'FieldDef' });
         t.punctuation(':');
@@ -1226,7 +1226,7 @@ describe('onlineParser', () => {
 
         t.keyword('input', { kind: 'InputDef' });
         t.name('SomeInputType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'InputFieldsDef' });
 
         t.attribute('someField', { kind: 'InputValueDef' });
         t.punctuation(':');
@@ -1246,7 +1246,7 @@ describe('onlineParser', () => {
 
         t.keyword('input', { kind: 'InputDef' });
         t.name('SomeInputType');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'InputFieldsDef' });
 
         t.attribute('someField', { kind: 'InputValueDef' });
         t.punctuation(':');
@@ -1271,7 +1271,7 @@ describe('onlineParser', () => {
 
         t.keyword('enum', { kind: 'EnumDef' });
         t.name('SomeEnum');
-        t.punctuation('{');
+        t.punctuation('{', { kind: 'EnumValuesDef' });
 
         t.value('Enum', 'SOME_ENUM_VALUE', { kind: 'EnumValueDef' });
         t.value('Enum', 'ANOTHER_ENUM_VALUE', { kind: 'EnumValueDef' });
@@ -1292,7 +1292,7 @@ describe('onlineParser', () => {
         t.keyword('enum', { kind: 'EnumDef' });
         t.name('SomeEnum');
         expectDirective({ t }, { name: 'someDirective' });
-        t.punctuation('{', { kind: 'EnumDef' });
+        t.punctuation('{', { kind: 'EnumValuesDef' });
 
         t.value('Enum', 'SOME_ENUM_VALUE', { kind: 'EnumValueDef' });
         t.value('Enum', 'ANOTHER_ENUM_VALUE', { kind: 'EnumValueDef' });


### PR DESCRIPTION
## Summary

The online parser used by `codemirror-graphql` required a field block on object, interface, input, and enum type definitions. Per the GraphQL spec those blocks are optional, so valid SDL like `type Bar @baz` or `extend type Foo @onType` (directives only, no body) was highlighted as an error (`invalidchar`).

This makes the field/value block optional, mirroring how `SelectionSet` is already optional on fields.

Closes #4206.

## Changes

- `graphql-language-service`: field/value blocks are now optional for object, interface, input, and enum type definitions (and their extensions) in the online parser grammar.
- Corrected the `schema-kitchen-sink.graphql` test fixture, which contained spec-invalid empty bodies (`extend type Foo @onType {}` and `type NoFields {}`), to match graphql-js, and removed it from the oxfmt ignore list so it is formatted again.

## How to verify

This affects the CodeMirror 5 `graphql` mode in `codemirror-graphql`. The GraphiQL netlify preview will not exercise it, since GraphiQL 5 uses Monaco rather than this parser.

To reproduce in a CodeMirror 5 editor:

```js
import CodeMirror from 'codemirror';
import 'codemirror-graphql/esm/mode';

CodeMirror(document.getElementById('editor'), {
  value: 'type Bar @baz',
  mode: 'graphql',
});
```

On `main`, the `type Bar @baz` tokens render with the `cm-invalidchar` class (red). On this branch they render normally. The same applies to bodyless `interface`, `enum`, and `input` definitions and their extensions.

Before / after screenshots of that editor are attached in a comment below.
