### PR TITLE
Limit Dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,5 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    open-pull-requests-limit: 10
+    # 0 disables version-update PRs; security updates still open (separate internal limit)
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Follow-up to #4366. That PR added the Dependabot config with `open-pull-requests-limit: 10`, which enables weekly version-update PRs for every dependency. This sets the limit to `0`, which disables version-update PRs while leaving security updates unaffected (they run off advisories with a separate internal limit). The repo stays effectively security-only, as it was before any config existed, but keeps the root scoping from #4366 so security updates update the single root `yarn.lock`.