### PR TITLE
Fix flaky deprecated-arguments docs cypress test

### DIFF
--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -116,9 +116,12 @@ describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
     // Open doc explorer
     cy.get('.graphiql-activity-rail-item').eq(0).click();
 
-    // Use search to navigate directly to hasArgs
-    cy.dataCy('doc-explorer-input').type('hasArgs');
-    cy.dataCy('doc-explorer-option').first().children().first().click();
+    // Select query type
+    cy.get('.graphiql-doc-explorer-type-name').first().click();
+
+    // Navigate into the field that has a deprecated argument. Match the field
+    // name node specifically; other fields' descriptions also mention "hasArgs".
+    cy.contains('.graphiql-doc-explorer-field-row-name', /^hasArgs$/).click();
 
     cy.contains('Show Deprecated Arguments').click();
     cy.get('.graphiql-doc-explorer-arguments-list-header').contains(


### PR DESCRIPTION
## Summary

- Fixes the long-standing flake in `docs.cy.ts` → "should show deprecated arguments category title" that has been intermittently failing v6 PR CI runs with `Expected to find content: 'Show Deprecated Arguments' but never did`.
- Root cause is a race against the doc-explorer search debounce; the fix removes the search dependency entirely.

## Root cause

The test navigated to the `hasArgs` field by typing into the doc-explorer search box and clicking the first result:

```js
cy.dataCy('doc-explorer-input').type('hasArgs');
cy.dataCy('doc-explorer-option').first().children().first().click();
```

The search box debounces result computation by 200ms (`debounce(200, ...)` in `search.tsx`), and the results list is initialized to the **empty-query** result set — which matches every type and field. So the moment the input is focused, a full, stale list of options is already rendered.

Cypress's `.first()` resolves as soon as *any* matching element exists. Under CI load, Cypress would grab and click the first option of the **stale full list** before the 200ms debounce filtered it down to `hasArgs`. That navigated to the wrong field's docs, where no "Show Deprecated Arguments" button exists, and the test timed out after 4000ms. Locally the debounce usually settled first, so it passed — a classic timing-dependent flake.

The sibling "deprecated fields" test never flaked because it navigates via the type tree and never touches search.

## Changes

- `docs.cy.ts`: navigate to `hasArgs` through the type tree (click the query type, then the `hasArgs` field row) instead of the debounced search box, mirroring the reliable "deprecated fields" test. The field-row name is matched with an anchored regex (`/^hasArgs$/`) since other fields' descriptions also mention `hasArgs`.

## Validation Steps

- `cd packages/graphiql && CI=true yarn e2e-server 'cypress run --spec cypress/e2e/docs.cy.ts'`
- The full `docs.cy.ts` suite passes, including the previously-flaky case. Ran 4× locally with no failures.
