### PR TITLE
v6: Tune light-theme tokens for WCAG AA contrast

### DIFF
--- a/.changeset/light-theme-token-tuning.md
+++ b/.changeset/light-theme-token-tuning.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': patch
+'@graphiql/plugin-query-builder': patch
+---
+
+Tune light theme tokens so borders, muted text, and several accent colors meet WCAG AA contrast. Dividers between panels are easier to see, disabled/dim text is more legible, and the orange and purple accent colors read correctly against light backgrounds. The green/red status buttons and the query builder's "inline argument" toggle now use white text in light theme so they stay readable.

--- a/packages/graphiql-plugin-query-builder/src/style.css
+++ b/packages/graphiql-plugin-query-builder/src/style.css
@@ -524,10 +524,14 @@ select.graphiql-qb-arg-select:focus {
 
 .graphiql-qb-var-toggle[aria-pressed='true'] {
   background: oklch(var(--accent-purple));
-  /* Dark purple background in light theme, light purple in dark theme.
-     Near-black text keeps ≥ 4.5:1 contrast on both surfaces. */
+  /* Light theme's accent-purple is dark enough that it needs light text;
+     dark theme's is light enough that it needs near-black text. */
   color: oklch(10% 0 0);
   border-color: transparent;
+
+  [data-theme='light'] & {
+    color: #fff;
+  }
 }
 
 .graphiql-qb-var-badge {

--- a/packages/graphiql-react/src/components/button/index.css
+++ b/packages/graphiql-react/src/components/button/index.css
@@ -57,10 +57,18 @@ button.graphiql-button {
     background-color: oklch(var(--accent-green));
     border-color: oklch(var(--accent-green));
     color: #000;
+
+    [data-theme='light'] & {
+      color: #fff;
+    }
   }
   &.graphiql-button-error {
     background-color: oklch(var(--accent-red));
     border-color: oklch(var(--accent-red));
     color: #000;
+
+    [data-theme='light'] & {
+      color: #fff;
+    }
   }
 }

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -82,27 +82,31 @@
   --bg-subtle: 96% 0.008 248;
   --bg-overlay: 92% 0.01 248;
 
-  /* Borders */
-  --border-default: 90% 0.01 248;
-  --border-muted: 85% 0.01 248;
-  --border-strong: 78% 0.012 248;
+  /* Borders — higher chroma than the dark theme so dividers hold up against
+   * the brighter backgrounds. */
+  --border-default: 86% 0.016 248;
+  --border-muted: 80% 0.018 248;
+  --border-strong: 72% 0.02 248;
 
   /* Foreground */
   --fg-default: 20% 0.013 248;
   --fg-strong: 12% 0.011 248;
   --fg-muted: 40% 0.013 248;
   --fg-subtle: 50% 0.012 248;
-  --fg-disabled: 65% 0.012 248;
-  --fg-dim: 75% 0.011 248;
+  --fg-disabled: 46% 0.012 248;
+  --fg-dim: 55% 0.011 248;
 
   /* Accents — slightly darker / more saturated for AA contrast on light bg */
   --accent-blue: 50% 0.193 248;
   --accent-green: 50% 0.176 145;
-  --accent-green-light: 65% 0.19 145;
+  /* Used as text (field/enum names), so on a light background it has to sit
+   * darker than `--accent-green` to clear AA — despite the "light" name, which
+   * describes its dark-theme appearance. Don't lighten it. */
+  --accent-green-light: 42% 0.19 145;
   --accent-yellow: 70% 0.15 86;
-  --accent-orange: 62% 0.165 60;
+  --accent-orange: 48% 0.165 60;
   --accent-red: 55% 0.224 27;
-  --accent-purple: 55% 0.18 295;
+  --accent-purple: 45% 0.18 295;
   --accent-pink: 58% 0.22 17;
 
   /* Action button (Run) — keeps the green; inverted bg lets it stand out */
@@ -232,22 +236,22 @@
     --bg-elevated: 100% 0 248;
     --bg-subtle: 96% 0.008 248;
     --bg-overlay: 92% 0.01 248;
-    --border-default: 90% 0.01 248;
-    --border-muted: 85% 0.01 248;
-    --border-strong: 78% 0.012 248;
+    --border-default: 86% 0.016 248;
+    --border-muted: 80% 0.018 248;
+    --border-strong: 72% 0.02 248;
     --fg-default: 20% 0.013 248;
     --fg-strong: 12% 0.011 248;
     --fg-muted: 40% 0.013 248;
     --fg-subtle: 50% 0.012 248;
-    --fg-disabled: 65% 0.012 248;
-    --fg-dim: 75% 0.011 248;
+    --fg-disabled: 46% 0.012 248;
+    --fg-dim: 55% 0.011 248;
     --accent-blue: 50% 0.193 248;
     --accent-green: 50% 0.176 145;
-    --accent-green-light: 65% 0.19 145;
+    --accent-green-light: 42% 0.19 145;
     --accent-yellow: 70% 0.15 86;
-    --accent-orange: 62% 0.165 60;
+    --accent-orange: 48% 0.165 60;
     --accent-red: 55% 0.224 27;
-    --accent-purple: 55% 0.18 295;
+    --accent-purple: 45% 0.18 295;
     --accent-pink: 58% 0.22 17;
     --btn-primary: 51% 0.15 145;
     --btn-primary-border: 45% 0.17 145;


### PR DESCRIPTION
## Summary

Went through the light theme tokens in `tokens.css` looking for contrast problems. Walking every Storybook story with the a11y addon turned up several real WCAG AA failures once actual component CSS rendered against the light palette, not just the raw token values in isolation:

- The panel dividers (`--border-default`, `--border-muted`, `--border-strong`) were nearly invisible against the light backgrounds — the activity rail and side panel dividers basically disappeared. Bumped their chroma and dropped lightness a bit so they hold up without changing the overall look.
- `--fg-disabled` and `--fg-dim` didn't hit 4.5:1 against `--bg-canvas`. Both get used as real text, not just decoration: search placeholders, disabled dropdown items, count badges and colons in the doc explorer.
- `--accent-green-light` is used as the link/text color for field and enum names in the doc explorer, and it was too washed out to pass as text.
- `--accent-orange` and `--accent-purple` failed wherever they show up as text: response tree values, query builder field types, the top bar's method toggle. Darkened both.
- Darkening `--accent-green`/`--accent-red` meant the black text on the "Copied!" and "Failed" status buttons stopped clearing 4.5:1. Same issue hit the query builder's purple "inline argument" toggle. Both switch to white text in light theme now.

Dark theme is untouched, and I didn't reach for new hues — just adjusted lightness/chroma on the existing palette.

A few deliberate calls worth calling out:

- Panel dividers are more visible now but kept intentionally subtle (well under 3:1). They're decorative structure rather than operable UI, and pushing them to a hard 3:1 reads as a heavier, boxier frame than the rest of the design wants.
- `--accent-green-light` ends up darker than `--accent-green` in light mode. That's required — it's used as text (field/enum names), and a lighter green can't clear 4.5:1 on a light background. The name describes its dark-theme appearance; there's a comment on the token so it doesn't get "corrected" back to lighter later.
- `--accent-yellow` is left as-is: it's only a small decorative status dot, never text, so it doesn't owe text contrast.

## Test plan

- [x] Switch to light theme and check that text is legible across the top bar, doc explorer, response pane, and dialogs.
- [x] Confirm the dividers next to the activity rail and side panel are actually visible against the canvas background.
- [x] Open the doc explorer and check that field/enum names and the more muted text (counts, colons) are readable.
- [x] Run a query that returns numbers and check the values are legible in the response tree view.
- [x] Open Settings → "Clear storage" and click "Clear data"; confirm the green success state ("Cleared data") reads clearly with its white text. (The red "Failed" state only fires if clearing throws — its contrast is covered by the Storybook a11y run rather than a manual step.)
- [x] In the query builder, toggle an argument to "Inline argument" and confirm the button text reads clearly against the purple fill.

Refs: graphql/graphiql#4219
