### PR TITLE
v6: Flatten the editor workspace frame

### DIFF
--- a/.changeset/flatten-editor-frame.md
+++ b/.changeset/flatten-editor-frame.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Flatten the editor workspace to the v6 layout. The editor area no longer floats as a rounded, shadowed card; it fills its column and is separated from the navigation and response panes by thin dividers.

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -26,15 +26,11 @@
 
 /* The current session and tabs */
 .graphiql-container .graphiql-sessions {
-  background-color: hsla(var(--color-neutral), var(--alpha-background-light));
-  /* Adding the 8px of padding to the inner border radius of the operation editor */
-  border-radius: calc(var(--border-radius-12) + var(--px-8));
+  background: oklch(var(--bg-canvas));
   display: flex;
   flex-direction: column;
   flex: 1;
   max-height: 100%;
-  margin: var(--px-16);
-  margin-left: 0;
   min-width: 0;
 }
 
@@ -112,9 +108,8 @@ button.graphiql-tab-strip-action {
 
 /* All editors (operation, variable, request headers) */
 .graphiql-container .graphiql-editors {
-  background-color: oklch(var(--bg-canvas));
-  border-radius: 0 0 var(--border-radius-12) var(--border-radius-12);
-  box-shadow: var(--popover-box-shadow);
+  background: oklch(var(--bg-canvas));
+  border-right: 1px solid oklch(var(--border-default));
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -1,6 +1,6 @@
 /* Everything */
 .graphiql-container {
-  background-color: hsl(var(--color-base));
+  background: oklch(var(--bg-canvas));
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -224,7 +224,7 @@ button.graphiql-tab-strip-action {
 
 /* Generic drag bar for horizontal resizing */
 .graphiql-horizontal-drag-bar {
-  width: var(--px-12);
+  width: var(--px-8);
   cursor: col-resize;
 }
 


### PR DESCRIPTION
## Summary

The editor area used to render as a rounded card — 20px corners, a 16px margin, drop shadow, the works. That's gone. The editor now fills its column edge to edge, with a 1px divider separating it from the activity rail and response pane instead of a floating panel.

## Test plan

- [x] Open GraphiQL. The editor area should have no rounded outer corners, no shadow, no floating margin.
- [ ] Check the boundaries between the activity rail, editor, and response pane — thin 1px dividers, not a gap or a doubled border.
- [x] Resize the window and drag the pane splitter around. No seams or gaps should show up at the edges.
- [x] Toggle Dark/Light. The flat shape should hold in both.

Refs: graphql/graphiql#4219
