### PR TITLE
v6: Make transport hooks satisfy the stricter `Transport` type

### DIFF
--- a/.changeset/fix-transport-hooks-types.md
+++ b/.changeset/fix-transport-hooks-types.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix `@graphiql/react` type error: the transport hooks `wrap()` and its test mocks now satisfy the stricter `Transport` type (which requires `url`, `method`, and `supportedMethods`).

--- a/packages/graphiql-react/src/transport-hooks.context.spec.tsx
+++ b/packages/graphiql-react/src/transport-hooks.context.spec.tsx
@@ -3,11 +3,21 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
+import type { Transport } from '@graphiql/toolkit';
 import {
   TransportHookContext,
   useGraphiQLPluginContext,
 } from './transport-hooks.context';
 import { TransportHookRegistry } from './transport-hooks';
+
+function makeTransport(send: Transport['send']): Transport {
+  return {
+    url: 'https://example.test/graphql',
+    method: 'POST',
+    supportedMethods: ['POST'],
+    send,
+  };
+}
 
 function wrapWith(registry: TransportHookRegistry | null) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -48,14 +58,14 @@ describe('useGraphiQLPluginContext', () => {
     result.current.transport!.onBeforeSend(cb);
 
     // Drive the registry directly to verify the callback is registered
-    const transport = registry.wrap({
-      send: async () => ({
+    const transport = registry.wrap(
+      makeTransport(async () => ({
         ok: true,
         body: {},
         timing: { totalMs: 0 },
         size: {},
-      }),
-    });
+      })),
+    );
     const iter = transport.send({ query: '{ test }' }) as AsyncIterable<any>;
     for await (const _ of iter) {
       /* consume */
@@ -75,14 +85,14 @@ describe('useGraphiQLPluginContext', () => {
     const cleanup = result.current.transport!.onBeforeSend(cb);
     cleanup();
 
-    const transport = registry.wrap({
-      send: async () => ({
+    const transport = registry.wrap(
+      makeTransport(async () => ({
         ok: true,
         body: {},
         timing: { totalMs: 0 },
         size: {},
-      }),
-    });
+      })),
+    );
     const iter = transport.send({ query: '{ test }' }) as AsyncIterable<any>;
     for await (const _ of iter) {
       /* consume */

--- a/packages/graphiql-react/src/transport-hooks.spec.ts
+++ b/packages/graphiql-react/src/transport-hooks.spec.ts
@@ -1,8 +1,21 @@
 'use no memo';
 
 import { describe, it, expect, vi } from 'vitest';
-import type { TransportRequest, TransportResponse } from '@graphiql/toolkit';
+import type {
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from '@graphiql/toolkit';
 import { TransportHookRegistry } from './transport-hooks';
+
+function makeTransport(send: Transport['send']): Transport {
+  return {
+    url: 'https://example.test/graphql',
+    method: 'POST',
+    supportedMethods: ['POST'],
+    send,
+  };
+}
 
 function makeResponse(
   overrides?: Partial<TransportResponse>,
@@ -38,9 +51,9 @@ describe('TransportHookRegistry', () => {
       const cb = vi.fn((req: TransportRequest) => req);
       registry.onBeforeSend(cb);
 
-      const transport = registry.wrap({
-        send: async () => makeResponse(),
-      });
+      const transport = registry.wrap(
+        makeTransport(async () => makeResponse()),
+      );
 
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
@@ -56,12 +69,12 @@ describe('TransportHookRegistry', () => {
       }));
 
       let capturedRequest: TransportRequest | undefined;
-      const transport = registry.wrap({
-        async send(req: TransportRequest) {
+      const transport = registry.wrap(
+        makeTransport(async (req: TransportRequest) => {
           capturedRequest = req;
           return makeResponse();
-        },
-      });
+        }),
+      );
 
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
@@ -77,12 +90,12 @@ describe('TransportHookRegistry', () => {
       });
 
       let capturedRequest: TransportRequest | undefined;
-      const transport = registry.wrap({
-        async send(req: TransportRequest) {
+      const transport = registry.wrap(
+        makeTransport(async (req: TransportRequest) => {
           capturedRequest = req;
           return makeResponse();
-        },
-      });
+        }),
+      );
 
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
@@ -102,7 +115,9 @@ describe('TransportHookRegistry', () => {
         return req;
       });
 
-      const transport = registry.wrap({ send: async () => makeResponse() });
+      const transport = registry.wrap(
+        makeTransport(async () => makeResponse()),
+      );
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
       );
@@ -117,7 +132,9 @@ describe('TransportHookRegistry', () => {
 
       remove();
 
-      const transport = registry.wrap({ send: async () => makeResponse() });
+      const transport = registry.wrap(
+        makeTransport(async () => makeResponse()),
+      );
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
       );
@@ -141,7 +158,7 @@ describe('TransportHookRegistry', () => {
       registry.onResponse(cb);
 
       const response = makeResponse();
-      const transport = registry.wrap({ send: async () => response });
+      const transport = registry.wrap(makeTransport(async () => response));
 
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
@@ -156,7 +173,9 @@ describe('TransportHookRegistry', () => {
       const remove = registry.onResponse(cb);
       remove();
 
-      const transport = registry.wrap({ send: async () => makeResponse() });
+      const transport = registry.wrap(
+        makeTransport(async () => makeResponse()),
+      );
       await collect(
         transport.send(makeRequest()) as AsyncIterable<TransportResponse>,
       );
@@ -178,9 +197,9 @@ describe('TransportHookRegistry', () => {
       const cb = vi.fn((req: TransportRequest) => req);
       registry.onBeforeSend(cb);
 
-      const transport = registry.wrap({
-        send: () => makeIterable([makeResponse()]),
-      });
+      const transport = registry.wrap(
+        makeTransport(() => makeIterable([makeResponse()])),
+      );
 
       const iter = transport.send(
         makeRequest(),
@@ -199,9 +218,9 @@ describe('TransportHookRegistry', () => {
 
       const r1 = makeResponse({ ok: true });
       const r2 = makeResponse({ ok: false });
-      const transport = registry.wrap({
-        send: () => makeIterable([r1, r2]),
-      });
+      const transport = registry.wrap(
+        makeTransport(() => makeIterable([r1, r2])),
+      );
 
       const iter = transport.send(
         makeRequest(),

--- a/packages/graphiql-react/src/transport-hooks.ts
+++ b/packages/graphiql-react/src/transport-hooks.ts
@@ -73,6 +73,7 @@ export class TransportHookRegistry {
     const { _beforeSend, _onResponse } = this;
 
     return {
+      ...transport,
       send(request: TransportRequest): AsyncIterable<TransportResponse> {
         return {
           [Symbol.asyncIterator]() {


### PR DESCRIPTION
## Summary

PR #4349 made `url`, `method`, and `supportedMethods` required on the `Transport` type, but the transport hooks added in #4351 still build `Transport` objects with only `send`. That left `@graphiql/react` failing its type check on `graphiql-6`, which blocks every PR targeting the branch.

- `wrap()` now spreads the wrapped transport, so `url`/`method`/`supportedMethods` (and `setMethod`) carry through to the returned transport instead of being dropped.
- The transport-hooks specs build their mock transports through a small helper that fills in the required fields.

## Test plan

- [x] `@graphiql/react` type-checks cleanly (CI Types Check passes).
- [x] The transport-hooks unit tests pass.

Refs: graphql/graphiql#4351, graphql/graphiql#4349