### PR TITLE
Fix netlify GraphQL demo function

### DIFF
--- a/functions/graphql.ts
+++ b/functions/graphql.ts
@@ -1,52 +1,119 @@
-import {
-  createHandler as createRawHandler,
-  HandlerOptions as RawHandlerOptions,
-  OperationContext,
-} from 'graphql-http';
 import type {
   Handler as NetlifyHandler,
   HandlerEvent as NetlifyHandlerEvent,
-  HandlerContext as NetlifyHandlerContext,
+  HandlerResponse as NetlifyHandlerResponse,
 } from '@netlify/functions';
 import * as graphql from 'graphql';
+import {
+  getGraphQLParameters,
+  processRequest,
+  type ProcessRequestResult,
+} from 'graphql-helix';
 import { createSchema } from '../packages/graphiql/test/schema.js';
 import { createExecute } from '../packages/graphiql/test/execute.js';
 
-/**
- * Handler options when using the netlify adapter
- *
- * @category Server/@netlify/functions
- */
-type HandlerOptions<Context extends OperationContext = undefined> =
-  RawHandlerOptions<NetlifyHandlerEvent, NetlifyHandlerContext, Context>;
+type HandlerOptions = {
+  schema: graphql.GraphQLSchema;
+  execute: (...args: any[]) => any;
+};
+
+function headersToObject(
+  headers: Iterable<{ name: string; value: string }>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const { name, value } of headers) {
+    result[name] = value;
+  }
+  return result;
+}
 
 /**
- * Create a GraphQL over HTTP spec compliant request handler for netlify functions
+ * Buffer an incremental-delivery (`@defer`/`@stream`) result into a single
+ * `multipart/mixed` response. Netlify's request/response functions can't stream,
+ * so every patch is collected and sent at once using the same wire format the
+ * dev server (`graphql-helix`) emits, which the GraphiQL fetcher already parses.
+ */
+async function bufferMultipartResponse(
+  result: Extract<ProcessRequestResult, { type: 'MULTIPART_RESPONSE' }>,
+): Promise<NetlifyHandlerResponse> {
+  const chunks = ['---'];
+  await result.subscribe(patch => {
+    const chunk = JSON.stringify(patch);
+    const data = [
+      '',
+      'Content-Type: application/json; charset=utf-8',
+      `Content-Length: ${chunk.length}`,
+      '',
+      chunk,
+    ];
+    if (patch.hasNext) {
+      data.push('---');
+    }
+    chunks.push(data.join('\r\n'));
+  });
+  chunks.push('\r\n-----\r\n');
+  return {
+    statusCode: 200,
+    headers: { 'Content-Type': 'multipart/mixed; boundary="-"' },
+    body: chunks.join(''),
+  };
+}
+
+/**
+ * Create a GraphQL request handler for netlify functions backed by
+ * `graphql-helix`, which supports incremental delivery (`@defer`/`@stream`)
+ * against `graphql-js` 17.
  *
  * @category Server/@netlify/functions
  */
-export function createHandler<Context extends OperationContext = undefined>(
-  options: HandlerOptions<Context>,
-): NetlifyHandler {
-  const handler = createRawHandler(options);
-  return async function handleRequest(req, ctx) {
+export function createHandler(options: HandlerOptions): NetlifyHandler {
+  return async function handleRequest(event: NetlifyHandlerEvent) {
     try {
-      const [body, init] = await handler({
-        method: req.httpMethod,
-        url: req.rawUrl,
-        headers: req.headers,
-        body: req.body,
-        raw: req,
-        context: ctx,
+      const rawBody =
+        event.body && event.isBase64Encoded
+          ? Buffer.from(event.body, 'base64').toString('utf8')
+          : event.body;
+      const request = {
+        body: rawBody ? JSON.parse(rawBody) : undefined,
+        headers: event.headers,
+        method: event.httpMethod,
+        query: event.queryStringParameters ?? {},
+      };
+
+      const { operationName, query, variables } = getGraphQLParameters(request);
+      const result = await processRequest({
+        operationName,
+        query,
+        variables,
+        request,
+        schema: options.schema,
+        execute: options.execute,
       });
+
+      if (result.type === 'RESPONSE') {
+        return {
+          statusCode: result.status,
+          headers: headersToObject(result.headers),
+          body: JSON.stringify(result.payload),
+        };
+      }
+      if (result.type === 'MULTIPART_RESPONSE') {
+        return bufferMultipartResponse(result);
+      }
+      // PUSH results are subscriptions, which need the WebSocket endpoint.
       return {
-        // if body is null, return undefined
-        body: body ?? undefined,
-        statusCode: init.status,
+        statusCode: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          errors: [
+            {
+              message:
+                'Subscriptions are not supported over HTTP. Use the WebSocket endpoint instead.',
+            },
+          ],
+        }),
       };
     } catch (err) {
-      // The handler shouldn't throw errors.
-      // If you wish to handle them differently, consider implementing your own request handler.
       console.error(
         'Internal error occurred during request handling. Please check your implementation.',
         err,

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "netlify-function",
   "private": true,
   "dependencies": {
-    "graphql": "^16.11.0",
-    "graphql-http": "^1.22.4"
+    "graphql": "^17.0.0-rc.0",
+    "graphql-helix": "^1.13.0"
   }
 }

--- a/packages/graphiql/test/package.json
+++ b/packages/graphiql/test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "express": "^4.20.0",
-    "graphql": "^17.0.0-alpha.8",
+    "graphql": "^17.0.0-rc.0",
     "graphql-helix": "^1.13.0",
     "graphql-ws": "^6.0.5",
     "ws": "8.20.1"

--- a/packages/vscode-graphql-execution/esbuild.js
+++ b/packages/vscode-graphql-execution/esbuild.js
@@ -5,10 +5,12 @@ const logger = console;
 
 const isWatchMode = arg === '--watch';
 
-// `@urql/core` deep-imports `graphql` ESM files by explicit `.mjs` path (e.g.
-// `graphql/error/GraphQLError.mjs`). `graphql` 17's `exports` map only exposes
-// `.js` deep paths, so esbuild can't resolve the `.mjs` ones. Redirect them to
-// the `.js` sibling, which the `exports` map allows.
+// `@urql/core` (pinned at 2.6.1) deep-imports `graphql` ESM files by explicit
+// `.mjs` path (e.g. `graphql/error/GraphQLError.mjs`). `graphql` 17's `exports`
+// map only exposes `.js` deep paths, so esbuild can't resolve the `.mjs` ones.
+// Redirect them to the `.js` sibling, which the `exports` map allows. Newer
+// `@urql/core` imports `graphql` top-level, so remove this shim once it's
+// upgraded past 2.6.1.
 const graphqlMjsResolver = {
   name: 'graphql-mjs-resolver',
   setup(buildApi) {

--- a/packages/vscode-graphql-execution/esbuild.js
+++ b/packages/vscode-graphql-execution/esbuild.js
@@ -5,12 +5,28 @@ const logger = console;
 
 const isWatchMode = arg === '--watch';
 
+// `@urql/core` deep-imports `graphql` ESM files by explicit `.mjs` path (e.g.
+// `graphql/error/GraphQLError.mjs`). `graphql` 17's `exports` map only exposes
+// `.js` deep paths, so esbuild can't resolve the `.mjs` ones. Redirect them to
+// the `.js` sibling, which the `exports` map allows.
+const graphqlMjsResolver = {
+  name: 'graphql-mjs-resolver',
+  setup(buildApi) {
+    buildApi.onResolve({ filter: /^graphql\/.*\.mjs$/ }, args => ({
+      path: require.resolve(args.path.replace(/\.mjs$/, '.js'), {
+        paths: [args.resolveDir],
+      }),
+    }));
+  },
+};
+
 build({
   entryPoints: ['src/extension.ts'],
   bundle: true,
   minify: arg === '--minify',
   platform: 'node',
   outdir: 'out/',
+  plugins: [graphqlMjsResolver],
   external: [
     'squirrelly',
     'teacup',

--- a/packages/vscode-graphql-execution/package.json
+++ b/packages/vscode-graphql-execution/package.json
@@ -106,7 +106,7 @@
     "cosmiconfig": "8.2.0",
     "cosmiconfig-toml-loader": "^1.0.0",
     "dotenv": "10.0.0",
-    "graphql": "^16.9.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.9.0 || ^17.0.0-rc.0",
     "graphql-config": "^5.1.6",
     "graphql-tag": "2.12.6",
     "graphql-ws": "5.10.0",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -186,7 +186,7 @@
     "ovsx": "0.8.3"
   },
   "dependencies": {
-    "graphql": "^16.9.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.9.0 || ^17.0.0-rc.0",
     "graphql-language-service-server": "^2.14.9",
     "typescript": "^5.8.0",
     "vscode-languageclient": "8.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13071,15 +13071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-http@npm:^1.22.4":
-  version: 1.22.4
-  resolution: "graphql-http@npm:1.22.4"
-  peerDependencies:
-    graphql: ">=0.11 <=16"
-  checksum: 10c0/039e55545fda36ba9bae566ae5d528c4dd9d5972ce3799413741f57309107849930343449b024874041cdcbb7242c0562a19c48d83fccabbf0c7d9f0d3d5a43a
-  languageName: node
-  linkType: hard
-
 "graphql-language-service-cli@workspace:packages/graphql-language-service-cli":
   version: 0.0.0-use.local
   resolution: "graphql-language-service-cli@workspace:packages/graphql-language-service-cli"
@@ -13215,10 +13206,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.9.0 || ^17.0.0-alpha.2, graphql@npm:^17.0.0-alpha.8":
+"graphql@npm:^16.9.0 || ^17.0.0-alpha.2":
   version: 17.0.0-alpha.8
   resolution: "graphql@npm:17.0.0-alpha.8"
   checksum: 10c0/e33ddf6afa36b6640e290412f1f307a0b2b9b3895ed7e273e4a4920f78fb8aa3118db359fa4da3f1c8c3493ea86db29b837b9436250ea9afa05f67b608bd6a8f
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^17.0.0-rc.0":
+  version: 17.0.0-rc.0
+  resolution: "graphql@npm:17.0.0-rc.0"
+  checksum: 10c0/06139f3df45496226d013d4f1a43a2aedb1e20b6a20c4a5b3cf099e5f5708275218ccf6ffdc47be9e35dda2c1ab70b6110aedb87900e3ddf47930acca54517b3
   languageName: node
   linkType: hard
 
@@ -16366,8 +16364,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "netlify-function@workspace:functions"
   dependencies:
-    graphql: "npm:^16.11.0"
-    graphql-http: "npm:^1.22.4"
+    graphql: "npm:^17.0.0-rc.0"
+    graphql-helix: "npm:^1.13.0"
   languageName: unknown
   linkType: soft
 
@@ -20437,7 +20435,7 @@ __metadata:
   resolution: "test-server@workspace:packages/graphiql/test"
   dependencies:
     express: "npm:^4.20.0"
-    graphql: "npm:^17.0.0-alpha.8"
+    graphql: "npm:^17.0.0-rc.0"
     graphql-helix: "npm:^1.13.0"
     graphql-ws: "npm:^6.0.5"
     ws: "npm:8.20.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13206,14 +13206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.9.0 || ^17.0.0-alpha.2":
-  version: 17.0.0-alpha.8
-  resolution: "graphql@npm:17.0.0-alpha.8"
-  checksum: 10c0/e33ddf6afa36b6640e290412f1f307a0b2b9b3895ed7e273e4a4920f78fb8aa3118db359fa4da3f1c8c3493ea86db29b837b9436250ea9afa05f67b608bd6a8f
-  languageName: node
-  linkType: hard
-
-"graphql@npm:^17.0.0-rc.0":
+"graphql@npm:^16.9.0 || ^17.0.0-alpha.2, graphql@npm:^17.0.0-rc.0":
   version: 17.0.0-rc.0
   resolution: "graphql@npm:17.0.0-rc.0"
   checksum: 10c0/06139f3df45496226d013d4f1a43a2aedb1e20b6a20c4a5b3cf099e5f5708275218ccf6ffdc47be9e35dda2c1ab70b6110aedb87900e3ddf47930acca54517b3

--- a/yarn.lock
+++ b/yarn.lock
@@ -13206,7 +13206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.9.0 || ^17.0.0-alpha.2, graphql@npm:^17.0.0-rc.0":
+"graphql@npm:^16.9.0 || ^17.0.0-rc.0, graphql@npm:^17.0.0-rc.0":
   version: 17.0.0-rc.0
   resolution: "graphql@npm:17.0.0-rc.0"
   checksum: 10c0/06139f3df45496226d013d4f1a43a2aedb1e20b6a20c4a5b3cf099e5f5708275218ccf6ffdc47be9e35dda2c1ab70b6110aedb87900e3ddf47930acca54517b3
@@ -21636,7 +21636,7 @@ __metadata:
     cosmiconfig-toml-loader: "npm:^1.0.0"
     dotenv: "npm:10.0.0"
     esbuild: "npm:0.18.10"
-    graphql: "npm:^16.9.0 || ^17.0.0-alpha.2"
+    graphql: "npm:^16.9.0 || ^17.0.0-rc.0"
     graphql-config: "npm:^5.1.6"
     graphql-tag: "npm:2.12.6"
     graphql-ws: "npm:5.10.0"
@@ -21667,7 +21667,7 @@ __metadata:
     "@types/vscode": "npm:1.62.0"
     "@vscode/vsce": "npm:^2.22.1-2"
     esbuild: "npm:0.18.10"
-    graphql: "npm:^16.9.0 || ^17.0.0-alpha.2"
+    graphql: "npm:^16.9.0 || ^17.0.0-rc.0"
     graphql-language-service-server: "npm:^2.14.9"
     ovsx: "npm:0.8.3"
     typescript: "npm:^5.8.0"


### PR DESCRIPTION
## Summary

The netlify demo function executed the example schema with `graphql` 16, but the schema's `@stream`/`@defer` fields use async-generator resolvers that only `graphql` 17 can execute, so any query touching `Person.friends` or `streamable` failed with `Expected Iterable, but did not find one`. This moves the function onto `graphql-helix` and `graphql` 17 (matching the dev server) and buffers incremental-delivery payloads into a single `multipart/mixed` response, since classic netlify functions can't stream. The test server is bumped to the `graphql` 17 RC along the way.

## Changes

- Rewrite `functions/graphql.ts` onto `graphql-helix`; buffer `@defer`/`@stream` results into one `multipart/mixed` response and return `400` for subscriptions, which need the WebSocket endpoint.
- Swap `graphql-http` for `graphql-helix` and bump `graphql` to `^17.0.0-rc.0` in `functions/package.json`.
- Bump `graphql` to `^17.0.0-rc.0` in `packages/graphiql/test/package.json`.

## Validation Steps

- [x] Open the demo and run `{ test { person { friends { name } } } }`; confirm it returns the four friends instead of an `Expected Iterable` error.
- [x] Run a `@stream` query (`{ streamable(delay: 0) @stream(initialCount: 2) { text } }`) and a `@defer` query against the netlify function; confirm the full result renders.
- [x] Confirm the dev server (`packages/graphiql/test/e2e-server.js`) still serves queries under the `graphql` 17 RC.