### PR TITLE
v6: Simplify the status bar and make the connection indicator functional

### DIFF
--- a/.changeset/status-bar-cleanup.md
+++ b/.changeset/status-bar-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Trim the status bar to a connection indicator (reflecting real idle/connecting/connected/error state) and a static types count, dropping the plugin count, encoding, and language labels.

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -33,7 +33,7 @@ export type { MethodPillProps, Operation } from './method-pill';
 export { TopBar, TopBarView } from './top-bar';
 export type { TopBarProps, TopBarViewProps } from './top-bar';
 export { StatusBar, StatusBarView } from './status-bar';
-export type { StatusBarProps, StatusBarViewProps } from './status-bar';
+export type { ConnectionStatus, StatusBarViewProps } from './status-bar';
 export { SidePanel, SidePanelView } from './side-panel';
 export type { SidePanelViewProps } from './side-panel';
 export { ActivityRail } from './activity-rail';

--- a/packages/graphiql-react/src/components/status-bar/index.css
+++ b/packages/graphiql-react/src/components/status-bar/index.css
@@ -12,10 +12,6 @@
   font-size: var(--font-size-eyebrow);
 }
 
-.graphiql-status-bar-spacer {
-  flex: 1;
-}
-
 .graphiql-status-bar-conn {
   display: inline-flex;
   align-items: center;
@@ -29,14 +25,18 @@
   border-radius: 50%;
 }
 
-.graphiql-status-bar-conn.connected .graphiql-status-bar-conn-dot {
+.graphiql-status-bar-conn-idle .graphiql-status-bar-conn-dot {
+  background: oklch(var(--fg-dim));
+}
+
+.graphiql-status-bar-conn-connecting .graphiql-status-bar-conn-dot {
+  background: oklch(var(--accent-yellow));
+}
+
+.graphiql-status-bar-conn-connected .graphiql-status-bar-conn-dot {
   background: oklch(var(--accent-green));
 }
 
-.graphiql-status-bar-conn.disconnected .graphiql-status-bar-conn-dot {
+.graphiql-status-bar-conn-error .graphiql-status-bar-conn-dot {
   background: oklch(var(--accent-red));
-}
-
-.graphiql-status-bar-plugins {
-  color: oklch(var(--accent-purple));
 }

--- a/packages/graphiql-react/src/components/status-bar/index.tsx
+++ b/packages/graphiql-react/src/components/status-bar/index.tsx
@@ -4,55 +4,61 @@ import type { FC } from 'react';
 import { useGraphiQL } from '../provider';
 import './index.css';
 
-export type StatusBarProps = {
-  encoding?: string;
+export type ConnectionStatus = 'idle' | 'connecting' | 'connected' | 'error';
+
+const CONNECTION_LABEL: Record<ConnectionStatus, string> = {
+  idle: 'Idle',
+  connecting: 'Connecting',
+  connected: 'Connected',
+  error: 'Connection error',
 };
 
-export type StatusBarViewProps = StatusBarProps & {
-  isConnected: boolean;
+export type StatusBarViewProps = {
+  connectionStatus: ConnectionStatus;
   typeCount: number;
-  pluginCount: number;
 };
 
 export const StatusBarView: FC<StatusBarViewProps> = ({
-  isConnected,
+  connectionStatus,
   typeCount,
-  pluginCount,
-  encoding = 'UTF-8',
 }) => (
   <footer className="graphiql-status-bar" role="contentinfo">
     <span
-      className={`graphiql-status-bar-conn${isConnected ? ' connected' : ' disconnected'}`}
+      className={`graphiql-status-bar-conn graphiql-status-bar-conn-${connectionStatus}`}
+      title={CONNECTION_LABEL[connectionStatus]}
     >
       <span className="graphiql-status-bar-conn-dot" aria-hidden="true" />
-      {isConnected ? 'Connected' : 'Disconnected'}
+      {CONNECTION_LABEL[connectionStatus]}
     </span>
-    {isConnected && (
+    {connectionStatus !== 'idle' && (
       <span className="graphiql-status-bar-types">{typeCount} types</span>
     )}
-    {pluginCount > 0 && (
-      <span className="graphiql-status-bar-plugins">
-        {pluginCount} {pluginCount === 1 ? 'plugin' : 'plugins'}
-      </span>
-    )}
-    <span className="graphiql-status-bar-spacer" />
-    <span>{encoding}</span>
-    <span>GraphQL</span>
   </footer>
 );
 
-export const StatusBar: FC<StatusBarProps> = props => {
+export const StatusBar: FC = () => {
   const schema = useGraphiQL(state => state.schema);
-  const plugins = useGraphiQL(state => state.plugins);
-  const isConnected = schema != null;
+  const fetchError = useGraphiQL(state => state.fetchError);
+  const isIntrospecting = useGraphiQL(state => state.isIntrospecting);
+  const isFetching = useGraphiQL(state => state.isFetching);
+  const lastResponse = useGraphiQL(state => state.lastResponse);
+
   const typeCount = schema ? Object.keys(schema.getTypeMap()).length : 0;
 
+  const connectionStatus: ConnectionStatus = (() => {
+    if (fetchError || lastResponse?.ok === false) {
+      return 'error';
+    }
+    if (isIntrospecting || isFetching) {
+      return 'connecting';
+    }
+    if (schema != null) {
+      return 'connected';
+    }
+    return 'idle';
+  })();
+
   return (
-    <StatusBarView
-      {...props}
-      isConnected={isConnected}
-      typeCount={typeCount}
-      pluginCount={plugins.length}
-    />
+    <StatusBarView connectionStatus={connectionStatus} typeCount={typeCount} />
   );
 };

--- a/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.stories.tsx
@@ -62,35 +62,30 @@ export default meta;
 
 type Story = StoryObj<typeof StatusBarView>;
 
-export const Disconnected: Story = {
+export const Idle: Story = {
   args: {
-    isConnected: false,
+    connectionStatus: 'idle',
     typeCount: 0,
-    pluginCount: 0,
+  },
+};
+
+export const Connecting: Story = {
+  args: {
+    connectionStatus: 'connecting',
+    typeCount: 0,
   },
 };
 
 export const Connected: Story = {
   args: {
-    isConnected: true,
+    connectionStatus: 'connected',
     typeCount,
-    pluginCount: 0,
   },
 };
 
-export const WithPlugins: Story = {
+export const ConnectionError: Story = {
   args: {
-    isConnected: true,
-    typeCount,
-    pluginCount: 2,
-  },
-};
-
-export const CustomEncoding: Story = {
-  args: {
-    isConnected: false,
+    connectionStatus: 'error',
     typeCount: 0,
-    pluginCount: 0,
-    encoding: 'UTF-16',
   },
 };

--- a/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
+++ b/packages/graphiql-react/src/components/status-bar/status-bar.test.tsx
@@ -6,83 +6,93 @@ import { buildSchema } from 'graphql';
 import { StatusBarView } from './';
 
 const SCHEMA = buildSchema(`type Query { hello: String }`);
-
-const CONNECTED_DEFAULTS = {
-  isConnected: true,
-  typeCount: Object.keys(SCHEMA.getTypeMap()).length,
-  pluginCount: 0,
-};
-
-const DISCONNECTED_DEFAULTS = {
-  isConnected: false,
-  typeCount: 0,
-  pluginCount: 0,
-};
+const typeCount = Object.keys(SCHEMA.getTypeMap()).length;
 
 describe('StatusBarView', () => {
-  it('shows "Disconnected" when not connected', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  it('shows "Idle" when no schema has been loaded and nothing is in flight', () => {
+    render(<StatusBarView connectionStatus="idle" typeCount={0} />);
+    expect(screen.getByText('Idle')).toBeInTheDocument();
   });
 
-  it('shows "Connected" when connected', () => {
-    render(<StatusBarView {...CONNECTED_DEFAULTS} />);
+  it('shows "Connecting" while introspecting or fetching', () => {
+    render(<StatusBarView connectionStatus="connecting" typeCount={0} />);
+    expect(screen.getByText('Connecting')).toBeInTheDocument();
+  });
+
+  it('shows "Connected" once a schema is loaded', () => {
+    render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
     expect(screen.getByText('Connected')).toBeInTheDocument();
   });
 
-  it('shows type count when connected', () => {
-    render(<StatusBarView {...CONNECTED_DEFAULTS} />);
-    expect(
-      screen.getByText(`${CONNECTED_DEFAULTS.typeCount} types`),
-    ).toBeInTheDocument();
+  it('shows "Connection error" when the last request failed', () => {
+    render(<StatusBarView connectionStatus="error" typeCount={0} />);
+    expect(screen.getByText('Connection error')).toBeInTheDocument();
   });
 
-  it('does not show type count when disconnected', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.queryByText(/types/)).toBeNull();
-  });
-
-  it('shows plugin count when plugins are registered', () => {
-    render(<StatusBarView {...CONNECTED_DEFAULTS} pluginCount={2} />);
-    expect(screen.getByText('2 plugins')).toBeInTheDocument();
-  });
-
-  it('uses singular "plugin" for one plugin', () => {
-    render(<StatusBarView {...CONNECTED_DEFAULTS} pluginCount={1} />);
-    expect(screen.getByText('1 plugin')).toBeInTheDocument();
-  });
-
-  it('does not show plugin count when no plugins are registered', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.queryByText(/plugin/)).toBeNull();
-  });
-
-  it('shows default encoding', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.getByText('UTF-8')).toBeInTheDocument();
-  });
-
-  it('shows custom encoding', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} encoding="UTF-16" />);
-    expect(screen.getByText('UTF-16')).toBeInTheDocument();
-  });
-
-  it('renders a status dot inside the connection label', () => {
-    const { container } = render(<StatusBarView {...CONNECTED_DEFAULTS} />);
+  it('renders a status dot reflecting the connection state', () => {
+    const { container } = render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
     expect(
       container.querySelector(
-        '.graphiql-status-bar-conn.connected .graphiql-status-bar-conn-dot',
+        '.graphiql-status-bar-conn-connected .graphiql-status-bar-conn-dot',
       ),
     ).not.toBeNull();
   });
 
-  it('always shows the GraphQL language label', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
-    expect(screen.getByText('GraphQL')).toBeInTheDocument();
+  it('sets an accessible title matching the connection label', () => {
+    const { container } = render(
+      <StatusBarView connectionStatus="error" typeCount={0} />,
+    );
+    expect(
+      container
+        .querySelector('.graphiql-status-bar-conn')
+        ?.getAttribute('title'),
+    ).toBe('Connection error');
+  });
+
+  it('shows type count once connected', () => {
+    render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
+    expect(screen.getByText(`${typeCount} types`)).toBeInTheDocument();
+  });
+
+  it('shows type count while an error is present (schema already loaded)', () => {
+    render(<StatusBarView connectionStatus="error" typeCount={typeCount} />);
+    expect(screen.getByText(`${typeCount} types`)).toBeInTheDocument();
+  });
+
+  it('does not show type count when idle', () => {
+    render(<StatusBarView connectionStatus="idle" typeCount={0} />);
+    expect(screen.queryByText(/types/)).toBeNull();
+  });
+
+  it('does not show a plugin count', () => {
+    render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
+    expect(screen.queryByText(/plugins?/)).toBeNull();
+  });
+
+  it('does not show the UTF-8 encoding label', () => {
+    render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
+    expect(screen.queryByText('UTF-8')).toBeNull();
+  });
+
+  it('does not show the GraphQL language label', () => {
+    render(
+      <StatusBarView connectionStatus="connected" typeCount={typeCount} />,
+    );
+    expect(screen.queryByText('GraphQL')).toBeNull();
   });
 
   it('renders as a footer with role contentinfo', () => {
-    render(<StatusBarView {...DISCONNECTED_DEFAULTS} />);
+    render(<StatusBarView connectionStatus="idle" typeCount={0} />);
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- The bottom status bar drops the plugin count, the `UTF-8` encoding label, and the `GraphQL` language label. None of them told the user anything useful; they just made the bar look like a code editor's chrome.
- The connection dot reflects real state instead of just "schema loaded or not." It's amber while introspection or a request is in flight, green once a schema is loaded, red when the last introspection or request failed, and gray when nothing has happened yet. Each state has a matching text label and an accessible title on the dot.
- The types count stays as a plain readout ("142 types") once a schema is loaded. It's deliberately not clickable, so the status bar doesn't reach into the doc-explorer plugin.
- This doesn't cover full subscription-level status (an open subscription's live/closed state, tracked separately from a one-shot query). The dot derives from schema-load state plus the last request's fetch/error state, which handles the common cases without new transport plumbing.

## Test plan

- [x] Open GraphiQL. The status bar shows only a connection dot with a label and a types count, with no plugin count, `UTF-8`, or `GraphQL`.
- [x] Before a schema loads, the dot is gray and reads "Idle".
- [x] While the schema is loading, the dot is amber and reads "Connecting".
- [x] Once the schema loads, the dot turns green, reads "Connected", and the types count appears.
- [x] Run a query successfully. The dot stays green.
- [x] Point the endpoint at something that errors (bad URL, malformed response). The dot turns red and reads "Connection error".
- [ ] `yarn workspace @graphiql/react test` passes.

Refs: graphql/graphiql#4219
