### PR TITLE
v6: Open schema search with Cmd+K and remove the dead top-bar button

### DIFF
--- a/.changeset/schema-search-cmdk.md
+++ b/.changeset/schema-search-cmdk.md
@@ -1,0 +1,7 @@
+---
+'@graphiql/react': patch
+'@graphiql/plugin-doc-explorer': patch
+'graphiql': patch
+---
+
+Schema search now opens with `Cmd/Ctrl+K`; removed the dead top-bar button that never opened anything.

--- a/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/components/__tests__/doc-explorer.spec.tsx
@@ -18,6 +18,7 @@ vi.mock('@graphiql/react', async () => {
   return {
     ...originalModule,
     useGraphiQL: vi.fn(),
+    useGraphiQLActions: vi.fn(() => ({ setVisiblePlugin: vi.fn() })),
   };
 });
 

--- a/packages/graphiql-plugin-doc-explorer/src/context.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/context.spec.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { type Mock } from 'vitest';
+import { useGraphiQL as $useGraphiQL, useGraphiQLActions as $useGraphiQLActions } from '@graphiql/react';
+import { DOC_EXPLORER_PLUGIN, DocExplorerStore } from './context';
+
+const useGraphiQL = $useGraphiQL as Mock;
+const useGraphiQLActions = $useGraphiQLActions as Mock;
+
+vi.mock('@graphiql/react', async () => {
+  const originalModule =
+    await vi.importActual<typeof import('@graphiql/react')>('@graphiql/react');
+  return {
+    ...originalModule,
+    useGraphiQL: vi.fn(),
+    useGraphiQLActions: vi.fn(),
+  };
+});
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: { field: { type: GraphQLString } },
+  }),
+});
+
+const setVisiblePlugin = vi.fn();
+
+function setup() {
+  useGraphiQL.mockImplementation(cb =>
+    cb({ schema, validationErrors: [], schemaReference: null }),
+  );
+  useGraphiQLActions.mockReturnValue({ setVisiblePlugin });
+  return render(
+    <DocExplorerStore>
+      <div />
+    </DocExplorerStore>,
+  );
+}
+
+describe('DocExplorerStore keyboard shortcut', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('opens the doc explorer on plain Cmd/Ctrl+K, without requiring Alt', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    await user.keyboard('{Meta>}{k}{/Meta}');
+
+    expect(setVisiblePlugin).toHaveBeenCalledWith(DOC_EXPLORER_PLUGIN);
+  });
+
+  it('does not open the doc explorer for Alt+Cmd/Ctrl+K (old binding)', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    await user.keyboard('{Alt>}{Meta>}{k}{/Meta}{/Alt}');
+
+    expect(setVisiblePlugin).not.toHaveBeenCalled();
+  });
+
+  it('focuses the search input after opening via Cmd/Ctrl+K', async () => {
+    const user = userEvent.setup();
+    setup();
+
+    const searchInput = document.createElement('div');
+    searchInput.className = 'graphiql-doc-explorer-search-input';
+    const clickSpy = vi.fn();
+    searchInput.addEventListener('click', clickSpy);
+    document.body.append(searchInput);
+
+    await user.keyboard('{Meta>}{k}{/Meta}');
+
+    await vi.waitFor(() => {
+      expect(clickSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('prevents default so Monaco does not swallow the shortcut', () => {
+    setup();
+
+    const event = new KeyboardEvent('keydown', {
+      code: 'KeyK',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    window.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(setVisiblePlugin).toHaveBeenCalledWith(DOC_EXPLORER_PLUGIN);
+  });
+});

--- a/packages/graphiql-plugin-doc-explorer/src/context.spec.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/context.spec.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 import { type Mock } from 'vitest';
-import { useGraphiQL as $useGraphiQL, useGraphiQLActions as $useGraphiQLActions } from '@graphiql/react';
+import {
+  useGraphiQL as $useGraphiQL,
+  useGraphiQLActions as $useGraphiQLActions,
+  isMacOs,
+} from '@graphiql/react';
 import { DOC_EXPLORER_PLUGIN, DocExplorerStore } from './context';
 
 const useGraphiQL = $useGraphiQL as Mock;
@@ -40,6 +43,22 @@ function setup() {
   );
 }
 
+// `isMacOs` is derived from the test environment's user agent, so build the
+// keydown event using whichever modifier this handler actually expects.
+function dispatchSearchShortcut(extra: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent('keydown', {
+    code: 'KeyK',
+    metaKey: isMacOs,
+    ctrlKey: !isMacOs,
+    bubbles: true,
+    cancelable: true,
+    ...extra,
+  });
+  const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+  window.dispatchEvent(event);
+  return { event, preventDefaultSpy };
+}
+
 describe('DocExplorerStore keyboard shortcut', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,53 +69,53 @@ describe('DocExplorerStore keyboard shortcut', () => {
     document.body.innerHTML = '';
   });
 
-  it('opens the doc explorer on plain Cmd/Ctrl+K, without requiring Alt', async () => {
-    const user = userEvent.setup();
+  it('opens the doc explorer on plain Cmd/Ctrl+K, without requiring Alt', () => {
     setup();
 
-    await user.keyboard('{Meta>}{k}{/Meta}');
+    dispatchSearchShortcut();
 
     expect(setVisiblePlugin).toHaveBeenCalledWith(DOC_EXPLORER_PLUGIN);
   });
 
-  it('does not open the doc explorer for Alt+Cmd/Ctrl+K (old binding)', async () => {
-    const user = userEvent.setup();
+  it('does not open the doc explorer for Alt+Cmd/Ctrl+K (old binding)', () => {
     setup();
 
-    await user.keyboard('{Alt>}{Meta>}{k}{/Meta}{/Alt}');
+    dispatchSearchShortcut({ altKey: true });
+
+    // The old binding required Alt; the new one doesn't care either way,
+    // so this should still fire. Guard against a regression back to
+    // requiring Alt by asserting it fires with Alt held too.
+    expect(setVisiblePlugin).toHaveBeenCalledWith(DOC_EXPLORER_PLUGIN);
+  });
+
+  it('does nothing when the modifier key is missing', () => {
+    setup();
+
+    dispatchSearchShortcut({ metaKey: false, ctrlKey: false });
 
     expect(setVisiblePlugin).not.toHaveBeenCalled();
   });
 
   it('focuses the search input after opening via Cmd/Ctrl+K', async () => {
-    const user = userEvent.setup();
     setup();
 
     const searchInput = document.createElement('div');
-    searchInput.className = 'graphiql-doc-explorer-search-input';
+    searchInput.className = 'graphiql-doc-explorer-search-row-input';
     const clickSpy = vi.fn();
     searchInput.addEventListener('click', clickSpy);
     document.body.append(searchInput);
 
-    await user.keyboard('{Meta>}{k}{/Meta}');
+    dispatchSearchShortcut();
 
     await vi.waitFor(() => {
       expect(clickSpy).toHaveBeenCalled();
     });
   });
 
-  it('prevents default so Monaco does not swallow the shortcut', () => {
+  it('prevents default so Monaco does not swallow the shortcut even with an editor focused', () => {
     setup();
 
-    const event = new KeyboardEvent('keydown', {
-      code: 'KeyK',
-      metaKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
-
-    window.dispatchEvent(event);
+    const { preventDefaultSpy } = dispatchSearchShortcut();
 
     expect(preventDefaultSpy).toHaveBeenCalled();
     expect(setVisiblePlugin).toHaveBeenCalledWith(DOC_EXPLORER_PLUGIN);

--- a/packages/graphiql-plugin-doc-explorer/src/context.tsx
+++ b/packages/graphiql-plugin-doc-explorer/src/context.tsx
@@ -18,6 +18,7 @@ import { FC, ReactElement, ReactNode, useEffect } from 'react';
 import {
   SchemaReference,
   useGraphiQL,
+  useGraphiQLActions,
   pick,
   createBoundedUseStore,
   GraphiQLPlugin,
@@ -268,12 +269,33 @@ export const docExplorerStore = createStore<DocExplorerStoreType>(
   }),
 );
 
+// The doc-explorer panel (and its search input) mounts asynchronously after
+// `setVisiblePlugin` commits, which isn't guaranteed to land within a single
+// animation frame, so poll across a few frames rather than assuming one is
+// enough.
+function focusSearchInputWhenMounted(framesLeft: number) {
+  if (framesLeft <= 0) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    const el = document.querySelector<HTMLDivElement>(
+      '.graphiql-doc-explorer-search-row-input',
+    );
+    if (el) {
+      el.click();
+    } else {
+      focusSearchInputWhenMounted(framesLeft - 1);
+    }
+  });
+}
+
 export const DocExplorerStore: FC<{
   children: ReactNode;
 }> = ({ children }) => {
   const { schema, validationErrors, schemaReference } = useGraphiQL(
     pick('schema', 'validationErrors', 'schemaReference'),
   );
+  const { setVisiblePlugin } = useGraphiQLActions();
 
   useEffect(() => {
     const { resolveSchemaReferenceToNavItem } =
@@ -295,35 +317,31 @@ export const DocExplorerStore: FC<{
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      const shouldFocusInput =
-        // Use an additional `Alt` key instead of `Cmd/Ctrl+K` because monaco-editor has a built-in
-        // shortcut for `Cmd/Ctrl+K`
-        event.altKey &&
+      const shouldOpenSearch =
         event[isMacOs ? 'metaKey' : 'ctrlKey'] &&
         // Using `event.code` because `event.key` will trigger different character
         // in English `˚` and in French `È`
         event.code === 'KeyK';
-      if (!shouldFocusInput) {
+      if (!shouldOpenSearch) {
         return;
       }
-      const button = document.querySelector<HTMLButtonElement>(
-        '.graphiql-sidebar button[aria-label="Show Documentation Explorer"]',
-      );
-      button?.click();
-      // Execute on next tick when doc explorer is opened and input exists in DOM
-      requestAnimationFrame(() => {
-        const el = document.querySelector<HTMLDivElement>(
-          '.graphiql-doc-explorer-search-input',
-        );
-        el?.click();
-      });
+      // Take priority over monaco-editor's built-in `Cmd/Ctrl+K` binding even
+      // when an editor pane has focus.
+      event.preventDefault();
+      event.stopPropagation();
+
+      setVisiblePlugin(DOC_EXPLORER_PLUGIN);
+      // The panel (and its search input) mounts after this state update
+      // commits, which isn't guaranteed to land within a single animation
+      // frame, so poll across a few frames rather than assuming one is enough.
+      focusSearchInputWhenMounted(10);
     }
 
-    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown, true);
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown, true);
     };
-  }, []);
+  }, [setVisiblePlugin]);
 
   return children as ReactElement;
 };

--- a/packages/graphiql-react/src/components/top-bar/index.css
+++ b/packages/graphiql-react/src/components/top-bar/index.css
@@ -44,22 +44,6 @@
   flex-shrink: 0;
 }
 
-.graphiql-top-bar-cmd {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--px-6);
-  padding: 0 var(--px-10);
-  height: 24px;
-  background: oklch(var(--bg-subtle));
-  border: 1px solid oklch(var(--border-strong));
-  border-radius: var(--radius-md);
-  color: oklch(var(--fg-subtle));
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-small);
-  cursor: pointer;
-  white-space: nowrap;
-}
-
 .graphiql-top-bar-endpoint {
   display: inline-flex;
   align-items: center;

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -127,14 +127,6 @@ export const TopBarView: FC<TopBarViewProps> = ({
         <span className="graphiql-top-bar-endpoint-url">{url}</span>
       </div>
 
-      <button type="button" className="graphiql-top-bar-cmd">
-        <span>Jump to schema</span>
-        <KeycapHint
-          keys={[MODIFIER.Meta, 'K']}
-          ariaLabel="Open command palette"
-        />
-      </button>
-
       {isBlocked ? (
         <Tooltip label={runDisabledReason}>
           {/* A native disabled button emits no pointer/focus events, so Radix

--- a/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
@@ -232,9 +232,9 @@ describe('TopBarView', () => {
     ).toBeNull();
   });
 
-  it('renders the command palette button', () => {
+  it('does not render a jump-to-schema button', () => {
     render(<TopBarView {...DEFAULTS} />);
-    expect(screen.getByText('Jump to schema')).toBeInTheDocument();
+    expect(screen.queryByText('Jump to schema')).not.toBeInTheDocument();
   });
 
   it('has role="banner" on the header element', () => {

--- a/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.test.tsx
@@ -232,11 +232,6 @@ describe('TopBarView', () => {
     ).toBeNull();
   });
 
-  it('does not render a jump-to-schema button', () => {
-    render(<TopBarView {...DEFAULTS} />);
-    expect(screen.queryByText('Jump to schema')).not.toBeInTheDocument();
-  });
-
   it('has role="banner" on the header element', () => {
     const { container } = render(<TopBarView {...DEFAULTS} />);
     expect(container.querySelector('header[role="banner"]')).not.toBeNull();

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -42,7 +42,7 @@ export const KEY_MAP = Object.freeze({
     key: 'Ctrl-F',
   },
   searchInDocs: {
-    key: 'Ctrl-Alt-K',
+    key: 'Ctrl-K',
   },
 });
 

--- a/packages/graphiql/src/GraphiQL.spec.tsx
+++ b/packages/graphiql/src/GraphiQL.spec.tsx
@@ -18,6 +18,7 @@ import {
   useGraphiQL,
   useOperationsEditorState,
   MonacoEditor,
+  isMacOs,
 } from '@graphiql/react';
 import '@graphiql/react/setup-workers/vite';
 
@@ -251,6 +252,34 @@ describe('GraphiQL', () => {
 
       await waitFor(() => {
         expect(container.querySelector('.graphiql-plugin')).not.toBeVisible();
+      });
+    });
+
+    it('reveals the plugin pane when Cmd/Ctrl+K opens the doc explorer', async () => {
+      const { container } = render(<GraphiQL fetcher={noOpFetcher} />);
+
+      const pane = container.querySelector('.graphiql-plugin');
+      await waitFor(() => {
+        expect(pane).not.toBeVisible();
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            code: 'KeyK',
+            metaKey: isMacOs,
+            ctrlKey: !isMacOs,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(pane).toBeVisible();
+        expect(
+          container.querySelector('.graphiql-doc-explorer'),
+        ).toBeInTheDocument();
       });
     });
   }); // plugins

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -378,12 +378,6 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
     }
   }, [visiblePlugin, pluginHiddenElement, setPluginHiddenElement]);
 
-  function onClickReference() {
-    if (pluginHiddenElement === 'first') {
-      setPluginHiddenElement(null);
-    }
-  }
-
   const toggleEditorTools: ButtonHandler = () => {
     setEditorToolsHiddenElement(
       editorToolsHiddenElement === 'second' ? null : 'second',
@@ -421,10 +415,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
         ref={editorToolsFirstRef}
       >
         {hasMonaco ? (
-          <QueryEditor
-            onClickReference={onClickReference}
-            onEdit={onEditQuery}
-          />
+          <QueryEditor onEdit={onEditQuery} />
         ) : (
           <Spinner />
         )}

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -414,11 +414,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
         aria-label="Operation Editor"
         ref={editorToolsFirstRef}
       >
-        {hasMonaco ? (
-          <QueryEditor onEdit={onEditQuery} />
-        ) : (
-          <Spinner />
-        )}
+        {hasMonaco ? <QueryEditor onEdit={onEditQuery} /> : <Spinner />}
 
         <div
           className="graphiql-toolbar"

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -10,7 +10,7 @@ import type {
   FC,
   ComponentPropsWithoutRef,
 } from 'react';
-import { Children, useRef, useState, Fragment } from 'react';
+import { Children, useEffect, useRef, useState, Fragment } from 'react';
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -366,6 +366,17 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
       children: [],
     },
   );
+
+  // `visiblePlugin` and the pane's collapsed state are separate: the store
+  // tracks which plugin is active, while `useDragResize` owns the pane width.
+  // Reveal the pane whenever a plugin becomes visible through any path that
+  // doesn't manage the drag-resize state itself (the ⌘K shortcut, the
+  // `visiblePlugin` prop, or a plugin calling `setVisiblePlugin` directly).
+  useEffect(() => {
+    if (visiblePlugin && pluginHiddenElement === 'first') {
+      setPluginHiddenElement(null);
+    }
+  }, [visiblePlugin, pluginHiddenElement, setPluginHiddenElement]);
 
   function onClickReference() {
     if (pluginHiddenElement === 'first') {


### PR DESCRIPTION
## Summary

Schema search was unreachable. The top-bar "Jump to schema" button had no `onClick`, and the real shortcut (`⌘⌥K`) clicked a `.graphiql-sidebar` button selector that stopped existing once v6 renamed that container to `.graphiql-activity-rail`.

The dead button is gone, and schema search is rebound to plain `⌘K` / `Ctrl+K`. The handler opens the doc explorer through `setVisiblePlugin` instead of clicking a DOM node, and it takes priority over monaco-editor's own `Cmd+K` binding, so it works whether or not an editor pane has focus. The shortcuts help dialog and key map are updated to match.

## Test plan

- [x] Press `⌘K` (or `Ctrl+K`) with no editor focused. The doc explorer opens and the search input is focused.
- [x] Click into the query editor, then press `⌘K`. The doc explorer still opens and search is focused; Monaco should not swallow the shortcut.
- [x] Confirm the old "Jump to schema" button in the top bar is gone.
- [x] Open the shortcuts help dialog (`?` or the help entry) and confirm "Search in documentation" lists `⌘K` with no Alt/Option.

Refs: graphql/graphiql#4219
