### PR TITLE
fix(graphql-language-service-server): import Logger from vscode-jsonrpc

### DIFF
--- a/.changeset/lsp-server-logger-import.md
+++ b/.changeset/lsp-server-logger-import.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service-server': patch
+---
+
+Import `Logger` from `vscode-jsonrpc` instead of `vscode-languageserver`. `Logger` is defined in `vscode-jsonrpc` (a direct dependency) and only reached `vscode-languageserver` through a transitive re-export, which `tsgo` failed to resolve on CI (`Module '"vscode-languageserver"' has no exported member 'Logger'`). Importing from the package that owns the type avoids relying on that fragile re-export chain.

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -53,7 +53,7 @@ import type { GraphQLCache } from './GraphQLCache';
 
 import { GraphQLConfig, GraphQLProjectConfig } from 'graphql-config';
 
-import type { Logger } from 'vscode-languageserver';
+import type { Logger } from 'vscode-jsonrpc';
 import {
   Hover,
   SymbolInformation,


### PR DESCRIPTION
## Summary

`graphql-language-service-server` imported the `Logger` type from `vscode-languageserver`, but `Logger` is defined in `vscode-jsonrpc` and only reaches `vscode-languageserver` through a transitive re-export (`export * from 'vscode-languageserver-protocol/'`). On CI this breaks `types:check`:

```
src/GraphQLLanguageService.ts(56,15): error TS2305:
Module '"vscode-languageserver"' has no exported member 'Logger'.
```

This imports `Logger` from `vscode-jsonrpc` instead, which owns the type and is already a direct dependency of the package (`vscode-jsonrpc: ^8.0.1`), avoiding the fragile re-export chain.

Fixes #4330.

## Two separate things are going on

These answer different questions and are both true:

**Why it surfaced now (Turborepo cache).** `graphql-language-service-server#types:check` is a cache hit for any PR that does not invalidate it, so the stale green result is reused. Only a PR that changes `graphql-language-service` (a dependency) busts that cache and forces a real re-run. That is when the latent error becomes visible (it surfaced on #4329, a `graphql-language-service` change).

**Where the type error manifests (platform).** When `types:check` actually runs, it fails on CI (Linux) but passes locally (macOS). The lockfile pins identical dependency versions in both places (`vscode-languageserver@8.0.1 -> vscode-languageserver-protocol@3.17.1`), so resolution is the only variable. `tsgo` is `@typescript/native-preview`, which ships a separate compiled native binary per OS/arch (`native-preview-linux-x64` on CI vs `native-preview-darwin-arm64` locally), and the pre-release binaries appear to resolve the trailing-slash re-export differently.

I am confident about the cache behavior and the fix. The platform mechanism is my best inference, since I can only test on macOS and cannot directly inspect the Linux `tsgo`'s resolution. Either way the fix is robust because it imports `Logger` from the package that owns it.

## Verification

- `tsgo --noEmit` and `oxlint` pass locally on the changed package.
- This PR's CI is the real verification: changing this file invalidates the cached `types:check` and forces a fresh run on Linux, and `Types Check` (along with all other checks) passes.
