### PR TITLE
v6: Shared `Dialog.Header`/`Body`/`Footer` styles

### DIFF
--- a/.changeset/dialog-chrome.md
+++ b/.changeset/dialog-chrome.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add shared dialog chrome to the `Dialog` compound component: `Dialog.Header` (title + close button with a divider), `Dialog.Body` (padded content region), and `Dialog.Footer` (right-aligned action row). The settings dialog now uses `Dialog.Header`, and consumers can build consistent dialogs without re-implementing the layout.

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -37,3 +37,34 @@
   padding: var(--px-12);
   width: var(--icon-size-md);
 }
+
+.graphiql-dialog-header {
+  align-items: center;
+  border-bottom: 1px solid oklch(var(--border-default));
+  display: flex;
+  justify-content: space-between;
+  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
+}
+
+.graphiql-dialog-title {
+  color: oklch(var(--fg-strong));
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  margin: 0;
+}
+
+.graphiql-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-16);
+  padding: var(--px-16);
+}
+
+.graphiql-dialog-footer {
+  border-top: 1px solid oklch(var(--border-default));
+  display: flex;
+  gap: var(--px-8);
+  justify-content: flex-end;
+  padding: var(--px-12) var(--px-16);
+}

--- a/packages/graphiql-react/src/components/dialog/index.tsx
+++ b/packages/graphiql-react/src/components/dialog/index.tsx
@@ -25,6 +25,48 @@ const DialogClose = forwardRef<
 ));
 DialogClose.displayName = 'Dialog.Close';
 
+/**
+ * The chrome at the top of a dialog: a title on the left and a close button on
+ * the right, with a bottom divider. A string child is wrapped in `Dialog.Title`
+ * automatically (Radix requires a title for accessibility); pass JSX to render
+ * your own title node.
+ */
+const DialogHeader = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, ref) => (
+  <div {...props} ref={ref} className={cn('graphiql-dialog-header', className)}>
+    {typeof children === 'string' ? (
+      <D.Title className="graphiql-dialog-title">{children}</D.Title>
+    ) : (
+      children
+    )}
+    <DialogClose />
+  </div>
+));
+DialogHeader.displayName = 'Dialog.Header';
+
+/** The content region of a dialog, with consistent padding. */
+const DialogBody = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
+  ({ children, className, ...props }, ref) => (
+    <div {...props} ref={ref} className={cn('graphiql-dialog-body', className)}>
+      {children}
+    </div>
+  ),
+);
+DialogBody.displayName = 'Dialog.Body';
+
+/** The action row at the bottom of a dialog, right-aligned with a top divider. */
+const DialogFooter = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, ref) => (
+  <div {...props} ref={ref} className={cn('graphiql-dialog-footer', className)}>
+    {children}
+  </div>
+));
+DialogFooter.displayName = 'Dialog.Footer';
+
 const DialogRoot: FC<D.DialogProps> = ({ children, ...props }) => {
   return (
     <D.Root {...props}>
@@ -41,4 +83,7 @@ export const Dialog = Object.assign(DialogRoot, {
   Title: D.Title,
   Trigger: D.Trigger,
   Description: D.Description,
+  Header: DialogHeader,
+  Body: DialogBody,
+  Footer: DialogFooter,
 });

--- a/packages/graphiql-react/src/components/settings-dialog/index.css
+++ b/packages/graphiql-react/src/components/settings-dialog/index.css
@@ -2,22 +2,6 @@
   min-width: 360px;
 }
 
-.graphiql-settings-dialog-header {
-  align-items: center;
-  border-bottom: 1px solid oklch(var(--border-default));
-  display: flex;
-  justify-content: space-between;
-  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
-}
-
-.graphiql-settings-dialog-title {
-  color: oklch(var(--fg-strong));
-  font-family: var(--font-family);
-  font-size: var(--font-size-body);
-  font-weight: 600;
-  margin: 0;
-}
-
 .graphiql-settings-dialog-body {
   display: flex;
   flex-direction: column;

--- a/packages/graphiql-react/src/components/settings-dialog/index.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/index.tsx
@@ -130,12 +130,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <div className="graphiql-settings-dialog">
-        <div className="graphiql-settings-dialog-header">
-          <Dialog.Title className="graphiql-settings-dialog-title">
-            Settings
-          </Dialog.Title>
-          <Dialog.Close />
-        </div>
+        <Dialog.Header>Settings</Dialog.Header>
 
         <div className="graphiql-settings-dialog-body">
           {!forcedThemeSetting && (


### PR DESCRIPTION
## Summary

Adds shared header/body/footer styles to the `Dialog` compound component in `@graphiql/react` so every dialog is consistent by construction instead of each one re-implementing the title/divider/padding/footer layout:

- **`Dialog.Header`** — title on the left, close button on the right, bottom divider. A string child is wrapped in `Dialog.Title` automatically (Radix needs a title for a11y); pass JSX for a custom title node.
- **`Dialog.Body`** — padded content region (flex column).
- **`Dialog.Footer`** — right-aligned action row with a top divider.

The settings dialog is refactored onto `Dialog.Header` to prove the abstraction (its bespoke `graphiql-settings-dialog-header/-title` markup and CSS are removed).

## Why

Broken out of the operation-collections PR (graphql/graphiql#4359), whose save / import-export dialogs needed these styles. Landing it on its own in the v6 line keeps the design-system change reviewable independently; #4359 is rebased on top of this branch.

## Test plan

- [ ] Open Settings — header (title + close + divider) renders as before
- [ ] `npx turbo run types:check --filter=@graphiql/react` passes