### PR TITLE
v6: Remove the legacy editor toolbar and corner logo

### DIFF
--- a/.changeset/remove-legacy-editor-chrome.md
+++ b/.changeset/remove-legacy-editor-chrome.md
@@ -1,0 +1,5 @@
+---
+'graphiql': minor
+---
+
+Remove the duplicated legacy editor toolbar and corner logo. Branding now appears only in the top bar, and the editor actions (prettify, merge fragments, copy, save) live together in the tab strip. Merge Fragments, previously only in the old toolbar, moves into the tab-strip actions.

--- a/.changeset/remove-legacy-editor-chrome.md
+++ b/.changeset/remove-legacy-editor-chrome.md
@@ -3,3 +3,5 @@
 ---
 
 Remove the duplicated legacy editor toolbar and corner logo. Branding now appears only in the top bar, and the editor actions (prettify, merge fragments, copy, save) live together in the tab strip. Merge Fragments, previously only in the old toolbar, moves into the tab-strip actions.
+
+The action buttons now sit at the right edge of the query editor rather than the far right of the response pane, so they stay next to the query you're editing and follow the editor/response divider as you resize it.

--- a/packages/graphiql/cypress/e2e/init.cy.ts
+++ b/packages/graphiql/cypress/e2e/init.cy.ts
@@ -32,7 +32,9 @@ describe('GraphiQL On Initialization', () => {
       '#graphiql',
       '.graphiql-container',
       '.graphiql-sessions',
+      '.graphiql-editor-column',
       '.graphiql-editors',
+      '.graphiql-response-column',
       '.graphiql-response',
       '.graphiql-editor-tool',
     ];
@@ -41,6 +43,18 @@ describe('GraphiQL On Initialization', () => {
     for (const cSelector of containers) {
       cy.get(cSelector).should('be.visible');
     }
+  });
+
+  it('Places the action buttons on the editor side of the split', () => {
+    cy.visit('/');
+    // The prettify/merge/copy/save buttons belong to the query editor, so they
+    // live in the editor column rather than floating over the response pane.
+    cy.get('.graphiql-editor-column .graphiql-tab-strip-actions')
+      .find('.graphiql-tab-strip-action')
+      .should('have.length.at.least', 3);
+    cy.get('.graphiql-response-column .graphiql-tab-strip-actions').should(
+      'not.exist',
+    );
   });
 
   it('Executes a GraphQL query over HTTP that has the expected result', () => {

--- a/packages/graphiql/cypress/e2e/merge-fragments.cy.ts
+++ b/packages/graphiql/cypress/e2e/merge-fragments.cy.ts
@@ -1,0 +1,23 @@
+describe('GraphiQL Merge Fragments', () => {
+  it('merges a fragment into the operation when clicked', () => {
+    const query = `fragment IdFragment on Test {
+  id
+}
+
+query TestQuery {
+  ...IdFragment
+}`;
+
+    cy.visitWithOp({ query });
+    cy.clickMergeFragments();
+
+    cy.get(
+      '.graphiql-query-editor .view-lines.monaco-mouse-cursor-text',
+    ).should(element => {
+      const text = element.get(0).innerText;
+      expect(text).to.not.contain('fragment IdFragment');
+      expect(text).to.not.contain('...IdFragment');
+      expect(text).to.contain('id');
+    });
+  });
+});

--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -70,6 +70,8 @@ declare namespace Cypress {
 
     clickPrettify(): Chainable<Element>;
 
+    clickMergeFragments(): Chainable<Element>;
+
     assertHasValues(op: Op): Chainable<Element>;
 
     assertQueryResult(expectedResult: MockResult): Chainable<Element>;
@@ -145,7 +147,11 @@ Cypress.Commands.add('clickExecuteQuery', () => {
 });
 
 Cypress.Commands.add('clickPrettify', () => {
-  cy.get('[aria-label="Prettify query (Shift-Ctrl-P)"]').click();
+  cy.get('[aria-label="Prettify query"]').click();
+});
+
+Cypress.Commands.add('clickMergeFragments', () => {
+  cy.get('[aria-label="Merge fragments into query"]').click();
 });
 
 Cypress.Commands.add('visitWithOp', ({ query, variables, variablesString }) => {

--- a/packages/graphiql/cypress/support/commands.ts
+++ b/packages/graphiql/cypress/support/commands.ts
@@ -143,7 +143,7 @@ Cypress.Commands.add('activateOperation', (operationName: string) => {
 });
 
 Cypress.Commands.add('clickExecuteQuery', () => {
-  cy.get('.graphiql-execute-button').click();
+  cy.get('[aria-label="Run query"]').click();
 });
 
 Cypress.Commands.add('clickPrettify', () => {

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -597,7 +597,7 @@ describe('GraphiQL', () => {
         </>
       );
 
-      const { container, getByRole } = render(
+      const { container, queryByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>{myFragment}</GraphiQL>,
       );
 
@@ -605,13 +605,15 @@ describe('GraphiQL', () => {
         expect(
           container.querySelector('.graphiql-container'),
         ).toBeInTheDocument();
-        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-        expect(getByRole('toolbar')).toBeInTheDocument();
+        expect(
+          container.querySelector('.graphiql-logo'),
+        ).not.toBeInTheDocument();
+        expect(queryByRole('toolbar')).not.toBeInTheDocument();
       });
     });
 
     it('properly ignores non-override children components', async () => {
-      const { container, getByRole } = render(
+      const { container, queryByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>
           <MyFunctionalComponent />
         </GraphiQL>,
@@ -621,8 +623,10 @@ describe('GraphiQL', () => {
         expect(
           container.querySelector('.graphiql-container'),
         ).toBeInTheDocument();
-        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-        expect(getByRole('toolbar')).toBeInTheDocument();
+        expect(
+          container.querySelector('.graphiql-logo'),
+        ).not.toBeInTheDocument();
+        expect(queryByRole('toolbar')).not.toBeInTheDocument();
       });
     });
 
@@ -634,7 +638,7 @@ describe('GraphiQL', () => {
         }
       }
 
-      const { container, getByRole } = render(
+      const { container, queryByRole } = render(
         <GraphiQL fetcher={noOpFetcher}>
           <MyClassComponent />
         </GraphiQL>,
@@ -644,8 +648,10 @@ describe('GraphiQL', () => {
         expect(
           container.querySelector('.graphiql-container'),
         ).toBeInTheDocument();
-        expect(container.querySelector('.graphiql-logo')).toBeInTheDocument();
-        expect(getByRole('toolbar')).toBeInTheDocument();
+        expect(
+          container.querySelector('.graphiql-logo'),
+        ).not.toBeInTheDocument();
+        expect(queryByRole('toolbar')).not.toBeInTheDocument();
       });
     });
 
@@ -700,6 +706,83 @@ describe('GraphiQL', () => {
         });
       });
     });
+  });
+
+  describe('tab strip actions', () => {
+    it('renders exactly one prettify, merge, copy, and save action, and no legacy toolbar or logo', async () => {
+      const { container } = render(
+        <GraphiQL fetcher={noOpFetcher} onSaveQuery={() => {}} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          container.querySelectorAll('[aria-label="Prettify query"]'),
+        ).toHaveLength(1);
+        expect(
+          container.querySelectorAll(
+            '[aria-label="Merge fragments into query"]',
+          ),
+        ).toHaveLength(1);
+        expect(
+          container.querySelectorAll('[aria-label="Copy query"]'),
+        ).toHaveLength(1);
+        expect(
+          container.querySelectorAll('[aria-label="Save query"]'),
+        ).toHaveLength(1);
+        expect(
+          container.querySelector('.graphiql-toolbar'),
+        ).not.toBeInTheDocument();
+        expect(
+          container.querySelector('.graphiql-logo'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('merges fragments into the operation when Merge Fragments is clicked', async () => {
+      let queryEditor: MonacoEditor;
+      let documentAST: unknown;
+
+      const HookConsumer: FC = () => {
+        const $queryEditor = useGraphiQL(state => state.queryEditor);
+        const $documentAST = useGraphiQL(state => state.documentAST);
+        useEffect(() => {
+          queryEditor = $queryEditor!;
+          documentAST = $documentAST;
+        }, [$queryEditor, $documentAST]);
+        return null;
+      };
+
+      const { getByLabelText } = render(
+        <GraphiQL fetcher={noOpFetcher}>
+          <HookConsumer />
+        </GraphiQL>,
+      );
+
+      const query = `fragment NameFragment on Query { q }
+query TestQuery { ...NameFragment }`;
+
+      await waitFor(() => {
+        expect(queryEditor).toBeTruthy();
+      });
+      act(() => {
+        queryEditor.setValue(query);
+      });
+
+      await waitFor(() => {
+        expect(queryEditor.getValue()).toContain('...NameFragment');
+        // The editor debounces content-change handling before it updates the
+        // document AST that `mergeQuery` reads from.
+        expect(documentAST).toBeTruthy();
+      });
+
+      fireEvent.click(getByLabelText('Merge fragments into query'));
+
+      await waitFor(() => {
+        const merged = queryEditor.getValue();
+        expect(merged).not.toContain('...NameFragment');
+        expect(merged).toContain('q');
+      });
+    }, 15_000);
   });
 
   it('should support multiple instances', async () => {

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -355,8 +355,9 @@ describe('GraphiQL', () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
       const dragBar = container.querySelector('.graphiql-horizontal-drag-bar')!;
-      const editorColumn =
-        container.querySelector<HTMLDivElement>('.graphiql-editor-column')!;
+      const editorColumn = container.querySelector<HTMLDivElement>(
+        '.graphiql-editor-column',
+      )!;
 
       act(() => {
         fireEvent.mouseDown(dragBar, {

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -355,8 +355,8 @@ describe('GraphiQL', () => {
       const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
 
       const dragBar = container.querySelector('.graphiql-horizontal-drag-bar')!;
-      const editors =
-        container.querySelector<HTMLDivElement>('.graphiql-editors')!;
+      const editorColumn =
+        container.querySelector<HTMLDivElement>('.graphiql-editor-column')!;
 
       act(() => {
         fireEvent.mouseDown(dragBar, {
@@ -374,7 +374,7 @@ describe('GraphiQL', () => {
 
       await waitFor(() => {
         // 700 / (900 - 700) = 3.5
-        expect(editors.style.flexGrow).toEqual('3.5');
+        expect(editorColumn.style.flexGrow).toEqual('3.5');
       });
 
       clientWidthSpy.mockRestore();

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -403,7 +403,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     editorToolsHiddenElement === 'second' ? ChevronUpIcon : ChevronDownIcon;
 
   const editors = (
-    <div className="graphiql-editors" ref={editorFirstRef}>
+    <div className="graphiql-editors">
       <section
         className="graphiql-query-editor"
         aria-label="Operation Editor"
@@ -485,132 +485,142 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
                 />
               )}
               <div ref={pluginSecondRef} className="graphiql-sessions">
-                <div className="graphiql-session-header">
-                  <Tabs
-                    ref={tabContainerRef}
-                    values={tabs}
-                    onReorder={moveTab}
-                    aria-label="Select active operation"
-                    className="no-scrollbar"
-                  >
-                    {tabs.map((tab, index) => {
-                      const isActive = index === activeTabIndex;
-                      // For the active tab, surface how many other operations the
-                      // document holds alongside the one the cursor is in. Only
-                      // when the active operation is named, so the title reads as
-                      // `<name> +N`; an anonymous active operation has no name to
-                      // anchor the count to.
-                      const otherOperations =
-                        isActive && tab.operationName && operations
-                          ? operations.length - 1
-                          : 0;
-                      const tabTitle =
-                        otherOperations > 0
-                          ? `${tab.title} +${otherOperations}`
-                          : tab.title;
-                      return (
-                        <Tab
-                          key={tab.id}
-                          // Prevent overscroll over container
-                          dragConstraints={tabContainerRef}
-                          value={tab}
-                          isActive={isActive}
-                          isDirty={
-                            canSave &&
-                            tab.lastSavedQuery !== null &&
-                            tab.query !== tab.lastSavedQuery
-                          }
-                        >
-                          <Tab.Button
-                            aria-controls="graphiql-session"
-                            id={`graphiql-session-tab-${index}`}
-                            title={tabTitle}
-                            onClick={handleTabClick}
-                          >
-                            {tabTitle}
-                          </Tab.Button>
-                          {tabs.length > 1 && (
-                            <Tab.Close onClick={handleTabClose} />
-                          )}
-                        </Tab>
-                      );
-                    })}
-                  </Tabs>
-                  <Tooltip label={LABEL.newTab}>
-                    <UnStyledButton
-                      type="button"
-                      className="graphiql-tab-add"
-                      onClick={addTab}
-                      aria-label={LABEL.newTab}
-                    >
-                      <PlusIcon aria-hidden="true" />
-                    </UnStyledButton>
-                  </Tooltip>
-                  <div className="graphiql-tab-strip-actions">
-                    <Tooltip label={LABEL.prettify}>
-                      <UnStyledButton
-                        type="button"
-                        className="graphiql-tab-strip-action"
-                        onClick={prettifyEditors}
-                        aria-label={LABEL.prettify}
+                <div className="graphiql-session-row">
+                  <div ref={editorFirstRef} className="graphiql-editor-column">
+                    <div className="graphiql-session-header">
+                      <Tabs
+                        ref={tabContainerRef}
+                        values={tabs}
+                        onReorder={moveTab}
+                        aria-label="Select active operation"
+                        className="no-scrollbar"
                       >
-                        <PrettifyIcon aria-hidden="true" />
-                      </UnStyledButton>
-                    </Tooltip>
-                    <Tooltip label={LABEL.merge}>
-                      <UnStyledButton
-                        type="button"
-                        className="graphiql-tab-strip-action"
-                        onClick={mergeQuery}
-                        aria-label={LABEL.merge}
-                      >
-                        <MergeIcon aria-hidden="true" />
-                      </UnStyledButton>
-                    </Tooltip>
-                    <Tooltip label={LABEL.copy}>
-                      <UnStyledButton
-                        type="button"
-                        className="graphiql-tab-strip-action"
-                        onClick={copyQuery}
-                        aria-label={LABEL.copy}
-                      >
-                        <CopyIcon aria-hidden="true" />
-                      </UnStyledButton>
-                    </Tooltip>
-                    {canSave && (
-                      <Tooltip label={LABEL.save}>
+                        {tabs.map((tab, index) => {
+                          const isActive = index === activeTabIndex;
+                          // For the active tab, surface how many other operations the
+                          // document holds alongside the one the cursor is in. Only
+                          // when the active operation is named, so the title reads as
+                          // `<name> +N`; an anonymous active operation has no name to
+                          // anchor the count to.
+                          const otherOperations =
+                            isActive && tab.operationName && operations
+                              ? operations.length - 1
+                              : 0;
+                          const tabTitle =
+                            otherOperations > 0
+                              ? `${tab.title} +${otherOperations}`
+                              : tab.title;
+                          return (
+                            <Tab
+                              key={tab.id}
+                              // Prevent overscroll over container
+                              dragConstraints={tabContainerRef}
+                              value={tab}
+                              isActive={isActive}
+                              isDirty={
+                                canSave &&
+                                tab.lastSavedQuery !== null &&
+                                tab.query !== tab.lastSavedQuery
+                              }
+                            >
+                              <Tab.Button
+                                aria-controls="graphiql-session"
+                                id={`graphiql-session-tab-${index}`}
+                                title={tabTitle}
+                                onClick={handleTabClick}
+                              >
+                                {tabTitle}
+                              </Tab.Button>
+                              {tabs.length > 1 && (
+                                <Tab.Close onClick={handleTabClose} />
+                              )}
+                            </Tab>
+                          );
+                        })}
+                      </Tabs>
+                      <Tooltip label={LABEL.newTab}>
                         <UnStyledButton
                           type="button"
-                          className="graphiql-tab-strip-action"
-                          onClick={saveQuery}
-                          aria-label={LABEL.save}
+                          className="graphiql-tab-add"
+                          onClick={addTab}
+                          aria-label={LABEL.newTab}
                         >
-                          <SaveIcon aria-hidden="true" />
+                          <PlusIcon aria-hidden="true" />
                         </UnStyledButton>
                       </Tooltip>
-                    )}
-                    {plugins.map(plugin =>
-                      plugin.sessionActions ? (
-                        <plugin.sessionActions key={plugin.title} />
-                      ) : null,
-                    )}
+                      <div className="graphiql-tab-strip-actions">
+                        <Tooltip label={LABEL.prettify}>
+                          <UnStyledButton
+                            type="button"
+                            className="graphiql-tab-strip-action"
+                            onClick={prettifyEditors}
+                            aria-label={LABEL.prettify}
+                          >
+                            <PrettifyIcon aria-hidden="true" />
+                          </UnStyledButton>
+                        </Tooltip>
+                        <Tooltip label={LABEL.merge}>
+                          <UnStyledButton
+                            type="button"
+                            className="graphiql-tab-strip-action"
+                            onClick={mergeQuery}
+                            aria-label={LABEL.merge}
+                          >
+                            <MergeIcon aria-hidden="true" />
+                          </UnStyledButton>
+                        </Tooltip>
+                        <Tooltip label={LABEL.copy}>
+                          <UnStyledButton
+                            type="button"
+                            className="graphiql-tab-strip-action"
+                            onClick={copyQuery}
+                            aria-label={LABEL.copy}
+                          >
+                            <CopyIcon aria-hidden="true" />
+                          </UnStyledButton>
+                        </Tooltip>
+                        {canSave && (
+                          <Tooltip label={LABEL.save}>
+                            <UnStyledButton
+                              type="button"
+                              className="graphiql-tab-strip-action"
+                              onClick={saveQuery}
+                              aria-label={LABEL.save}
+                            >
+                              <SaveIcon aria-hidden="true" />
+                            </UnStyledButton>
+                          </Tooltip>
+                        )}
+                        {plugins.map(plugin =>
+                          plugin.sessionActions ? (
+                            <plugin.sessionActions key={plugin.title} />
+                          ) : null,
+                        )}
+                      </div>
+                      {logo}
+                    </div>
+                    <div
+                      role="tabpanel"
+                      id="graphiql-session" // used by aria-controls="graphiql-session"
+                      aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
+                    >
+                      {editors}
+                    </div>
                   </div>
-                  {logo}
-                </div>
-                <div
-                  role="tabpanel"
-                  id="graphiql-session" // used by aria-controls="graphiql-session"
-                  aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
-                >
-                  {editors}
                   <div
                     className="graphiql-horizontal-drag-bar"
                     ref={editorDragBarRef}
                   />
-                  <div className="graphiql-response" ref={editorSecondRef}>
-                    {isFetching && <Spinner />}
-                    <ResponseEditor responseTooltip={responseTooltip} />
-                    {footer}
+                  <div
+                    ref={editorSecondRef}
+                    className="graphiql-response-column"
+                  >
+                    <div className="graphiql-response-header" />
+                    <div className="graphiql-response">
+                      {isFetching && <Spinner />}
+                      <ResponseEditor responseTooltip={responseTooltip} />
+                      {footer}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -615,7 +615,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
                     ref={editorSecondRef}
                     className="graphiql-response-column"
                   >
-                    <div className="graphiql-response-header" />
                     <div className="graphiql-response">
                       {isFetching && <Spinner />}
                       <ResponseEditor responseTooltip={responseTooltip} />

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -15,8 +15,8 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   CopyIcon,
-  ExecuteButton,
   GraphiQLProvider,
+  MergeIcon,
   PlusIcon,
   PortalProvider,
   PrettifyIcon,
@@ -223,6 +223,7 @@ type ButtonHandler = MouseEventHandler<HTMLButtonElement>;
 const LABEL = {
   newTab: 'New tab',
   prettify: 'Prettify query',
+  merge: 'Merge fragments into query',
   copy: 'Copy query',
   save: 'Save query',
 };
@@ -249,6 +250,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     saveQuery,
     copyQuery,
     prettifyEditors,
+    mergeQuery,
   } = useGraphiQLActions();
   const {
     initialVariables,
@@ -361,8 +363,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       return acc;
     },
     {
-      logo: <GraphiQL.Logo />,
-      toolbar: <GraphiQL.Toolbar />,
       children: [],
     },
   );
@@ -417,15 +417,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
         ) : (
           <Spinner />
         )}
-
-        <div
-          className="graphiql-toolbar"
-          role="toolbar"
-          aria-label="Editor Commands"
-        >
-          <ExecuteButton />
-          {toolbar}
-        </div>
+        {toolbar}
       </section>
 
       <div ref={editorToolsDragBarRef} className="graphiql-editor-tools">
@@ -563,6 +555,16 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
                         aria-label={LABEL.prettify}
                       >
                         <PrettifyIcon aria-hidden="true" />
+                      </UnStyledButton>
+                    </Tooltip>
+                    <Tooltip label={LABEL.merge}>
+                      <UnStyledButton
+                        type="button"
+                        className="graphiql-tab-strip-action"
+                        onClick={mergeQuery}
+                        aria-label={LABEL.merge}
+                      >
+                        <MergeIcon aria-hidden="true" />
                       </UnStyledButton>
                     </Tooltip>
                     <Tooltip label={LABEL.copy}>

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -77,6 +77,15 @@
   border-bottom: 1px solid oklch(var(--border-default));
 }
 
+/* The tab strip carries its own shorter height + bottom divider by default,
+   which double-lines against the header divider. Stretch it to the full header
+   height and drop its border so the header shows a single divider. */
+.graphiql-container .graphiql-session-header .graphiql-tabs {
+  height: auto;
+  align-self: stretch;
+  border-bottom: none;
+}
+
 /* The button to add a new tab */
 button.graphiql-tab-add {
   padding: var(--px-4);
@@ -260,6 +269,16 @@ button.graphiql-tab-strip-action {
 .graphiql-horizontal-drag-bar {
   width: var(--px-8);
   cursor: col-resize;
+}
+
+/* The editor/response resizer straddles the divider instead of taking layout
+   width of its own, so the response pane sits flush against the divider rather
+   than being pushed over by the bar. Width stays the same so the resize math
+   (which reads the bar's clientWidth) is unaffected. */
+.graphiql-container .graphiql-session-row > .graphiql-horizontal-drag-bar {
+  margin-inline: calc(var(--px-8) / -2);
+  position: relative;
+  z-index: 1;
 }
 
 .graphiql-horizontal-drag-bar:hover::after {

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -42,12 +42,11 @@
 }
 
 /* The editor side of the split: session header stacked above the editors.
-   The divider between the two panes runs the full height of this column. */
+   The divider between the two panes is drawn by the drag bar's sash. */
 .graphiql-container .graphiql-editor-column {
   display: flex;
   flex-direction: column;
   min-width: 0;
-  border-right: 1px solid oklch(var(--border-default));
 }
 
 /* The response side of the split */
@@ -265,34 +264,41 @@ button.graphiql-tab-strip-action {
   overflow: hidden;
 }
 
-/* Generic drag bar for horizontal resizing */
+/* Horizontal resizer, styled as a "sash": zero layout width so the panes sit
+   flush, an invisible expanded hit area straddling the seam, and a 1px divider
+   line. Width 0 also keeps the resize math (which subtracts the bar's
+   clientWidth) pixel-exact. */
 .graphiql-horizontal-drag-bar {
-  width: var(--px-8);
-  cursor: col-resize;
-}
-
-/* The editor/response resizer straddles the divider instead of taking layout
-   width of its own, so the response pane sits flush against the divider rather
-   than being pushed over by the bar. Width stays the same so the resize math
-   (which reads the bar's clientWidth) is unaffected. */
-.graphiql-container .graphiql-session-row > .graphiql-horizontal-drag-bar {
-  margin-inline: calc(var(--px-8) / -2);
+  width: 0;
   position: relative;
   z-index: 1;
 }
 
-.graphiql-horizontal-drag-bar:hover::after {
-  border: var(--px-2) solid
-    hsla(var(--color-neutral), var(--alpha-background-heavy));
-  border-radius: var(--border-radius-2);
+/* The grab zone: 8px straddling the seam, with no layout footprint. */
+.graphiql-horizontal-drag-bar::before {
   content: '';
-  display: block;
-  height: 25%;
-  margin: 0 auto;
-  position: relative;
-  /* (100% - 25%) / 2 = 37.5% */
-  top: 37.5%;
-  width: 0;
+  position: absolute;
+  inset-block: 0;
+  left: calc(var(--px-8) / -2);
+  width: var(--px-8);
+  cursor: col-resize;
+}
+
+/* The visible divider line, centered on the seam. */
+.graphiql-horizontal-drag-bar::after {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  left: -0.5px;
+  width: 1px;
+  background: oklch(var(--border-default));
+}
+
+/* Thicken the divider on hover/drag as the resize affordance. */
+.graphiql-horizontal-drag-bar:hover::after,
+.graphiql-horizontal-drag-bar:active::after {
+  left: -1px;
+  width: 2px;
 }
 
 .graphiql-container .graphiql-chevron-icon {

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -71,13 +71,13 @@ button.graphiql-tab-strip-action {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--px-4);
+  padding: var(--px-6);
   color: oklch(var(--fg-subtle));
 
   & > svg {
     display: block;
-    height: var(--icon-size-md);
-    width: var(--icon-size-md);
+    height: var(--icon-size-lg);
+    width: var(--icon-size-lg);
   }
 
   &:hover {

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -58,17 +58,23 @@
 }
 
 /* Match the response header's height to the editor's session header so the
-   view picker lines up with the tabs and action buttons across the split. */
+   view picker lines up with the tabs and action buttons across the split, and
+   drop its left padding so its content sits flush with the pane edge like the
+   tabs do on the editor side. */
 .graphiql-container .graphiql-response-header {
   height: var(--session-header-height);
+  padding-left: 0;
 }
 
-/* The session header containing tabs and the action buttons */
+/* The session header (tabs + action buttons) reads as a toolbar strip, matching
+   the elevated surface and divider of the response header across the split. */
 .graphiql-container .graphiql-session-header {
   height: var(--session-header-height);
   align-items: center;
   display: flex;
   gap: var(--px-8);
+  background: oklch(var(--bg-elevated));
+  border-bottom: 1px solid oklch(var(--border-default));
 }
 
 /* The button to add a new tab */

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -224,6 +224,8 @@ button.graphiql-tab-strip-action {
 /* The response view */
 .graphiql-container .graphiql-response {
   display: flex;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   flex-direction: column;
 }

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -59,7 +59,7 @@ button.graphiql-tab-add {
   }
 }
 
-/* Right-side tab strip action buttons (prettify, copy, save) */
+/* Right-side tab strip action buttons (prettify, merge, copy, save) */
 .graphiql-tab-strip-actions {
   display: flex;
   align-items: center;
@@ -85,7 +85,7 @@ button.graphiql-tab-strip-action {
   }
 }
 
-/* The GraphiQL logo */
+/* The GraphiQL.Logo slot, opt-in only: branding lives in the top bar by default */
 .graphiql-container .graphiql-logo {
   margin-left: auto;
   color: hsla(var(--color-neutral), var(--alpha-secondary));
@@ -130,7 +130,8 @@ button.graphiql-tab-strip-action {
   width: 100%;
 }
 
-/* The vertical toolbar next to the operation editor */
+/* The GraphiQL.Toolbar slot, opt-in only: prettify/merge/copy live in the
+   tab strip by default */
 .graphiql-container .graphiql-toolbar {
   width: var(--toolbar-width);
   display: flex;

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -38,12 +38,39 @@
   min-width: 0;
 }
 
-/* The session header containing tabs and the logo */
+/* The editor and response panes, split by the horizontal drag bar */
+.graphiql-container .graphiql-session-row {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  padding: var(--px-8);
+}
+
+/* The editor side of the split: session header stacked above the editors */
+.graphiql-container .graphiql-editor-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* The response side of the split */
+.graphiql-container .graphiql-response-column {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* Placeholder band keeping the response top aligned with the editor top */
+.graphiql-container .graphiql-response-header {
+  height: var(--session-header-height);
+  flex-shrink: 0;
+}
+
+/* The session header containing tabs and the action buttons */
 .graphiql-container .graphiql-session-header {
   height: var(--session-header-height);
   align-items: center;
   display: flex;
-  padding: var(--px-8) var(--px-8) 0;
   gap: var(--px-8);
 }
 
@@ -107,7 +134,7 @@ button.graphiql-tab-strip-action {
 .graphiql-container #graphiql-session {
   display: flex;
   flex: 1;
-  padding: 0 var(--px-8) var(--px-8);
+  min-height: 0;
 }
 
 /* All editors (operation, variable, request headers) */

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -57,12 +57,10 @@
 }
 
 /* Match the response header's height to the editor's session header so the
-   view picker lines up with the tabs and action buttons across the split, and
-   drop its left padding so its content sits flush with the pane edge like the
-   tabs do on the editor side. */
+   view picker lines up with the tabs and action buttons across the split. The
+   default horizontal padding keeps the status off the divider. */
 .graphiql-container .graphiql-response-header {
   height: var(--session-header-height);
-  padding-left: 0;
 }
 
 /* The session header (tabs + action buttons) reads as a toolbar strip, matching
@@ -272,6 +270,7 @@ button.graphiql-tab-strip-action {
   width: 0;
   position: relative;
   z-index: 1;
+  cursor: col-resize;
 }
 
 /* The grab zone: 8px straddling the seam, with no layout footprint. */

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -57,10 +57,10 @@
   min-width: 0;
 }
 
-/* Placeholder band keeping the response top aligned with the editor top */
+/* Match the response header's height to the editor's session header so the
+   view picker lines up with the tabs and action buttons across the split. */
 .graphiql-container .graphiql-response-header {
   height: var(--session-header-height);
-  flex-shrink: 0;
 }
 
 /* The session header containing tabs and the action buttons */
@@ -223,8 +223,6 @@ button.graphiql-tab-strip-action {
 
 /* The response view */
 .graphiql-container .graphiql-response {
-  /* Add some padding so it doesn't touch the tabs */
-  padding-top: var(--px-16);
   display: flex;
   width: 100%;
   flex-direction: column;

--- a/packages/graphiql/src/ui/toolbar.tsx
+++ b/packages/graphiql/src/ui/toolbar.tsx
@@ -22,6 +22,9 @@ const DefaultToolbarRenderProps: FC<{
 
 /**
  * Configure the UI by providing this Component as a child of GraphiQL.
+ * Not rendered by default: the tab strip's action buttons cover prettify,
+ * merge, and copy out of the box. This remains available for embedders who
+ * want the standalone toolbar.
  */
 export const GraphiQLToolbar: FC<{
   children?: typeof DefaultToolbarRenderProps | ReactNode;
@@ -30,7 +33,15 @@ export const GraphiQLToolbar: FC<{
   const { copyQuery, prettifyEditors, mergeQuery } = useGraphiQLActions();
 
   if (!isRenderProp) {
-    return children as ReactElement;
+    return (
+      <div
+        className="graphiql-toolbar"
+        role="toolbar"
+        aria-label="Editor Commands"
+      >
+        {children as ReactElement}
+      </div>
+    );
   }
 
   const prettify = (
@@ -60,5 +71,19 @@ export const GraphiQLToolbar: FC<{
     </ToolbarButton>
   );
 
-  return children({ prettify, copy, merge });
+  const rendered = (children as typeof DefaultToolbarRenderProps)({
+    prettify,
+    copy,
+    merge,
+  }) as ReactElement;
+
+  return (
+    <div
+      className="graphiql-toolbar"
+      role="toolbar"
+      aria-label="Editor Commands"
+    >
+      {rendered}
+    </div>
+  );
 };


### PR DESCRIPTION
## Summary

- Remove the legacy vertical editor toolbar and the floating "GraphiQL" corner logo. Branding now lives only in the top bar, and editor actions live only in the tab strip.
- Move Merge Fragments, previously available only in the old toolbar, into the tab-strip actions alongside Prettify, Copy, and Save, so the action isn't lost.
- The composable `Toolbar`/`Logo` render-prop slots still work for embedders. Only the default rendering is removed.
- Enlarge the tab-strip action buttons so they're easier to click.
- Position the action buttons at the right edge of the query editor instead of the far right of the response pane, so they stay next to the query and follow the editor/response divider as it's resized. The sessions area is split into an editor column and a response column divided by the drag bar; the tab strip lives in the editor column.

## Test plan

- [x] Open GraphiQL. There's no floating vertical button column and no corner logo over the editor; branding appears once, in the top bar.
- [x] The tab strip shows Prettify, Merge Fragments, Copy, and Save, each exactly once.
- [x] The action buttons sit at the right edge of the query editor (by the editor/response divider), not over the response pane, and follow the divider when it's dragged.
- [x] Write a query that references a fragment, click Merge Fragments, and confirm the fragment gets inlined into the operation.
- [x] Prettify reformats the query, Copy copies it, and the single Run button in the top bar still executes it.
- [x] The Prettify, Merge, and Copy keyboard shortcuts still work.
- [x] The tab-strip action buttons read as comfortably sized, not cramped, and stay evenly spaced and aligned with the tab labels.

Refs: graphql/graphiql#4219