### PR TITLE
v6: polyfill `localStorage` in test setup for Node 24 + jsdom

### DIFF
--- a/.changeset/localstorage-polyfill.md
+++ b/.changeset/localstorage-polyfill.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': patch
+'@graphiql/toolkit': patch
+---
+
+Add an in-memory `localStorage` polyfill to test setup files so that `StorageAPI` can construct in Node 24 + jsdom environments where `window` is defined but `localStorage` is not.

--- a/.changeset/localstorage-polyfill.md
+++ b/.changeset/localstorage-polyfill.md
@@ -1,6 +1,0 @@
----
-'@graphiql/react': patch
-'@graphiql/toolkit': patch
----
-
-Add an in-memory `localStorage` polyfill to test setup files so that `StorageAPI` can construct in Node 24 + jsdom environments where `window` is defined but `localStorage` is not.

--- a/packages/graphiql-react/setup-files.ts
+++ b/packages/graphiql-react/setup-files.ts
@@ -8,13 +8,13 @@ if (typeof localStorage === 'undefined') {
   const store = new Map<string, string>();
   globalThis.localStorage = {
     getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => {
+    setItem(key: string, value: string) {
       store.set(key, value);
     },
-    removeItem: (key: string) => {
+    removeItem(key: string) {
       store.delete(key);
     },
-    clear: () => {
+    clear() {
       store.clear();
     },
     get length() {

--- a/packages/graphiql-toolkit/setup-files.ts
+++ b/packages/graphiql-toolkit/setup-files.ts
@@ -1,7 +1,3 @@
-import { vi, afterEach } from 'vitest';
-import '@testing-library/jest-dom/vitest';
-import { cleanup } from '@testing-library/react';
-
 // Node 24 + jsdom defines `window` but not `localStorage`. Polyfill with a
 // minimal in-memory implementation so StorageAPI can construct without error.
 if (typeof localStorage === 'undefined') {
@@ -23,8 +19,3 @@ if (typeof localStorage === 'undefined') {
     key: (index: number) => [...store.keys()][index] ?? null,
   };
 }
-
-afterEach(cleanup);
-
-// to make it works like Jest (auto-mocking)
-vi.mock('monaco-editor');

--- a/packages/graphiql-toolkit/setup-files.ts
+++ b/packages/graphiql-toolkit/setup-files.ts
@@ -4,13 +4,13 @@ if (typeof localStorage === 'undefined') {
   const store = new Map<string, string>();
   globalThis.localStorage = {
     getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => {
+    setItem(key: string, value: string) {
       store.set(key, value);
     },
-    removeItem: (key: string) => {
+    removeItem(key: string) {
       store.delete(key);
     },
-    clear: () => {
+    clear() {
       store.clear();
     },
     get length() {

--- a/packages/graphiql-toolkit/vitest.config.mts
+++ b/packages/graphiql-toolkit/vitest.config.mts
@@ -3,5 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: ['./setup-files.ts'],
   },
 });


### PR DESCRIPTION
Node 24 ships with a `jsdom` version that defines `window` but leaves `localStorage` undefined, which causes `StorageAPI` to throw on construction in unit tests. This adds a minimal in-memory `localStorage` polyfill to the vitest setup files for `@graphiql/react` and `@graphiql/toolkit`, gated on `typeof localStorage === 'undefined'` so it has no effect in environments where the real API is present. The toolkit package previously had no setup file, so this also wires one into its `vitest.config.mts`.