### PR TITLE
v6: Cap tooltip height and raise its stacking so it stays on-screen

### DIFF
--- a/.changeset/tooltip-viewport.md
+++ b/.changeset/tooltip-viewport.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Keep tooltips within the viewport and above page content. Tooltips now cap their height to the available space and scroll long content instead of pushing the page out of bounds, and they render above sticky headers and dialogs.

--- a/packages/graphiql-react/src/components/tooltip/index.css
+++ b/packages/graphiql-react/src/components/tooltip/index.css
@@ -1,4 +1,16 @@
 .graphiql-tooltip {
+  /* Sit above page content (sticky headers use z-index: 1, dialogs use 10). */
+  z-index: 100;
+  /* Cap to the space Radix measured between the trigger and the viewport edge,
+     less the status bar, so a tall tooltip (e.g. a markdown deprecation reason)
+     scrolls and stops above the status bar instead of running off-screen.
+     border-box keeps the padding inside the cap so the box, not just its
+     content, fits. */
+  box-sizing: border-box;
+  max-height: calc(
+    var(--radix-tooltip-content-available-height) - var(--status-bar-height)
+  );
+  overflow-y: auto;
   background: oklch(var(--bg-elevated));
   border: 1px solid oklch(var(--border-default));
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary

GraphiQL tooltips had no height cap or `z-index`, so long content (for example a markdown deprecation reason) could grow past the viewport and make the whole page scroll, and sticky headers or dialogs could paint over them. Tooltips now cap their height to the space between the trigger and the status bar, scroll any overflow, and render above page content.

## Changes

- Add `z-index` so tooltips sit above sticky headers and dialogs.
- Cap `max-height` to Radix's measured available height minus the status bar, with `overflow-y: auto`.
- Use `box-sizing: border-box` so padding stays within the cap.

## Validation Steps

- [x] Hover a trigger with content taller than the viewport (e.g. a field with a long markdown deprecation reason); confirm the tooltip caps height, scrolls, and stops above the status bar instead of growing the page.
- [x] Confirm the page does not become scrollable when the tooltip opens, in both Safari and Chrome.
- [x] Hover near a sticky header or with a dialog open; confirm the tooltip renders above it.
- [x] Confirm short tooltips look unchanged.