### PR TITLE
fix(graphiql-react): preserve host when previewing image URLs

### DIFF
--- a/.changeset/image-preview-absolute-url.md
+++ b/.changeset/image-preview-absolute-url.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix image previews in the response viewer fetching from the wrong host. Monaco splits the hovered word on `:`, so a full URL like `https://example.com/img.png` reaches the preview as the protocol-relative `//example.com/img.png`. The preview stripped the leading character, turning that into the host-relative `/example.com/img.png` and fetching it from the current origin. The original host is now preserved.

--- a/packages/graphiql-react/src/components/image-preview.spec.ts
+++ b/packages/graphiql-react/src/components/image-preview.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { ImagePreview, pathToURL } from './image-preview';
+
+describe('pathToURL', () => {
+  it('keeps the original host for full URLs', () => {
+    // Monaco splits the word on `:`, so a full `https://example.com/img.png`
+    // arrives here as the protocol-relative `//example.com/img.png`.
+    const url = pathToURL('//example.com/img.png');
+    expect(url?.host).toBe('example.com');
+    expect(url?.pathname).toBe('/img.png');
+  });
+
+  it('resolves relative paths against the current origin', () => {
+    const url = pathToURL('/images/foo.png');
+    expect(url?.host).toBe(location.host);
+    expect(url?.pathname).toBe('/images/foo.png');
+  });
+});
+
+describe('ImagePreview.shouldRender', () => {
+  it('renders for image URLs on another host', () => {
+    expect(ImagePreview.shouldRender('//example.com/img.png')).toBe(true);
+  });
+
+  it('renders for relative image paths', () => {
+    expect(ImagePreview.shouldRender('/images/foo.png')).toBe(true);
+  });
+
+  it('does not render for non-image URLs', () => {
+    expect(ImagePreview.shouldRender('//example.com/data.json')).toBe(false);
+  });
+});

--- a/packages/graphiql-react/src/components/image-preview.tsx
+++ b/packages/graphiql-react/src/components/image-preview.tsx
@@ -64,8 +64,13 @@ export const ImagePreview = Object.assign(ImagePreview_, {
   },
 });
 
-function pathToURL(path: string) {
-  const value = path.slice(1).trim();
+export function pathToURL(path: string) {
+  // `path` is the word under the cursor from Monaco's `getWordAtPosition`. For a
+  // full URL such as `https://example.com/img.png`, Monaco splits on the `:`, so
+  // the word is the protocol-relative `//example.com/img.png`. Resolving that
+  // against the current origin keeps the original host. Do not strip the leading
+  // character: doing so turns `//host/path` into the host-relative `/host/path`.
+  const value = path.trim();
   try {
     return new URL(value, location.protocol + '//' + location.host);
   } catch {}


### PR DESCRIPTION
## Summary

In the response viewer, hovering an image URL shows an inline preview. The preview gets the hovered word from Monaco's `getWordAtPosition`, and Monaco's JSON word pattern treats `:` as a separator. So a full URL like `https://example.com/img.png` arrives as the protocol-relative `//example.com/img.png`.

`pathToURL` then stripped the leading character (`path.slice(1)`), turning `//example.com/img.png` into the host-relative `/example.com/img.png`, so the image was fetched from the current origin (`https://<current-host>/example.com/img.png`) instead of the real host.

The fix stops stripping that character. `//host/path` now resolves to the original host, and relative paths such as `/images/foo.png` still resolve against the current origin.

Closes #4101.

## How to verify

1. Run a query whose response contains a field with a full `https://` image URL (for example a logo or avatar hosted on another domain).
2. In the response pane, hover over the path part of that URL to trigger the image preview.

- Before: the preview is broken, because it requests the image from the current host.
- After: the preview loads, because it requests the image from the original host.

A unit test (`image-preview.spec.ts`) also covers this: `pathToURL('//example.com/img.png')` now resolves to host `example.com` rather than the current origin.

## Credit

Thanks to @nastoychev for the report and for pinpointing `pathToURL` and the expected behavior.
