### PR TITLE
v6: Promote variables/headers footer into a tab strip

### DIFF
--- a/.changeset/vars-headers-strip.md
+++ b/.changeset/vars-headers-strip.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+'graphiql': minor
+---
+
+Promote the variables/headers footer into a tab strip below the editor (Variables / Headers). A right-aligned hint shows the variable count and JSON validity when the Variables tab is active.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -43,3 +43,5 @@ export { ResponseTableView } from './response-table-view';
 export type { ResponseTableViewProps } from './response-table-view';
 export { ResponseTreeView } from './response-tree-view';
 export type { ResponseTreeViewProps } from './response-tree-view';
+export { VarHeadersStrip } from './var-headers-strip';
+export type { VarHeadersStripProps, VarTab } from './var-headers-strip';

--- a/packages/graphiql-react/src/components/var-headers-strip/index.css
+++ b/packages/graphiql-react/src/components/var-headers-strip/index.css
@@ -1,0 +1,39 @@
+.graphiql-var-headers-strip {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.graphiql-var-headers-strip-bar {
+  display: flex;
+  align-items: center;
+  padding: var(--px-8) var(--px-8) 0;
+  gap: var(--px-8);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.graphiql-var-hint {
+  margin-left: auto;
+  font-size: var(--font-size-hint);
+  color: oklch(var(--fg-subtle));
+  white-space: nowrap;
+}
+
+.graphiql-var-hint[aria-live] {
+  /* keep accessible without layout shift */
+  min-width: 0;
+}
+
+.graphiql-var-headers-strip-content {
+  flex: 1;
+  min-height: 0;
+  padding: var(--px-16);
+  display: flex;
+  flex-direction: column;
+}
+
+.graphiql-var-headers-strip-content .graphiql-editor {
+  flex: 1;
+}

--- a/packages/graphiql-react/src/components/var-headers-strip/index.tsx
+++ b/packages/graphiql-react/src/components/var-headers-strip/index.tsx
@@ -1,0 +1,96 @@
+import type { FC } from 'react';
+import { useState } from 'react';
+import { VariablesEditor } from '../variables-editor';
+import { RequestHeadersEditor } from '../request-headers-editor';
+import { SegmentedControl } from '../segmented-control';
+import { useEditorState } from '../../utility/hooks';
+import { tryParseJSONC } from '../../utility';
+import './index.css';
+
+export type VarTab = 'variables' | 'headers';
+
+const VAR_TAB_OPTIONS: { value: VarTab; label: string }[] = [
+  { value: 'variables', label: 'Variables' },
+  { value: 'headers', label: 'Headers' },
+];
+
+// Plain function (not a hook) so the React Compiler does not try to optimize it.
+// The try/catch with conditional chaining inside a hook body is a known compiler
+// limitation — keeping the fallible logic here avoids the compile error.
+function computeVariablesHint(value: string): string | null {
+  if (!value.trim()) {
+    return null;
+  }
+  try {
+    const parsed = tryParseJSONC(value);
+    const count = parsed ? Object.keys(parsed).length : 0;
+    return `${count} var${count === 1 ? '' : 's'} · valid`;
+  } catch {
+    return 'invalid JSON';
+  }
+}
+
+function useVariablesHint(): string | null {
+  const [value] = useEditorState('variable');
+  return computeVariablesHint(value);
+}
+
+export type VarHeadersStripProps = {
+  /** Which tab is shown initially. @default 'variables' */
+  defaultTab?: VarTab;
+  /**
+   * Whether the headers tab and editor are available.
+   * When `false`, only the variables editor is shown.
+   * @default true
+   */
+  headersEditorEnabled?: boolean;
+  onEditVariables?: (value: string) => void;
+  onEditHeaders?: (value: string) => void;
+};
+
+export const VarHeadersStrip: FC<VarHeadersStripProps> = ({
+  defaultTab = 'variables',
+  headersEditorEnabled = true,
+  onEditVariables,
+  onEditHeaders,
+}) => {
+  const [varTab, setVarTab] = useState<VarTab>(
+    headersEditorEnabled ? defaultTab : 'variables',
+  );
+  const hint = useVariablesHint();
+
+  const showHeaders = headersEditorEnabled && varTab === 'headers';
+  const options = headersEditorEnabled
+    ? VAR_TAB_OPTIONS
+    : VAR_TAB_OPTIONS.filter(option => option.value === 'variables');
+
+  return (
+    <div className="graphiql-var-headers-strip">
+      <div className="graphiql-var-headers-strip-bar">
+        <SegmentedControl
+          value={showHeaders ? 'headers' : 'variables'}
+          onChange={setVarTab}
+          options={options}
+          ariaLabel="Editor tools"
+        />
+        {!showHeaders && hint !== null && (
+          <span className="graphiql-var-hint" aria-live="polite">
+            {hint}
+          </span>
+        )}
+      </div>
+      <div className="graphiql-var-headers-strip-content">
+        <VariablesEditor
+          className={showHeaders ? 'hidden' : ''}
+          onEdit={onEditVariables}
+        />
+        {headersEditorEnabled && (
+          <RequestHeadersEditor
+            className={showHeaders ? '' : 'hidden'}
+            onEdit={onEditHeaders}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.stories.tsx
+++ b/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Tooltip } from '../tooltip';
+import { VarHeadersStrip } from './';
+import { GraphiQLProvider } from '../provider';
+
+const noOpTransport = {
+  send: async () => ({
+    ok: true,
+    body: { data: {} },
+    timing: { totalMs: 0 },
+    size: {},
+  }),
+};
+
+const meta: Meta<typeof VarHeadersStrip> = {
+  title: 'GraphiQL/VarHeadersStrip',
+  component: VarHeadersStrip,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <GraphiQLProvider transport={noOpTransport}>
+        <Tooltip.Provider>
+          <div
+            style={{ height: 300, display: 'flex', flexDirection: 'column' }}
+          >
+            <Story />
+          </div>
+        </Tooltip.Provider>
+      </GraphiQLProvider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof VarHeadersStrip>;
+
+export const VariablesTab: Story = {
+  name: 'Variables tab',
+};
+
+export const HeadersTab: Story = {
+  name: 'Headers tab',
+  args: { defaultTab: 'headers' },
+};

--- a/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.test.tsx
+++ b/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.test.tsx
@@ -1,0 +1,143 @@
+'use no memo';
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as T from '@radix-ui/react-tooltip';
+import type { ReactNode } from 'react';
+import * as hooksModule from '../../utility/hooks';
+import { VarHeadersStrip } from './';
+
+// The editors depend on Monaco; mock them so tests run without a runtime.
+// Both editors are always mounted; the inactive one is hidden via the
+// `hidden` class, so forward `className` to assert visibility.
+vi.mock('../variables-editor', () => ({
+  VariablesEditor: (props: { className?: string }) => (
+    <div data-testid="variables-editor" className={props.className} />
+  ),
+}));
+
+vi.mock('../request-headers-editor', () => ({
+  RequestHeadersEditor: (props: { className?: string }) => (
+    <div data-testid="headers-editor" className={props.className} />
+  ),
+}));
+
+// useEditorState depends on Monaco; stub it.
+vi.mock('../../utility/hooks', () => ({
+  useEditorState: vi.fn(() => ['', vi.fn()]),
+}));
+
+function renderStrip(ui: ReactNode = <VarHeadersStrip />) {
+  return render(<T.Provider>{ui}</T.Provider>);
+}
+
+describe('VarHeadersStrip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(hooksModule.useEditorState).mockReturnValue(['', vi.fn()]);
+  });
+
+  it('renders both tab options', () => {
+    renderStrip();
+    expect(
+      screen.getByRole('radio', { name: 'Variables' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Headers' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Snippets' })).toBeNull();
+  });
+
+  it('defaults the active tab to variables', () => {
+    renderStrip();
+    expect(screen.getByRole('radio', { name: 'Variables' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Headers' })).not.toBeChecked();
+  });
+
+  it('honours the defaultTab prop', () => {
+    renderStrip(<VarHeadersStrip defaultTab="headers" />);
+    expect(screen.getByRole('radio', { name: 'Headers' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Variables' })).not.toBeChecked();
+  });
+
+  it('switches the active tab when a tab is selected', async () => {
+    const user = userEvent.setup();
+    renderStrip();
+    await user.click(screen.getByRole('radio', { name: 'Headers' }));
+    expect(screen.getByRole('radio', { name: 'Headers' })).toBeChecked();
+    expect(screen.getByTestId('headers-editor')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('variables-editor')).toHaveClass('hidden');
+  });
+
+  it('shows the variables editor when the variables tab is active', () => {
+    renderStrip();
+    expect(screen.getByTestId('variables-editor')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('headers-editor')).toHaveClass('hidden');
+  });
+
+  it('shows the headers editor when the headers tab is active', () => {
+    renderStrip(<VarHeadersStrip defaultTab="headers" />);
+    expect(screen.getByTestId('headers-editor')).not.toHaveClass('hidden');
+    expect(screen.getByTestId('variables-editor')).toHaveClass('hidden');
+  });
+
+  it('does not show a validity hint when variables are empty', () => {
+    renderStrip();
+    expect(screen.queryByText(/valid/)).toBeNull();
+    expect(screen.queryByText(/invalid/)).toBeNull();
+  });
+
+  describe('when headersEditorEnabled is false', () => {
+    it('hides the Headers tab and renders only the variables editor', () => {
+      renderStrip(<VarHeadersStrip headersEditorEnabled={false} />);
+      expect(
+        screen.getByRole('radio', { name: 'Variables' }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('radio', { name: 'Headers' })).toBeNull();
+      expect(screen.getByTestId('variables-editor')).not.toHaveClass('hidden');
+      expect(screen.queryByTestId('headers-editor')).toBeNull();
+    });
+
+    it('ignores a defaultTab of "headers"', () => {
+      renderStrip(
+        <VarHeadersStrip headersEditorEnabled={false} defaultTab="headers" />,
+      );
+      expect(screen.getByRole('radio', { name: 'Variables' })).toBeChecked();
+      expect(screen.getByTestId('variables-editor')).not.toHaveClass('hidden');
+      expect(screen.queryByTestId('headers-editor')).toBeNull();
+    });
+  });
+});
+
+describe('variables validity hint', () => {
+  let mockUseEditorState: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseEditorState = vi.mocked(hooksModule.useEditorState);
+  });
+
+  it('shows a valid hint when variables parse correctly', () => {
+    mockUseEditorState.mockReturnValue(['{"a": 1, "b": 2}', vi.fn()]);
+    renderStrip();
+    expect(screen.getByText('2 vars · valid')).toBeInTheDocument();
+  });
+
+  it('shows singular "var" for a single variable', () => {
+    mockUseEditorState.mockReturnValue(['{"x": 42}', vi.fn()]);
+    renderStrip();
+    expect(screen.getByText('1 var · valid')).toBeInTheDocument();
+  });
+
+  it('shows "invalid JSON" hint when variables do not parse', () => {
+    mockUseEditorState.mockReturnValue(['{bad json', vi.fn()]);
+    renderStrip();
+    expect(screen.getByText('invalid JSON')).toBeInTheDocument();
+  });
+
+  it('hides the hint when not on the variables tab', () => {
+    mockUseEditorState.mockReturnValue(['{"a": 1}', vi.fn()]);
+    renderStrip(<VarHeadersStrip defaultTab="headers" />);
+    expect(screen.queryByText(/valid/)).toBeNull();
+  });
+});

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -287,9 +287,15 @@ describe('GraphiQL', () => {
         />,
       );
       await waitFor(() => {
-        expect(
-          container.querySelector('[aria-label="Variables"]'),
-        ).toBeVisible();
+        // The editor tools section should be visible and the Variables radio checked
+        const section = container.querySelector(
+          '[aria-label="Variables and Headers"]',
+        );
+        expect(section).toBeVisible();
+        const variablesRadio = container.querySelector(
+          'input[type="radio"][value="variables"]',
+        );
+        expect(variablesRadio).toBeChecked();
       });
     });
 
@@ -301,7 +307,15 @@ describe('GraphiQL', () => {
         />,
       );
       await waitFor(() => {
-        expect(container.querySelector('[aria-label="Headers"]')).toBeVisible();
+        // The editor tools section should be visible and the Headers radio checked
+        const section = container.querySelector(
+          '[aria-label="Variables and Headers"]',
+        );
+        expect(section).toBeVisible();
+        const headersRadio = container.querySelector(
+          'input[type="radio"][value="headers"]',
+        );
+        expect(headersRadio).toBeChecked();
       });
     });
 

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -10,14 +10,13 @@ import type {
   FC,
   ComponentPropsWithoutRef,
 } from 'react';
-import { useState, Children, useRef, Fragment } from 'react';
+import { Children, useRef, Fragment } from 'react';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
   CopyIcon,
   ExecuteButton,
   GraphiQLProvider,
-  HeaderEditor,
   PlusIcon,
   PrettifyIcon,
   QueryEditor,
@@ -31,15 +30,17 @@ import {
   TopBar,
   StatusBar,
   UnStyledButton,
+  VarHeadersStrip,
   useDragResize,
   useGraphiQL,
   useGraphiQLSettings,
   pick,
-  VariableEditor,
   EditorProps,
   cn,
   useGraphiQLActions,
   useMonaco,
+  VariableEditor,
+  HeaderEditor,
 } from '@graphiql/react';
 import type { Fetcher, Transport } from '@graphiql/toolkit';
 import { HistoryStore, HISTORY_PLUGIN } from '@graphiql/plugin-history';
@@ -218,8 +219,8 @@ const LABEL = {
 
 export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
   forcedTheme,
-  isHeadersEditorEnabled = true,
   defaultEditorToolsVisibility,
+  isHeadersEditorEnabled = true,
   children: $children,
   confirmCloseTab,
   className,
@@ -293,20 +294,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     storageKey: 'secondaryEditorFlex',
   });
 
-  const [activeSecondaryEditor, setActiveSecondaryEditor] = useState<
-    'variables' | 'headers'
-  >(() => {
-    if (
-      defaultEditorToolsVisibility === 'variables' ||
-      defaultEditorToolsVisibility === 'headers'
-    ) {
-      return defaultEditorToolsVisibility;
-    }
-    return !initialVariables && initialHeaders && isHeadersEditorEnabled
-      ? 'headers'
-      : 'variables';
-  });
-
   const { logo, toolbar, footer, children } = Children.toArray(
     $children,
   ).reduce<{
@@ -343,14 +330,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       pluginResize.setHiddenElement(null);
     }
   }
-
-  const handleToolsTabClick: ButtonHandler = event => {
-    if (editorToolsResize.hiddenElement === 'second') {
-      editorToolsResize.setHiddenElement(null);
-    }
-    const tabName = event.currentTarget.dataset.name as 'variables' | 'headers';
-    setActiveSecondaryEditor(tabName);
-  };
 
   const toggleEditorTools: ButtonHandler = () => {
     editorToolsResize.setHiddenElement(
@@ -410,33 +389,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       </section>
 
       <div ref={editorToolsResize.dragBarRef} className="graphiql-editor-tools">
-        <UnStyledButton
-          type="button"
-          className={cn(
-            activeSecondaryEditor === 'variables' &&
-              editorToolsResize.hiddenElement !== 'second' &&
-              'active',
-          )}
-          onClick={handleToolsTabClick}
-          data-name="variables"
-        >
-          Variables
-        </UnStyledButton>
-        {isHeadersEditorEnabled && (
-          <UnStyledButton
-            type="button"
-            className={cn(
-              activeSecondaryEditor === 'headers' &&
-                editorToolsResize.hiddenElement !== 'second' &&
-                'active',
-            )}
-            onClick={handleToolsTabClick}
-            data-name="headers"
-          >
-            Headers
-          </UnStyledButton>
-        )}
-
         <Tooltip label={editorToolsText}>
           <UnStyledButton
             type="button"
@@ -454,21 +406,22 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
 
       <section
         className="graphiql-editor-tool"
-        aria-label={
-          activeSecondaryEditor === 'variables' ? 'Variables' : 'Headers'
-        }
+        aria-label="Variables and Headers"
         ref={editorToolsResize.secondRef}
       >
-        <VariableEditor
-          className={activeSecondaryEditor === 'variables' ? '' : 'hidden'}
-          onEdit={onEditVariables}
+        <VarHeadersStrip
+          defaultTab={((d: typeof defaultEditorToolsVisibility) => {
+            if (d === 'variables' || d === 'headers') {
+              return d;
+            }
+            return !initialVariables && initialHeaders && isHeadersEditorEnabled
+              ? 'headers'
+              : 'variables';
+          })(defaultEditorToolsVisibility)}
+          headersEditorEnabled={isHeadersEditorEnabled}
+          onEditVariables={onEditVariables}
+          onEditHeaders={onEditHeaders}
         />
-        {isHeadersEditorEnabled && (
-          <HeaderEditor
-            className={activeSecondaryEditor === 'headers' ? '' : 'hidden'}
-            onEdit={onEditHeaders}
-          />
-        )}
       </section>
     </div>
   );

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -180,8 +180,10 @@ button.graphiql-tab-strip-action {
 
 /* An editor tool, e.g. variables or request headers editor */
 .graphiql-container .graphiql-editor-tool {
+  display: flex;
+  flex-direction: column;
   flex: 1;
-  padding: var(--px-16);
+  min-height: 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

The variables/headers footer below the operation editor is replaced by a `VarHeadersStrip` component with two tabs: Variables and Headers. The existing JSON editors are reused under their respective tabs. A right-aligned validity hint on the Variables tab shows how many variables are defined and whether they parse as valid JSON.

## Test plan

- [ ] Switch between Variables and Headers tabs; each shows the correct editor
- [ ] Edit variables JSON; the validity hint updates to reflect the count and valid/invalid state
- [ ] Empty variables editor shows no hint
- [ ] Existing variables and headers content is preserved when switching tabs
- [ ] The strip is vertically resizable using the drag handle above it
- [ ] The show/hide toggle collapses and restores the strip
- [ ] Active tab persists across page reload (stored in localStorage)

Refs: graphql/graphiql#4219
