### PR TITLE
Upgrade `@urql/core` to v6 in vscode-graphql-execution

### DIFF
--- a/.changeset/upgrade-urql-v6.md
+++ b/.changeset/upgrade-urql-v6.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-execution': patch
+---
+
+Upgrade `@urql/core` to v6 and remove the esbuild shim that redirected `graphql` `.mjs` imports.

--- a/packages/vscode-graphql-execution/esbuild.js
+++ b/packages/vscode-graphql-execution/esbuild.js
@@ -5,30 +5,12 @@ const logger = console;
 
 const isWatchMode = arg === '--watch';
 
-// `@urql/core` (pinned at 2.6.1) deep-imports `graphql` ESM files by explicit
-// `.mjs` path (e.g. `graphql/error/GraphQLError.mjs`). `graphql` 17's `exports`
-// map only exposes `.js` deep paths, so esbuild can't resolve the `.mjs` ones.
-// Redirect them to the `.js` sibling, which the `exports` map allows. Newer
-// `@urql/core` imports `graphql` top-level, so remove this shim once it's
-// upgraded past 2.6.1.
-const graphqlMjsResolver = {
-  name: 'graphql-mjs-resolver',
-  setup(buildApi) {
-    buildApi.onResolve({ filter: /^graphql\/.*\.mjs$/ }, args => ({
-      path: require.resolve(args.path.replace(/\.mjs$/, '.js'), {
-        paths: [args.resolveDir],
-      }),
-    }));
-  },
-};
-
 build({
   entryPoints: ['src/extension.ts'],
   bundle: true,
   minify: arg === '--minify',
   platform: 'node',
   outdir: 'out/',
-  plugins: [graphqlMjsResolver],
   external: [
     'squirrelly',
     'teacup',

--- a/packages/vscode-graphql-execution/package.json
+++ b/packages/vscode-graphql-execution/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@graphql-tools/code-file-loader": "8.0.3",
-    "@urql/core": "2.6.1",
+    "@urql/core": "^6.0.1",
     "@whatwg-node/fetch": "0.2.8",
     "capitalize": "2.0.4",
     "cosmiconfig": "8.2.0",
@@ -108,7 +108,6 @@
     "dotenv": "10.0.0",
     "graphql": "^16.9.0 || ^17.0.0-rc.0",
     "graphql-config": "^5.1.6",
-    "graphql-tag": "2.12.6",
     "graphql-ws": "5.10.0",
     "nullthrows": "1.1.1",
     "svelte": "^5.55.7",

--- a/packages/vscode-graphql-execution/src/helpers/network.ts
+++ b/packages/vscode-graphql-execution/src/helpers/network.ts
@@ -1,5 +1,4 @@
 import { visit, OperationTypeNode, GraphQLError } from 'graphql';
-import { gql } from 'graphql-tag';
 import { fetch } from '@whatwg-node/fetch';
 import { Agent } from 'node:https';
 import * as ws from 'ws';
@@ -12,8 +11,10 @@ import { GraphQLProjectConfig } from 'graphql-config';
 import { createClient as createWSClient, OperationResult } from 'graphql-ws';
 import {
   CombinedError,
+  cacheExchange,
   createClient,
-  defaultExchanges,
+  fetchExchange,
+  gql,
   subscriptionExchange,
 } from '@urql/core';
 
@@ -48,7 +49,7 @@ export class NetworkHelper {
     // it is similar to passing the nodejs env variable flag, except configured on a per-request basis here
     const agent = new Agent({ rejectUnauthorized });
 
-    const exchanges = [...defaultExchanges];
+    const exchanges = [cacheExchange, fetchExchange];
     if (operation === 'subscription') {
       const wsEndpointURL = endpoint.url.replace(/^http/, 'ws');
       const wsClient = createWSClient({
@@ -56,11 +57,16 @@ export class NetworkHelper {
         connectionAckWaitTimeout: 3000,
         webSocketImpl: ws,
       });
-      exchanges.push(
+      exchanges.splice(
+        1,
+        0,
         subscriptionExchange({
           forwardSubscription: op => ({
             subscribe: sink => ({
-              unsubscribe: wsClient.subscribe(op, sink),
+              unsubscribe: wsClient.subscribe(
+                { ...op, query: op.query || '' },
+                sink,
+              ),
             }),
           }),
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,18 @@ __metadata:
   version: 10
   cacheKey: 10c0
 
+"@0no-co/graphql.web@npm:^1.0.13":
+  version: 1.2.0
+  resolution: "@0no-co/graphql.web@npm:1.2.0"
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+  peerDependenciesMeta:
+    graphql:
+      optional: true
+  checksum: 10c0/4eed600962bfab42afb49cddcfb31a47b00502f59707609cf160559920ce0f5cf8874791e4cafc465ede30ae291992f3f892bc757b2a989e80e50e358f71c518
+  languageName: node
+  linkType: hard
+
 "@adobe/css-tools@npm:^4.4.0":
   version: 4.4.1
   resolution: "@adobe/css-tools@npm:4.4.1"
@@ -6916,15 +6928,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@urql/core@npm:2.6.1":
-  version: 2.6.1
-  resolution: "@urql/core@npm:2.6.1"
+"@urql/core@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@urql/core@npm:6.0.1"
   dependencies:
-    "@graphql-typed-document-node/core": "npm:^3.1.1"
-    wonka: "npm:^4.0.14"
-  peerDependencies:
-    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/2b08658227b3f7959f2e1c2af956e296fff9ca80d1f79477987495c7922774bfcee13c6fc4bf4b7eda08c9db3d761350fe84b361f2631c12feede0d910abd5b7
+    "@0no-co/graphql.web": "npm:^1.0.13"
+    wonka: "npm:^6.3.2"
+  checksum: 10c0/44ff0d12dcef1e47338a9ff1217759d1124fa66eec1eec21ff9622e44c179b9d66fa78f462f195bfd8b790b04609abbe5a0674cbfcb0bc6d9c6fe6223d7d7b5b
   languageName: node
   linkType: hard
 
@@ -13153,17 +13163,6 @@ __metadata:
     graphql: ./dist/temp-bin.js
   languageName: unknown
   linkType: soft
-
-"graphql-tag@npm:2.12.6":
-  version: 2.12.6
-  resolution: "graphql-tag@npm:2.12.6"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  peerDependencies:
-    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-  checksum: 10c0/7763a72011bda454ed8ff1a0d82325f43ca6478e4ce4ab8b7910c4c651dd00db553132171c04d80af5d5aebf1ef6a8a9fd53ccfa33b90ddc00aa3d4be6114419
-  languageName: node
-  linkType: hard
 
 "graphql-ws@npm:5.10.0":
   version: 5.10.0
@@ -21631,7 +21630,7 @@ __metadata:
     "@types/node": "npm:^24"
     "@types/vscode": "npm:1.62.0"
     "@types/ws": "npm:8.2.2"
-    "@urql/core": "npm:2.6.1"
+    "@urql/core": "npm:^6.0.1"
     "@vscode/vsce": "npm:^2.22.1-2"
     "@whatwg-node/fetch": "npm:0.2.8"
     capitalize: "npm:2.0.4"
@@ -21641,7 +21640,6 @@ __metadata:
     esbuild: "npm:0.18.10"
     graphql: "npm:^16.9.0 || ^17.0.0-rc.0"
     graphql-config: "npm:^5.1.6"
-    graphql-tag: "npm:2.12.6"
     graphql-ws: "npm:5.10.0"
     nullthrows: "npm:1.1.1"
     ovsx: "npm:0.8.3"
@@ -22365,10 +22363,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wonka@npm:^4.0.14":
-  version: 4.0.15
-  resolution: "wonka@npm:4.0.15"
-  checksum: 10c0/b93f15339c0de08259439d3c5bd3a03ca44196fbd7553cbe13c844e7b3ff2eb31b5dc4a0b2e0c3c2119160e65fc471d8366f4559744b53ab52763eb463b6793b
+"wonka@npm:^6.3.2":
+  version: 6.3.6
+  resolution: "wonka@npm:6.3.6"
+  checksum: 10c0/a8887a7766cf9519b4f80b43842fe1b6575a0f5edf397c5a32c267185bd999af9d3c42d91d6d7cd86d3ec89fdc5f8909bb542004d184fcaad794d25e821ff70d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrades `@urql/core` from 2.6.1 to 6.0.1 in the `vscode-graphql-execution` extension. Because v6 no longer depends on `graphql` (it uses `@0no-co/graphql.web`), it stops deep-importing `graphql/*.mjs`, which lets us delete the esbuild resolver shim that worked around graphql 17's `exports` map. The major jump also required adapting to a handful of removed APIs.

## Changes

- Bump `@urql/core` to `^6.0.1`.
- Remove the `graphql-mjs-resolver` esbuild plugin.
- Replace the removed `defaultExchanges` with explicit `cacheExchange`/`fetchExchange`, splicing in `subscriptionExchange` for subscriptions.
- Switch `gql` from `graphql-tag` to `@urql/core` and drop the `graphql-tag` dependency.
- Normalize the forwarded subscription `query` to a string for `graphql-ws`.

## Validation Steps

- [ ] In a project with a configured GraphQL endpoint, run a query inline and confirm results render.
- [ ] Run a mutation inline and confirm results render.
- [ ] Run a subscription against a `graphql-ws` endpoint and confirm updates stream in.