### PR TITLE
v6: Add theme / density / font-size controls to settings dialog

### DIFF
--- a/.changeset/settings-dialog-presets.md
+++ b/.changeset/settings-dialog-presets.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+'graphiql': minor
+---
+
+Add `SettingsDialog` with theme, density, font-size, and persist-headers controls backed by `useGraphiQLSettings`. Density and font-size presets fill in concrete token values for the `[data-density]` and `[data-font-size]` blocks in `tokens.css`. Monaco editor font size, the status bar, and UI icon sizes follow the active font-size preset. The `forcedTheme` and `showPersistHeadersSettings` props continue to work, with `forcedTheme` hiding the theme control.

--- a/packages/graphiql-react/src/components/activity-rail/index.css
+++ b/packages/graphiql-react/src/components/activity-rail/index.css
@@ -55,8 +55,8 @@
 }
 
 .graphiql-activity-rail-item svg {
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-lg);
+  height: var(--icon-size-lg);
 }
 
 .graphiql-activity-rail-spacer {
@@ -92,6 +92,6 @@
 }
 
 .graphiql-activity-rail-settings svg {
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size-lg);
+  height: var(--icon-size-lg);
 }

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -33,7 +33,7 @@
 .graphiql-dialog-close > svg {
   color: oklch(var(--fg-muted));
   display: block;
-  height: var(--px-12);
+  height: var(--icon-size-md);
   padding: var(--px-12);
-  width: var(--px-12);
+  width: var(--icon-size-md);
 }

--- a/packages/graphiql-react/src/components/execute-button/index.css
+++ b/packages/graphiql-react/src/components/execute-button/index.css
@@ -24,8 +24,8 @@ button.graphiql-execute-button {
   & > svg {
     color: #fff;
     display: block;
-    height: var(--px-16);
+    height: var(--icon-size-lg);
     margin: auto;
-    width: var(--px-16);
+    width: var(--icon-size-lg);
   }
 }

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -45,3 +45,5 @@ export { ResponseTreeView } from './response-tree-view';
 export type { ResponseTreeViewProps } from './response-tree-view';
 export { VarHeadersStrip } from './var-headers-strip';
 export type { VarHeadersStripProps, VarTab } from './var-headers-strip';
+export { SettingsDialog } from './settings-dialog';
+export type { SettingsDialogProps } from './settings-dialog';

--- a/packages/graphiql-react/src/components/panel-header/index.css
+++ b/packages/graphiql-react/src/components/panel-header/index.css
@@ -37,6 +37,6 @@
 }
 
 .graphiql-panel-header-actions svg {
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
 }

--- a/packages/graphiql-react/src/components/response-header/index.css
+++ b/packages/graphiql-react/src/components/response-header/index.css
@@ -125,6 +125,6 @@
 }
 
 .graphiql-transport-upgrade-banner-dismiss > svg {
-  width: 12px;
-  height: 12px;
+  width: var(--icon-size-md);
+  height: var(--icon-size-md);
 }

--- a/packages/graphiql-react/src/components/settings-dialog/index.css
+++ b/packages/graphiql-react/src/components/settings-dialog/index.css
@@ -1,0 +1,63 @@
+.graphiql-settings-dialog {
+  min-width: 360px;
+}
+
+.graphiql-settings-dialog-header {
+  align-items: center;
+  border-bottom: 1px solid oklch(var(--border-default));
+  display: flex;
+  justify-content: space-between;
+  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
+}
+
+.graphiql-settings-dialog-title {
+  color: oklch(var(--fg-strong));
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  margin: 0;
+}
+
+.graphiql-settings-dialog-body {
+  display: flex;
+  flex-direction: column;
+  padding: var(--px-4) 0;
+}
+
+.graphiql-settings-section {
+  align-items: center;
+  border-bottom: 1px solid oklch(var(--border-muted));
+  display: flex;
+  gap: var(--px-16);
+  justify-content: space-between;
+  padding: var(--px-12) var(--px-16);
+}
+
+.graphiql-settings-section:last-child {
+  border-bottom: none;
+}
+
+.graphiql-settings-section-title {
+  color: oklch(var(--fg-default));
+  flex-shrink: 0;
+  font-family: var(--font-family);
+  font-size: var(--font-size-small);
+  font-weight: 500;
+  letter-spacing: var(--letter-spacing-ui);
+  margin: 0;
+  min-width: 72px;
+}
+
+.graphiql-settings-section-label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-4);
+}
+
+.graphiql-settings-section-caption {
+  color: oklch(var(--fg-muted));
+  font-family: var(--font-family);
+  font-size: var(--font-size-eyebrow);
+  letter-spacing: var(--letter-spacing-ui);
+  margin: 0;
+}

--- a/packages/graphiql-react/src/components/settings-dialog/index.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/index.tsx
@@ -1,0 +1,215 @@
+'use no memo';
+
+import type { FC } from 'react';
+import { Dialog } from '../dialog';
+import { SegmentedControl } from '../segmented-control';
+import { Button } from '../button';
+import { useGraphiQL, useGraphiQLActions } from '../provider';
+import {
+  useGraphiQLSettings,
+  type Theme,
+  type Density,
+  type FontSize,
+} from '../../hooks/use-graphiql-settings';
+import { useMonaco } from '../../stores';
+import { useEffect, useState } from 'react';
+import './index.css';
+
+const FONT_SIZE_PX: Record<FontSize, number> = {
+  compact: 12,
+  default: 13,
+  large: 14,
+  xl: 16,
+};
+
+const FORCED_THEME_TO_SETTING: Record<'light' | 'dark' | 'system', Theme> = {
+  light: 'light',
+  dark: 'dark',
+  system: 'auto',
+};
+
+const PERSIST_HEADERS_OPTIONS: { value: 'on' | 'off'; label: string }[] = [
+  { value: 'on', label: 'On' },
+  { value: 'off', label: 'Off' },
+];
+
+const THEME_OPTIONS: { value: Theme; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
+
+const DENSITY_OPTIONS: { value: Density; label: string }[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'comfortable', label: 'Comfortable' },
+  { value: 'spacious', label: 'Spacious' },
+];
+
+const FONT_SIZE_OPTIONS: { value: FontSize; label: string }[] = [
+  { value: 'compact', label: 'Compact' },
+  { value: 'default', label: 'Default' },
+  { value: 'large', label: 'Large' },
+  { value: 'xl', label: 'Extra Large' },
+];
+
+export interface SettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Enforce a specific theme. When set, the theme control is hidden.
+   */
+  forcedTheme?: 'light' | 'dark' | 'system';
+  /**
+   * Whether the "persist headers" control is shown.
+   */
+  showPersistHeadersSettings?: boolean;
+}
+
+/**
+ * Settings dialog with controls for theme, density, font size, and header
+ * persistence. Reads and writes appearance settings via `useGraphiQLSettings`.
+ * Monaco editor font size is updated to match the active font-size preset.
+ */
+export const SettingsDialog: FC<SettingsDialogProps> = ({
+  open,
+  onOpenChange,
+  forcedTheme,
+  showPersistHeadersSettings,
+}) => {
+  const { theme, setTheme, density, setDensity, fontSize, setFontSize } =
+    useGraphiQLSettings();
+  const monaco = useMonaco(state => state.monaco);
+  const shouldPersistHeaders = useGraphiQL(state => state.shouldPersistHeaders);
+  const storage = useGraphiQL(state => state.storage);
+  const { setShouldPersistHeaders } = useGraphiQLActions();
+  const [clearStorageStatus, setClearStorageStatus] = useState<
+    'success' | 'error' | undefined
+  >();
+
+  // Reset the clear-storage button state when the dialog closes.
+  useEffect(() => {
+    if (!open) {
+      setClearStorageStatus(undefined);
+    }
+  }, [open]);
+
+  function handleClearData() {
+    try {
+      storage.clear();
+      setClearStorageStatus('success');
+    } catch {
+      setClearStorageStatus('error');
+    }
+  }
+
+  // Keep Monaco editor font size in sync with the active preset.
+  useEffect(() => {
+    if (!monaco) {
+      return;
+    }
+    const px = FONT_SIZE_PX[fontSize];
+    monaco.editor.getEditors().forEach(editor => {
+      editor.updateOptions({ fontSize: px });
+    });
+  }, [fontSize, monaco]);
+
+  // Resolve to a valid setting; an unrecognized `forcedTheme` (e.g. from a URL
+  // param) maps to `undefined` and is ignored, leaving the theme control shown.
+  const forcedThemeSetting = forcedTheme
+    ? FORCED_THEME_TO_SETTING[forcedTheme]
+    : undefined;
+
+  // Enforce a forced theme when provided. The equality guard keeps `setTheme`
+  // (recreated each render) from looping, so all deps can be listed honestly.
+  useEffect(() => {
+    if (forcedThemeSetting && theme !== forcedThemeSetting) {
+      setTheme(forcedThemeSetting);
+    }
+  }, [forcedThemeSetting, theme, setTheme]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <div className="graphiql-settings-dialog">
+        <div className="graphiql-settings-dialog-header">
+          <Dialog.Title className="graphiql-settings-dialog-title">
+            Settings
+          </Dialog.Title>
+          <Dialog.Close />
+        </div>
+
+        <div className="graphiql-settings-dialog-body">
+          {!forcedThemeSetting && (
+            <section className="graphiql-settings-section">
+              <h3 className="graphiql-settings-section-title">Theme</h3>
+              <SegmentedControl
+                value={theme}
+                onChange={setTheme}
+                ariaLabel="Theme"
+                options={THEME_OPTIONS}
+              />
+            </section>
+          )}
+
+          <section className="graphiql-settings-section">
+            <h3 className="graphiql-settings-section-title">Density</h3>
+            <SegmentedControl
+              value={density}
+              onChange={setDensity}
+              ariaLabel="Density"
+              options={DENSITY_OPTIONS}
+            />
+          </section>
+
+          <section className="graphiql-settings-section">
+            <h3 className="graphiql-settings-section-title">Font size</h3>
+            <SegmentedControl
+              value={fontSize}
+              onChange={setFontSize}
+              ariaLabel="Font size"
+              options={FONT_SIZE_OPTIONS}
+            />
+          </section>
+
+          {showPersistHeadersSettings && (
+            <section className="graphiql-settings-section">
+              <div className="graphiql-settings-section-label">
+                <h3 className="graphiql-settings-section-title">
+                  Persist headers
+                </h3>
+                <p className="graphiql-settings-section-caption">
+                  Save headers upon reloading. Only enable if you trust this
+                  device.
+                </p>
+              </div>
+              <SegmentedControl
+                value={shouldPersistHeaders ? 'on' : 'off'}
+                onChange={value => setShouldPersistHeaders(value === 'on')}
+                ariaLabel="Persist headers"
+                options={PERSIST_HEADERS_OPTIONS}
+              />
+            </section>
+          )}
+
+          <section className="graphiql-settings-section">
+            <div className="graphiql-settings-section-label">
+              <h3 className="graphiql-settings-section-title">Clear storage</h3>
+              <p className="graphiql-settings-section-caption">
+                Remove all locally stored data and start fresh.
+              </p>
+            </div>
+            <Button
+              type="button"
+              state={clearStorageStatus}
+              disabled={clearStorageStatus === 'success'}
+              onClick={handleClearData}
+            >
+              {{ success: 'Cleared data', error: 'Failed' }[
+                clearStorageStatus!
+              ] ?? 'Clear data'}
+            </Button>
+          </section>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/packages/graphiql-react/src/components/settings-dialog/settings-dialog.stories.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/settings-dialog.stories.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../button';
+import { GraphiQLProvider } from '../provider';
+import { SettingsDialog } from './index';
+
+const noOpTransport = {
+  send: async () => ({
+    ok: true,
+    body: { data: {} },
+    timing: { totalMs: 0 },
+    size: {},
+  }),
+};
+
+const meta: Meta<typeof SettingsDialog> = {
+  title: 'Components/SettingsDialog',
+  component: SettingsDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <GraphiQLProvider transport={noOpTransport}>
+        <Story />
+      </GraphiQLProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SettingsDialog>;
+
+export const Default: Story = {
+  render: function DefaultStory() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Settings</Button>
+        <SettingsDialog open={open} onOpenChange={setOpen} />
+      </>
+    );
+  },
+};
+
+export const AlwaysOpen: Story = {
+  render: function AlwaysOpenStory() {
+    return <SettingsDialog open onOpenChange={() => {}} />;
+  },
+};
+
+export const WithPersistHeaders: Story = {
+  name: 'With persist-headers control',
+  render: function WithPersistHeadersStory() {
+    return (
+      <SettingsDialog open onOpenChange={() => {}} showPersistHeadersSettings />
+    );
+  },
+};

--- a/packages/graphiql-react/src/components/settings-dialog/settings-dialog.test.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/settings-dialog.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SettingsDialog, type SettingsDialogProps } from './index';
+import { SETTINGS_STORAGE_KEY } from '../../hooks/use-graphiql-settings';
+
+// The Monaco store performs dynamic imports of monaco-editor / monaco-graphql
+// that don't resolve in jsdom. Stub it out so the dialog can render without
+// a real editor environment.
+vi.mock('../../stores/monaco', () => ({
+  monacoStore: {
+    getState: () => ({ monaco: undefined, monacoGraphQL: undefined }),
+    subscribe: () => () => {},
+  },
+  useMonaco: (selector: (state: { monaco: undefined }) => unknown) =>
+    selector({ monaco: undefined }),
+}));
+
+// The persist-headers and clear-storage controls read/write the GraphiQL store;
+// mock the hooks so the dialog can render without a provider.
+const mockSetShouldPersistHeaders = vi.fn();
+const mockStorage = { clear: vi.fn() };
+let mockShouldPersistHeaders = false;
+
+type MockState = { shouldPersistHeaders: boolean; storage: typeof mockStorage };
+
+vi.mock('../provider', () => ({
+  useGraphiQL: (selector: (s: MockState) => unknown) =>
+    selector({
+      shouldPersistHeaders: mockShouldPersistHeaders,
+      storage: mockStorage,
+    }),
+  useGraphiQLActions: () => ({
+    setShouldPersistHeaders: mockSetShouldPersistHeaders,
+  }),
+}));
+
+// Polyfill localStorage for environments that lack it.
+beforeAll(() => {
+  if (globalThis.localStorage === undefined) {
+    const store = new Map<string, string>();
+    const storage: Storage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem(key: string, value: string) {
+        store.set(key, value);
+      },
+      removeItem(key: string) {
+        store.delete(key);
+      },
+      clear() {
+        store.clear();
+      },
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+      get length() {
+        return store.size;
+      },
+    };
+    Object.defineProperty(window, 'localStorage', {
+      writable: true,
+      value: storage,
+    });
+  }
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string): MediaQueryList =>
+      ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }) as unknown as MediaQueryList,
+  });
+});
+
+beforeEach(() => {
+  localStorage.removeItem(SETTINGS_STORAGE_KEY);
+  mockShouldPersistHeaders = false;
+  mockSetShouldPersistHeaders.mockClear();
+  mockStorage.clear.mockClear();
+  // Ensure a graphiql-container exists for useGraphiQLSettings' DOM effect.
+  const existing = document.querySelector('.graphiql-container');
+  if (!existing) {
+    const c = document.createElement('div');
+    c.className = 'graphiql-container';
+    document.body.append(c);
+  }
+});
+
+function renderDialog(open = true, props: Partial<SettingsDialogProps> = {}) {
+  const onOpenChange = vi.fn();
+  render(<SettingsDialog open={open} onOpenChange={onOpenChange} {...props} />);
+  return { onOpenChange };
+}
+
+describe('SettingsDialog — renders', () => {
+  it('shows the Settings title when open', () => {
+    renderDialog();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('shows Theme, Density, and Font size section headings', () => {
+    renderDialog();
+    // Each section renders an h3 title and a fieldset legend — query by role.
+    expect(screen.getAllByText('Theme').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Density').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Font size').length).toBeGreaterThanOrEqual(1);
+    // Confirm the section headings are present as h3 elements.
+    const headings = screen.getAllByRole('heading', { level: 3 });
+    const headingTexts = headings.map(h => h.textContent);
+    expect(headingTexts).toContain('Theme');
+    expect(headingTexts).toContain('Density');
+    expect(headingTexts).toContain('Font size');
+  });
+});
+
+describe('SettingsDialog — theme control', () => {
+  it('renders Auto / Light / Dark options', () => {
+    renderDialog();
+    const fieldset = screen.getByRole('group', { name: 'Theme' });
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Auto' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Light' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Dark' }),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults to Auto', () => {
+    renderDialog();
+    const auto = screen.getByRole('radio', { name: 'Auto' });
+    expect(auto).toBeChecked();
+  });
+
+  it('switches theme to Dark on click', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    const dark = screen.getByRole('radio', { name: 'Dark' });
+    await user.click(dark);
+    expect(dark).toBeChecked();
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY)!);
+    expect(stored.theme).toBe('dark');
+  });
+});
+
+describe('SettingsDialog — density control', () => {
+  it('renders Compact / Comfortable / Spacious options', () => {
+    renderDialog();
+    const fieldset = screen.getByRole('group', { name: 'Density' });
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Compact' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Comfortable' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Spacious' }),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults to Comfortable', () => {
+    renderDialog();
+    expect(screen.getByRole('radio', { name: 'Comfortable' })).toBeChecked();
+  });
+
+  it('switches density to Compact on click', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    const fieldset = screen.getByRole('group', { name: 'Density' });
+    const compact = within(fieldset).getByRole('radio', { name: 'Compact' });
+    await user.click(compact);
+    expect(compact).toBeChecked();
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY)!);
+    expect(stored.density).toBe('compact');
+  });
+});
+
+describe('SettingsDialog — font size control', () => {
+  it('renders Compact / Default / Large / Extra Large options', () => {
+    renderDialog();
+    const fieldset = screen.getByRole('group', { name: 'Font size' });
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Compact' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Default' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Large' }),
+    ).toBeInTheDocument();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Extra Large' }),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults to Default', () => {
+    renderDialog();
+    expect(screen.getByRole('radio', { name: 'Default' })).toBeChecked();
+  });
+
+  it('switches font size to Large on click', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    const large = screen.getByRole('radio', { name: 'Large' });
+    await user.click(large);
+    expect(large).toBeChecked();
+    const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY)!);
+    expect(stored.fontSize).toBe('large');
+  });
+});
+
+describe('SettingsDialog — forcedTheme', () => {
+  it('hides the Theme control when forcedTheme is set', () => {
+    renderDialog(true, { forcedTheme: 'dark' });
+    expect(screen.queryByRole('group', { name: 'Theme' })).toBeNull();
+    // Other controls remain.
+    expect(screen.getByRole('group', { name: 'Density' })).toBeInTheDocument();
+  });
+
+  it('forces the theme into storage', async () => {
+    renderDialog(true, { forcedTheme: 'light' });
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY)!);
+      expect(stored.theme).toBe('light');
+    });
+  });
+
+  it('ignores an unrecognized forcedTheme value', () => {
+    renderDialog(true, { forcedTheme: 'nonsense' as never });
+    // Invalid value is ignored, so the theme control stays visible.
+    expect(screen.getByRole('group', { name: 'Theme' })).toBeInTheDocument();
+  });
+});
+
+describe('SettingsDialog — persist headers', () => {
+  it('is hidden unless showPersistHeadersSettings is set', () => {
+    renderDialog();
+    expect(screen.queryByRole('group', { name: 'Persist headers' })).toBeNull();
+  });
+
+  it('renders On / Off reflecting the current value', () => {
+    mockShouldPersistHeaders = true;
+    renderDialog(true, { showPersistHeadersSettings: true });
+    const fieldset = screen.getByRole('group', { name: 'Persist headers' });
+    expect(within(fieldset).getByRole('radio', { name: 'On' })).toBeChecked();
+    expect(
+      within(fieldset).getByRole('radio', { name: 'Off' }),
+    ).not.toBeChecked();
+  });
+
+  it('calls setShouldPersistHeaders(true) when On is clicked', async () => {
+    const user = userEvent.setup();
+    renderDialog(true, { showPersistHeadersSettings: true });
+    const fieldset = screen.getByRole('group', { name: 'Persist headers' });
+    await user.click(within(fieldset).getByRole('radio', { name: 'On' }));
+    expect(mockSetShouldPersistHeaders).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('SettingsDialog — clear storage', () => {
+  it('clears storage and shows confirmation when clicked', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+    await user.click(screen.getByRole('button', { name: 'Clear data' }));
+    expect(mockStorage.clear).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole('button', { name: 'Cleared data' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('SettingsDialog — closed state', () => {
+  it('does not render content when closed', () => {
+    renderDialog(false);
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument();
+  });
+});

--- a/packages/graphiql-react/src/components/tabs/index.css
+++ b/packages/graphiql-react/src/components/tabs/index.css
@@ -91,8 +91,8 @@
     line-height: 0;
 
     & > svg {
-      height: 10px;
-      width: 10px;
+      height: var(--icon-size-sm);
+      width: var(--icon-size-sm);
     }
 
     &:hover {

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -49,11 +49,6 @@
   /* Typography */
   --font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
   --font-family-mono: 'JetBrains Mono', ui-monospace, monospace;
-  --font-size-body: 13px;
-  --font-size-small: 11px;
-  --font-size-mono: 12px;
-  --font-size-eyebrow: 10.5px;
-  --line-height-body: 18px;
   --letter-spacing-ui: -0.005em;
 
   /* Spacing scale */
@@ -67,12 +62,8 @@
   --px-24: 24px;
   --px-32: 32px;
 
-  /* Layout dimensions */
-  --top-bar-height: 40px;
-  --status-bar-height: 24px;
-  --rail-width: 48px;
+  /* Layout dimensions (fixed; density-controlled dimensions live below) */
   --side-panel-width: 340px;
-  --tab-strip-height: 32px;
 
   /* Radii */
   --radius-sm: 4px;
@@ -123,6 +114,98 @@
     0 4px 12px oklch(0% 0 0 / 0.08), 0 1px 3px oklch(0% 0 0 / 0.04);
 
   /* Typography, spacing, dimensions, and radii are inherited from :root. */
+}
+
+/* -------------------------------------------------------------------------
+ * Density presets
+ *
+ * `comfortable` is the default; the combined selector makes it the fallback
+ * when the attribute is absent.
+ * ---------------------------------------------------------------------- */
+
+:root,
+[data-density='comfortable'] {
+  --row-padding-y: 5px;
+  --row-padding-x: 14px;
+  --button-padding-y: 4px;
+  --button-padding-x: 10px;
+  --top-bar-height: 40px;
+  --status-bar-height: 24px;
+  --rail-width: 48px;
+  --tab-strip-height: 32px;
+}
+
+[data-density='compact'] {
+  --row-padding-y: 2px;
+  --row-padding-x: 10px;
+  --button-padding-y: 2px;
+  --button-padding-x: 7px;
+  --top-bar-height: 34px;
+  --status-bar-height: 20px;
+  --rail-width: 42px;
+  --tab-strip-height: 26px;
+}
+
+[data-density='spacious'] {
+  --row-padding-y: 9px;
+  --row-padding-x: 19px;
+  --button-padding-y: 7px;
+  --button-padding-x: 14px;
+  --top-bar-height: 48px;
+  --status-bar-height: 30px;
+  --rail-width: 56px;
+  --tab-strip-height: 40px;
+}
+
+/* -------------------------------------------------------------------------
+ * Font-size presets
+ *
+ * `default` doubles as the fallback via the combined selector.
+ * ---------------------------------------------------------------------- */
+
+:root,
+[data-font-size='default'] {
+  --font-size-body: 13px;
+  --font-size-small: 11px;
+  --font-size-mono: 12px;
+  --font-size-eyebrow: 10.5px;
+  --line-height-body: 18px;
+  --icon-size-sm: 10px;
+  --icon-size-md: 12px;
+  --icon-size-lg: 16px;
+}
+
+[data-font-size='compact'] {
+  --font-size-body: 12px;
+  --font-size-small: 11px;
+  --font-size-mono: 11.5px;
+  --font-size-eyebrow: 10px;
+  --line-height-body: 16px;
+  --icon-size-sm: 9px;
+  --icon-size-md: 11px;
+  --icon-size-lg: 15px;
+}
+
+[data-font-size='large'] {
+  --font-size-body: 14px;
+  --font-size-small: 12px;
+  --font-size-mono: 13px;
+  --font-size-eyebrow: 11.5px;
+  --line-height-body: 20px;
+  --icon-size-sm: 11px;
+  --icon-size-md: 13px;
+  --icon-size-lg: 18px;
+}
+
+[data-font-size='xl'] {
+  --font-size-body: 16px;
+  --font-size-small: 14px;
+  --font-size-mono: 14px;
+  --font-size-eyebrow: 13px;
+  --line-height-body: 22px;
+  --icon-size-sm: 12px;
+  --icon-size-md: 15px;
+  --icon-size-lg: 20px;
 }
 
 /*

--- a/packages/graphiql/cypress/e2e/theme.cy.ts
+++ b/packages/graphiql/cypress/e2e/theme.cy.ts
@@ -1,24 +1,4 @@
 describe('Theme', () => {
-  describe('`forcedTheme`', () => {
-    it('Switches to light theme when `forcedTheme` is light', () => {
-      cy.visit('?forcedTheme=light');
-      cy.get('body').should('have.class', 'graphiql-light');
-    });
-
-    it('Switches to dark theme when `forcedTheme` is dark', () => {
-      cy.visit('?forcedTheme=dark');
-      cy.get('body').should('have.class', 'graphiql-dark');
-    });
-
-    it('Defaults to light theme when `forcedTheme` value is invalid', () => {
-      cy.visit('?forcedTheme=invalid');
-      cy.get('.graphiql-activity-rail-settings').click();
-      cy.get('.graphiql-dialog-section-title')
-        .eq(1)
-        .should('have.text', 'Theme'); // Check for the presence of the theme dialog
-    });
-  });
-
   describe('`defaultTheme`', () => {
     it('should have light theme', () => {
       cy.visit('?defaultTheme=light');

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -425,51 +425,47 @@ describe('GraphiQL', () => {
     });
   }); // panel resizing
 
-  it('allows the user to control persisting headers if it is true', async () => {
-    const { container, findByText } = render(
-      <GraphiQL shouldPersistHeaders fetcher={noOpFetcher} />,
-    );
+  describe('Settings dialog', () => {
+    async function openSettings(container: HTMLElement) {
+      await act(async () => {
+        fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+      return document.querySelector('[role="dialog"]')!;
+    }
 
-    act(() => {
-      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
+    it('shows the persist-headers control when shouldPersistHeaders is true', async () => {
+      const { container } = render(
+        <GraphiQL shouldPersistHeaders fetcher={noOpFetcher} />,
+      );
+      const dialog = await openSettings(container);
+      expect(dialog).toHaveTextContent('Persist headers');
     });
 
-    const element = await findByText('Persist headers');
-    expect(element).toBeInTheDocument();
-  });
-
-  it('allows the user to control persisting headers if it is not passed in', async () => {
-    const { container, findByText } = render(
-      <GraphiQL fetcher={noOpFetcher} />,
-    );
-
-    act(() => {
-      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
+    it('shows the persist-headers control by default', async () => {
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+      const dialog = await openSettings(container);
+      expect(dialog).toHaveTextContent('Persist headers');
     });
 
-    const element = await findByText('Persist headers');
-    expect(element).toBeInTheDocument();
-  });
-
-  it('does not allow the user to control persisting headers is false', async () => {
-    const { container, findByText } = render(
-      <GraphiQL shouldPersistHeaders={false} fetcher={noOpFetcher} />,
-    );
-
-    act(() => {
-      fireEvent.click(container.querySelector('[aria-label="Settings"]')!);
+    it('hides the persist-headers control when shouldPersistHeaders is false', async () => {
+      const { container } = render(
+        <GraphiQL shouldPersistHeaders={false} fetcher={noOpFetcher} />,
+      );
+      const dialog = await openSettings(container);
+      // "Density" confirms the dialog is open before asserting absence.
+      expect(dialog).toHaveTextContent('Density');
+      expect(dialog).not.toHaveTextContent('Persist headers');
     });
 
-    const callback = async () => {
-      try {
-        // Expecting non-existence; short-circuit instead of waiting the default.
-        await findByText('Persist headers', undefined, { timeout: 1000 });
-      } catch {
-        // eslint-disable-next-line no-throw-literal
-        throw 'failed';
-      }
-    };
-    await expect(callback).rejects.toEqual('failed');
+    it('hides the theme control when forcedTheme is set', async () => {
+      const { container } = render(
+        <GraphiQL forcedTheme="dark" fetcher={noOpFetcher} />,
+      );
+      const dialog = await openSettings(container);
+      expect(dialog).toHaveTextContent('Density');
+      expect(dialog).not.toHaveTextContent('Theme');
+    });
   });
 
   describe('Tabs', () => {

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -54,8 +54,8 @@ button.graphiql-tab-add {
   & > svg {
     color: hsla(var(--color-neutral), var(--alpha-secondary));
     display: block;
-    height: var(--px-16);
-    width: var(--px-16);
+    height: var(--icon-size-lg);
+    width: var(--icon-size-lg);
   }
 }
 
@@ -76,8 +76,8 @@ button.graphiql-tab-strip-action {
 
   & > svg {
     display: block;
-    height: 13px;
-    width: 13px;
+    height: var(--icon-size-md);
+    width: var(--icon-size-md);
   }
 
   &:hover {

--- a/packages/graphiql/src/ui/activity-bar.tsx
+++ b/packages/graphiql/src/ui/activity-bar.tsx
@@ -1,68 +1,35 @@
-import { type FC, type MouseEventHandler, useEffect, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 import {
   ActivityRail,
-  Button,
-  ButtonGroup,
-  cn,
   Dialog,
   isMacOs,
-  pick,
-  useGraphiQL,
-  useGraphiQLActions,
+  SettingsDialog,
   useDragResize,
   VisuallyHidden,
   type GraphiQLPlugin,
 } from '@graphiql/react';
 import { ShortKeys } from './short-keys';
 
-const THEMES = ['light', 'dark', 'system'] as const;
-
 export interface ActivityBarProps {
   /**
-   * `forcedTheme` allows enforcement of a specific theme for GraphiQL.
-   * This is useful when you want to make sure that GraphiQL is always
-   * rendered with a specific theme.
+   * Enforce a specific theme; hides the theme control in the settings dialog.
    */
-  forcedTheme?: (typeof THEMES)[number];
-
+  forcedTheme?: 'light' | 'dark' | 'system';
   /**
-   * Indicates if settings for persisting headers should appear in the
-   * settings modal.
+   * Whether the "persist headers" control appears in the settings dialog.
    */
   showPersistHeadersSettings?: boolean;
-
   setHiddenElement: ReturnType<typeof useDragResize>['setHiddenElement'];
 }
 
-type ButtonHandler = MouseEventHandler<HTMLButtonElement>;
-
 export const ActivityBar: FC<ActivityBarProps> = ({
-  forcedTheme: $forcedTheme,
+  forcedTheme,
   showPersistHeadersSettings,
   setHiddenElement,
 }) => {
-  const forcedTheme =
-    $forcedTheme && THEMES.includes($forcedTheme) ? $forcedTheme : undefined;
-
-  const { setShouldPersistHeaders, setTheme } = useGraphiQLActions();
-  const { shouldPersistHeaders, theme, storage } = useGraphiQL(
-    pick('shouldPersistHeaders', 'theme', 'storage'),
-  );
-
-  useEffect(() => {
-    if (forcedTheme === 'system') {
-      setTheme(null);
-    } else if (forcedTheme === 'light' || forcedTheme === 'dark') {
-      setTheme(forcedTheme);
-    }
-  }, [forcedTheme, setTheme]);
-
   const [showDialog, setShowDialog] = useState<
     'settings' | 'short-keys' | null
   >(null);
-  const [clearStorageStatus, setClearStorageStatus] = useState<
-    'success' | 'error' | undefined
-  >();
 
   useEffect(() => {
     function openSettings(event: KeyboardEvent) {
@@ -80,7 +47,6 @@ export const ActivityBar: FC<ActivityBarProps> = ({
   function handleOpenSettingsDialog(isOpen: boolean) {
     if (!isOpen) {
       setShowDialog(null);
-      setClearStorageStatus(undefined);
     }
   }
 
@@ -89,27 +55,6 @@ export const ActivityBar: FC<ActivityBarProps> = ({
       setShowDialog(null);
     }
   }
-
-  function handleClearData() {
-    try {
-      storage.clear();
-      setClearStorageStatus('success');
-    } catch {
-      setClearStorageStatus('error');
-    }
-  }
-
-  const handlePersistHeaders: ButtonHandler = event => {
-    setShouldPersistHeaders(event.currentTarget.dataset.value === 'true');
-  };
-
-  const handleChangeTheme: ButtonHandler = event => {
-    const selectedTheme = event.currentTarget.dataset.theme as
-      | 'light'
-      | 'dark'
-      | undefined;
-    setTheme(selectedTheme || null);
-  };
 
   function handlePluginToggle(nextPlugin: GraphiQLPlugin | null) {
     if (nextPlugin === null) {
@@ -145,111 +90,12 @@ export const ActivityBar: FC<ActivityBarProps> = ({
           <ShortKeys />
         </div>
       </Dialog>
-      <Dialog
+      <SettingsDialog
         open={showDialog === 'settings'}
         onOpenChange={handleOpenSettingsDialog}
-      >
-        <div className="graphiql-dialog-header">
-          <Dialog.Title className="graphiql-dialog-title">
-            Settings
-          </Dialog.Title>
-          <VisuallyHidden>
-            <Dialog.Description>
-              This modal lets you adjust header persistence, interface theme,
-              and clear local storage.
-            </Dialog.Description>
-          </VisuallyHidden>
-          <Dialog.Close />
-        </div>
-        {showPersistHeadersSettings ? (
-          <div className="graphiql-dialog-section">
-            <div>
-              <div className="graphiql-dialog-section-title">
-                Persist headers
-              </div>
-              <div className="graphiql-dialog-section-caption">
-                Save headers upon reloading.{' '}
-                <span className="graphiql-warning-text">
-                  Only enable if you trust this device.
-                </span>
-              </div>
-            </div>
-            <ButtonGroup>
-              <Button
-                type="button"
-                id="enable-persist-headers"
-                className={cn(shouldPersistHeaders && 'active')}
-                data-value="true"
-                onClick={handlePersistHeaders}
-              >
-                On
-              </Button>
-              <Button
-                type="button"
-                id="disable-persist-headers"
-                className={cn(!shouldPersistHeaders && 'active')}
-                onClick={handlePersistHeaders}
-              >
-                Off
-              </Button>
-            </ButtonGroup>
-          </div>
-        ) : null}
-        {!forcedTheme && (
-          <div className="graphiql-dialog-section">
-            <div>
-              <div className="graphiql-dialog-section-title">Theme</div>
-              <div className="graphiql-dialog-section-caption">
-                Adjust how the interface appears.
-              </div>
-            </div>
-            <ButtonGroup>
-              <Button
-                type="button"
-                className={cn(theme === null && 'active')}
-                onClick={handleChangeTheme}
-              >
-                System
-              </Button>
-              <Button
-                type="button"
-                className={cn(theme === 'light' && 'active')}
-                data-theme="light"
-                onClick={handleChangeTheme}
-              >
-                Light
-              </Button>
-              <Button
-                type="button"
-                className={cn(theme === 'dark' && 'active')}
-                data-theme="dark"
-                onClick={handleChangeTheme}
-              >
-                Dark
-              </Button>
-            </ButtonGroup>
-          </div>
-        )}
-        <div className="graphiql-dialog-section">
-          <div>
-            <div className="graphiql-dialog-section-title">Clear storage</div>
-            <div className="graphiql-dialog-section-caption">
-              Remove all locally stored data and start fresh.
-            </div>
-          </div>
-          <Button
-            type="button"
-            state={clearStorageStatus}
-            disabled={clearStorageStatus === 'success'}
-            onClick={handleClearData}
-          >
-            {{
-              success: 'Cleared data',
-              error: 'Failed',
-            }[clearStorageStatus!] || 'Clear data'}
-          </Button>
-        </div>
-      </Dialog>
+        forcedTheme={forcedTheme}
+        showPersistHeadersSettings={showPersistHeadersSettings}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

The settings dialog exposes segmented controls for theme, density, font size, and header persistence, backed by the `useGraphiQLSettings` hook from #4322. Density and font-size presets fill in the `[data-density]` and `[data-font-size]` token blocks, so changing a preset adjusts spacing and typography; the font-size preset also drives the status bar text, UI icon sizes, and the Monaco editor font. `SettingsDialog` lives in `@graphiql/react` and is wired into the `graphiql` activity bar, replacing the previous inline settings UI; the `forcedTheme` and `showPersistHeadersSettings` props continue to work, with `forcedTheme` hiding the theme control.

## Test plan

- [x] On the deploy preview, open the settings dialog from the activity-bar gear; confirm Theme, Density, Font size, and Persist headers controls render.
- [x] Change Density (Compact / Comfortable / Spacious) and confirm spacing visibly shifts: top-bar height, activity-rail width, row padding.
- [x] Change Font size (Compact / Default / Large / Extra Large) and confirm the editor text, the status bar text, and the toolbar/rail icons all scale.
- [x] Switch Theme (Auto / Light / Dark) and confirm the app re-themes.
- [x] Toggle Persist headers On, set a header, reload; confirm it is restored only when On.

Refs: graphql/graphiql#4219
