### PR TITLE
Highlight GraphQL string values as strings, not comments

### DIFF
--- a/.changeset/graphql-value-string-highlighting.md
+++ b/.changeset/graphql-value-string-highlighting.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Highlight GraphQL string values — including single-line and block (triple-quoted) strings in directive and field arguments, list items, and default values — as strings instead of comments. Descriptions are now scoped as documentation (`comment.block.documentation` / `comment.line.documentation`) so themes can style them distinctly while still defaulting to comment colors.

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -8,6 +8,7 @@
       "patterns": [
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-string" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-fragment-definition" },
         { "include": "#graphql-directive-definition" },
@@ -47,7 +48,7 @@
         },
         { "include": "#graphql-variable-definitions" },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-selection-set" },
         { "include": "#graphql-directive" },
@@ -88,7 +89,7 @@
               }
             },
             { "include": "#graphql-comment" },
-            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-block-string-value" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-directive" },
             { "include": "#graphql-ampersand" },
@@ -96,7 +97,7 @@
           ]
         },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-directive" },
         { "include": "#graphql-type-object" },
@@ -120,6 +121,7 @@
       "patterns": [
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-string" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-object-type" },
         { "include": "#graphql-type-definition" },
@@ -138,13 +140,14 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-directive" },
         { "include": "#graphql-variable-definitions" },
         { "include": "#graphql-type-object" },
         { "include": "#graphql-colon" },
         { "include": "#graphql-input-types" },
+        { "include": "#graphql-variable-assignment" },
         { "include": "#literal-quasi-embedded" }
       ]
     },
@@ -182,20 +185,20 @@
                   }
                 },
                 { "include": "#graphql-comment" },
-                { "include": "#graphql-description-docstring" },
+                { "include": "#graphql-block-string-value" },
                 { "include": "#graphql-description-singleline" },
                 { "include": "#graphql-colon" },
                 { "include": "#graphql-skip-newlines" }
               ]
             },
             { "include": "#graphql-comment" },
-            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-block-string-value" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-skip-newlines" }
           ]
         },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-directive" },
         { "include": "#graphql-skip-newlines" }
@@ -212,37 +215,49 @@
               "name": "punctuation.whitespace.comment.leading.graphql"
             }
           }
-        },
-        {
-          "name": "comment.line.graphql.js",
-          "begin": "(\"\"\")",
-          "end": "(\"\"\")",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.whitespace.comment.leading.graphql"
-            }
-          }
-        },
-        {
-          "name": "comment.line.graphql.js",
-          "begin": "(\")",
-          "end": "(\")",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.whitespace.comment.leading.graphql"
-            }
-          }
         }
       ]
+    },
+    "graphql-description-string": {
+      "comment": "single-line string description; included only in definition positions, never where a string value can appear",
+      "name": "comment.line.documentation.graphql",
+      "begin": "(\")",
+      "end": "(\")",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.whitespace.comment.leading.graphql"
+        }
+      }
     },
     "graphql-description-singleline": {
       "name": "comment.line.number-sign.graphql",
       "match": "#(?=([^\"]*\"[^\"]*\")*[^\"]*$).*$"
     },
     "graphql-description-docstring": {
-      "name": "comment.block.graphql",
+      "name": "comment.block.documentation.graphql",
       "begin": "\"\"\"",
       "end": "\"\"\""
+    },
+    "graphql-block-string-value": {
+      "comment": "triple-quoted block string used as a value; not a description",
+      "contentName": "string.quoted.triple.graphql",
+      "begin": "\\s*+((\"\"\"))",
+      "end": "((\"\"\"))",
+      "beginCaptures": {
+        "1": { "name": "string.quoted.triple.graphql" },
+        "2": { "name": "punctuation.definition.string.begin.graphql" }
+      },
+      "endCaptures": {
+        "1": { "name": "string.quoted.triple.graphql" },
+        "2": { "name": "punctuation.definition.string.end.graphql" }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.graphql",
+          "match": "\\\\\"\"\""
+        },
+        { "include": "#literal-quasi-embedded" }
+      ]
     },
     "graphql-variable-definitions": {
       "begin": "\\s*(\\()",
@@ -253,6 +268,7 @@
       "patterns": [
         { "include": "#graphql-comment" },
         { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-description-string" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-variable-definition" },
         { "include": "#literal-quasi-embedded" }
@@ -271,7 +287,7 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-directive" },
         { "include": "#graphql-colon" },
@@ -301,7 +317,7 @@
           },
           "patterns": [
             { "include": "#graphql-comment" },
-            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-block-string-value" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-input-types" },
             { "include": "#graphql-comma" },
@@ -372,7 +388,7 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-arguments" },
         { "include": "#literal-quasi-embedded" },
@@ -462,7 +478,7 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-field" },
         { "include": "#graphql-fragment-spread" },
@@ -505,7 +521,7 @@
       "patterns": [
         { "include": "#graphql-arguments" },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-selection-set" },
         { "include": "#graphql-directive" },
@@ -524,7 +540,7 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-selection-set" },
         { "include": "#graphql-directive" },
@@ -544,7 +560,7 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         {
           "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?:\\s*(:))",
@@ -558,7 +574,7 @@
           },
           "patterns": [
             { "include": "#graphql-comment" },
-            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-block-string-value" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-directive" },
             { "include": "#graphql-value" },
@@ -646,6 +662,7 @@
 
             { "include": "#graphql-comment" },
             { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-description-string" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-directive" },
             { "include": "#graphql-enum-value" },
@@ -653,7 +670,7 @@
           ]
         },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-directive" }
       ]
@@ -665,7 +682,7 @@
     "graphql-value": {
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-variable-name" },
         { "include": "#graphql-float-value" },
         { "include": "#graphql-string-value" },
@@ -739,7 +756,7 @@
           },
           "patterns": [
             { "include": "#graphql-comment" },
-            { "include": "#graphql-description-docstring" },
+            { "include": "#graphql-block-string-value" },
             { "include": "#graphql-description-singleline" },
             { "include": "#graphql-skip-newlines" },
             { "include": "#literal-quasi-embedded" },
@@ -753,7 +770,7 @@
           ]
         },
         { "include": "#graphql-comment" },
-        { "include": "#graphql-description-docstring" },
+        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-skip-newlines" },
         { "include": "#literal-quasi-embedded" }

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/descriptions-and-values.graphql
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/descriptions-and-values.graphql
@@ -1,0 +1,54 @@
+# a hash comment stays a comment
+
+"Top-level type description"
+type User {
+  "Field description"
+  fullName(
+    "Argument description"
+    prefix: String = "Mr."
+  ): String @deprecated(reason: "use displayName")
+  tags(filter: [String!] = ["active", "verified"]): [String!]!
+}
+
+"Input description"
+input UserFilter {
+  "Input field description"
+  limit: Int = 10
+  name: String = "anon"
+  note: String = """block string default value"""
+}
+
+"""
+Block description
+"""
+enum Role {
+  "Enum value description"
+  ADMIN
+  MEMBER
+}
+
+directive @sample(
+  "Directive argument description"
+  mode: String = "fast"
+) on FIELD_DEFINITION
+
+query {
+  search(term: "single line value", body: """block string value""") {
+    id
+  }
+}
+
+"Operation description"
+query GetUser(
+  "Variable description"
+  $id: ID = "default-id"
+) {
+  user(id: $id) {
+    ...UserFields
+  }
+}
+
+"Fragment description"
+fragment UserFields on User {
+  name
+}

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/descriptions-and-values.graphql
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/descriptions-and-values.graphql
@@ -3,10 +3,8 @@
 "Top-level type description"
 type User {
   "Field description"
-  fullName(
-    "Argument description"
-    prefix: String = "Mr."
-  ): String @deprecated(reason: "use displayName")
+  fullName("Argument description" prefix: String = "Mr."): String
+    @deprecated(reason: "use displayName")
   tags(filter: [String!] = ["active", "verified"]): [String!]!
 }
 
@@ -15,7 +13,9 @@ input UserFilter {
   "Input field description"
   limit: Int = 10
   name: String = "anon"
-  note: String = """block string default value"""
+  note: String = """
+  block string default value
+  """
 }
 
 """
@@ -33,7 +33,12 @@ directive @sample(
 ) on FIELD_DEFINITION
 
 query {
-  search(term: "single line value", body: """block string value""") {
+  search(
+    term: "single line value"
+    body: """
+    block string value
+    """
+  ) {
     id
   }
 }

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -29,7 +29,7 @@ const graphql = graphql`
 `;
 
 const graphql = graphql(`
-  """ this is a comment """
+  """ this is an operation description """
   query {
     user(id: "5", name: ${variable}) {
       something
@@ -84,7 +84,7 @@ const queryWithInlineComment = `
 
 const queryWithLeadingComment = /* GraphQL */ `
   query {
-    """ this is a comment """
+    # this is a comment
     user(id: "5", name: boolean) {
       something
     }

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
@@ -497,7 +497,10 @@ value                  | meta.type.interface.graphql meta.type.object.graphql va
 :                      | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
                        | meta.type.interface.graphql meta.type.object.graphql
 Int                    | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
- = 42                  | meta.type.interface.graphql meta.type.object.graphql
+                       | meta.type.interface.graphql meta.type.object.graphql
+=                      | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
+                       | meta.type.interface.graphql meta.type.object.graphql
+42                     | meta.type.interface.graphql meta.type.object.graphql constant.numeric.float.graphql
 }                      | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
                        | 
 interface              | meta.type.interface.graphql keyword.interface.graphql
@@ -644,4 +647,260 @@ Droid                  | support.type.graphql
                        | 
 TestType               | support.type.graphql
                        | 
+`;
+
+exports[`source.graphql grammar > should tokenize descriptions as documentation and argument values as strings 1`] = `
+# a hash comment stays a comment | comment.line.graphql.js
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Top-level type description       | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+type                             | meta.type.interface.graphql keyword.type.graphql
+                                 | meta.type.interface.graphql
+User                             | meta.type.interface.graphql support.type.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+{                                | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Field description                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+fullName                         | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+(                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Argument description             | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+prefix                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+=                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.assignment.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+Mr.                              | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+)                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+@deprecated                      | meta.type.interface.graphql meta.type.object.graphql entity.name.function.directive.graphql
+(                                | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+reason                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql variable.parameter.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+use displayName                  | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+)                                | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+tags                             | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+(                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+filter                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql
+[                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql meta.brace.square.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql support.type.builtin.graphql
+!                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql keyword.operator.nulltype.graphql
+]                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql meta.brace.square.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+=                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.assignment.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql
+[                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql meta.brace.square.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+active                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+verified                         | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+]                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.listvalues.graphql meta.brace.square.graphql
+)                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql
+[                                | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql meta.brace.square.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql support.type.builtin.graphql
+!                                | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql keyword.operator.nulltype.graphql
+]                                | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql meta.brace.square.graphql
+!                                | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql keyword.operator.nulltype.graphql
+}                                | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Input description                | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+input                            | meta.type.interface.graphql keyword.input.graphql
+                                 | meta.type.interface.graphql
+UserFilter                       | meta.type.interface.graphql support.type.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+{                                | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Input field description          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+limit                            | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+Int                              | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+=                                | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+10                               | meta.type.interface.graphql meta.type.object.graphql constant.numeric.float.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+name                             | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+=                                | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+anon                             | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql
+"                                | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+note                             | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+String                           | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+=                                | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql
+"""                              | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
+block string default value       | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql
+"""                              | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
+}                                | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | 
+"""                              | comment.block.documentation.graphql
+Block description                | comment.block.documentation.graphql
+"""                              | comment.block.documentation.graphql
+enum                             | meta.enum.graphql keyword.enum.graphql
+                                 | meta.enum.graphql
+Role                             | meta.enum.graphql support.type.enum.graphql
+                                 | meta.enum.graphql meta.type.object.graphql
+{                                | meta.enum.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | meta.enum.graphql meta.type.object.graphql
+"                                | meta.enum.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Enum value description           | meta.enum.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                | meta.enum.graphql meta.type.object.graphql comment.line.documentation.graphql
+  ADMIN                          | meta.enum.graphql meta.type.object.graphql constant.character.enum.graphql
+  MEMBER                         | meta.enum.graphql meta.type.object.graphql constant.character.enum.graphql
+}                                | meta.enum.graphql meta.type.object.graphql punctuation.operation.graphql
+                                 | 
+directive                        | keyword.directive.graphql
+                                 | 
+@sample                          | entity.name.function.directive.graphql
+(                                | meta.brace.round.graphql
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Directive argument description   | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+                                 | meta.variables.graphql
+mode                             | meta.variables.graphql variable.parameter.graphql
+:                                | meta.variables.graphql punctuation.colon.graphql
+                                 | meta.variables.graphql
+String                           | meta.variables.graphql support.type.builtin.graphql
+                                 | meta.variables.graphql
+=                                | meta.variables.graphql punctuation.assignment.graphql
+                                 | meta.variables.graphql
+"                                | meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+fast                             | meta.variables.graphql string.quoted.double.graphql
+"                                | meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+)                                | meta.brace.round.graphql
+                                 | 
+on                               | keyword.on.graphql
+                                 | 
+FIELD_DEFINITION                 | support.type.location.graphql
+                                 | 
+query                            | keyword.operation.graphql
+                                 | meta.selectionset.graphql
+{                                | meta.selectionset.graphql punctuation.operation.graphql
+                                 | meta.selectionset.graphql
+search                           | meta.selectionset.graphql variable.graphql
+(                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+term                             | meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                | meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
+"                                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+single line value                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                | meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
+body                             | meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                | meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
+"""                              | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
+block string value               | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql
+"""                              | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
+)                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+{                                | meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+id                               | meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+}                                | meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+}                                | meta.selectionset.graphql punctuation.operation.graphql
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Operation description            | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+query                            | keyword.operation.graphql
+                                 | 
+GetUser                          | entity.name.function.graphql
+(                                | meta.brace.round.graphql
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Variable description             | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+                                 | meta.variables.graphql
+$id                              | meta.variables.graphql variable.parameter.graphql
+:                                | meta.variables.graphql punctuation.colon.graphql
+                                 | meta.variables.graphql
+ID                               | meta.variables.graphql support.type.builtin.graphql
+                                 | meta.variables.graphql
+=                                | meta.variables.graphql punctuation.assignment.graphql
+                                 | meta.variables.graphql
+"                                | meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+default-id                       | meta.variables.graphql string.quoted.double.graphql
+"                                | meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+)                                | meta.brace.round.graphql
+                                 | meta.selectionset.graphql
+{                                | meta.selectionset.graphql punctuation.operation.graphql
+                                 | meta.selectionset.graphql
+user                             | meta.selectionset.graphql variable.graphql
+(                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                               | meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                | meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
+$id                              | meta.selectionset.graphql meta.arguments.graphql variable.graphql
+)                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+{                                | meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+...                              | meta.selectionset.graphql meta.selectionset.graphql keyword.operator.spread.graphql
+UserFields                       | meta.selectionset.graphql meta.selectionset.graphql variable.fragment.graphql
+                                 | meta.selectionset.graphql meta.selectionset.graphql
+}                                | meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+}                                | meta.selectionset.graphql punctuation.operation.graphql
+                                 | 
+"                                | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Fragment description             | comment.line.documentation.graphql
+"                                | comment.line.documentation.graphql
+fragment                         | meta.fragment.graphql keyword.fragment.graphql
+                                 | meta.fragment.graphql
+UserFields                       | meta.fragment.graphql entity.name.fragment.graphql
+                                 | meta.fragment.graphql
+on                               | meta.fragment.graphql keyword.on.graphql
+                                 | meta.fragment.graphql
+User                             | meta.fragment.graphql support.type.graphql
+                                 | meta.fragment.graphql meta.selectionset.graphql
+{                                | meta.fragment.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                 | meta.fragment.graphql meta.selectionset.graphql
+name                             | meta.fragment.graphql meta.selectionset.graphql variable.graphql
+}                                | meta.fragment.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                 | 
 `;

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
@@ -667,7 +667,6 @@ Field description                | meta.type.interface.graphql meta.type.object.
                                  | meta.type.interface.graphql meta.type.object.graphql
 fullName                         | meta.type.interface.graphql meta.type.object.graphql variable.graphql
 (                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
-                                 | meta.type.interface.graphql meta.type.object.graphql
 "                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
 Argument description             | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
 "                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
@@ -682,7 +681,6 @@ String                           | meta.type.interface.graphql meta.type.object.
 "                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
 Mr.                              | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql
 "                                | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-                                 | meta.type.interface.graphql meta.type.object.graphql
 )                                | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
 :                                | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
                                  | meta.type.interface.graphql meta.type.object.graphql
@@ -771,7 +769,8 @@ String                           | meta.type.interface.graphql meta.type.object.
 =                                | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
                                  | meta.type.interface.graphql meta.type.object.graphql
 """                              | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
-block string default value       | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql
+  block string default value     | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql
+                                 | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql
 """                              | meta.type.interface.graphql meta.type.object.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
 }                                | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
                                  | 
@@ -822,20 +821,22 @@ query                            | keyword.operation.graphql
                                  | meta.selectionset.graphql
 search                           | meta.selectionset.graphql variable.graphql
 (                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
 term                             | meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
 :                                | meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
                                  | meta.selectionset.graphql meta.arguments.graphql
 "                                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
 single line value                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
 "                                | meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                | meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
                                  | meta.selectionset.graphql meta.arguments.graphql
 body                             | meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
 :                                | meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
                                  | meta.selectionset.graphql meta.arguments.graphql
 """                              | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
-block string value               | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql
+    block string value           | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql
 """                              | meta.selectionset.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
+                                 | meta.selectionset.graphql meta.arguments.graphql
 )                                | meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
                                  | meta.selectionset.graphql meta.selectionset.graphql
 {                                | meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -177,9 +177,9 @@ graphql                                | entity.name.function.tagged-template.js
 (                                      | 
 \`                                      | punctuation.definition.string.template.begin.js
                                        | meta.embedded.block.graphql
-"""                                    | meta.embedded.block.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                     | meta.embedded.block.graphql comment.line.graphql.js
-"""                                    | meta.embedded.block.graphql comment.line.graphql.js
+"""                                    | meta.embedded.block.graphql comment.block.documentation.graphql
+ this is an operation description      | meta.embedded.block.graphql comment.block.documentation.graphql
+"""                                    | meta.embedded.block.graphql comment.block.documentation.graphql
                                        | meta.embedded.block.graphql
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
@@ -418,10 +418,8 @@ const queryWithLeadingComment =        |
 query                                  | meta.embedded.block.graphql keyword.operation.graphql
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 {                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
- this is a comment                     | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-"""                                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+                                       | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+# this is a comment                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
                                        | meta.embedded.block.graphql meta.selectionset.graphql
 user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
 (                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql

--- a/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
@@ -22,4 +22,11 @@ describe('source.graphql grammar', () => {
     );
     expect(result).toMatchSnapshot();
   });
+  it('should tokenize descriptions as documentation and argument values as strings', async () => {
+    const result = await tokenizeFile(
+      '__fixtures__/descriptions-and-values.graphql',
+      scope,
+    );
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

- GraphQL string values — single-line and block (triple-quoted) — in directive and field arguments, list items, and default values are now highlighted as strings (`string.quoted.double.graphql` / `string.quoted.triple.graphql`) instead of comments. The grammar's comment rule previously matched any `"…"`, so argument and default string values were scoped as comments.
- Descriptions are scoped as documentation (`comment.block.documentation.graphql` / `comment.line.documentation.graphql`) and only in valid description positions per the GraphQL spec — type-system definitions and executable operation, fragment, and variable descriptions — so themes can distinguish them while still defaulting to comment coloring.
- Field and input default values are now tokenized (the `=` and value on a field definition were previously left unscoped).

## Test plan

- `yarn workspace vscode-graphql-syntax test` passes.
- Added a `descriptions-and-values.graphql` fixture and snapshot covering descriptions in every valid position and string values (single- and triple-quoted) across arguments, lists, and default values; updated the embedded-GraphQL fixture to distinguish an operation description from a `#` comment.

Closes #2358

_Drafted by Claude (Anthropic AI assistant)._
