### PR TITLE
v6: Add spec-compliant GET support to `createTransport`

### DIFF
--- a/.changeset/transport-get-method.md
+++ b/.changeset/transport-get-method.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': minor
+---
+
+`createTransport` now supports GET requests per the GraphQL over HTTP spec. Pass `method: 'GET'` and `supportedMethods: ['GET', 'POST']` to encode query parameters into the URL with no request body. Mutations always use POST regardless of the selected method, as required by the spec. `Transport` gains `url`, `method`, `supportedMethods`, and an optional `setMethod` for switching between methods at runtime. The low-level `simpleHttpTransport` and `multipartHttpTransport` primitives also accept an optional `method` argument for callers that need more control.

--- a/packages/graphiql-plugin-history/src/history.stories.tsx
+++ b/packages/graphiql-plugin-history/src/history.stories.tsx
@@ -19,6 +19,9 @@ function withHistoryContext(children: ReactNode) {
     <Tooltip.Provider>
       <GraphiQLProvider
         transport={{
+          url: 'https://example.com/graphql',
+          method: 'POST' as const,
+          supportedMethods: ['POST' as const],
           send: async () => ({
             ok: true,
             body: { data: {} },

--- a/packages/graphiql-react/src/components/settings-dialog/settings-dialog.stories.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/settings-dialog.stories.tsx
@@ -5,6 +5,9 @@ import { GraphiQLProvider } from '../provider';
 import { SettingsDialog } from './index';
 
 const noOpTransport = {
+  url: 'https://example.com/graphql',
+  method: 'POST' as const,
+  supportedMethods: ['POST' as const],
   send: async () => ({
     ok: true,
     body: { data: {} },

--- a/packages/graphiql-react/src/components/side-panel/side-panel.stories.tsx
+++ b/packages/graphiql-react/src/components/side-panel/side-panel.stories.tsx
@@ -5,6 +5,9 @@ import { DocsIcon, HistoryIcon } from '../../icons';
 import { SidePanel } from './';
 
 const mockTransport = {
+  url: 'https://example.com/graphql',
+  method: 'POST' as const,
+  supportedMethods: ['POST' as const],
   send: async () => ({
     ok: true,
     body: { data: null },

--- a/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
@@ -3,6 +3,9 @@ import { GraphiQLProvider } from '../provider';
 import { TopBar } from './';
 
 const noOpTransport = {
+  url: 'https://example.com/graphql',
+  method: 'POST' as const,
+  supportedMethods: ['POST' as const],
   send: async () => ({
     ok: true,
     body: { data: {} },

--- a/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.stories.tsx
+++ b/packages/graphiql-react/src/components/var-headers-strip/var-headers-strip.stories.tsx
@@ -4,6 +4,9 @@ import { VarHeadersStrip } from './';
 import { GraphiQLProvider } from '../provider';
 
 const noOpTransport = {
+  url: 'https://example.com/graphql',
+  method: 'POST' as const,
+  supportedMethods: ['POST' as const],
   send: async () => ({
     ok: true,
     body: { data: {} },

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -129,7 +129,11 @@ function buildGetUrl(baseUrl: string, graphQLParams: FetcherParams): string {
  * `createTransport`, which composes this primitive in a spec-compliant way.
  */
 export const simpleHttpTransport =
-  (options: CreateFetcherOptions, httpFetch: typeof fetch, method: 'GET' | 'POST' = 'POST') =>
+  (
+    options: CreateFetcherOptions,
+    httpFetch: typeof fetch,
+    method: 'GET' | 'POST' = 'POST',
+  ) =>
   async (
     graphQLParams: FetcherParams,
     fetcherOpts?: FetcherOpts,

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -100,18 +100,54 @@ export const isSubscriptionWithName = (
 };
 
 /**
+ * Build a URL with GraphQL parameters encoded into the query string per the
+ * GraphQL over HTTP spec. `variables` and `extensions`, when present, are
+ * JSON-stringified. No request body is sent with GET requests.
+ */
+function buildGetUrl(baseUrl: string, graphQLParams: FetcherParams): string {
+  const params = new URLSearchParams();
+  params.set('query', graphQLParams.query);
+  if (graphQLParams.operationName != null) {
+    params.set('operationName', graphQLParams.operationName);
+  }
+  if (graphQLParams.variables != null) {
+    params.set('variables', JSON.stringify(graphQLParams.variables));
+  }
+  const sep = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${sep}${params.toString()}`;
+}
+
+/**
  * Perform a simple HTTP/S request and return the full `TransportResponse`
  * (parsed body plus wire metadata). This is the primitive that
  * `createSimpleFetcher` projects down to the body, and that `createTransport`
  * exposes whole.
+ *
+ * Pass `method: 'GET'` to encode the GraphQL params into the URL and send no
+ * body. The default is `'POST'`. Note that this primitive does not enforce the
+ * spec rule that mutations must not use GET — that policy lives in
+ * `createTransport`, which composes this primitive in a spec-compliant way.
  */
 export const simpleHttpTransport =
-  (options: CreateFetcherOptions, httpFetch: typeof fetch) =>
+  (options: CreateFetcherOptions, httpFetch: typeof fetch, method: 'GET' | 'POST' = 'POST') =>
   async (
     graphQLParams: FetcherParams,
     fetcherOpts?: FetcherOpts,
   ): Promise<TransportResponse> => {
     const startMs = performance.now();
+    if (method === 'GET') {
+      const url = buildGetUrl(options.url, graphQLParams);
+      const response = await httpFetch(url, {
+        method: 'GET',
+        headers: {
+          accept: 'application/graphql-response+json, application/json;q=0.9',
+          ...options.headers,
+          ...fetcherOpts?.headers,
+        },
+      });
+      const body = await response.json();
+      return toTransportResponse(body, response, startMs);
+    }
     const requestBody = JSON.stringify(graphQLParams);
     const response = await httpFetch(options.url, {
       method: 'POST',
@@ -218,29 +254,48 @@ export const createLegacyWebsocketsFetcher =
  * Perform an `IncrementalDelivery` (`multipart/mixed`) request for `@stream` /
  * `@defer`, yielding a `TransportResponse` per chunk. HTTP metadata is read once
  * from the raw response and attached to every chunk (they share one response).
+ *
+ * Pass `method: 'GET'` to encode GraphQL params into the URL. Same escape-hatch
+ * caveat as `simpleHttpTransport` — mutation enforcement lives in `createTransport`.
  */
 export const multipartHttpTransport = (
   options: CreateFetcherOptions,
   httpFetch: typeof fetch,
+  method: 'GET' | 'POST' = 'POST',
 ) =>
   async function* (
     graphQLParams: FetcherParams,
     fetcherOpts?: FetcherOpts,
   ): AsyncGenerator<TransportResponse> {
     const startMs = performance.now();
-    const requestBody = JSON.stringify(graphQLParams);
-    const rawResponse = await httpFetch(options.url, {
-      method: 'POST',
-      body: requestBody,
-      headers: {
-        'content-type': 'application/json',
-        accept: 'application/json, multipart/mixed',
-        ...options.headers,
-        // allow user-defined headers to override
-        // the static provided headers
-        ...fetcherOpts?.headers,
-      },
-    });
+    let rawResponse: Response;
+    let requestBody: string | undefined;
+
+    if (method === 'GET') {
+      const url = buildGetUrl(options.url, graphQLParams);
+      rawResponse = await httpFetch(url, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json, multipart/mixed',
+          ...options.headers,
+          ...fetcherOpts?.headers,
+        },
+      });
+    } else {
+      requestBody = JSON.stringify(graphQLParams);
+      rawResponse = await httpFetch(options.url, {
+        method: 'POST',
+        body: requestBody,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, multipart/mixed',
+          ...options.headers,
+          // allow user-defined headers to override
+          // the static provided headers
+          ...fetcherOpts?.headers,
+        },
+      });
+    }
     const response = await meros<
       Extract<ExecutionResultPayload, { hasNext: boolean }>
     >(rawResponse, { multiple: true });

--- a/packages/graphiql-toolkit/src/create-transport/__tests__/createTransport.spec.ts
+++ b/packages/graphiql-toolkit/src/create-transport/__tests__/createTransport.spec.ts
@@ -1,4 +1,12 @@
-import { type Mock, describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+  type Mock,
+  describe,
+  it,
+  expect,
+  vi,
+  afterEach,
+  beforeEach,
+} from 'vitest';
 import 'isomorphic-fetch';
 
 import { createTransport } from '../createTransport';
@@ -173,8 +181,7 @@ describe('createSimpleFetcher (backward-compatible)', () => {
 });
 
 const MUTATION = 'mutation DoThing { doThing }';
-const QUERY_WITH_VARS =
-  'query Q($id: ID!) { node(id: $id) { __typename } }';
+const QUERY_WITH_VARS = 'query Q($id: ID!) { node(id: $id) { __typename } }';
 
 describe('createTransport — GET method', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
@@ -190,13 +197,16 @@ describe('createTransport — GET method', () => {
   });
 
   it('defaults to POST-only: no setMethod, requests go out as POST', () => {
-    const transport = createTransport({ url: URL, fetch: mockFetch as typeof fetch });
+    const transport = createTransport({
+      url: URL,
+      fetch: mockFetch as typeof fetch,
+    });
     expect(transport.method).toBe('POST');
     expect(transport.supportedMethods).toEqual(['POST']);
     expect(transport.setMethod).toBeUndefined();
   });
 
-  it('GET-only: active method is GET when supportedMethods is [\'GET\']', () => {
+  it("GET-only: active method is GET when supportedMethods is ['GET']", () => {
     const transport = createTransport({
       url: URL,
       supportedMethods: ['GET'],
@@ -217,7 +227,10 @@ describe('createTransport — GET method', () => {
 
     await transport.send({ query: QUERY });
 
-    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     expect(fetchInit.method).toBe('GET');
     expect(fetchInit.body).toBeUndefined();
     const parsed = new globalThis.URL(fetchedUrl);
@@ -246,7 +259,10 @@ describe('createTransport — GET method', () => {
 
     await transport.send({ query: QUERY });
 
-    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
     expect(fetchInit.method).toBe('GET');
     expect(fetchInit.body).toBeUndefined();
     const parsed = new globalThis.URL(fetchedUrl);
@@ -267,7 +283,9 @@ describe('createTransport — GET method', () => {
 
     const [fetchedUrl] = mockFetch.mock.calls[0] as [string];
     const parsed = new globalThis.URL(fetchedUrl);
-    expect(parsed.searchParams.get('variables')).toBe(JSON.stringify(variables));
+    expect(parsed.searchParams.get('variables')).toBe(
+      JSON.stringify(variables),
+    );
   });
 
   it('GET query encodes operationName in the URL', async () => {
@@ -317,7 +335,9 @@ describe('createTransport — GET method', () => {
     const [, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(fetchInit.method).toBe('POST');
     expect(typeof fetchInit.body).toBe('string');
-    expect(JSON.parse(fetchInit.body as string)).toMatchObject({ query: MUTATION });
+    expect(JSON.parse(fetchInit.body as string)).toMatchObject({
+      query: MUTATION,
+    });
   });
 
   it('both methods: active method defaults to POST when no method opt is passed', () => {

--- a/packages/graphiql-toolkit/src/create-transport/__tests__/createTransport.spec.ts
+++ b/packages/graphiql-toolkit/src/create-transport/__tests__/createTransport.spec.ts
@@ -1,4 +1,4 @@
-import { type Mock, describe, it, expect, vi, afterEach } from 'vitest';
+import { type Mock, describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import 'isomorphic-fetch';
 
 import { createTransport } from '../createTransport';
@@ -169,5 +169,225 @@ describe('createSimpleFetcher (backward-compatible)', () => {
     );
     const result = await fetcher({ query: QUERY }, {});
     expect(result).toEqual({ data: { __typename: 'Query' } });
+  });
+});
+
+const MUTATION = 'mutation DoThing { doThing }';
+const QUERY_WITH_VARS =
+  'query Q($id: ID!) { node(id: $id) { __typename } }';
+
+describe('createTransport — GET method', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi
+      .fn()
+      .mockResolvedValue(mockResponse({ data: { __typename: 'Query' } }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to POST-only: no setMethod, requests go out as POST', () => {
+    const transport = createTransport({ url: URL, fetch: mockFetch as typeof fetch });
+    expect(transport.method).toBe('POST');
+    expect(transport.supportedMethods).toEqual(['POST']);
+    expect(transport.setMethod).toBeUndefined();
+  });
+
+  it('GET-only: active method is GET when supportedMethods is [\'GET\']', () => {
+    const transport = createTransport({
+      url: URL,
+      supportedMethods: ['GET'],
+      fetch: mockFetch as typeof fetch,
+    });
+    expect(transport.method).toBe('GET');
+    expect(transport.supportedMethods).toEqual(['GET']);
+    expect(transport.setMethod).toBeUndefined();
+  });
+
+  it('GET-only: a query goes out as GET with params in the URL', async () => {
+    const transport = createTransport({
+      url: URL,
+      supportedMethods: ['GET'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY });
+
+    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchInit.method).toBe('GET');
+    expect(fetchInit.body).toBeUndefined();
+    const parsed = new globalThis.URL(fetchedUrl);
+    expect(parsed.searchParams.get('query')).toBe(QUERY);
+  });
+
+  it('GET-only: a mutation throws a clear error', () => {
+    const transport = createTransport({
+      url: URL,
+      supportedMethods: ['GET'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    expect(() => transport.send({ query: MUTATION })).toThrow(/mutation.*GET/i);
+  });
+
+  it('GET query encodes params in the URL with no request body', async () => {
+    const transport = createTransport({
+      url: URL,
+      method: 'GET',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY });
+
+    const [fetchedUrl, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchInit.method).toBe('GET');
+    expect(fetchInit.body).toBeUndefined();
+    const parsed = new globalThis.URL(fetchedUrl);
+    expect(parsed.searchParams.get('query')).toBe(QUERY);
+  });
+
+  it('GET query encodes variables as a JSON string in the URL', async () => {
+    const variables = { id: '123' };
+    const transport = createTransport({
+      url: URL,
+      method: 'GET',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY_WITH_VARS, variables });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string];
+    const parsed = new globalThis.URL(fetchedUrl);
+    expect(parsed.searchParams.get('variables')).toBe(JSON.stringify(variables));
+  });
+
+  it('GET query encodes operationName in the URL', async () => {
+    const transport = createTransport({
+      url: URL,
+      method: 'GET',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY_WITH_VARS, operationName: 'Q' });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string];
+    const parsed = new globalThis.URL(fetchedUrl);
+    expect(parsed.searchParams.get('operationName')).toBe('Q');
+  });
+
+  it('GET query omits variables and operationName when absent', async () => {
+    const transport = createTransport({
+      url: URL,
+      method: 'GET',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY });
+
+    const [fetchedUrl] = mockFetch.mock.calls[0] as [string];
+    const parsed = new globalThis.URL(fetchedUrl);
+    expect(parsed.searchParams.has('variables')).toBe(false);
+    expect(parsed.searchParams.has('operationName')).toBe(false);
+  });
+
+  it('mutation is sent as POST even when GET is selected (both supported)', async () => {
+    const transport = createTransport({
+      url: URL,
+      method: 'GET',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: MUTATION });
+
+    const [, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchInit.method).toBe('POST');
+    expect(typeof fetchInit.body).toBe('string');
+    expect(JSON.parse(fetchInit.body as string)).toMatchObject({ query: MUTATION });
+  });
+
+  it('both methods: active method defaults to POST when no method opt is passed', () => {
+    const transport = createTransport({
+      url: URL,
+      supportedMethods: ['GET', 'POST'],
+      fetch: mockFetch as typeof fetch,
+    });
+    expect(transport.method).toBe('POST');
+    expect(transport.setMethod).toBeDefined();
+  });
+
+  it('setMethod switches the active method', async () => {
+    const transport = createTransport({
+      url: URL,
+      method: 'POST',
+      supportedMethods: ['GET', 'POST'],
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    expect(transport.method).toBe('POST');
+    transport.setMethod?.('GET');
+    expect(transport.method).toBe('GET');
+
+    await transport.send({ query: QUERY });
+    const [, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(fetchInit.method).toBe('GET');
+  });
+
+  it('setMethod throws when asked to switch to an unsupported method', () => {
+    const transport = createTransport({
+      url: URL,
+      supportedMethods: ['GET', 'POST'],
+      fetch: mockFetch as typeof fetch,
+    });
+    // TypeScript would catch this at compile time; this verifies the runtime guard.
+    expect(() => transport.setMethod?.('GET' as never)).not.toThrow();
+    // Simulating a value that isn't in supportedMethods by bypassing types.
+    expect(() =>
+      (transport.setMethod as (m: string) => void)?.('DELETE'),
+    ).toThrow(/not supported/i);
+  });
+
+  it('throws at construction when method is not in supportedMethods', () => {
+    expect(() =>
+      createTransport({
+        url: URL,
+        method: 'GET',
+        supportedMethods: ['POST'],
+        fetch: mockFetch as typeof fetch,
+      }),
+    ).toThrow(/not in supportedMethods/i);
+  });
+
+  it('POST keeps content-type and accept headers', async () => {
+    const transport = createTransport({
+      url: URL,
+      enableIncrementalDelivery: false,
+      fetch: mockFetch as typeof fetch,
+    });
+
+    await transport.send({ query: QUERY });
+
+    const [, fetchInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((fetchInit.headers as Record<string, string>)['content-type']).toBe(
+      'application/json',
+    );
+    expect((fetchInit.headers as Record<string, string>).accept).toMatch(
+      'application/graphql-response+json',
+    );
   });
 });

--- a/packages/graphiql-toolkit/src/create-transport/createTransport.ts
+++ b/packages/graphiql-toolkit/src/create-transport/createTransport.ts
@@ -120,7 +120,8 @@ export function createTransport(opts: CreateTransportOptions): Transport {
   // Default to POST when available; otherwise fall back to whichever single
   // method was configured (e.g. GET-only).
   let activeMethod: HttpMethod =
-    opts.method ?? (supportedMethods.includes('POST') ? 'POST' : supportedMethods[0]);
+    opts.method ??
+    (supportedMethods.includes('POST') ? 'POST' : supportedMethods[0]);
 
   function send(
     req: TransportRequest,
@@ -149,7 +150,7 @@ export function createTransport(opts: CreateTransportOptions): Transport {
       if (!supportedMethods.includes('POST')) {
         throw new Error(
           'Cannot execute a mutation over GET. ' +
-            'This transport is configured as GET-only (supportedMethods: [\'GET\']). ' +
+            "This transport is configured as GET-only (supportedMethods: ['GET']). " +
             'Add POST to supportedMethods or switch to a POST-capable transport.',
         );
       }
@@ -157,9 +158,17 @@ export function createTransport(opts: CreateTransportOptions): Transport {
     }
 
     if (incrementalDelivery) {
-      return multipartHttpTransport(fetcherOptions, httpFetch, method)(params, fetcherOpts);
+      return multipartHttpTransport(
+        fetcherOptions,
+        httpFetch,
+        method,
+      )(params, fetcherOpts);
     }
-    return simpleHttpTransport(fetcherOptions, httpFetch, method)(params, fetcherOpts);
+    return simpleHttpTransport(
+      fetcherOptions,
+      httpFetch,
+      method,
+    )(params, fetcherOpts);
   }
 
   const transport: Transport = {

--- a/packages/graphiql-toolkit/src/create-transport/createTransport.ts
+++ b/packages/graphiql-toolkit/src/create-transport/createTransport.ts
@@ -12,6 +12,7 @@ import type {
 } from '../create-fetcher/types';
 import type {
   CreateTransportOptions,
+  HttpMethod,
   Transport,
   TransportRequest,
   TransportResponse,
@@ -36,6 +37,27 @@ function selectedOperationIsSubscription(
       ? operations[0]
       : undefined;
   return operation?.operation === 'subscription';
+}
+
+function selectedOperationIsMutation(
+  query: string,
+  operationName?: string | null,
+): boolean {
+  let document;
+  try {
+    document = parse(query);
+  } catch {
+    return false;
+  }
+  const operations = document.definitions.filter(
+    (def): def is OperationDefinitionNode => def.kind === 'OperationDefinition',
+  );
+  const operation = operationName
+    ? operations.find(op => op.name?.value === operationName)
+    : operations.length === 1
+      ? operations[0]
+      : undefined;
+  return operation?.operation === 'mutation';
 }
 
 const byteLength = (value: string): number =>
@@ -72,11 +94,12 @@ function toSubscriptionResponse(
  *   toolkit does not construct one for you.
  */
 export function createTransport(opts: CreateTransportOptions): Transport {
-  const httpFetch =
+  const httpFetchOrFalse =
     opts.fetch || (typeof window !== 'undefined' && window.fetch);
-  if (!httpFetch) {
+  if (!httpFetchOrFalse) {
     throw new Error('No valid fetch implementation available');
   }
+  const httpFetch: typeof fetch = httpFetchOrFalse;
 
   const incrementalDelivery = opts.enableIncrementalDelivery !== false;
 
@@ -85,8 +108,19 @@ export function createTransport(opts: CreateTransportOptions): Transport {
     headers: opts.headers,
   };
 
-  const simple = simpleHttpTransport(fetcherOptions, httpFetch);
-  const multipart = multipartHttpTransport(fetcherOptions, httpFetch);
+  const supportedMethods: HttpMethod[] = opts.supportedMethods ?? ['POST'];
+
+  if (opts.method !== undefined && !supportedMethods.includes(opts.method)) {
+    throw new Error(
+      `"${opts.method}" is not in supportedMethods (${supportedMethods.join(', ')}). ` +
+        `Either add it to supportedMethods or omit the method option.`,
+    );
+  }
+
+  // Default to POST when available; otherwise fall back to whichever single
+  // method was configured (e.g. GET-only).
+  let activeMethod: HttpMethod =
+    opts.method ?? (supportedMethods.includes('POST') ? 'POST' : supportedMethods[0]);
 
   function send(
     req: TransportRequest,
@@ -101,13 +135,53 @@ export function createTransport(opts: CreateTransportOptions): Transport {
     if (selectedOperationIsSubscription(req.query, req.operationName)) {
       return subscribe(opts.subscriptionClient, params);
     }
-    if (incrementalDelivery) {
-      return multipart(params, fetcherOpts);
+
+    // The GraphQL over HTTP spec forbids executing mutations over GET.
+    // https://graphql.github.io/graphql-over-http/rfcs/GraphQLOverHTTP.html#sec-GET
+    // When GET is the active method and the operation is a mutation, use POST
+    // if it is available. If POST is not supported (GET-only transport), throw —
+    // a spec-compliant server would reject the request with 405 anyway.
+    let method: HttpMethod = activeMethod;
+    if (
+      activeMethod === 'GET' &&
+      selectedOperationIsMutation(req.query, req.operationName)
+    ) {
+      if (!supportedMethods.includes('POST')) {
+        throw new Error(
+          'Cannot execute a mutation over GET. ' +
+            'This transport is configured as GET-only (supportedMethods: [\'GET\']). ' +
+            'Add POST to supportedMethods or switch to a POST-capable transport.',
+        );
+      }
+      method = 'POST';
     }
-    return simple(params, fetcherOpts);
+
+    if (incrementalDelivery) {
+      return multipartHttpTransport(fetcherOptions, httpFetch, method)(params, fetcherOpts);
+    }
+    return simpleHttpTransport(fetcherOptions, httpFetch, method)(params, fetcherOpts);
   }
 
-  return { send };
+  const transport: Transport = {
+    url: opts.url,
+    method: activeMethod,
+    supportedMethods,
+    send,
+  };
+
+  if (supportedMethods.length > 1) {
+    transport.setMethod = (method: HttpMethod) => {
+      if (!supportedMethods.includes(method)) {
+        throw new Error(
+          `"${method}" is not supported by this transport (supportedMethods: ${supportedMethods.join(', ')}).`,
+        );
+      }
+      activeMethod = method;
+      transport.method = method;
+    };
+  }
+
+  return transport;
 }
 
 async function* subscribe(

--- a/packages/graphiql-toolkit/src/create-transport/types.ts
+++ b/packages/graphiql-toolkit/src/create-transport/types.ts
@@ -49,12 +49,31 @@ export type TransportResponse = {
   size: { request?: number; response?: number };
 };
 
+export type HttpMethod = 'GET' | 'POST';
+
 /**
  * Wire-level transport. `send()` returns a single Promise for queries and
  * mutations, or an AsyncIterable for subscriptions and incremental delivery
  * (each event/chunk is wrapped in its own `TransportResponse`).
  */
 export type Transport = {
+  /**
+   * The endpoint URL this transport sends requests to.
+   */
+  url: string;
+  /**
+   * Currently active HTTP method.
+   */
+  method: HttpMethod;
+  /**
+   * HTTP methods this transport is configured to use. Defaults to `['POST']`.
+   */
+  supportedMethods: HttpMethod[];
+  /**
+   * Present only when `supportedMethods` has more than one entry. Switches the
+   * active HTTP method used by subsequent `send()` calls.
+   */
+  setMethod?: (method: HttpMethod) => void;
   send(
     request: TransportRequest,
   ): Promise<TransportResponse> | AsyncIterable<TransportResponse>;
@@ -89,4 +108,15 @@ export type CreateTransportOptions = {
    * Custom fetch implementation. Defaults to the global fetch.
    */
   fetch?: typeof fetch;
+  /**
+   * Initial HTTP method to use for queries. Defaults to `'POST'`.
+   * When set to `'GET'`, queries are encoded into the URL per the
+   * GraphQL over HTTP spec; mutations always use POST regardless.
+   */
+  method?: HttpMethod;
+  /**
+   * HTTP methods this transport should advertise as supported.
+   * Defaults to `['POST']`. Pass `['GET', 'POST']` to allow switching.
+   */
+  supportedMethods?: HttpMethod[];
 };

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -53,6 +53,9 @@ describe('GraphiQL', () => {
       // The runtime guard in `GraphiQLProvider` belt-and-suspenders the type
       // check.
       const transport: Transport = {
+        url: 'https://example.com/graphql',
+        method: 'POST',
+        supportedMethods: ['POST'],
         send: async () => ({
           ok: true,
           body: { data: {} },


### PR DESCRIPTION
## Summary

- `createTransport` now has a coherent method-resolution model driven by `supportedMethods`. The default is POST-only (`method: 'POST'`, `supportedMethods: ['POST']`, no `setMethod`). Pass `['GET', 'POST']` for both, or `['GET']` for GET-only.
- When both methods are supported, the active method defaults to POST (unless `opts.method` overrides) and `setMethod` is available to switch at runtime. GET queries encode `query`, `operationName`, and `variables` into the URL with no request body; POST keeps the existing JSON body.
- Mutations are handled per the GraphQL-over-HTTP spec: a GET-only transport throws a clear error (a compliant server would return 405), and a both-methods transport with GET active transparently falls back to POST.

## Changes

- `createTransport.ts`: method resolution from `supportedMethods` — POST-only default with no `setMethod`; GET-only defaults active method to GET; both-methods defaults to POST with `setMethod` exposed.
- GET request encoding: `query`, `operationName`, and `variables` serialized into the URL query string, no body sent. POST requests still carry `Content-Type: application/json` and the spec `Accept` header.
- Mutation handling: GET-only transport throws an error mentioning "mutation" and "GET"; both-methods transport sends mutations as POST even when GET is the active method.
- Construction- and runtime-time guards: `opts.method` must be a member of `supportedMethods` (throws at construction); `setMethod` validates its argument and throws if unsupported.
- `types.ts`: new types for `supportedMethods` / method resolution. `create-fetcher/lib.ts`: updated to the new transport semantics. Adds a changeset.

## Validation Steps

1. From `packages/graphiql-toolkit`, run the transport and fetcher suites: `vitest run src/create-transport src/create-fetcher`.
2. POST-only default: construct with no `supportedMethods`; verify `method` is `'POST'`, `supportedMethods` is `['POST']`, and `setMethod` is `undefined`.
3. GET-only (`supportedMethods: ['GET']`): active method is `'GET'` without passing `opts.method`; a query goes out as GET with params in the URL and no body; a mutation throws an error mentioning "mutation" and "GET".
4. Both methods with `method: 'GET'`: a query encodes params in the URL; a mutation is sent as POST despite GET being active.
5. `opts.method` not in `supportedMethods` throws at construction; `setMethod` to an unsupported method throws at runtime; a valid `setMethod` switches the active method for subsequent requests.

Refs: graphql/graphiql#4219
Spec: https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md