### PR TITLE
v6: Expose transport request/response hooks to plugins

### DIFF
--- a/.changeset/plugin-context-transport-hooks.md
+++ b/.changeset/plugin-context-transport-hooks.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Plugins now have access to `transport.onBeforeSend` and `transport.onResponse` hooks via `useGraphiQLPluginContext()`. Use `onBeforeSend` to inspect or transform outgoing requests; use `onResponse` to observe each response. Both return a cleanup function. The `transport` field on the context is `undefined` when the host uses the legacy `fetcher` prop; plugins should guard with optional chaining.

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -8,6 +8,8 @@ import {
   useId,
   useState,
 } from 'react';
+import { TransportHookRegistry } from '../transport-hooks';
+import { TransportHookContext } from '../transport-hooks.context';
 import { create, useStore, UseBoundStore, StoreApi } from 'zustand';
 import { useShallow } from 'zustand/shallow';
 import { StorageAPI } from '@graphiql/toolkit';
@@ -182,6 +184,11 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
   ...props
 }) => {
   const storeRef = useRef<GraphiQLStore>(null!);
+  // The hook registry for the transport path. Absent in fetcher mode. Created
+  // once from the initial `transport` prop, mirroring the store's lazy init.
+  const [registry] = useState<TransportHookRegistry | null>(() =>
+    transport ? new TransportHookRegistry() : null,
+  );
   const uriInstanceId = useId();
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- false positive
   if (storeRef.current === null) {
@@ -278,7 +285,8 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
         })(...args);
         const executionSlice = createExecutionSlice({
           fetcher,
-          transport,
+          transport:
+            transport && registry ? registry.wrap(transport) : transport,
           getDefaultFieldNames,
           overrideOperationName: operationName,
         })(...args);
@@ -334,9 +342,11 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
   //   }
   // }, [shouldPersistHeaders]);
 
-  // Execution sync
+  // Execution sync — rewrap transport with the hook registry on change
   useDidUpdate(() => {
-    storeRef.current.setState({ fetcher, transport });
+    const wrappedTransport =
+      transport && registry ? registry.wrap(transport) : transport;
+    storeRef.current.setState({ fetcher, transport: wrappedTransport });
   }, [fetcher, transport]);
 
   // Plugin sync
@@ -401,9 +411,11 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
   }, []);
 
   return (
-    <GraphiQLContext.Provider value={storeRef}>
-      {children}
-    </GraphiQLContext.Provider>
+    <TransportHookContext.Provider value={registry}>
+      <GraphiQLContext.Provider value={storeRef}>
+        {children}
+      </GraphiQLContext.Provider>
+    </TransportHookContext.Provider>
   );
 };
 

--- a/packages/graphiql-react/src/index.ts
+++ b/packages/graphiql-react/src/index.ts
@@ -1,5 +1,16 @@
 import './style/root.css';
 
+export {
+  useGraphiQLPluginContext,
+  type GraphiQLPluginContext,
+  type PluginTransportContext,
+} from './transport-hooks.context';
+export type {
+  OnBeforeSendCallback,
+  OnResponseCallback,
+  CleanupFn,
+} from './transport-hooks';
+
 export { useMonaco } from './stores';
 export * from './utility';
 export { Uri, KeyMod, KeyCode, Range } from './utility/monaco-ssr';

--- a/packages/graphiql-react/src/transport-hooks.context.spec.tsx
+++ b/packages/graphiql-react/src/transport-hooks.context.spec.tsx
@@ -1,0 +1,93 @@
+'use no memo';
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+  TransportHookContext,
+  useGraphiQLPluginContext,
+} from './transport-hooks.context';
+import { TransportHookRegistry } from './transport-hooks';
+
+function wrapWith(registry: TransportHookRegistry | null) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <TransportHookContext.Provider value={registry}>
+        {children}
+      </TransportHookContext.Provider>
+    );
+  };
+}
+
+describe('useGraphiQLPluginContext', () => {
+  it('returns empty context when no registry is present (fetcher path)', () => {
+    const { result } = renderHook(() => useGraphiQLPluginContext(), {
+      wrapper: wrapWith(null),
+    });
+    expect(result.current.transport).toBeUndefined();
+  });
+
+  it('returns transport hooks when a registry is present (transport path)', () => {
+    const registry = new TransportHookRegistry();
+    const { result } = renderHook(() => useGraphiQLPluginContext(), {
+      wrapper: wrapWith(registry),
+    });
+    expect(result.current.transport).toBeDefined();
+    expect(typeof result.current.transport?.onBeforeSend).toBe('function');
+    expect(typeof result.current.transport?.onResponse).toBe('function');
+  });
+
+  it('onBeforeSend from plugin context wires into the registry', async () => {
+    const registry = new TransportHookRegistry();
+    const cb = vi.fn((req: any) => req);
+
+    const { result } = renderHook(() => useGraphiQLPluginContext(), {
+      wrapper: wrapWith(registry),
+    });
+
+    result.current.transport!.onBeforeSend(cb);
+
+    // Drive the registry directly to verify the callback is registered
+    const transport = registry.wrap({
+      send: async () => ({
+        ok: true,
+        body: {},
+        timing: { totalMs: 0 },
+        size: {},
+      }),
+    });
+    const iter = transport.send({ query: '{ test }' }) as AsyncIterable<any>;
+    for await (const _ of iter) {
+      /* consume */
+    }
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('onBeforeSend cleanup from plugin context removes the hook', async () => {
+    const registry = new TransportHookRegistry();
+    const cb = vi.fn((req: any) => req);
+
+    const { result } = renderHook(() => useGraphiQLPluginContext(), {
+      wrapper: wrapWith(registry),
+    });
+
+    const cleanup = result.current.transport!.onBeforeSend(cb);
+    cleanup();
+
+    const transport = registry.wrap({
+      send: async () => ({
+        ok: true,
+        body: {},
+        timing: { totalMs: 0 },
+        size: {},
+      }),
+    });
+    const iter = transport.send({ query: '{ test }' }) as AsyncIterable<any>;
+    for await (const _ of iter) {
+      /* consume */
+    }
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/graphiql-react/src/transport-hooks.context.ts
+++ b/packages/graphiql-react/src/transport-hooks.context.ts
@@ -1,0 +1,73 @@
+import { createContext, useContext } from 'react';
+import type { TransportHookRegistry } from './transport-hooks';
+
+/**
+ * Carries the `TransportHookRegistry` for the current provider tree.
+ * The value is `null` when no registry exists (legacy `fetcher` path).
+ */
+export const TransportHookContext = createContext<TransportHookRegistry | null>(
+  null,
+);
+
+/**
+ * The transport-related subset of the plugin context.
+ * Present only when the host uses the `transport` prop.
+ */
+export type PluginTransportContext = {
+  /**
+   * Register a callback that runs before each request is sent.
+   * The callback receives the outgoing `TransportRequest` and must return
+   * the (possibly mutated) request, optionally async.
+   *
+   * Returns a cleanup function; call it to remove the hook.
+   *
+   * @example
+   * ```ts
+   * const ctx = useGraphiQLPluginContext();
+   * useEffect(() => ctx.transport?.onBeforeSend(req => ({
+   *   ...req,
+   *   headers: { ...req.headers, 'X-Plugin-Header': '1' },
+   * })), []);
+   * ```
+   */
+  onBeforeSend: TransportHookRegistry['onBeforeSend'];
+
+  /**
+   * Register a callback that runs after each response is received.
+   * Returns a cleanup function; call it to remove the hook.
+   */
+  onResponse: TransportHookRegistry['onResponse'];
+};
+
+/**
+ * Context available to all plugins mounted inside a `<GraphiQLProvider>`.
+ */
+export type GraphiQLPluginContext = {
+  /**
+   * Transport hook registration. Present only when the host supplies a
+   * `transport` prop. Access via optional chaining:
+   * `ctx.transport?.onBeforeSend(...)`.
+   */
+  transport?: PluginTransportContext;
+};
+
+/**
+ * Returns context that plugins can use to interact with the GraphiQL runtime.
+ *
+ * Call from inside a plugin's `content` component (which renders within the
+ * `<GraphiQLProvider>` tree).
+ *
+ * `ctx.transport` is `undefined` when the host uses the legacy `fetcher` prop.
+ */
+export function useGraphiQLPluginContext(): GraphiQLPluginContext {
+  const registry = useContext(TransportHookContext);
+  if (registry === null) {
+    return {};
+  }
+  return {
+    transport: {
+      onBeforeSend: registry.onBeforeSend.bind(registry),
+      onResponse: registry.onResponse.bind(registry),
+    },
+  };
+}

--- a/packages/graphiql-react/src/transport-hooks.spec.ts
+++ b/packages/graphiql-react/src/transport-hooks.spec.ts
@@ -1,0 +1,218 @@
+'use no memo';
+
+import { describe, it, expect, vi } from 'vitest';
+import type { TransportRequest, TransportResponse } from '@graphiql/toolkit';
+import { TransportHookRegistry } from './transport-hooks';
+
+function makeResponse(
+  overrides?: Partial<TransportResponse>,
+): TransportResponse {
+  return {
+    ok: true,
+    body: { data: { hello: 'world' } },
+    timing: { totalMs: 42 },
+    size: {},
+    ...overrides,
+  };
+}
+
+function makeRequest(overrides?: Partial<TransportRequest>): TransportRequest {
+  return { query: '{ hello }', ...overrides };
+}
+
+/** Consume an AsyncIterable and return all values. */
+async function collect(
+  iter: AsyncIterable<TransportResponse>,
+): Promise<TransportResponse[]> {
+  const results: TransportResponse[] = [];
+  for await (const item of iter) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe('TransportHookRegistry', () => {
+  describe('onBeforeSend', () => {
+    it('calls registered callbacks before send', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn((req: TransportRequest) => req);
+      registry.onBeforeSend(cb);
+
+      const transport = registry.wrap({
+        send: async () => makeResponse(),
+      });
+
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it('allows the callback to mutate the request', async () => {
+      const registry = new TransportHookRegistry();
+      registry.onBeforeSend(req => ({
+        ...req,
+        headers: { ...req.headers, 'X-Plugin-Header': 'injected' },
+      }));
+
+      let capturedRequest: TransportRequest | undefined;
+      const transport = registry.wrap({
+        async send(req: TransportRequest) {
+          capturedRequest = req;
+          return makeResponse();
+        },
+      });
+
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(capturedRequest?.headers?.['X-Plugin-Header']).toBe('injected');
+    });
+
+    it('supports async callbacks', async () => {
+      const registry = new TransportHookRegistry();
+      registry.onBeforeSend(async req => {
+        await Promise.resolve();
+        return { ...req, headers: { 'X-Async': 'yes' } };
+      });
+
+      let capturedRequest: TransportRequest | undefined;
+      const transport = registry.wrap({
+        async send(req: TransportRequest) {
+          capturedRequest = req;
+          return makeResponse();
+        },
+      });
+
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(capturedRequest?.headers?.['X-Async']).toBe('yes');
+    });
+
+    it('chains multiple callbacks in registration order', async () => {
+      const order: string[] = [];
+      const registry = new TransportHookRegistry();
+      registry.onBeforeSend(req => {
+        order.push('first');
+        return req;
+      });
+      registry.onBeforeSend(req => {
+        order.push('second');
+        return req;
+      });
+
+      const transport = registry.wrap({ send: async () => makeResponse() });
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+
+      expect(order).toEqual(['first', 'second']);
+    });
+
+    it('cleanup removes the callback', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn((req: TransportRequest) => req);
+      const remove = registry.onBeforeSend(cb);
+
+      remove();
+
+      const transport = registry.wrap({ send: async () => makeResponse() });
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(cb).not.toHaveBeenCalled();
+    });
+
+    it('cleanup is idempotent', () => {
+      const registry = new TransportHookRegistry();
+      const remove = registry.onBeforeSend(req => req);
+      expect(() => {
+        remove();
+        remove();
+      }).not.toThrow();
+    });
+  });
+
+  describe('onResponse', () => {
+    it('calls registered callbacks after send', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn();
+      registry.onResponse(cb);
+
+      const response = makeResponse();
+      const transport = registry.wrap({ send: async () => response });
+
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(cb).toHaveBeenCalledOnce();
+      expect(cb).toHaveBeenCalledWith(response);
+    });
+
+    it('cleanup removes the callback', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn();
+      const remove = registry.onResponse(cb);
+      remove();
+
+      const transport = registry.wrap({ send: async () => makeResponse() });
+      await collect(
+        transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
+      );
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('async iterable path (subscriptions)', () => {
+    async function* makeIterable(
+      responses: TransportResponse[],
+    ): AsyncIterable<TransportResponse> {
+      for (const r of responses) {
+        yield r;
+      }
+    }
+
+    it('calls onBeforeSend before the stream starts', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn((req: TransportRequest) => req);
+      registry.onBeforeSend(cb);
+
+      const transport = registry.wrap({
+        send: () => makeIterable([makeResponse()]),
+      });
+
+      const iter = transport.send(
+        makeRequest(),
+      ) as AsyncIterable<TransportResponse>;
+      for await (const _ of iter) {
+        /* consume */
+      }
+
+      expect(cb).toHaveBeenCalledOnce();
+    });
+
+    it('calls onResponse for each emitted chunk', async () => {
+      const registry = new TransportHookRegistry();
+      const cb = vi.fn();
+      registry.onResponse(cb);
+
+      const r1 = makeResponse({ ok: true });
+      const r2 = makeResponse({ ok: false });
+      const transport = registry.wrap({
+        send: () => makeIterable([r1, r2]),
+      });
+
+      const iter = transport.send(
+        makeRequest(),
+      ) as AsyncIterable<TransportResponse>;
+      for await (const _ of iter) {
+        /* consume */
+      }
+
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenNthCalledWith(1, r1);
+      expect(cb).toHaveBeenNthCalledWith(2, r2);
+    });
+  });
+});

--- a/packages/graphiql-react/src/transport-hooks.ts
+++ b/packages/graphiql-react/src/transport-hooks.ts
@@ -1,0 +1,162 @@
+import type {
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from '@graphiql/toolkit';
+
+/** A function invoked before a request is sent; may transform the request. */
+export type OnBeforeSendCallback = (
+  req: TransportRequest,
+) => TransportRequest | Promise<TransportRequest>;
+
+/** A function invoked after a response is received. */
+export type OnResponseCallback = (res: TransportResponse) => void;
+
+/** Cleanup function returned by hook registration. Call it to remove the hook. */
+export type CleanupFn = () => void;
+
+/**
+ * Registry of request/response hooks for the transport path.
+ * Created once per `<GraphiQLProvider transport={...}>` mount.
+ * Absent (i.e. context value is `undefined`) when the host uses a `fetcher`.
+ */
+export class TransportHookRegistry {
+  /** @internal */
+  readonly _beforeSend: OnBeforeSendCallback[] = [];
+  /** @internal */
+  readonly _onResponse: OnResponseCallback[] = [];
+
+  /**
+   * Register a callback that runs before each request is sent.
+   * The callback may return a (possibly async) transformed `TransportRequest`.
+   * Returns a cleanup function that removes the callback.
+   */
+  onBeforeSend(cb: OnBeforeSendCallback): CleanupFn {
+    this._beforeSend.push(cb);
+    return () => {
+      const idx = this._beforeSend.indexOf(cb);
+      if (idx !== -1) {
+        this._beforeSend.splice(idx, 1);
+      }
+    };
+  }
+
+  /**
+   * Register a callback that runs after each response is received.
+   * Returns a cleanup function that removes the callback.
+   */
+  onResponse(cb: OnResponseCallback): CleanupFn {
+    this._onResponse.push(cb);
+    return () => {
+      const idx = this._onResponse.indexOf(cb);
+      if (idx !== -1) {
+        this._onResponse.splice(idx, 1);
+      }
+    };
+  }
+
+  /**
+   * Wrap a `Transport` so all `onBeforeSend` and `onResponse` hooks are
+   * invoked transparently on each call to `send()`.
+   *
+   * The wrapped transport always returns an `AsyncIterable<TransportResponse>`.
+   * For queries and mutations (where the underlying transport returns a
+   * `Promise`), the iterable emits exactly one value then completes.
+   * For subscriptions and incremental delivery (where the underlying transport
+   * returns an `AsyncIterable`), each chunk is forwarded in turn.
+   *
+   * Hooks run in registration order: all `onBeforeSend` callbacks complete
+   * before the underlying `send()` is called; all `onResponse` callbacks fire
+   * after each response value is received.
+   */
+  wrap(transport: Transport): Transport {
+    const { _beforeSend, _onResponse } = this;
+
+    return {
+      send(request: TransportRequest): AsyncIterable<TransportResponse> {
+        return {
+          [Symbol.asyncIterator]() {
+            let iter: AsyncIterator<TransportResponse> | null = null;
+            let singlePromise: Promise<TransportResponse> | null = null;
+            let done = false;
+
+            return {
+              async next(): Promise<IteratorResult<TransportResponse>> {
+                if (done) {
+                  return {
+                    value: undefined as unknown as TransportResponse,
+                    done: true,
+                  };
+                }
+
+                // First call: run onBeforeSend hooks then delegate to transport
+                if (iter === null && singlePromise === null) {
+                  // Run all onBeforeSend hooks in order
+                  let req = request;
+                  for (const cb of _beforeSend) {
+                    req = await cb(req);
+                  }
+
+                  const result = transport.send(req);
+
+                  if (
+                    result !== null &&
+                    typeof result === 'object' &&
+                    Symbol.asyncIterator in result
+                  ) {
+                    // Iterable path: subscriptions / incremental delivery
+                    iter = (result as AsyncIterable<TransportResponse>)[
+                      Symbol.asyncIterator
+                    ]();
+                  } else {
+                    // Promise path: queries / mutations
+                    singlePromise = result as Promise<TransportResponse>;
+                  }
+                }
+
+                if (singlePromise !== null) {
+                  const tr = await singlePromise;
+                  for (const cb of _onResponse) {
+                    cb(tr);
+                  }
+                  done = true;
+                  return { value: tr, done: false };
+                }
+
+                // Iterable path
+                const result = await iter!.next();
+                if (result.done) {
+                  done = true;
+                  return {
+                    value: undefined as unknown as TransportResponse,
+                    done: true,
+                  };
+                }
+                for (const cb of _onResponse) {
+                  cb(result.value);
+                }
+                return result;
+              },
+
+              return(value?: unknown) {
+                done = true;
+                return (
+                  iter?.return?.(value) ??
+                  Promise.resolve({
+                    value: undefined as unknown as TransportResponse,
+                    done: true as const,
+                  })
+                );
+              },
+
+              throw(error?: unknown) {
+                done = true;
+                return iter?.throw?.(error) ?? Promise.reject(error);
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+}

--- a/packages/graphiql-react/vite.config.mts
+++ b/packages/graphiql-react/vite.config.mts
@@ -58,7 +58,12 @@ export const plugins: PluginOption[] = [
   dts({
     include: ['src/**'],
     outDir: ['dist'],
-    exclude: ['**/*.spec.{ts,tsx}', '**/__tests__/'],
+    exclude: [
+      '**/*.spec.{ts,tsx}',
+      '**/*.test.{ts,tsx}',
+      '**/*.stories.{ts,tsx}',
+      '**/__tests__/',
+    ],
   }),
   {
     name: 'copy-original-setup-workers-file',


### PR DESCRIPTION
## Summary

`useGraphiQLPluginContext()` now returns a `transport` field that lets plugins register request and response hooks via `ctx.transport?.onBeforeSend(cb)` and `ctx.transport?.onResponse(cb)`. Each callback returns a cleanup function for removal. The field is absent when the host passes a `fetcher` rather than a `transport`, so plugins can detect the supported path with a simple optional chain. The hook registry wraps the underlying transport transparently: query, mutation, subscription, and incremental-delivery flows all pass through the registered callbacks.

## Test plan

- [x] In a plugin's `content` component, call `useGraphiQLPluginContext()` and register an `onBeforeSend` hook that adds a header; run a query and confirm the header reaches the server.
- [x] Register an `onResponse` hook and confirm it fires with the response envelope after each query or subscription chunk.
- [x] Call the cleanup function returned by `onBeforeSend`; confirm the hook no longer fires on subsequent requests.
- [x] Mount `<GraphiQLProvider fetcher={...}>` (no `transport`) and confirm `ctx.transport` is `undefined`.

Refs: graphql/graphiql#4219
