### PR TITLE
v6: Document the OKLCH token system in the `@graphiql/react` README

### DIFF
--- a/.changeset/readme-oklch-tokens.md
+++ b/.changeset/readme-oklch-tokens.md
@@ -1,5 +1,0 @@
----
-'@graphiql/react': patch
----
-
-Document the v6 OKLCH design tokens (`--bg-*`, `--border-*`, `--fg-*`, `--accent-*`, `--type-*`, `--btn-*`, `--radius-*`, `--shadow-*`) and the `typeCategory` helper in the README's theming section, and mark the legacy v5 `--color-*` HSL variables deprecated.

--- a/.changeset/readme-oklch-tokens.md
+++ b/.changeset/readme-oklch-tokens.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Document the v6 OKLCH design tokens (`--bg-*`, `--border-*`, `--fg-*`, `--accent-*`, `--type-*`, `--btn-*`, `--radius-*`, `--shadow-*`) and the `typeCategory` helper in the README's theming section, and mark the legacy v5 `--color-*` HSL variables deprecated.

--- a/docs/migration/graphiql-6.0.0.md
+++ b/docs/migration/graphiql-6.0.0.md
@@ -48,7 +48,7 @@ The new tokens are stored as `L% C H` component triplets (lightness percent, chr
 
 There is no published mapping from the nine v5 `--color-*` names to these — the two palettes aren't a 1:1 redesign of each other. Some v5 roles split into several v6 tokens (one `--color-base` background becomes four: `--bg-canvas`, `--bg-elevated`, `--bg-subtle`, `--bg-overlay`), and v6 introduces categories v5 didn't have at all, like a three-step border scale and a dedicated `--fg-disabled` / `--fg-dim` pair for de-emphasized text. If you have a bespoke theme, treat the new token list as a fresh design surface to map your brand colors onto rather than a mechanical find-and-replace of the old one.
 
-The v5 variables are still documented in the [`@graphiql/react` README](../../packages/graphiql-react/README.md#theming); the new token file itself, [`tokens.css`](../../packages/graphiql-react/src/style/tokens.css), is the source of truth for the v6 set until the README catches up.
+Both token sets are documented in the [`@graphiql/react` README](../../packages/graphiql-react/README.md#theming); [`tokens.css`](../../packages/graphiql-react/src/style/tokens.css) remains the canonical source for exact values.
 
 ### Migrating `--color-*` overrides
 

--- a/packages/graphiql-react/README.md
+++ b/packages/graphiql-react/README.md
@@ -135,13 +135,83 @@ As of v6 the customization surface is the OKLCH design-token set in the
 
 ### Colors
 
+GraphiQL's UI colors come from the v6 OKLCH design tokens documented below. The
+v5 `--color-*` HSL variables are **deprecated** and kept only for backward
+compatibility — see [Deprecated: v5 HSL variables](#deprecated-v5-hsl-variables).
+
+#### OKLCH tokens (v6)
+
+Colors are defined as
+[OKLCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch)
+component triplets — `L% C H` (lightness, chroma, hue) — stored without the
+`oklch()` wrapper so callers can add alpha at the use site:
+
+```css
+background: oklch(var(--bg-canvas));
+color: oklch(var(--fg-default) / 0.6);
+```
+
+The tokens are scoped to `[data-theme='dark']` and `[data-theme='light']`
+rather than a media query, so a given variable resolves correctly regardless of
+which theme is active. The full set, defined in `tokens.css`, with when to reach
+for each:
+
+**Backgrounds** — surfaces, ordered by how they stack:
+
+- `--bg-canvas` — the primary content surface: editors, side panels, the active tab. The base layer everything else sits on.
+- `--bg-elevated` — bars and floating chrome above the canvas: the tab strip, panel and response headers, tooltips, dropdown menus, popovers.
+- `--bg-subtle` — recessed fills _inside_ a surface: text inputs, secondary-button faces, segmented-control tracks, inline code.
+- `--bg-overlay` — transient interaction layers painted on top of a surface: hover, selected, and pressed states.
+
+**Borders** — increasing prominence:
+
+- `--border-default` — the standard divider and component outline; your default choice.
+- `--border-muted` — a fainter separator for low-emphasis internal divisions (menu-item rules, quiet section breaks).
+- `--border-strong` — the most visible edge, for inputs and dividers that must read clearly against busy content.
+
+**Foreground** — text and icon emphasis, brightest to faintest:
+
+- `--fg-strong` — high-emphasis text: headings, active or selected labels.
+- `--fg-default` — body text; the default content color.
+- `--fg-muted` — secondary text and resting icons: labels, captions, metadata.
+- `--fg-subtle` — tertiary text and quieter icons, one step below muted.
+- `--fg-disabled` — text and icons of disabled controls.
+- `--fg-dim` — the faintest marks: decorative or comment-level.
+
+**Accents** — the raw hue palette for syntax and status. You rarely set these directly; components and the `--type-*` tokens assign the roles (links and focus rings → `--accent-blue`, errors → `--accent-red`, success → `--accent-green`, deprecation → `--accent-orange`, and so on). The full set: `--accent-blue`, `--accent-green`, `--accent-green-light`, `--accent-yellow`, `--accent-orange`, `--accent-red`, `--accent-purple`, `--accent-pink`.
+
+**Type-name categories** — `--type-composite`, `--type-scalar`, `--type-enum`, `--type-input`. Color GraphQL type names by kind; see the note below.
+
+**Run button** — `--btn-primary` and `--btn-primary-border`: fill and border for the primary action (Run). A fixed mid-tone green tuned to keep light text legible in both themes — reserve it for the main call-to-action rather than general buttons.
+
+**Radii** — `--radius-sm` (4px; small controls: buttons, inputs, chips), `--radius-md` (6px; menus and cards), `--radius-lg` (8px; dialogs and large panels).
+
+**Shadow** — `--shadow-popover`: the elevation shadow for floating surfaces (menus, tooltips, dialogs).
+
+**Type-name categories.** In the schema-aware plugins (doc explorer, query
+builder), type names are colored by GraphQL kind rather than a single color:
+object/interface/union share `--type-composite`, scalars use `--type-scalar`,
+enums use `--type-enum`, and input objects use `--type-input`. By default each
+aliases an `--accent-*` token, so you can retint either the accent or the
+`--type-*` token directly. (In the light theme `--type-input` isn't an alias —
+`--accent-yellow` is only AA-contrast-safe as a background fill, not as text, so
+it gets its own darker gold.)
+
+If you're building a plugin that renders type names and want it to match,
+`@graphiql/react` exports a `typeCategory(type)` helper that maps any
+`GraphQLType` to `'scalar' | 'enum' | 'input' | 'composite'` (unwrapping list
+and non-null wrappers first). Apply the corresponding `--type-*` token to your
+markup; the internal attribute and class names GraphiQL uses for this are not
+part of the public API.
+
+#### Deprecated: v5 HSL variables
+
 > **Deprecated (v6):** The v5 `--color-*` HSL variables (`--color-primary`,
 > `--color-neutral`, `--color-base`, and so on) described below are **deprecated
 > as of v6** and are no longer read by any component. They remain defined —
 > frozen at their v5 values — for backward compatibility, but overriding them no
-> longer re-themes GraphiQL. Retheme with the OKLCH tokens in
-> [`tokens.css`](https://github.com/graphql/graphiql/blob/main/packages/graphiql-react/src/style/tokens.css)
-> instead; the [v6 migration guide](https://github.com/graphql/graphiql/blob/main/docs/migration/graphiql-6.0.0.md#migrating---color--overrides)
+> longer re-themes GraphiQL. Retheme with the OKLCH tokens above instead; the
+> [v6 migration guide](https://github.com/graphql/graphiql/blob/main/docs/migration/graphiql-6.0.0.md#migrating---color--overrides)
 > maps each v5 variable to its v6 replacement.
 
 The deprecated v5 colors are defined using the


### PR DESCRIPTION
## Summary

Documents the v6 OKLCH design-token system in the `@graphiql/react` README's theming section — the `--bg-*` / `--border-*` / `--fg-*` / `--accent-*` / `--type-*` / `--btn-*` / `--radius-*` / `--shadow-*` families, the `L% C H` triplet convention, the type-name category tokens, and the exported `typeCategory` helper. Also marks the legacy v5 `--color-*` HSL variables deprecated and updates the migration-guide caveat now that the README documents both sets.

Docs follow-up to #4416 (the `--color-*` deprecation and `@graphiql/plugin-explorer` removal).

## Test plan

- [x] Render the README theming section: the OKLCH token list matches `tokens.css`, the `typeCategory` description is accurate, and the intra-page + `tokens.css` / migration-guide links resolve.

Refs: graphql/graphiql#4219
