### PR TITLE
v6: Add `ResponseTreeView`

### DIFF
--- a/.changeset/response-tree-view.md
+++ b/.changeset/response-tree-view.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add `ResponseTreeView` component for the response pane's Tree view. Renders GraphQL response JSON as a collapsible tree with type-colored values. Top-level nodes expand by default; deeper levels are collapsed. Selecting "Tree" in the response pane view toggle now shows the tree instead of a placeholder.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -39,3 +39,5 @@ export { ActivityRail } from './activity-rail';
 export type { ActivityRailProps } from './activity-rail';
 export { ResponseHeader } from './response-header';
 export type { ResponseHeaderProps } from './response-header';
+export { ResponseTreeView } from './response-tree-view';
+export type { ResponseTreeViewProps } from './response-tree-view';

--- a/packages/graphiql-react/src/components/response-editor.tsx
+++ b/packages/graphiql-react/src/components/response-editor.tsx
@@ -4,6 +4,7 @@ import { createRoot, Root } from 'react-dom/client';
 import { useGraphiQL, useGraphiQLActions } from './provider';
 import { ImagePreview } from './image-preview';
 import { ResponseHeader } from './response-header';
+import { ResponseTreeView } from './response-tree-view';
 import {
   getOrCreateModel,
   createEditor,
@@ -195,22 +196,27 @@ export const ResponseEditor: FC<ResponseEditorProps> = ({
           onCopy={handleCopy}
         />
       )}
-      {responseView === 'json' ? (
-        <section
-          ref={ref}
-          aria-label="Result Window"
-          aria-live="polite"
-          aria-atomic="true"
-          tabIndex={0}
-          onKeyDown={onEditorContainerKeyDown}
-          className="result-window"
-        />
-      ) : (
+      <section
+        ref={ref}
+        aria-label="Result Window"
+        aria-live="polite"
+        aria-atomic="true"
+        tabIndex={0}
+        onKeyDown={onEditorContainerKeyDown}
+        className="result-window"
+        hidden={responseView !== 'json'}
+      />
+      {responseView === 'tree' &&
+        (lastResponse ? (
+          <ResponseTreeView data={lastResponse.body} />
+        ) : (
+          <div className="graphiql-response-empty-state" role="status">
+            <span>Run a query to see the tree view.</span>
+          </div>
+        ))}
+      {responseView === 'table' && (
         <div className="graphiql-response-empty-state" role="status">
-          <span>
-            {responseView === 'tree' ? 'Tree' : 'Table'} view is not yet
-            available.
-          </span>
+          <span>Table view is not yet available.</span>
         </div>
       )}
     </div>

--- a/packages/graphiql-react/src/components/response-tree-view/index.css
+++ b/packages/graphiql-react/src/components/response-tree-view/index.css
@@ -1,0 +1,68 @@
+.graphiql-response-tree {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-mono);
+  line-height: 1.6;
+  color: oklch(var(--fg-default));
+  padding: var(--px-12) var(--px-16);
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.graphiql-tree-row {
+  display: flex;
+  align-items: baseline;
+  gap: var(--px-4);
+  white-space: nowrap;
+}
+
+.graphiql-tree-key {
+  color: oklch(var(--fg-default));
+  flex-shrink: 0;
+}
+
+.graphiql-tree-colon {
+  color: oklch(var(--fg-muted));
+  flex-shrink: 0;
+}
+
+.graphiql-tree-summary {
+  color: oklch(var(--fg-muted));
+}
+
+/* Scalar value colors matching the editor tokenizer palette */
+.graphiql-tree-string {
+  color: oklch(var(--accent-blue));
+}
+
+.graphiql-tree-number {
+  color: oklch(var(--accent-orange));
+}
+
+.graphiql-tree-bool {
+  color: oklch(var(--accent-purple));
+}
+
+.graphiql-tree-null {
+  color: oklch(var(--fg-muted));
+  font-style: italic;
+}
+
+.graphiql-tree-toggle {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: oklch(var(--fg-muted));
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+  user-select: none;
+}
+
+.graphiql-tree-toggle:hover {
+  color: oklch(var(--fg-default));
+}

--- a/packages/graphiql-react/src/components/response-tree-view/index.tsx
+++ b/packages/graphiql-react/src/components/response-tree-view/index.tsx
@@ -53,7 +53,7 @@ type RootValueProps = {
 // Renders a value that has no key label (used when the root body is not an object).
 const RootValue: FC<RootValueProps> = ({ value, initiallyExpandedDepth }) => {
   const expandable = value !== null && typeof value === 'object';
-  const [open, setOpen] = useState(0 < initiallyExpandedDepth);
+  const [open, setOpen] = useState(initiallyExpandedDepth > 0);
 
   if (!expandable) {
     const valueClass = `graphiql-tree-value graphiql-tree-${scalarClass(value)}`;

--- a/packages/graphiql-react/src/components/response-tree-view/index.tsx
+++ b/packages/graphiql-react/src/components/response-tree-view/index.tsx
@@ -1,0 +1,193 @@
+'use no memo';
+
+import { useState, type FC } from 'react';
+import './index.css';
+
+export type ResponseTreeViewProps = {
+  /** The JSON value to render. Typically the parsed response body. */
+  data: unknown;
+  /**
+   * Nodes at depth < this value start expanded; deeper nodes start collapsed.
+   * @default 1
+   */
+  initiallyExpandedDepth?: number;
+};
+
+export const ResponseTreeView: FC<ResponseTreeViewProps> = ({
+  data,
+  initiallyExpandedDepth = 1,
+}) => {
+  // Render top-level keys of an object directly (no synthetic root wrapper).
+  // This avoids the redundant `data > data > ...` nesting when the response
+  // envelope itself has a `data` key.
+  if (data !== null && typeof data === 'object' && !Array.isArray(data)) {
+    const entries = Object.entries(data as object);
+    return (
+      <div className="graphiql-response-tree">
+        {entries.map(([k, v]) => (
+          <TreeNode
+            key={k}
+            name={k}
+            value={v}
+            depth={0}
+            initiallyExpandedDepth={initiallyExpandedDepth}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Non-object body (scalar, null, array) — render as a single unnamed value.
+  return (
+    <div className="graphiql-response-tree">
+      <RootValue value={data} initiallyExpandedDepth={initiallyExpandedDepth} />
+    </div>
+  );
+};
+
+type RootValueProps = {
+  value: unknown;
+  initiallyExpandedDepth: number;
+};
+
+// Renders a value that has no key label (used when the root body is not an object).
+const RootValue: FC<RootValueProps> = ({ value, initiallyExpandedDepth }) => {
+  const expandable = value !== null && typeof value === 'object';
+  const [open, setOpen] = useState(0 < initiallyExpandedDepth);
+
+  if (!expandable) {
+    const valueClass = `graphiql-tree-value graphiql-tree-${scalarClass(value)}`;
+    return (
+      <div className="graphiql-tree-row" style={{ paddingLeft: 0 }}>
+        <span className={valueClass}>{formatScalar(value)}</span>
+      </div>
+    );
+  }
+
+  const isArr = Array.isArray(value);
+  const entries = isArr
+    ? (value as unknown[]).map((v, i) => [String(i), v] as const)
+    : Object.entries(value as object);
+  const count = entries.length;
+  const summary = isArr ? `Array [${count}]` : `Object {${count}}`;
+
+  return (
+    <div>
+      <div className="graphiql-tree-row" style={{ paddingLeft: 0 }}>
+        <button
+          type="button"
+          className="graphiql-tree-toggle"
+          aria-label={open ? 'Collapse' : 'Expand'}
+          aria-expanded={open}
+          onClick={() => setOpen(o => !o)}
+        >
+          {open ? '▾' : '▸'}
+        </button>
+        <span className="graphiql-tree-summary">{summary}</span>
+      </div>
+      {open && (
+        <div>
+          {entries.map(([k, v]) => (
+            <TreeNode
+              key={k}
+              name={k}
+              value={v}
+              depth={1}
+              initiallyExpandedDepth={initiallyExpandedDepth}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+type TreeNodeProps = {
+  name: string;
+  value: unknown;
+  depth: number;
+  initiallyExpandedDepth: number;
+};
+
+const TreeNode: FC<TreeNodeProps> = ({
+  name,
+  value,
+  depth,
+  initiallyExpandedDepth,
+}) => {
+  const expandable = value !== null && typeof value === 'object';
+  const [open, setOpen] = useState(depth < initiallyExpandedDepth);
+
+  if (!expandable) {
+    const valueClass = `graphiql-tree-value graphiql-tree-${scalarClass(value)}`;
+    return (
+      <div className="graphiql-tree-row" style={{ paddingLeft: depth * 16 }}>
+        <span className="graphiql-tree-key">{name}</span>
+        <span className="graphiql-tree-colon">:</span>
+        <span className={valueClass}>{formatScalar(value)}</span>
+      </div>
+    );
+  }
+
+  const isArr = Array.isArray(value);
+  const entries = isArr
+    ? (value as unknown[]).map((v, i) => [String(i), v] as const)
+    : Object.entries(value as object);
+  const count = entries.length;
+  const summary = isArr ? `Array [${count}]` : `Object {${count}}`;
+
+  return (
+    <div>
+      <div className="graphiql-tree-row" style={{ paddingLeft: depth * 16 }}>
+        <button
+          type="button"
+          className="graphiql-tree-toggle"
+          aria-label={open ? 'Collapse' : 'Expand'}
+          aria-expanded={open}
+          onClick={() => setOpen(o => !o)}
+        >
+          {open ? '▾' : '▸'}
+        </button>
+        <span className="graphiql-tree-key">{name}</span>
+        <span className="graphiql-tree-colon">:</span>
+        <span className="graphiql-tree-summary">{summary}</span>
+      </div>
+      {open && (
+        <div>
+          {entries.map(([k, v]) => (
+            <TreeNode
+              key={k}
+              name={k}
+              value={v}
+              depth={depth + 1}
+              initiallyExpandedDepth={initiallyExpandedDepth}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function scalarClass(v: unknown): string {
+  if (typeof v === 'string') {
+    return 'string';
+  }
+  if (typeof v === 'number') {
+    return 'number';
+  }
+  if (typeof v === 'boolean') {
+    return 'bool';
+  }
+  return 'null';
+}
+
+function formatScalar(v: unknown): string {
+  if (typeof v === 'string') {
+    return JSON.stringify(v);
+  }
+  if (v === null) {
+    return 'null';
+  }
+  return String(v);
+}

--- a/packages/graphiql-react/src/components/response-tree-view/response-tree-view.stories.ts
+++ b/packages/graphiql-react/src/components/response-tree-view/response-tree-view.stories.ts
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ResponseTreeView } from './';
+
+const meta: Meta<typeof ResponseTreeView> = {
+  title: 'Components/ResponseTreeView',
+  component: ResponseTreeView,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof ResponseTreeView>;
+
+export const NullResponse: Story = {
+  name: 'Null value',
+  args: {
+    data: null,
+  },
+};
+
+export const ScalarString: Story = {
+  name: 'Scalar string',
+  args: {
+    data: 'Hello, GraphQL!',
+  },
+};
+
+export const SimpleObject: Story = {
+  name: 'Simple object (top level expanded)',
+  args: {
+    data: {
+      data: {
+        id: '1',
+        name: 'Luke Skywalker',
+        height: 172,
+        mass: 77,
+        appearsIn: ['NEWHOPE', 'EMPIRE', 'JEDI'],
+      },
+    },
+  },
+};
+
+export const NestedObject: Story = {
+  name: 'Nested object (deeper levels collapsed)',
+  args: {
+    data: {
+      data: {
+        hero: {
+          name: 'R2-D2',
+          friends: [
+            {
+              name: 'Luke Skywalker',
+              homeworld: { name: 'Tatooine' },
+            },
+            {
+              name: 'Han Solo',
+              homeworld: { name: 'Corellia' },
+            },
+            {
+              name: 'Leia Organa',
+              homeworld: { name: 'Alderaan' },
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export const LargeArray: Story = {
+  name: 'Large array (collapsed)',
+  args: {
+    data: {
+      data: {
+        allPeople: {
+          edges: Array.from({ length: 82 }, (_, i) => ({
+            node: { id: String(i + 1), name: `Person ${i + 1}` },
+          })),
+        },
+      },
+    },
+    initiallyExpandedDepth: 1,
+  },
+};
+
+export const MixedTypes: Story = {
+  name: 'Mixed scalar types',
+  args: {
+    data: {
+      data: {
+        string: 'hello',
+        number: 42,
+        float: 3.14,
+        boolean: true,
+        falsyBool: false,
+        nullValue: null,
+        emptyString: '',
+      },
+    },
+  },
+};
+
+export const EmptyObject: Story = {
+  name: 'Empty object',
+  args: {
+    data: {},
+  },
+};
+
+export const ErrorResponse: Story = {
+  name: 'Error response',
+  args: {
+    data: {
+      errors: [
+        {
+          message: 'Cannot query field "notARealField" on type "Query".',
+          locations: [{ line: 3, column: 5 }],
+          path: ['hero', 'notARealField'],
+        },
+      ],
+      data: null,
+    },
+  },
+};

--- a/packages/graphiql-react/src/components/response-tree-view/response-tree-view.test.tsx
+++ b/packages/graphiql-react/src/components/response-tree-view/response-tree-view.test.tsx
@@ -1,0 +1,164 @@
+'use no memo';
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ResponseTreeView } from './';
+
+describe('ResponseTreeView', () => {
+  it('renders a string scalar value', () => {
+    render(<ResponseTreeView data="hello" />);
+    expect(screen.getByText(/"hello"/)).toBeInTheDocument();
+  });
+
+  it('renders a number scalar value', () => {
+    render(<ResponseTreeView data={42} />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders null', () => {
+    render(<ResponseTreeView data={null} />);
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+
+  it('renders boolean false', () => {
+    render(<ResponseTreeView data={false} />);
+    expect(screen.getByText('false')).toBeInTheDocument();
+  });
+
+  it('renders top-level object keys directly (no synthetic root wrapper)', () => {
+    render(<ResponseTreeView data={{ data: { id: '1' }, errors: [] }} />);
+    // Both top-level envelope keys appear directly — no extra wrapper row
+    expect(screen.getByText('data')).toBeInTheDocument();
+    expect(screen.getByText('errors')).toBeInTheDocument();
+  });
+
+  it('renders a nested object with child count summary when collapsed', () => {
+    // The summary appears on nested object values, not the top-level keys
+    render(
+      <ResponseTreeView
+        data={{ nested: { a: 1, b: 2 } }}
+        initiallyExpandedDepth={0}
+      />,
+    );
+    expect(screen.getByText('Object {2}')).toBeInTheDocument();
+  });
+
+  it('renders an array with child count summary when collapsed', () => {
+    render(
+      <ResponseTreeView
+        data={[1, 2, 3]}
+        initiallyExpandedDepth={0}
+      />,
+    );
+    expect(screen.getByText('Array [3]')).toBeInTheDocument();
+  });
+
+  it('top-level object keys are expanded by default', () => {
+    render(<ResponseTreeView data={{ name: 'GraphiQL' }} />);
+    // child value should be visible without any interaction
+    expect(screen.getByText('name')).toBeInTheDocument();
+    expect(screen.getByText(/"GraphiQL"/)).toBeInTheDocument();
+  });
+
+  it('nested objects are collapsed by default', () => {
+    // top-level keys (depth 0) expand by default; deeper keys do not.
+    render(
+      <ResponseTreeView data={{ outer: { middle: { inner: 'value' } } }} />,
+    );
+    // `outer` (depth 0) is expanded — `middle` is visible
+    expect(screen.getByText('outer')).toBeInTheDocument();
+    expect(screen.getByText('middle')).toBeInTheDocument();
+    // `middle` (depth 1) is collapsed — `inner` is not visible
+    expect(screen.queryByText('inner')).toBeNull();
+  });
+
+  it('expands a collapsed node on toggle click', async () => {
+    const user = userEvent.setup();
+    render(
+      <ResponseTreeView data={{ outer: { middle: { inner: 'value' } } }} />,
+    );
+    // `middle` (depth 1) starts collapsed
+    const collapsed = screen
+      .getAllByRole('button')
+      .find(b => b.getAttribute('aria-expanded') === 'false');
+    expect(collapsed).toBeDefined();
+    await user.click(collapsed!);
+    expect(screen.getByText('inner')).toBeInTheDocument();
+  });
+
+  it('collapses an expanded top-level key on toggle click', async () => {
+    const user = userEvent.setup();
+    render(<ResponseTreeView data={{ hero: { id: '1' } }} />);
+    // hero is expanded by default (depth 0 < initiallyExpandedDepth 1)
+    const toggle = screen.getByRole('button', { name: /collapse/i });
+    await user.click(toggle);
+    // hero's child `id` is no longer visible
+    expect(screen.queryByText('id')).toBeNull();
+  });
+
+  it('toggle button has correct aria-expanded when open', () => {
+    // Need a nested object so there's a toggle button at the top level
+    render(<ResponseTreeView data={{ group: { a: 1 } }} />);
+    const btn = screen.getByRole('button', { name: /collapse/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggle button has correct aria-expanded when closed', () => {
+    render(
+      <ResponseTreeView
+        data={{ group: { a: 1 } }}
+        initiallyExpandedDepth={0}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: /expand/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders a large array count correctly', () => {
+    render(
+      <ResponseTreeView
+        data={Array.from({ length: 100 }, (_, i) => i)}
+        initiallyExpandedDepth={0}
+      />,
+    );
+    expect(screen.getByText('Array [100]')).toBeInTheDocument();
+  });
+
+  it('renders empty object with no rows', () => {
+    render(<ResponseTreeView data={{}} />);
+    expect(document.querySelector('.graphiql-response-tree')).toBeInTheDocument();
+    expect(document.querySelector('.graphiql-tree-row')).toBeNull();
+  });
+
+  it('renders empty array', () => {
+    render(
+      <ResponseTreeView data={[]} initiallyExpandedDepth={0} />,
+    );
+    expect(screen.getByText('Array [0]')).toBeInTheDocument();
+  });
+
+  it('renders array items with numeric keys when expanded', () => {
+    render(
+      <ResponseTreeView
+        data={['a', 'b']}
+        initiallyExpandedDepth={1}
+      />,
+    );
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders sibling top-level envelope keys (data + errors)', () => {
+    render(
+      <ResponseTreeView
+        data={{
+          data: { hero: { name: 'R2-D2' } },
+          errors: [{ message: 'oops' }],
+        }}
+      />,
+    );
+    expect(screen.getByText('data')).toBeInTheDocument();
+    expect(screen.getByText('errors')).toBeInTheDocument();
+  });
+});

--- a/packages/graphiql-react/src/components/response-tree-view/response-tree-view.test.tsx
+++ b/packages/graphiql-react/src/components/response-tree-view/response-tree-view.test.tsx
@@ -45,12 +45,7 @@ describe('ResponseTreeView', () => {
   });
 
   it('renders an array with child count summary when collapsed', () => {
-    render(
-      <ResponseTreeView
-        data={[1, 2, 3]}
-        initiallyExpandedDepth={0}
-      />,
-    );
+    render(<ResponseTreeView data={[1, 2, 3]} initiallyExpandedDepth={0} />);
     expect(screen.getByText('Array [3]')).toBeInTheDocument();
   });
 
@@ -127,24 +122,19 @@ describe('ResponseTreeView', () => {
 
   it('renders empty object with no rows', () => {
     render(<ResponseTreeView data={{}} />);
-    expect(document.querySelector('.graphiql-response-tree')).toBeInTheDocument();
+    expect(
+      document.querySelector('.graphiql-response-tree'),
+    ).toBeInTheDocument();
     expect(document.querySelector('.graphiql-tree-row')).toBeNull();
   });
 
   it('renders empty array', () => {
-    render(
-      <ResponseTreeView data={[]} initiallyExpandedDepth={0} />,
-    );
+    render(<ResponseTreeView data={[]} initiallyExpandedDepth={0} />);
     expect(screen.getByText('Array [0]')).toBeInTheDocument();
   });
 
   it('renders array items with numeric keys when expanded', () => {
-    render(
-      <ResponseTreeView
-        data={['a', 'b']}
-        initiallyExpandedDepth={1}
-      />,
-    );
+    render(<ResponseTreeView data={['a', 'b']} initiallyExpandedDepth={1} />);
     expect(screen.getByText('0')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
   });

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -21,6 +21,7 @@ acao
 acmerc
 aivazis
 akshat
+alderaan
 alexey
 alok
 amfoss
@@ -52,6 +53,7 @@ codegen
 codemirror
 codesandbox
 codespaces
+corellia
 codicon
 colmena
 combobox
@@ -97,6 +99,7 @@ graphqls
 ˈɡrafək
 harshith
 headlessui
+homeworld
 heyenbrock
 hola
 htmling
@@ -118,6 +121,7 @@ keycap
 kumar
 languageservice
 leebyron
+leia
 Leko
 LekoArts
 lezer
@@ -206,6 +210,7 @@ sfc's
 sgrove
 simha
 singleline
+skywalker
 snyk
 socker
 sonarjs
@@ -223,6 +228,7 @@ svgo
 svgr
 tanay
 tanaypratap
+tatooine
 testid
 testonly
 therox


### PR DESCRIPTION
## Summary

Adds `ResponseTreeView`, a custom collapsible tree renderer for GraphQL response JSON. When the user switches to the Tree view in the response pane, they now see the actual response rendered as an expandable tree rather than a placeholder message. Top-level keys are expanded by default; nested objects and arrays start collapsed with a summary showing their child count. Values are colored by type to match the editor's tokenizer palette: strings in blue, numbers in orange, booleans in purple, and null in muted gray.

## Test plan

- [x] Open the example app, run a query, and switch the response pane to Tree view. Verify the response renders as a tree with the top level expanded.
- [x] Click a collapsed object or array node and confirm it expands to show children. Click again to confirm it collapses.
- [x] Confirm `aria-expanded` updates correctly on each toggle button (check with browser DevTools or a screen reader).
- [x] Switch back to JSON view and verify the Monaco editor reappears with the response intact.
- [x] Run a query that returns nested objects more than two levels deep. Confirm only depth 0 is expanded by default; click to drill in.
- [x] Check the tree renders correctly in both dark and light themes.
