### PR TITLE
v6: Remove editor tab/editor inset padding

### DIFF
--- a/.changeset/flush-editor-inset.md
+++ b/.changeset/flush-editor-inset.md
@@ -1,0 +1,5 @@
+---
+'graphiql': patch
+---
+
+Remove the inset padding around the editor tab strip and editor area so they sit flush against the workspace edges and the column divider.

--- a/packages/graphiql/src/graphiql.css
+++ b/packages/graphiql/src/graphiql.css
@@ -39,7 +39,6 @@
   height: var(--session-header-height);
   align-items: center;
   display: flex;
-  padding: var(--px-8) var(--px-8) 0;
   gap: var(--px-8);
 }
 
@@ -103,7 +102,6 @@ button.graphiql-tab-strip-action {
 .graphiql-container #graphiql-session {
   display: flex;
   flex: 1;
-  padding: 0 var(--px-8) var(--px-8);
 }
 
 /* All editors (operation, variable, request headers) */


### PR DESCRIPTION
## Summary

The editor tab strip and editor area sat inset 8px from their column edges. That padding was there to clear the rounded corner of the old editor card, which has since been flattened, so the inset no longer does anything. It just reads as uneven whitespace, most noticeably on the left. This drops it so the tabs and editors sit flush against the column edges and the divider.

## Test plan

- [x] Open GraphiQL. The tabs and editor area sit flush against the left edge of their column — no gap between them and the activity-rail divider.
- [x] There's no extra gap above the tabs or below the editor; the editor region fills its column.
- [x] The tab labels still line up with the editor content beneath them.
- [x] Toggle Dark and Light — the flush layout holds in both.

Refs: graphql/graphiql#4219
