### PR TITLE
Patch-bump CDN example packages to trigger esm.sh rebuild

### DIFF
--- a/.changeset/cdn-esmsh-rebuild.md
+++ b/.changeset/cdn-esmsh-rebuild.md
@@ -1,0 +1,8 @@
+---
+'graphiql': patch
+'@graphiql/plugin-explorer': patch
+'@graphiql/react': patch
+'@graphiql/toolkit': patch
+---
+
+Release a patch version of the packages served from esm.sh in the [GraphiQL CDN example](examples/graphiql-cdn/index.html) to trigger a rebuild on esm.sh now that a longstanding esm.sh issue has been fixed.


### PR DESCRIPTION
esm.sh recently fixed an issue that affected the [GraphiQL CDN example](https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html). esm.sh rebuilds a package's bundle when a new version is published, so a fresh patch release is needed to fix-forward and pick up the fix.

This change only adds a changeset that patch-bumps every package the CDN example pulls from esm.sh: `graphiql`, `@graphiql/plugin-explorer`, `@graphiql/react`, and `@graphiql/toolkit`.