### PR TITLE
v6: Stop unstyled buttons from leaking the native `buttonface` background

### DIFF
--- a/.changeset/quiet-plums-relax.md
+++ b/.changeset/quiet-plums-relax.md
@@ -2,4 +2,4 @@
 '@graphiql/react': patch
 ---
 
-Make `useGraphiQLSettings` the single writer of the `data-theme` attribute (scoped to the GraphiQL container) by dropping a redundant write to `<html>` from the theme store.
+Stop unstyled buttons (`.graphiql-un-styled`) from painting the native `buttonface` background, which ignored the active theme when the OS color scheme differed from it. Also make `useGraphiQLSettings` the single writer of the `data-theme` attribute by dropping a redundant `<html>` write from the theme store.

--- a/.changeset/quiet-plums-relax.md
+++ b/.changeset/quiet-plums-relax.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Make `useGraphiQLSettings` the single writer of the `data-theme` attribute (scoped to the GraphiQL container) by dropping a redundant write to `<html>` from the theme store.

--- a/packages/graphiql-react/src/components/button/index.css
+++ b/packages/graphiql-react/src/components/button/index.css
@@ -1,5 +1,9 @@
 .graphiql-un-styled {
   all: unset;
+  /* `all: unset` leaves the native button appearance, which paints a UA
+     `buttonface` background that ignores the theme (visible when the OS color
+     scheme differs from the active theme). Clear it explicitly. */
+  background: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
 

--- a/packages/graphiql-react/src/stores/theme.ts
+++ b/packages/graphiql-react/src/stores/theme.ts
@@ -60,10 +60,12 @@ export const createThemeSlice: CreateThemeSlice =
         document.body.classList.remove('graphiql-light', 'graphiql-dark');
         if (theme) {
           document.body.classList.add(`graphiql-${theme}`);
-          document.documentElement.setAttribute('data-theme', theme);
-        } else {
-          document.documentElement.removeAttribute('data-theme');
         }
+        // `data-theme` (the v6 design-token attribute) is owned by
+        // `useGraphiQLSettings`, which scopes it to the GraphiQL container so
+        // portaled overlays inherit it. Writing it here too would race that
+        // writer and — since the token selectors are unscoped attribute
+        // selectors — leak the theme onto the whole document.
         const { monaco } = monacoStore.getState();
         const resolvedTheme = theme ?? getSystemTheme();
         const monacoTheme = editorTheme![resolvedTheme];


### PR DESCRIPTION
Two small theming fixes:

- **Unstyled buttons no longer leak the native `buttonface` background.** `.graphiql-un-styled` relies on `all: unset`, but that leaves the native button appearance, so these buttons painted a UA `buttonface` background that ignored the active theme whenever the OS color scheme differed from it. Setting `background: none` clears it.
- **Single writer for `data-theme`.** `useGraphiQLSettings` already writes `data-theme` to the GraphiQL container, which is where dialogs, dropdowns, and tooltips portal (via #4381); `stores/theme.ts` was redundantly writing it to `<html>` too. Dropping that write leaves one source of truth.

Refs: graphql/graphiql#4219
