### PR TITLE
v6: Portal Radix content into the container + consistent `Dialog` styling

### DIFF
--- a/.changeset/dialog-styles.md
+++ b/.changeset/dialog-styles.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': minor
+---
+
+Add shared header/body/footer styles to the `Dialog` compound component: `Dialog.Header` (title + close button with a divider), `Dialog.Body` (padded content region), and `Dialog.Footer` (right-aligned action row). The settings dialog now uses `Dialog.Header`, and consumers can build consistent dialogs without re-implementing the layout.

--- a/.changeset/dialog-styles.md
+++ b/.changeset/dialog-styles.md
@@ -1,5 +1,8 @@
 ---
 '@graphiql/react': minor
+'graphiql': minor
 ---
 
-Add shared header/body/footer styles to the `Dialog` compound component: `Dialog.Header` (title + close button with a divider), `Dialog.Body` (padded content region), and `Dialog.Footer` (right-aligned action row). The settings dialog now uses `Dialog.Header`, and consumers can build consistent dialogs without re-implementing the layout.
+Render Radix portals (dialogs, tooltips, dropdown menus) inside the GraphiQL container instead of `document.body`, via a new `PortalProvider`. Portaled content now inherits the container's `data-theme` / `data-density` / `data-font-size` tokens through normal CSS inheritance, so dialogs, tooltips, and menus respect the user's appearance settings. The legacy per-portal variable re-injection in `root.css` is removed in favor of inheritance.
+
+Add shared header/body/footer styles to the `Dialog` compound component: `Dialog.Header` (title + close button with a divider), `Dialog.Body` (padded content region), and `Dialog.Footer` (right-aligned action row). Header, body, and footer padding scale with the density setting via new `--dialog-*` tokens, the header is tightened (smaller close-button hit area, optical alignment), and the settings dialog now uses `Dialog.Header`. Consumers can build consistent dialogs without re-implementing the layout.

--- a/packages/graphiql-react/src/components/dialog/dialog.stories.tsx
+++ b/packages/graphiql-react/src/components/dialog/dialog.stories.tsx
@@ -12,21 +12,6 @@ export default meta;
 
 type Story = StoryObj;
 
-const headerStyle = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: 'var(--px-4) var(--px-4) var(--px-4) var(--px-16)',
-  borderBottom: '1px solid oklch(var(--border-default))',
-} as const;
-
-const bodyStyle = {
-  padding: 'var(--px-16)',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--px-12)',
-} as const;
-
 export const Default: Story = {
   render: function DefaultStory() {
     const [open, setOpen] = useState(false);
@@ -35,15 +20,12 @@ export const Default: Story = {
         <Button onClick={() => setOpen(true)}>Open settings</Button>
         <Dialog open={open} onOpenChange={setOpen}>
           <div style={{ minWidth: 360 }}>
-            <div style={headerStyle}>
-              <Dialog.Title style={{ margin: 0 }}>Settings</Dialog.Title>
-              <Dialog.Close />
-            </div>
-            <div style={bodyStyle}>
+            <Dialog.Header>Settings</Dialog.Header>
+            <Dialog.Body>
               <Dialog.Description style={{ margin: 0 }}>
                 Update your preferences.
               </Dialog.Description>
-            </div>
+            </Dialog.Body>
           </div>
         </Dialog>
       </>
@@ -59,29 +41,18 @@ export const ConfirmAction: Story = {
         <Button onClick={() => setOpen(true)}>Discard changes</Button>
         <Dialog open={open} onOpenChange={setOpen}>
           <div style={{ minWidth: 360 }}>
-            <div style={headerStyle}>
-              <Dialog.Title style={{ margin: 0 }}>
-                Discard changes?
-              </Dialog.Title>
-              <Dialog.Close />
-            </div>
-            <div style={bodyStyle}>
+            <Dialog.Header>Discard changes?</Dialog.Header>
+            <Dialog.Body>
               <Dialog.Description style={{ margin: 0 }}>
                 Your unsaved changes will be lost.
               </Dialog.Description>
-              <div
-                style={{
-                  display: 'flex',
-                  gap: 'var(--px-8)',
-                  justifyContent: 'flex-end',
-                }}
-              >
-                <Button onClick={() => setOpen(false)}>Cancel</Button>
-                <Button variant="primary" onClick={() => setOpen(false)}>
-                  Discard
-                </Button>
-              </div>
-            </div>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+              <Button variant="primary" onClick={() => setOpen(false)}>
+                Discard
+              </Button>
+            </Dialog.Footer>
           </div>
         </Dialog>
       </>

--- a/packages/graphiql-react/src/components/dialog/dialog.test.tsx
+++ b/packages/graphiql-react/src/components/dialog/dialog.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { Dialog } from './';
+import { PortalProvider } from '../portal';
+
+afterEach(cleanup);
+
+describe('Dialog — portal container', () => {
+  it('portals to document.body when no PortalProvider is present', () => {
+    render(
+      <Dialog open>
+        <Dialog.Header>Title</Dialog.Header>
+      </Dialog>,
+    );
+    const dialog = document.querySelector('.graphiql-dialog');
+    expect(dialog).toBeInTheDocument();
+    // Falls back to body — not nested under a GraphiQL container.
+    expect(dialog?.closest('.graphiql-container')).toBeNull();
+  });
+
+  it('renders inside the container provided by PortalProvider', () => {
+    const container = document.createElement('div');
+    container.className = 'graphiql-container';
+    container.setAttribute('data-density', 'compact');
+    document.body.append(container);
+
+    render(
+      <PortalProvider container={container}>
+        <Dialog open>
+          <Dialog.Header>Title</Dialog.Header>
+        </Dialog>
+      </PortalProvider>,
+    );
+
+    const dialog = document.querySelector('.graphiql-dialog');
+    expect(dialog).toBeInTheDocument();
+    // The whole point: portaled content lives inside the container, so it
+    // inherits its data-density / data-font-size / data-theme tokens.
+    expect(container.contains(dialog!)).toBe(true);
+
+    container.remove();
+  });
+});

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -30,11 +30,20 @@
   z-index: 10;
 }
 
-.graphiql-dialog-close > svg {
+.graphiql-dialog-close {
+  border-radius: var(--radius-sm);
   color: oklch(var(--fg-muted));
+  padding: var(--px-6);
+
+  &:hover {
+    background: oklch(var(--bg-overlay));
+    color: oklch(var(--fg-default));
+  }
+}
+
+.graphiql-dialog-close > svg {
   display: block;
   height: var(--icon-size-md);
-  padding: var(--px-12);
   width: var(--icon-size-md);
 }
 
@@ -43,7 +52,10 @@
   border-bottom: 1px solid oklch(var(--border-default));
   display: flex;
   justify-content: space-between;
-  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
+  /* Slightly less padding on the close-button side so the icon optically aligns
+     with the title; the button carries its own padding for the hit target. */
+  padding: var(--dialog-bar-padding-y) var(--px-10) var(--dialog-bar-padding-y)
+    var(--dialog-padding-x);
 }
 
 .graphiql-dialog-title {
@@ -51,14 +63,15 @@
   font-family: var(--font-family);
   font-size: var(--font-size-body);
   font-weight: 600;
+  line-height: var(--line-height-body);
   margin: 0;
 }
 
 .graphiql-dialog-body {
   display: flex;
   flex-direction: column;
-  gap: var(--px-16);
-  padding: var(--px-16);
+  gap: var(--dialog-gap);
+  padding: var(--dialog-padding-y) var(--dialog-padding-x);
 }
 
 .graphiql-dialog-footer {
@@ -66,5 +79,5 @@
   display: flex;
   gap: var(--px-8);
   justify-content: flex-end;
-  padding: var(--px-12) var(--px-16);
+  padding: var(--dialog-bar-padding-y) var(--dialog-padding-x);
 }

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -33,7 +33,7 @@
 .graphiql-dialog-close {
   border-radius: var(--radius-sm);
   color: oklch(var(--fg-muted));
-  padding: var(--px-6);
+  padding: var(--px-4);
 
   &:hover {
     background: oklch(var(--bg-overlay));
@@ -52,9 +52,10 @@
   border-bottom: 1px solid oklch(var(--border-default));
   display: flex;
   justify-content: space-between;
-  /* Slightly less padding on the close-button side so the icon optically aligns
-     with the title; the button carries its own padding for the hit target. */
-  padding: var(--dialog-bar-padding-y) var(--px-10) var(--dialog-bar-padding-y)
+  /* Less padding on the close-button side so the icon optically aligns with the
+     title (button padding + this ≈ --dialog-padding-x); the button carries its
+     own padding for the hit target. */
+  padding: var(--dialog-bar-padding-y) var(--px-12) var(--dialog-bar-padding-y)
     var(--dialog-padding-x);
 }
 

--- a/packages/graphiql-react/src/components/dialog/index.css
+++ b/packages/graphiql-react/src/components/dialog/index.css
@@ -37,3 +37,34 @@
   padding: var(--px-12);
   width: var(--icon-size-md);
 }
+
+.graphiql-dialog-header {
+  align-items: center;
+  border-bottom: 1px solid oklch(var(--border-default));
+  display: flex;
+  justify-content: space-between;
+  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
+}
+
+.graphiql-dialog-title {
+  color: oklch(var(--fg-strong));
+  font-family: var(--font-family);
+  font-size: var(--font-size-body);
+  font-weight: 600;
+  margin: 0;
+}
+
+.graphiql-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--px-16);
+  padding: var(--px-16);
+}
+
+.graphiql-dialog-footer {
+  border-top: 1px solid oklch(var(--border-default));
+  display: flex;
+  gap: var(--px-8);
+  justify-content: flex-end;
+  padding: var(--px-12) var(--px-16);
+}

--- a/packages/graphiql-react/src/components/dialog/index.tsx
+++ b/packages/graphiql-react/src/components/dialog/index.tsx
@@ -2,6 +2,7 @@ import { cn } from '../../utility';
 import { forwardRef, FC, ComponentPropsWithoutRef } from 'react';
 import { CloseIcon } from '../../icons';
 import { UnStyledButton } from '../button';
+import { usePortalContainer } from '../portal';
 import * as D from '@radix-ui/react-dialog';
 import { Root as VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
@@ -68,9 +69,10 @@ const DialogFooter = forwardRef<
 DialogFooter.displayName = 'Dialog.Footer';
 
 const DialogRoot: FC<D.DialogProps> = ({ children, ...props }) => {
+  const container = usePortalContainer();
   return (
     <D.Root {...props}>
-      <D.Portal>
+      <D.Portal container={container}>
         <D.Overlay className="graphiql-dialog-overlay" />
         <D.Content className="graphiql-dialog">{children}</D.Content>
       </D.Portal>

--- a/packages/graphiql-react/src/components/dialog/index.tsx
+++ b/packages/graphiql-react/src/components/dialog/index.tsx
@@ -25,6 +25,48 @@ const DialogClose = forwardRef<
 ));
 DialogClose.displayName = 'Dialog.Close';
 
+/**
+ * The styled header of a dialog: a title on the left and a close button on the
+ * right, with a bottom divider. A string child is wrapped in `Dialog.Title`
+ * automatically (Radix requires a title for accessibility); pass JSX to render
+ * your own title node.
+ */
+const DialogHeader = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, ref) => (
+  <div {...props} ref={ref} className={cn('graphiql-dialog-header', className)}>
+    {typeof children === 'string' ? (
+      <D.Title className="graphiql-dialog-title">{children}</D.Title>
+    ) : (
+      children
+    )}
+    <DialogClose />
+  </div>
+));
+DialogHeader.displayName = 'Dialog.Header';
+
+/** The content region of a dialog, with consistent padding. */
+const DialogBody = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<'div'>>(
+  ({ children, className, ...props }, ref) => (
+    <div {...props} ref={ref} className={cn('graphiql-dialog-body', className)}>
+      {children}
+    </div>
+  ),
+);
+DialogBody.displayName = 'Dialog.Body';
+
+/** The action row at the bottom of a dialog, right-aligned with a top divider. */
+const DialogFooter = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<'div'>
+>(({ children, className, ...props }, ref) => (
+  <div {...props} ref={ref} className={cn('graphiql-dialog-footer', className)}>
+    {children}
+  </div>
+));
+DialogFooter.displayName = 'Dialog.Footer';
+
 const DialogRoot: FC<D.DialogProps> = ({ children, ...props }) => {
   return (
     <D.Root {...props}>
@@ -41,4 +83,7 @@ export const Dialog = Object.assign(DialogRoot, {
   Title: D.Title,
   Trigger: D.Trigger,
   Description: D.Description,
+  Header: DialogHeader,
+  Body: DialogBody,
+  Footer: DialogFooter,
 });

--- a/packages/graphiql-react/src/components/dropdown-menu/index.css
+++ b/packages/graphiql-react/src/components/dropdown-menu/index.css
@@ -23,7 +23,7 @@
   margin: var(--px-4);
   outline: none;
   overflow: hidden;
-  padding: var(--px-6) var(--px-8);
+  padding: var(--row-padding-y) var(--row-padding-x);
   text-overflow: ellipsis;
   white-space: nowrap;
 

--- a/packages/graphiql-react/src/components/dropdown-menu/index.tsx
+++ b/packages/graphiql-react/src/components/dropdown-menu/index.tsx
@@ -11,6 +11,7 @@ import {
   Root,
 } from '@radix-ui/react-dropdown-menu';
 import { UnStyledButton } from '../button';
+import { usePortalContainer } from '../portal';
 import './index.css';
 
 const Button = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(
@@ -29,8 +30,9 @@ const Content: FC<DropdownMenuContentProps> = ({
   className,
   ...props
 }) => {
+  const container = usePortalContainer();
   return (
-    <Portal>
+    <Portal container={container}>
       <RadixContent
         align={align}
         sideOffset={sideOffset}

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -14,6 +14,7 @@ export { ButtonGroup } from './button-group';
 export { Dialog } from './dialog';
 export { DropdownMenu } from './dropdown-menu';
 export { MarkdownContent } from './markdown-content';
+export { PortalProvider, usePortalContainer } from './portal';
 export { Spinner } from './spinner';
 export { Tabs, Tab } from './tabs';
 export { Tooltip } from './tooltip';

--- a/packages/graphiql-react/src/components/portal/index.tsx
+++ b/packages/graphiql-react/src/components/portal/index.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, FC, ReactNode } from 'react';
+
+/**
+ * The DOM element that Radix portals (dialog, tooltip, dropdown) render into.
+ *
+ * GraphiQL writes its `data-theme` / `data-density` / `data-font-size`
+ * attributes onto the `.graphiql-container` element, and those attributes drive
+ * the design tokens. Radix portals default to `document.body`, which lives
+ * outside the container, so portaled content would not inherit any of them.
+ * Providing the container here lets each portal render inside it and pick the
+ * tokens up through normal CSS inheritance.
+ *
+ * `undefined` (no provider, e.g. a component rendered standalone in tests or
+ * Storybook) means "use Radix's default" — `document.body`.
+ */
+const PortalContext = createContext<HTMLElement | null | undefined>(undefined);
+
+export const PortalProvider: FC<{
+  container: HTMLElement | null;
+  children: ReactNode;
+}> = ({ container, children }) => (
+  <PortalContext.Provider value={container}>{children}</PortalContext.Provider>
+);
+
+/**
+ * The element Radix portals should render into, or `undefined`/`null` to fall
+ * back to `document.body`. Pass straight to a Radix `Portal`'s `container` prop.
+ */
+export function usePortalContainer(): HTMLElement | null | undefined {
+  return useContext(PortalContext);
+}

--- a/packages/graphiql-react/src/components/settings-dialog/index.css
+++ b/packages/graphiql-react/src/components/settings-dialog/index.css
@@ -2,22 +2,6 @@
   min-width: 360px;
 }
 
-.graphiql-settings-dialog-header {
-  align-items: center;
-  border-bottom: 1px solid oklch(var(--border-default));
-  display: flex;
-  justify-content: space-between;
-  padding: var(--px-12) var(--px-4) var(--px-12) var(--px-16);
-}
-
-.graphiql-settings-dialog-title {
-  color: oklch(var(--fg-strong));
-  font-family: var(--font-family);
-  font-size: var(--font-size-body);
-  font-weight: 600;
-  margin: 0;
-}
-
 .graphiql-settings-dialog-body {
   display: flex;
   flex-direction: column;

--- a/packages/graphiql-react/src/components/settings-dialog/index.tsx
+++ b/packages/graphiql-react/src/components/settings-dialog/index.tsx
@@ -130,12 +130,7 @@ export const SettingsDialog: FC<SettingsDialogProps> = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <div className="graphiql-settings-dialog">
-        <div className="graphiql-settings-dialog-header">
-          <Dialog.Title className="graphiql-settings-dialog-title">
-            Settings
-          </Dialog.Title>
-          <Dialog.Close />
-        </div>
+        <Dialog.Header>Settings</Dialog.Header>
 
         <div className="graphiql-settings-dialog-body">
           {!forcedThemeSetting && (

--- a/packages/graphiql-react/src/components/tooltip/index.tsx
+++ b/packages/graphiql-react/src/components/tooltip/index.tsx
@@ -1,5 +1,6 @@
 import type { FC, ReactNode } from 'react';
 import * as T from '@radix-ui/react-tooltip';
+import { usePortalContainer } from '../portal';
 import './index.css';
 
 export const TooltipRoot: FC<T.TooltipContentProps & { label: ReactNode }> = ({
@@ -9,10 +10,11 @@ export const TooltipRoot: FC<T.TooltipContentProps & { label: ReactNode }> = ({
   sideOffset = 5,
   label,
 }) => {
+  const container = usePortalContainer();
   return (
     <T.Root>
       <T.Trigger asChild>{children}</T.Trigger>
-      <T.Portal>
+      <T.Portal container={container}>
         <T.Content
           className="graphiql-tooltip"
           align={align}

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -8,11 +8,12 @@
   font-variant-ligatures: none;
 }
 
-.graphiql-container,
-.graphiql-dialog,
-.graphiql-dialog-overlay,
-.graphiql-tooltip,
-[data-radix-popper-content-wrapper] {
+/*
+ * Radix portals (dialog, tooltip, dropdown) now render inside
+ * `.graphiql-container` via PortalProvider, so they inherit these variables
+ * through normal DOM ancestry — they no longer need to be re-listed here.
+ */
+.graphiql-container {
   /* Colors */
   --color-primary: 320, 95%, 43%;
   --color-secondary: 242, 51%, 61%;
@@ -75,11 +76,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  body:not(.graphiql-light) .graphiql-container,
-  body:not(.graphiql-light) .graphiql-dialog,
-  body:not(.graphiql-light) .graphiql-dialog-overlay,
-  body:not(.graphiql-light) .graphiql-tooltip,
-  body:not(.graphiql-light) [data-radix-popper-content-wrapper] {
+  body:not(.graphiql-light) .graphiql-container {
     --color-primary: 338, 100%, 67%;
     --color-secondary: 243, 100%, 77%;
     --color-tertiary: 188, 100%, 44%;
@@ -95,11 +92,7 @@
   }
 }
 
-body.graphiql-dark .graphiql-container,
-body.graphiql-dark .graphiql-dialog,
-body.graphiql-dark .graphiql-dialog-overlay,
-body.graphiql-dark .graphiql-tooltip,
-body.graphiql-dark [data-radix-popper-content-wrapper] {
+body.graphiql-dark .graphiql-container {
   --color-primary: 338, 100%, 67%;
   --color-secondary: 243, 100%, 77%;
   --color-tertiary: 188, 100%, 44%;

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -9,9 +9,8 @@
 }
 
 /*
- * Radix portals (dialog, tooltip, dropdown) now render inside
- * `.graphiql-container` via PortalProvider, so they inherit these variables
- * through normal DOM ancestry — they no longer need to be re-listed here.
+ * Radix portals (dialog, tooltip, dropdown) render inside `.graphiql-container`
+ * via PortalProvider, so they inherit these variables through DOM ancestry.
  */
 .graphiql-container {
   /* Colors */

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -133,6 +133,10 @@
   --status-bar-height: 24px;
   --rail-width: 48px;
   --tab-strip-height: 32px;
+  --dialog-padding-x: 16px;
+  --dialog-padding-y: 16px;
+  --dialog-bar-padding-y: 8px;
+  --dialog-gap: 16px;
 }
 
 [data-density='compact'] {
@@ -144,6 +148,10 @@
   --status-bar-height: 20px;
   --rail-width: 42px;
   --tab-strip-height: 26px;
+  --dialog-padding-x: 12px;
+  --dialog-padding-y: 12px;
+  --dialog-bar-padding-y: 6px;
+  --dialog-gap: 12px;
 }
 
 [data-density='spacious'] {
@@ -155,6 +163,10 @@
   --status-bar-height: 30px;
   --rail-width: 56px;
   --tab-strip-height: 40px;
+  --dialog-padding-x: 20px;
+  --dialog-padding-y: 20px;
+  --dialog-bar-padding-y: 12px;
+  --dialog-gap: 20px;
 }
 
 /* -------------------------------------------------------------------------

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -135,7 +135,7 @@
   --tab-strip-height: 32px;
   --dialog-padding-x: 16px;
   --dialog-padding-y: 16px;
-  --dialog-bar-padding-y: 8px;
+  --dialog-bar-padding-y: 6px;
   --dialog-gap: 16px;
 }
 
@@ -150,7 +150,7 @@
   --tab-strip-height: 26px;
   --dialog-padding-x: 12px;
   --dialog-padding-y: 12px;
-  --dialog-bar-padding-y: 6px;
+  --dialog-bar-padding-y: 4px;
   --dialog-gap: 12px;
 }
 
@@ -165,7 +165,7 @@
   --tab-strip-height: 40px;
   --dialog-padding-x: 20px;
   --dialog-padding-y: 20px;
-  --dialog-bar-padding-y: 12px;
+  --dialog-bar-padding-y: 10px;
   --dialog-gap: 20px;
 }
 

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -10,7 +10,7 @@ import type {
   FC,
   ComponentPropsWithoutRef,
 } from 'react';
-import { Children, useRef, Fragment } from 'react';
+import { Children, useRef, useState, Fragment } from 'react';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -18,6 +18,7 @@ import {
   ExecuteButton,
   GraphiQLProvider,
   PlusIcon,
+  PortalProvider,
   PrettifyIcon,
   QueryEditor,
   ResponseEditor,
@@ -263,6 +264,17 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
   const hasMonaco = useMonaco(state => Boolean(state.monaco));
 
   const containerRef = useRef<HTMLDivElement>(null);
+  // Radix portals (dialogs, tooltips, dropdowns) render into this element so
+  // they inherit the container's `data-theme` / `data-density` / `data-font-size`
+  // tokens instead of escaping to `document.body`. It lives in state so portals
+  // re-render into it once the container mounts.
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const setContainerRef = (node: HTMLDivElement | null) => {
+    containerRef.current = node;
+    setPortalContainer(node);
+  };
   useGraphiQLSettings(containerRef);
 
   const pluginResize = useDragResize({
@@ -433,138 +445,146 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
 
   return (
     <Tooltip.Provider>
-      <div ref={containerRef} className={cn('graphiql-container', className)}>
-        <TopBar />
-        <div className="graphiql-body">
-          <ActivityBar
-            forcedTheme={forcedTheme}
-            showPersistHeadersSettings={showPersistHeadersSettings}
-            setHiddenElement={pluginResize.setHiddenElement}
-          />
-          <div className="graphiql-main">
-            <div ref={pluginResize.firstRef} className="graphiql-plugin">
-              <SidePanel />
-            </div>
-            {visiblePlugin && (
-              <div
-                className="graphiql-horizontal-drag-bar"
-                ref={pluginResize.dragBarRef}
-              />
-            )}
-            <div ref={pluginResize.secondRef} className="graphiql-sessions">
-              <div className="graphiql-session-header">
-                <Tabs
-                  ref={tabContainerRef}
-                  values={tabs}
-                  onReorder={moveTab}
-                  aria-label="Select active operation"
-                  className="no-scrollbar"
-                >
-                  {tabs.map((tab, index) => {
-                    const isActive = index === activeTabIndex;
-                    // For the active tab, surface how many other operations the
-                    // document holds alongside the one the cursor is in. Only
-                    // when the active operation is named, so the title reads as
-                    // `<name> +N`; an anonymous active operation has no name to
-                    // anchor the count to.
-                    const otherOperations =
-                      isActive && tab.operationName && operations
-                        ? operations.length - 1
-                        : 0;
-                    const tabTitle =
-                      otherOperations > 0
-                        ? `${tab.title} +${otherOperations}`
-                        : tab.title;
-                    return (
-                      <Tab
-                        key={tab.id}
-                        // Prevent overscroll over container
-                        dragConstraints={tabContainerRef}
-                        value={tab}
-                        isActive={isActive}
-                        isDirty={tab.query !== tab.lastSavedQuery}
-                      >
-                        <Tab.Button
-                          aria-controls="graphiql-session"
-                          id={`graphiql-session-tab-${index}`}
-                          title={tabTitle}
-                          onClick={handleTabClick}
-                        >
-                          {tabTitle}
-                        </Tab.Button>
-                        {tabs.length > 1 && (
-                          <Tab.Close onClick={handleTabClose} />
-                        )}
-                      </Tab>
-                    );
-                  })}
-                </Tabs>
-                <Tooltip label={LABEL.newTab}>
-                  <UnStyledButton
-                    type="button"
-                    className="graphiql-tab-add"
-                    onClick={addTab}
-                    aria-label={LABEL.newTab}
-                  >
-                    <PlusIcon aria-hidden="true" />
-                  </UnStyledButton>
-                </Tooltip>
-                <div className="graphiql-tab-strip-actions">
-                  <Tooltip label={LABEL.prettify}>
-                    <UnStyledButton
-                      type="button"
-                      className="graphiql-tab-strip-action"
-                      onClick={prettifyEditors}
-                      aria-label={LABEL.prettify}
-                    >
-                      <PrettifyIcon aria-hidden="true" />
-                    </UnStyledButton>
-                  </Tooltip>
-                  <Tooltip label={LABEL.copy}>
-                    <UnStyledButton
-                      type="button"
-                      className="graphiql-tab-strip-action"
-                      onClick={copyQuery}
-                      aria-label={LABEL.copy}
-                    >
-                      <CopyIcon aria-hidden="true" />
-                    </UnStyledButton>
-                  </Tooltip>
-                  <Tooltip label={LABEL.save}>
-                    <UnStyledButton
-                      type="button"
-                      className="graphiql-tab-strip-action"
-                      onClick={saveQuery}
-                      aria-label={LABEL.save}
-                    >
-                      <SaveIcon aria-hidden="true" />
-                    </UnStyledButton>
-                  </Tooltip>
-                </div>
-                {logo}
+      <PortalProvider container={portalContainer}>
+        <div
+          ref={setContainerRef}
+          className={cn('graphiql-container', className)}
+        >
+          <TopBar />
+          <div className="graphiql-body">
+            <ActivityBar
+              forcedTheme={forcedTheme}
+              showPersistHeadersSettings={showPersistHeadersSettings}
+              setHiddenElement={pluginResize.setHiddenElement}
+            />
+            <div className="graphiql-main">
+              <div ref={pluginResize.firstRef} className="graphiql-plugin">
+                <SidePanel />
               </div>
-              <div
-                role="tabpanel"
-                id="graphiql-session" // used by aria-controls="graphiql-session"
-                aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
-              >
-                {editors}
+              {visiblePlugin && (
                 <div
                   className="graphiql-horizontal-drag-bar"
-                  ref={editorResize.dragBarRef}
+                  ref={pluginResize.dragBarRef}
                 />
-                <div className="graphiql-response" ref={editorResize.secondRef}>
-                  {isFetching && <Spinner />}
-                  <ResponseEditor responseTooltip={responseTooltip} />
-                  {footer}
+              )}
+              <div ref={pluginResize.secondRef} className="graphiql-sessions">
+                <div className="graphiql-session-header">
+                  <Tabs
+                    ref={tabContainerRef}
+                    values={tabs}
+                    onReorder={moveTab}
+                    aria-label="Select active operation"
+                    className="no-scrollbar"
+                  >
+                    {tabs.map((tab, index) => {
+                      const isActive = index === activeTabIndex;
+                      // For the active tab, surface how many other operations the
+                      // document holds alongside the one the cursor is in. Only
+                      // when the active operation is named, so the title reads as
+                      // `<name> +N`; an anonymous active operation has no name to
+                      // anchor the count to.
+                      const otherOperations =
+                        isActive && tab.operationName && operations
+                          ? operations.length - 1
+                          : 0;
+                      const tabTitle =
+                        otherOperations > 0
+                          ? `${tab.title} +${otherOperations}`
+                          : tab.title;
+                      return (
+                        <Tab
+                          key={tab.id}
+                          // Prevent overscroll over container
+                          dragConstraints={tabContainerRef}
+                          value={tab}
+                          isActive={isActive}
+                          isDirty={tab.query !== tab.lastSavedQuery}
+                        >
+                          <Tab.Button
+                            aria-controls="graphiql-session"
+                            id={`graphiql-session-tab-${index}`}
+                            title={tabTitle}
+                            onClick={handleTabClick}
+                          >
+                            {tabTitle}
+                          </Tab.Button>
+                          {tabs.length > 1 && (
+                            <Tab.Close onClick={handleTabClose} />
+                          )}
+                        </Tab>
+                      );
+                    })}
+                  </Tabs>
+                  <Tooltip label={LABEL.newTab}>
+                    <UnStyledButton
+                      type="button"
+                      className="graphiql-tab-add"
+                      onClick={addTab}
+                      aria-label={LABEL.newTab}
+                    >
+                      <PlusIcon aria-hidden="true" />
+                    </UnStyledButton>
+                  </Tooltip>
+                  <div className="graphiql-tab-strip-actions">
+                    <Tooltip label={LABEL.prettify}>
+                      <UnStyledButton
+                        type="button"
+                        className="graphiql-tab-strip-action"
+                        onClick={prettifyEditors}
+                        aria-label={LABEL.prettify}
+                      >
+                        <PrettifyIcon aria-hidden="true" />
+                      </UnStyledButton>
+                    </Tooltip>
+                    <Tooltip label={LABEL.copy}>
+                      <UnStyledButton
+                        type="button"
+                        className="graphiql-tab-strip-action"
+                        onClick={copyQuery}
+                        aria-label={LABEL.copy}
+                      >
+                        <CopyIcon aria-hidden="true" />
+                      </UnStyledButton>
+                    </Tooltip>
+                    <Tooltip label={LABEL.save}>
+                      <UnStyledButton
+                        type="button"
+                        className="graphiql-tab-strip-action"
+                        onClick={saveQuery}
+                        aria-label={LABEL.save}
+                      >
+                        <SaveIcon aria-hidden="true" />
+                      </UnStyledButton>
+                    </Tooltip>
+                  </div>
+                  {logo}
+                </div>
+                <div
+                  role="tabpanel"
+                  id="graphiql-session" // used by aria-controls="graphiql-session"
+                  aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
+                >
+                  {editors}
+                  <div
+                    className="graphiql-horizontal-drag-bar"
+                    ref={editorResize.dragBarRef}
+                  />
+                  <div
+                    className="graphiql-response"
+                    ref={editorResize.secondRef}
+                  >
+                    {isFetching && <Spinner />}
+                    <ResponseEditor responseTooltip={responseTooltip} />
+                    {footer}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
+          <StatusBar />
         </div>
-        <StatusBar />
-      </div>
-      {children}
+        {children}
+      </PortalProvider>
     </Tooltip.Provider>
   );
 };

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -264,10 +264,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
   const hasMonaco = useMonaco(state => Boolean(state.monaco));
 
   const containerRef = useRef<HTMLDivElement>(null);
-  // Radix portals (dialogs, tooltips, dropdowns) render into this element so
-  // they inherit the container's `data-theme` / `data-density` / `data-font-size`
-  // tokens instead of escaping to `document.body`. It lives in state so portals
-  // re-render into it once the container mounts.
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(
     null,
   );


### PR DESCRIPTION
## Summary

Two related changes to the `@graphiql/react` design system, landed together on the v6 line:

**1. Render Radix portals inside the GraphiQL container.**
`Dialog`, `Tooltip`, and `DropdownMenu` portal through Radix to `document.body` by default — outside `.graphiql-container`, which is where the `data-theme` / `data-density` / `data-font-size` attributes live. So portaled content never inherited those tokens, and `root.css` had to re-list `.graphiql-dialog` / `.graphiql-tooltip` / `[data-radix-popper-content-wrapper]` in its variable-injection blocks to re-inject the values.

A new `PortalProvider` exposes the container element; each Radix `Portal` now receives it via `container`. Portaled content renders inside the container and inherits the appearance tokens through normal CSS ancestry, so dialogs/tooltips/menus respect the user's **density, font-size, and theme** settings. The per-portal re-injection in `root.css` is dropped in favor of inheritance. Falls back to `document.body` when no provider is present (standalone components, tests, Storybook).

**2. Shared, density-aware `Dialog` styling.**
- `Dialog.Header` / `Dialog.Body` / `Dialog.Footer` compound components (header = title + close button + divider; body = padded content; footer = right-aligned actions).
- The header was ~60px tall: the close button padded its 12px icon with another 12px on every side (a 36px box) *and* the header added 12px top/bottom. The padding now lives on the close button with a smaller hit area + hover affordance, and the header is tightened.
- Header/body/footer padding scales with density via new `--dialog-*` tokens; the title picks up `--line-height-body`; dropdown-menu items use the density row padding.
- The settings dialog uses `Dialog.Header`, and the dialog stories are migrated onto the compound components.

## Why

Broken out of the operation-collections PR (#4359), whose save / import-export dialogs needed consistent dialog styles. While wiring those up, the portal-out-of-container issue surfaced as the root cause of dialogs/tooltips not honoring appearance settings — fixing it here makes the whole portal surface consistent by construction.

## Test plan

- [x] `turbo run types:check` passes for `@graphiql/react` and `graphiql`
- [x] `oxlint` / `oxfmt` clean on changed files
- [x] Unit tests pass — new `dialog.test.tsx` asserts portal-into-container vs. body fallback; existing `settings-dialog.test.tsx` still green (21 tests)
- [ ] Visual: open Settings, a dropdown menu, and a tooltip at each density / font-size preset and confirm they scale; verify tooltip/dropdown **positioning** is unaffected by the portal move (collision boundary is now the container)
- [ ] Visual: dialog header is noticeably less chunky; close button has a hover state

## Notes / follow-ups

- `root.css` still pins `--font-size-body` (and `--font-family`) on `.graphiql-container` to legacy v5 values, which shadows the v6 `[data-font-size]` preset for `--font-size-body` container-wide. That's a pre-existing token-migration issue beyond this PR's scope; density, `--icon-size-*`, `--line-height-body`, and `--font-size-small` are unaffected and do scale.