### PR TITLE
v6: Drop the deprecated `legacyClient` fetcher alias

### DIFF
--- a/.changeset/drop-legacy-client-alias.md
+++ b/.changeset/drop-legacy-client-alias.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/toolkit': major
+---
+
+Remove the deprecated `legacyClient` alias from `CreateFetcherOptions`. It duplicated `legacyWsClient` — pass `legacyWsClient` instead.

--- a/docs/migration/graphiql-6.0.0.md
+++ b/docs/migration/graphiql-6.0.0.md
@@ -163,6 +163,8 @@ See the [`@graphiql/react` README](../../packages/graphiql-react/README.md#avail
 
 The HTTP options object carries over. Subscriptions are different: `createTransport` does not build a subscription client for you. You construct your own `graphql-ws` (or `graphql-sse`) client and pass it as `subscriptionClient`. There is no `subscriptionUrl`, `wsClient`, `legacyWsClient`, or `wsConnectionParams` option on `createTransport` — those remain `createGraphiQLFetcher`-only.
 
+One of those `createGraphiQLFetcher` options did change: the deprecated `legacyClient` alias has been removed. It was a duplicate name for `legacyWsClient`, so if you passed `legacyClient`, rename it to `legacyWsClient` — same `subscriptions-transport-ws` client, one name instead of two.
+
 **Before:**
 
 ```ts

--- a/packages/graphiql-toolkit/docs/create-fetcher.md
+++ b/packages/graphiql-toolkit/docs/create-fetcher.md
@@ -116,7 +116,7 @@ const App = () => {
 };
 ```
 
-### `legacyWsClient` or `legacyClient`
+### `legacyWsClient`
 
 Provide a legacy subscriptions client using `subscriptions-transport-ws`
 protocol. Using this option bypasses `subscriptionUrl`. In theory, this could be
@@ -162,11 +162,11 @@ const root = createRoot(document.getElementById('graphiql'));
 root.render(<App />);
 ```
 
-### Custom `legacyClient` Example
+### Custom `legacyWsClient` Example
 
 (not recommended)
 
-By providing the `legacyClient` you can support a `subscriptions-transport-ws`
+By providing the `legacyWsClient` you can support a `subscriptions-transport-ws`
 client implementation, or equivalent:
 
 ```jsx

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/buildFetcher.spec.ts
@@ -118,16 +118,16 @@ describe('createGraphiQLFetcher', () => {
     expect(createWebsocketsFetcherFromUrl.mock.calls).toEqual([]);
   });
 
-  it('returns fetcher with custom legacyClient', () => {
+  it('returns fetcher with custom legacyWsClient', () => {
     // @ts-expect-error
     createClient.mockReturnValue('WSClient');
     // @ts-expect-error
     createLegacyWebsocketsFetcher.mockReturnValue('CustomWSSFetcher');
 
-    const legacyClient = new SubscriptionClient(wssURL);
+    const legacyWsClient = new SubscriptionClient(wssURL);
     const args = {
       url: serverURL,
-      legacyClient,
+      legacyWsClient,
       enableIncrementalDelivery: true,
     };
 

--- a/packages/graphiql-toolkit/src/create-fetcher/__tests__/lib.spec.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/__tests__/lib.spec.ts
@@ -77,10 +77,10 @@ describe('getWsFetcher', () => {
     await getWsFetcher({ url: '', wsClient: true });
     expect(createClient.mock.calls).toHaveLength(0);
   });
-  it('creates a subscriptions-transports-ws observable when custom legacyClient option is provided', async () => {
+  it('creates a subscriptions-transports-ws observable when custom legacyWsClient option is provided', async () => {
     // @ts-expect-error
     createClient.mockReturnValue(true);
-    await getWsFetcher({ url: '', legacyClient: true });
+    await getWsFetcher({ url: '', legacyWsClient: true });
     expect(createClient.mock.calls).toHaveLength(0);
     expect(SubscriptionClient.mock.calls).toHaveLength(0);
   });

--- a/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/createFetcher.ts
@@ -52,7 +52,7 @@ export function createGraphiQLFetcher(options: CreateFetcherOptions): Fetcher {
           `Your GraphiQL createFetcher is not properly configured for websocket subscriptions yet. ${
             options.subscriptionUrl
               ? `Provided URL ${options.subscriptionUrl} failed`
-              : 'Please provide subscriptionUrl, wsClient or legacyClient option first.'
+              : 'Please provide subscriptionUrl, wsClient or legacyWsClient option first.'
           }`,
         );
       }

--- a/packages/graphiql-toolkit/src/create-fetcher/lib.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/lib.ts
@@ -386,7 +386,7 @@ export const createMultipartFetcher = (
   };
 
 /**
- * If `wsClient` or `legacyClient` are provided, then `subscriptionUrl` is overridden.
+ * If `wsClient` or `legacyWsClient` are provided, then `subscriptionUrl` is overridden.
  */
 export async function getWsFetcher(
   options: CreateFetcherOptions,
@@ -401,8 +401,7 @@ export async function getWsFetcher(
       ...fetcherOpts?.headers,
     });
   }
-  const legacyWebsocketsClient = options.legacyClient || options.legacyWsClient;
-  if (legacyWebsocketsClient) {
-    return createLegacyWebsocketsFetcher(legacyWebsocketsClient);
+  if (options.legacyWsClient) {
+    return createLegacyWebsocketsFetcher(options.legacyWsClient);
   }
 }

--- a/packages/graphiql-toolkit/src/create-fetcher/types.ts
+++ b/packages/graphiql-toolkit/src/create-fetcher/types.ts
@@ -112,10 +112,6 @@ export interface CreateFetcherOptions {
    */
   legacyWsClient?: any;
   /**
-   * alias for `legacyWsClient`
-   */
-  legacyClient?: any;
-  /**
    * Request headers you can provide statically.
    *
    * If you enable the request headers editor and the user provides


### PR DESCRIPTION
## Summary

Removes the deprecated `legacyClient` field from `CreateFetcherOptions` in `@graphiql/toolkit`. It was just a duplicate name for `legacyWsClient`, and having two names for one option is a needless footgun. Anyone on the `subscriptions-transport-ws` path keeps using `legacyWsClient` exactly as before.

The 6.0 migration guide gets a short note documenting the rename.

## Test plan

- [x] Pass a fetcher config with only `legacyWsClient` set to `createGraphiQLFetcher` and confirm subscriptions still route through the legacy websocket client as before.
- [x] Check the `CreateFetcherOptions` type in an editor and confirm `legacyClient` no longer autocompletes, and passing it is a type error.
- [x] Open `docs/migration/graphiql-6.0.0.md` and confirm the `createGraphiQLFetcher` section notes the `legacyClient` → `legacyWsClient` rename.

Refs: graphql/graphiql#4219
