### PR TITLE
v6: Make the Monaco editors follow the theme toggle

### DIFF
--- a/.changeset/monaco-theme-follow-toggle.md
+++ b/.changeset/monaco-theme-follow-toggle.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix the Monaco editors not recoloring when the theme is changed. Switching between Light, Dark, and Auto now updates the query, variables, and response editors immediately, not just the surrounding UI.

--- a/.changeset/monaco-theme-follow-toggle.md
+++ b/.changeset/monaco-theme-follow-toggle.md
@@ -1,5 +1,6 @@
 ---
 '@graphiql/react': patch
+'graphiql': patch
 ---
 
-Fix the Monaco editors not recoloring when the theme is changed. Switching between Light, Dark, and Auto now updates the query, variables, and response editors immediately, not just the surrounding UI.
+Fix the Monaco editors not recoloring when the theme is changed. Switching between Light, Dark, and Auto now updates the editors — background included — immediately, not just the surrounding UI.

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -103,7 +103,6 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     externalFragments,
     uriInstanceId,
     storage,
-    monacoTheme,
   } = useGraphiQL(
     pick(
       'initialQuery',
@@ -115,7 +114,6 @@ export const OperationEditor: FC<OperationEditorProps> = ({
       'externalFragments',
       'uriInstanceId',
       'storage',
-      'monacoTheme',
     ),
   );
   const ref = useRef<HTMLDivElement>(null!);
@@ -287,10 +285,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
       uri: operationUri.path.replace('/', ''),
       value: initialQuery,
     });
-    const editor = createEditor(ref, {
-      model,
-      theme: monacoTheme,
-    });
+    const editor = createEditor(ref, { model });
     setEditor({ queryEditor: editor });
 
     // We don't use the generic `useChangeHandler` hook here because we want to

--- a/packages/graphiql-react/src/hooks/use-graphiql-settings.spec.ts
+++ b/packages/graphiql-react/src/hooks/use-graphiql-settings.spec.ts
@@ -8,6 +8,21 @@ import {
   vi,
 } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { MONACO_THEME_NAME } from '../constants';
+
+// The settings hook drives the Monaco theme through `monacoStore`; stub it
+// out so tests can control the mock editor instance the hook sees.
+let mockMonaco: { editor: { setTheme: ReturnType<typeof vi.fn> } } | undefined;
+
+vi.mock('../stores/monaco', () => ({
+  monacoStore: {
+    getState: () => ({ monaco: mockMonaco }),
+    subscribe: () => () => {},
+  },
+  useMonaco: (selector: (state: { monaco: typeof mockMonaco }) => unknown) =>
+    selector({ monaco: mockMonaco }),
+}));
+
 import {
   useGraphiQLSettings,
   SETTINGS_STORAGE_KEY,
@@ -70,6 +85,7 @@ beforeAll(() => {
 beforeEach(() => {
   clearStorage();
   matchMediaMatches = false;
+  mockMonaco = { editor: { setTheme: vi.fn() } };
 });
 
 afterEach(() => {
@@ -235,5 +251,53 @@ describe('useGraphiQLSettings — auto theme', () => {
     expect(container.getAttribute('data-theme')).toBe('light');
 
     container.remove();
+  });
+});
+
+describe('useGraphiQLSettings — drives the Monaco theme', () => {
+  it('applies the resolved theme to Monaco on mount', () => {
+    setStorage({ theme: 'dark' });
+    renderHook(() => useGraphiQLSettings());
+
+    expect(mockMonaco!.editor.setTheme).toHaveBeenCalledWith(
+      MONACO_THEME_NAME.dark,
+    );
+  });
+
+  it('calls monaco.editor.setTheme with the light theme name on setTheme("light")', () => {
+    const { result } = renderHook(() => useGraphiQLSettings());
+
+    act(() => {
+      result.current.setTheme('light');
+    });
+
+    expect(mockMonaco!.editor.setTheme).toHaveBeenCalledWith(
+      MONACO_THEME_NAME.light,
+    );
+  });
+
+  it('calls monaco.editor.setTheme with the dark theme name on setTheme("dark")', () => {
+    const { result } = renderHook(() => useGraphiQLSettings());
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(mockMonaco!.editor.setTheme).toHaveBeenCalledWith(
+      MONACO_THEME_NAME.dark,
+    );
+  });
+
+  it('does not call monaco.editor.setTheme when monaco is not yet initialized', () => {
+    mockMonaco = undefined;
+    const { result } = renderHook(() => useGraphiQLSettings());
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    // Nothing to assert on `setTheme` itself since there's no monaco
+    // instance, but the hook must not throw when monaco is unavailable.
+    expect(result.current.theme).toBe('dark');
   });
 });

--- a/packages/graphiql-react/src/hooks/use-graphiql-settings.ts
+++ b/packages/graphiql-react/src/hooks/use-graphiql-settings.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { RefObject } from 'react';
+import { useMonaco } from '../stores';
+import { MONACO_THEME_NAME } from '../constants';
 
 export type Theme = 'auto' | 'light' | 'dark';
 export type Density = 'compact' | 'comfortable' | 'spacious';
@@ -56,6 +58,7 @@ export function useGraphiQLSettings(
   containerRef?: RefObject<HTMLElement | null>,
 ) {
   const [settings, setSettings] = useState<GraphiQLSettings>(readSettings);
+  const monaco = useMonaco(state => state.monaco);
 
   function setTheme(theme: Theme) {
     setSettings(s => ({ ...s, theme }));
@@ -69,21 +72,25 @@ export function useGraphiQLSettings(
     setSettings(s => ({ ...s, fontSize }));
   }
 
-  // Persist and apply data-* attributes whenever settings change.
+  // Persist and apply data-* attributes whenever settings change. This is
+  // also the single place that drives the Monaco editors' theme, so the
+  // chrome and the editors never fall out of sync.
   useEffect(() => {
     writeSettings(settings);
+
+    const resolvedTheme = resolveTheme(settings.theme);
 
     const target =
       containerRef?.current ??
       document.querySelector<HTMLElement>('.graphiql-container');
-    if (!target) {
-      return;
+    if (target) {
+      target.setAttribute('data-theme', resolvedTheme);
+      target.setAttribute('data-density', settings.density);
+      target.setAttribute('data-font-size', settings.fontSize);
     }
 
-    target.setAttribute('data-theme', resolveTheme(settings.theme));
-    target.setAttribute('data-density', settings.density);
-    target.setAttribute('data-font-size', settings.fontSize);
-  }, [settings, containerRef]);
+    monaco?.editor.setTheme(MONACO_THEME_NAME[resolvedTheme]);
+  }, [settings, containerRef, monaco]);
 
   // When theme is 'auto', track system preference changes live.
   useEffect(() => {
@@ -94,20 +101,23 @@ export function useGraphiQLSettings(
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
 
     function onSystemThemeChange() {
+      const resolvedTheme = resolveTheme('auto');
+
       const target =
         containerRef?.current ??
         document.querySelector<HTMLElement>('.graphiql-container');
-      if (!target) {
-        return;
+      if (target) {
+        target.setAttribute('data-theme', resolvedTheme);
       }
-      target.setAttribute('data-theme', resolveTheme('auto'));
+
+      monaco?.editor.setTheme(MONACO_THEME_NAME[resolvedTheme]);
     }
 
     mql.addEventListener('change', onSystemThemeChange);
     return () => {
       mql.removeEventListener('change', onSystemThemeChange);
     };
-  }, [settings.theme, containerRef]);
+  }, [settings.theme, containerRef, monaco]);
 
   return { ...settings, setTheme, setDensity, setFontSize };
 }

--- a/packages/graphiql-react/src/stores/theme.ts
+++ b/packages/graphiql-react/src/stores/theme.ts
@@ -1,6 +1,5 @@
 import type * as monaco from 'monaco-editor';
 import { STORAGE_KEY, MONACO_THEME_NAME } from '../constants';
-import { monacoStore } from './monaco';
 import type { StateCreator } from 'zustand';
 import type { SlicesWithActions, Theme } from '../types';
 
@@ -11,8 +10,6 @@ type MonacoTheme =
 
 export interface ThemeSlice {
   theme: Theme;
-
-  monacoTheme?: MonacoTheme;
 }
 
 export interface ThemeActions {
@@ -49,37 +46,20 @@ type CreateThemeSlice = (
   }
 >;
 
-export const createThemeSlice: CreateThemeSlice =
-  ({ editorTheme }) =>
-  (set, get) => ({
-    theme: null,
-    actions: {
-      setTheme(theme) {
-        const { storage } = get();
-        storage.set(STORAGE_KEY.theme, theme ?? '');
-        document.body.classList.remove('graphiql-light', 'graphiql-dark');
-        if (theme) {
-          document.body.classList.add(`graphiql-${theme}`);
-          document.documentElement.setAttribute('data-theme', theme);
-        } else {
-          document.documentElement.removeAttribute('data-theme');
-        }
-        const { monaco } = monacoStore.getState();
-        const resolvedTheme = theme ?? getSystemTheme();
-        const monacoTheme = editorTheme![resolvedTheme];
-        monaco?.editor.setTheme(monacoTheme);
-        set({ theme, monacoTheme });
-      },
+export const createThemeSlice: CreateThemeSlice = () => (set, get) => ({
+  theme: null,
+  actions: {
+    setTheme(theme) {
+      const { storage } = get();
+      storage.set(STORAGE_KEY.theme, theme ?? '');
+      document.body.classList.remove('graphiql-light', 'graphiql-dark');
+      if (theme) {
+        document.body.classList.add(`graphiql-${theme}`);
+        document.documentElement.setAttribute('data-theme', theme);
+      } else {
+        document.documentElement.removeAttribute('data-theme');
+      }
+      set({ theme });
     },
-  });
-
-/**
- * Get the resolved theme - dark or light
- * @see https://github.com/pacocoursey/next-themes/blob/c89d0191ce0f19215d7ddfa9eb28e1e4f94d37e5/next-themes/src/index.tsx#L255
- */
-function getSystemTheme() {
-  const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-  const isDark = mediaQueryList.matches;
-  const systemTheme = isDark ? 'dark' : 'light';
-  return systemTheme;
-}
+  },
+});

--- a/packages/graphiql/cypress/e2e/theme.cy.ts
+++ b/packages/graphiql/cypress/e2e/theme.cy.ts
@@ -9,4 +9,65 @@ describe('Theme', () => {
       cy.get('body').should('have.class', 'graphiql-dark');
     });
   });
+
+  describe('Settings theme toggle', () => {
+    function editorBackground() {
+      return cy
+        .get('.graphiql-editors')
+        .then($el => getComputedStyle($el[0]).backgroundColor);
+    }
+
+    function openSettingsAndChooseTheme(theme: 'light' | 'dark') {
+      cy.get('[aria-label="Settings"]').click();
+      cy.get('.graphiql-dialog').should('be.visible');
+      // The radio input itself is visually hidden (a custom-styled control),
+      // so `check` is the reliable way to select it.
+      cy.get(`input[type="radio"][value="${theme}"]`).check({ force: true });
+      cy.get(`input[type="radio"][value="${theme}"]`).should('be.checked');
+      // Assert the effect landed while the dialog is still open, before
+      // closing it — closing and immediately reopening the dialog for the
+      // next toggle races with Radix's dismiss/focus-return handling.
+      cy.get('.graphiql-container').should('have.attr', 'data-theme', theme);
+      cy.get('.graphiql-dialog-close').click();
+      cy.get('.graphiql-dialog').should('not.exist');
+    }
+
+    beforeEach(() => {
+      // The theme setting persists to localStorage and defaults to 'auto',
+      // which depends on the OS color-scheme preference. Start every test
+      // from an explicit, deterministic Dark baseline instead of inheriting
+      // whatever the previous test (or the test runner's OS) prefers.
+      cy.clearLocalStorage();
+      cy.visit('/', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem(
+            'graphiql:settings',
+            JSON.stringify({ theme: 'dark' }),
+          );
+        },
+      });
+      cy.get('.graphiql-container').should('have.attr', 'data-theme', 'dark');
+    });
+
+    it('recolors the editor background, not just the syntax tokens, when switching to Light', () => {
+      editorBackground().then(darkBackground => {
+        openSettingsAndChooseTheme('light');
+
+        // The bug this guards against: only the Monaco syntax tokens used to
+        // recolor on toggle while `.graphiql-editors` kept its dark
+        // background, because it was still painted by a legacy token that
+        // the Settings-driven `data-theme` toggle never updated.
+        editorBackground().should('not.equal', darkBackground);
+      });
+    });
+
+    it('restores the dark editor background when switching back to Dark', () => {
+      editorBackground().then(originalDarkBackground => {
+        openSettingsAndChooseTheme('light');
+        openSettingsAndChooseTheme('dark');
+
+        editorBackground().should('equal', originalDarkBackground);
+      });
+    });
+  });
 });

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -112,7 +112,7 @@ button.graphiql-tab-strip-action {
 
 /* All editors (operation, variable, request headers) */
 .graphiql-container .graphiql-editors {
-  background-color: hsl(var(--color-base));
+  background-color: oklch(var(--bg-canvas));
   border-radius: 0 0 var(--border-radius-12) var(--border-radius-12);
   box-shadow: var(--popover-box-shadow);
   display: flex;


### PR DESCRIPTION
## Summary

- Changing the theme (Light/Dark/Auto) now recolors the Monaco editors too, not just the surrounding chrome. The toggle was writing `data-theme` on the container but never telling Monaco to switch, so the editors stayed on whatever theme they booted with.
- The same effect that sets `data-theme` now also resolves the theme and calls `monaco.editor.setTheme`, so there's one place responsible for both.

## Test plan

- [x] `yarn workspace @graphiql/react test` passes, including a new test that asserts `monaco.editor.setTheme` gets called on theme change.
- [x] Type a query, open Settings, switch to Light. The editors should turn light immediately (light background, dark tokens).
- [x] Switch back to Dark. Editors should return to dark immediately.
- [x] Set Auto with the OS in the opposite mode. Editors should match the OS.
- [x] Reload with Light persisted. Editors should boot light, no dark flash.

Refs: graphql/graphiql#4219
