### PR TITLE
v6: Fix flaky Monaco hover assertion in lint cypress tests

### DIFF
--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -171,13 +171,32 @@ Cypress.Commands.add(
         }[severity];
         expect(markers[0].severity).eq(markerSeverity);
       }
-      cy.contains(text).trigger('mousemove', {
-        // Hover in the right corner, because some errors like `Expected comma or closing brace` are
-        // highlighted at the end
-        position: 'bottomRight',
-        force: true, // otherwise popup doesn't show
-      });
-      cy.contains(message);
     });
+    // Monaco computes the hover tooltip from a single `mousemove`. When that
+    // event fires before the hover provider has picked up the latest markers,
+    // the tooltip never renders and no further event re-asks for it. Re-trigger
+    // until the message shows so the assertion stops racing the tooltip.
+    assertHoverShowsMessage(text, message);
   },
 );
+
+function assertHoverShowsMessage(text: string, message: string, attempt = 0) {
+  cy.contains(text).trigger('mousemove', {
+    // Hover in the right corner, because some errors like `Expected comma or closing brace` are
+    // highlighted at the end
+    position: 'bottomRight',
+    force: true, // otherwise popup doesn't show
+  });
+  if (attempt >= 10) {
+    cy.contains(message); // out of retries: assert directly so failures report clearly
+    return;
+  }
+  cy.get('body').then($body => {
+    if ($body.text().includes(message)) {
+      cy.contains(message);
+    } else {
+      cy.wait(300);
+      assertHoverShowsMessage(text, message, attempt + 1);
+    }
+  });
+}


### PR DESCRIPTION
`assertLinterMarkWithMessage` triggers Monaco's hover tooltip with one `mousemove`, then looks for the message text. If that fires before Monaco has the latest markers, it computes an empty hover and never retries, so the tooltip never shows and the assertion times out (`Expected to find content: '...' but never did`). The marker is already checked directly via `getModelMarkers`, so only the hover step was flaky.

Now it re-triggers the `mousemove` until the message shows, capped, with a direct assertion at the end so real failures still surface. Fixes the intermittent `lint.cy.ts` failure on "Marks syntax errors in variables JSON as error", and the helper change covers the other lint tests too.

Same class of `...but never did` flake as #4348, which fixed a similar race in `docs.cy.ts`.