### PR TITLE
v6: Simplify `.browserslistrc` to the `defaults` preset

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,1 @@
-last 2 versions
-Firefox ESR
-not dead
-not IE 11
-not ios 10
+defaults

--- a/.changeset/browserslist-defaults.md
+++ b/.changeset/browserslist-defaults.md
@@ -1,0 +1,6 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+---
+
+Simplify the build's `.browserslistrc` to the `defaults` preset. It covers the modern browsers that support the OKLCH color system v6 relies on, and replaces the hand-maintained target list.


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `.browserslistrc` (`last 2 versions` / `Firefox ESR` / `not dead` / `not IE 11` / `not ios 10`) with the standard `defaults` preset (`> 0.5%, last 2 versions, Firefox ESR, not dead`). It covers the modern browsers that support the OKLCH color functions v6 relies on, without carrying a bespoke exclusion list.

Split out of the `legacyClient` removal (#4392) — the two were unrelated.

## Test plan

- [x] Run `npx browserslist` at the repo root and confirm it resolves a sane, modern target list with no errors.
- [x] Run a production build and confirm the output still loads and runs in a current browser (no unexpected syntax/transform regressions).

Refs: graphql/graphiql#4219
