### PR TITLE
fix(vscode-graphql-syntax): don't highlight .graphql() member calls as embedded GraphQL

### DIFF
--- a/.changeset/fix-graphql-method-highlight.md
+++ b/.changeset/fix-graphql-method-highlight.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Prevent GraphQL syntax highlighting from leaking into JavaScript and TypeScript after `.graphql()` member calls.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -6,7 +6,11 @@
   "proseWrap": "never",
   "printWidth": 80,
   "sortPackageJson": false,
-  "ignorePatterns": ["**/CHANGELOG.md", "working-group/agendas/**"],
+  "ignorePatterns": [
+    "**/CHANGELOG.md",
+    "working-group/agendas/**",
+    "packages/vscode-graphql-syntax/tests/__fixtures__/**"
+  ],
   "overrides": [
     {
       "files": ["*.md", "*.mdx"],

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -1,9 +1,9 @@
 {
   "scopeName": "inline.graphql",
-  "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro | text.html.vue) -source.graphql -inline.graphql -string -comment",
+  "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro | text.html.vue) -source.graphql -inline.graphql -string -comment -meta.function-call",
   "patterns": [
     {
-      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:[^<>\\r\\n]+|\\g<typeArguments>)*>))?\\s*\\(",
+      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![#$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:\"(?:[^\"\\\\\\r\\n]|\\\\.)*\"|'(?:[^'\\\\\\r\\n]|\\\\.)*'|[^<>\"'\\r\\n]+|\\g<typeArguments>)*>))?\\s*\\(",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -57,7 +57,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:[^<>\\r\\n]+|\\g<typeArguments>)*>))?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
+      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![#$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:\"(?:[^\"\\\\\\r\\n]|\\\\.)*\"|'(?:[^'\\\\\\r\\n]|\\\\.)*'|[^<>\"'\\r\\n]+|\\g<typeArguments>)*>))?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro | text.html.vue) -source.graphql -inline.graphql -string -comment",
   "patterns": [
     {
-      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(?<![.$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:<[^>]*>)?\\s*\\(",
+      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:[^<>\\r\\n]+|\\g<typeArguments>)*>))?\\s*\\(",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -57,7 +57,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(?<![.$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:<[^>]*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
+      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(?<!\\.(?:\\s|/\\*[\\s\\S]*?\\*/|//[^\\r\\n]*(?:\\r?\\n|$))*)(?<![$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:(?<typeArguments><(?:[^<>\\r\\n]+|\\g<typeArguments>)*>))?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"
@@ -68,10 +68,10 @@
         "3": {
           "name": "entity.name.function.tagged-template.js"
         },
-        "4": {
+        "5": {
           "name": "comment.graphql.js"
         },
-        "5": {
+        "6": {
           "name": "punctuation.definition.string.template.begin.js"
         }
       },

--- a/packages/vscode-graphql-syntax/grammars/graphql.js.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.js.json
@@ -3,7 +3,7 @@
   "injectionSelector": "L:(meta.embedded.block.javascript | meta.embedded.block.typescript | source.js | source.ts | source.tsx | source.vue | source.svelte | source.astro | text.html.vue) -source.graphql -inline.graphql -string -comment",
   "patterns": [
     {
-      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*\\(",
+      "begin": "\\s*+(?:(Relay)\\??\\.)(QL)|(?<![.$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:<[^>]*>)?\\s*\\(",
       "end": "\\)",
       "beginCaptures": {
         "1": {
@@ -57,7 +57,7 @@
     },
     {
       "contentName": "meta.embedded.block.graphql",
-      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(gql|graphql|graphql\\.experimental)\\s*(?:<.*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
+      "begin": "\\s*+(?:(?:(?:(Relay)\\??\\.)(QL)|(?<![.$\\w])(gql|graphql|graphql\\.experimental)\\s*(?:<[^>]*>)?\\s*)|(/\\* GraphQL \\*/))\\s*(`|')",
       "beginCaptures": {
         "1": {
           "name": "variable.other.class.js"

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/multiline-member.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/multiline-member.ts
@@ -1,0 +1,2 @@
+client.
+  graphql('query { id }');

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/source.ts.json
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/source.ts.json
@@ -1,0 +1,11 @@
+{
+  "scopeName": "source.ts.test",
+  "patterns": [
+    {
+      "name": "meta.function-call.ts",
+      "begin": "\\b[_$[:alpha:]][_$[:alnum:]]*\\.\\s*$",
+      "end": "(?=\\()",
+      "patterns": [{ "include": "$self" }]
+    }
+  ]
+}

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -101,3 +101,19 @@ const queryWithLeadingAboveComment =
       }
     }
   `;
+
+const response = await client.graphql(graphql, { issue });
+
+if (response) {
+  const afterAmplify = true;
+}
+
+foo.graphql();
+
+const afterMember = 'after';
+
+graphql.experimental(`query { id }`);
+
+obj.graphql.experimental(`query { id }`);
+
+const afterExperimental = true;

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -104,6 +104,10 @@ const queryWithLeadingAboveComment =
 
 const response = await client.graphql(graphql, { issue });
 
+client. graphql(graphql, { issue });
+
+client./* comment */graphql(graphql, { issue });
+
 if (response) {
   const afterAmplify = true;
 }

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.js
@@ -116,6 +116,18 @@ foo.graphql();
 
 const afterMember = 'after';
 
+class PrivateGraphqlClient {
+  #graphql(query) {
+    return query;
+  }
+
+  execute() {
+    return this.#graphql('query { id }');
+  }
+}
+
+const afterPrivateMember = 'after';
+
 graphql.experimental(`query { id }`);
 
 obj.graphql.experimental(`query { id }`);

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -61,3 +61,19 @@ const queryWithLeadingComment = /* GraphQL */ `
     }
   }
 `;
+
+const response = await client.graphql<Response>(graphql, { issue });
+
+if (response) {
+  const afterAmplify = true;
+}
+
+foo.graphql();
+
+const afterMember = 'after';
+
+graphql.experimental(`query { id }`);
+
+obj.graphql.experimental(`query { id }`);
+
+const afterExperimental = true;

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -31,6 +31,10 @@ const nestedQuery = graphql<Result<User>>('query { id }');
 
 const nestedTaggedQuery = graphql<Result<User>>`query { id }`;
 
+const quotedGenericQuery = graphql<{ operator: '>' }>('query { id }');
+
+const afterQuotedGeneric = 'after';
+
 const query = graphql('query { id }');
 
 const query = graphql<Generic>('query { id }');

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/test.ts
@@ -27,6 +27,10 @@ const query = graphql<SomeGeneric>`
 
 const query = graphql<Generic>('query { id }');
 
+const nestedQuery = graphql<Result<User>>('query { id }');
+
+const nestedTaggedQuery = graphql<Result<User>>`query { id }`;
+
 const query = graphql('query { id }');
 
 const query = graphql<Generic>('query { id }');
@@ -63,6 +67,10 @@ const queryWithLeadingComment = /* GraphQL */ `
 `;
 
 const response = await client.graphql<Response>(graphql, { issue });
+
+client. graphql<Response>(graphql, { issue });
+
+client./* comment */graphql<Response>(graphql, { issue });
 
 if (response) {
   const afterAmplify = true;

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -471,6 +471,18 @@ foo.graphql();                                             |
                                                            | 
 const afterMember = 'after';                               | 
                                                            | 
+class PrivateGraphqlClient {                               | 
+  #graphql(query) {                                        | 
+    return query;                                          | 
+  }                                                        | 
+                                                           | 
+  execute() {                                              | 
+    return this.#graphql('query { id }');                  | 
+  }                                                        | 
+}                                                          | 
+                                                           | 
+const afterPrivateMember = 'after';                        | 
+                                                           | 
 graphql.experimental                                       | entity.name.function.tagged-template.js
 (                                                          | 
 \`                                                          | punctuation.definition.string.template.begin.js
@@ -664,6 +676,23 @@ id                                                                   | meta.embe
 }                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
 \`                                                                    | punctuation.definition.string.template.end.js
 ;                                                                    | 
+                                                                     | 
+const quotedGenericQuery =                                           | 
+graphql                                                              | entity.name.function.tagged-template.js
+<{ operator: '>' }>(                                                 | 
+'                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const afterQuotedGeneric = 'after';                                  | 
                                                                      | 
 const query =                                                        | 
 graphql                                                              | entity.name.function.tagged-template.js

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -65,398 +65,426 @@ const { film } = json.data;                                     |
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple ecmascript file 1`] = `
-/* eslint-disable */                   | 
-/* prettier-ignore */                  | 
-// @ts-nocheck                         | 
-                                       | 
-const variable = 'test';               | 
-                                       | 
-gql                                    | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const graphql =                        | 
-                                       | 
-graphql                                | entity.name.function.tagged-template.js
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const graphql =                        | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-"""                                    | meta.embedded.block.graphql comment.block.documentation.graphql
- this is an operation description      | meta.embedded.block.graphql comment.block.documentation.graphql
-"""                                    | meta.embedded.block.graphql comment.block.documentation.graphql
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- $                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-variable                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-                                       | 
-const after1 = 'after';                | 
-                                       | 
-const graphql =                        | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-                                       | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-\`                                      | punctuation.definition.string.template.end.js
-,                                      | 
-  [var1, var2],                        | 
-)                                      | 
-;                                      | 
-                                       | 
-const after2 = 'after';                | 
-                                       | 
-const query =                          | 
-                                       | 
-/* GraphQL */                          | comment.graphql.js
-                                       | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-'                                      | punctuation.definition.string.template.end.js
-;                                      | 
-const query =                          | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql
-'                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-const query =                          | 
-graphql                                | entity.name.function.tagged-template.js
-(                                      | 
-'                                      | punctuation.definition.string.template.begin.js
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-(                                      | meta.embedded.block.graphql meta.brace.round.graphql
-$id                                    | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.variables.graphql
-ID                                     | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
-!                                      | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
-)                                      | meta.embedded.block.graphql meta.brace.round.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-test                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                                      | punctuation.definition.string.template.end.js
-)                                      | 
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-\`                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-'                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql
-'                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-'                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql
-'                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-const queryWithInlineComment =         | 
-\`                                      | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                               | taggedTemplates comment.line.graphql.js
-                                       | taggedTemplates meta.embedded.block.graphql
-query                                  | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | taggedTemplates punctuation.definition.string.template.end.js
-;                                      | 
-const queryWithInlineComment = \`       | 
-#graphql                               | 
- query {                               | 
-        user(id: "5", name: boolean) { | 
-            something                  | 
-        }                              | 
-    }                                  | 
-\`;                                     | 
-                                       | 
-const queryWithLeadingComment =        | 
-                                       | 
-/* GraphQL */                          | comment.graphql.js
-                                       | 
-\`                                      | punctuation.definition.string.template.begin.js
-                                       | meta.embedded.block.graphql
-query                                  | meta.embedded.block.graphql keyword.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
-# this is a comment                    | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-user                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                              | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                       | meta.embedded.block.graphql meta.selectionset.graphql
-}                                      | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                                      | punctuation.definition.string.template.end.js
-;                                      | 
-                                       | 
-// TODO: fix this                      | 
-const queryWithLeadingAboveComment =   | 
-  /* GraphQL */                        | 
-  \`                                    | 
-    query {                            | 
-      user(id: "5", name: boolean) {   | 
-        something                      | 
-      }                                | 
-    }                                  | 
-  \`;                                   | 
-                                       | 
+/* eslint-disable */                                       | 
+/* prettier-ignore */                                      | 
+// @ts-nocheck                                             | 
+                                                           | 
+const variable = 'test';                                   | 
+                                                           | 
+gql                                                        | entity.name.function.tagged-template.js
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+graphql                                                    | entity.name.function.tagged-template.js
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+const graphql =                                            | 
+                                                           | 
+graphql                                                    | entity.name.function.tagged-template.js
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+const graphql =                                            | 
+graphql                                                    | entity.name.function.tagged-template.js
+(                                                          | 
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+"""                                                        | meta.embedded.block.graphql comment.block.documentation.graphql
+ this is an operation description                          | meta.embedded.block.graphql comment.block.documentation.graphql
+"""                                                        | meta.embedded.block.graphql comment.block.documentation.graphql
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ $                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+variable                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql constant.character.enum.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.objectvalues.graphql meta.brace.curly.graphql
+)                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+)                                                          | 
+;                                                          | 
+                                                           | 
+const after1 = 'after';                                    | 
+                                                           | 
+const graphql =                                            | 
+graphql                                                    | entity.name.function.tagged-template.js
+(                                                          | 
+                                                           | 
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql
+(                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                                        | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.variables.graphql
+ID                                                         | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                          | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+test                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+,                                                          | 
+  [var1, var2],                                            | 
+)                                                          | 
+;                                                          | 
+                                                           | 
+const after2 = 'after';                                    | 
+                                                           | 
+const query =                                              | 
+                                                           | 
+/* GraphQL */                                              | comment.graphql.js
+                                                           | 
+'                                                          | punctuation.definition.string.template.begin.js
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql
+'                                                          | punctuation.definition.string.template.end.js
+;                                                          | 
+const query =                                              | 
+graphql                                                    | entity.name.function.tagged-template.js
+(                                                          | 
+'                                                          | punctuation.definition.string.template.begin.js
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+(                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                                        | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.variables.graphql
+ID                                                         | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                          | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql
+'                                                          | punctuation.definition.string.template.end.js
+)                                                          | 
+;                                                          | 
+const query =                                              | 
+graphql                                                    | entity.name.function.tagged-template.js
+(                                                          | 
+'                                                          | punctuation.definition.string.template.begin.js
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+(                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+$id                                                        | meta.embedded.block.graphql meta.variables.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.variables.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.variables.graphql
+ID                                                         | meta.embedded.block.graphql meta.variables.graphql support.type.builtin.graphql
+!                                                          | meta.embedded.block.graphql meta.variables.graphql keyword.operator.nulltype.graphql
+)                                                          | meta.embedded.block.graphql meta.brace.round.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+test                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                          | punctuation.definition.string.template.end.js
+)                                                          | 
+;                                                          | 
+                                                           | 
+const queryWithInlineComment =                             | 
+\`                                                          | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                   | taggedTemplates comment.line.graphql.js
+                                                           | taggedTemplates meta.embedded.block.graphql
+query                                                      | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | taggedTemplates punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+const queryWithInlineComment =                             | 
+'                                                          | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                   | taggedTemplates comment.line.graphql.js
+                                                           | taggedTemplates meta.embedded.block.graphql
+query                                                      | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+id                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql
+'                                                          | taggedTemplates punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+const queryWithInlineComment =                             | 
+'                                                          | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                   | taggedTemplates comment.line.graphql.js
+                                                           | taggedTemplates meta.embedded.block.graphql
+query                                                      | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+id                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql
+'                                                          | taggedTemplates punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+const queryWithInlineComment =                             | 
+\`                                                          | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                   | taggedTemplates comment.line.graphql.js
+                                                           | taggedTemplates meta.embedded.block.graphql
+query                                                      | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | taggedTemplates punctuation.definition.string.template.end.js
+;                                                          | 
+const queryWithInlineComment = \`                           | 
+#graphql                                                   | 
+ query {                                                   | 
+        user(id: "5", name: boolean) {                     | 
+            something                                      | 
+        }                                                  | 
+    }                                                      | 
+\`;                                                         | 
+                                                           | 
+const queryWithLeadingComment =                            | 
+                                                           | 
+/* GraphQL */                                              | comment.graphql.js
+                                                           | 
+\`                                                          | punctuation.definition.string.template.begin.js
+                                                           | meta.embedded.block.graphql
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+# this is a comment                                        | meta.embedded.block.graphql meta.selectionset.graphql comment.line.graphql.js
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                       | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                       | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                  | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+;                                                          | 
+                                                           | 
+// TODO: fix this                                          | 
+const queryWithLeadingAboveComment =                       | 
+  /* GraphQL */                                            | 
+  \`                                                        | 
+    query {                                                | 
+      user(id: "5", name: boolean) {                       | 
+        something                                          | 
+      }                                                    | 
+    }                                                      | 
+  \`;                                                       | 
+                                                           | 
+const response = await client.graphql(graphql, { issue }); | 
+                                                           | 
+if (response) {                                            | 
+  const afterAmplify = true;                               | 
+}                                                          | 
+                                                           | 
+foo.graphql();                                             | 
+                                                           | 
+const afterMember = 'after';                               | 
+                                                           | 
+graphql.experimental                                       | entity.name.function.tagged-template.js
+(                                                          | 
+\`                                                          | punctuation.definition.string.template.begin.js
+query                                                      | meta.embedded.block.graphql keyword.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                         | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                           | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                          | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                          | punctuation.definition.string.template.end.js
+)                                                          | 
+;                                                          | 
+                                                           | 
+obj.graphql.experimental(\`query { id }\`);                  | 
+                                                           | 
+const afterExperimental = true;                            | 
+                                                           | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple svelte file 1`] = `
@@ -485,258 +513,286 @@ hello                  | meta.embedded.block.graphql meta.selectionset.graphql v
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple typescript file 1`] = `
-/* eslint-disable */            | 
-// @ts-nocheck                  | 
-                                | 
-gql                             | entity.name.function.tagged-template.js
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-graphql                         | entity.name.function.tagged-template.js
-<SomeGeneric>                   | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const query =                   | 
-                                | 
-graphql                         | entity.name.function.tagged-template.js
-<SomeGeneric>                   | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const query =                   | 
-graphql                         | entity.name.function.tagged-template.js
-<Generic>(                      | 
-'                               | punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query =                   | 
-graphql                         | entity.name.function.tagged-template.js
-(                               | 
-'                               | punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query =                   | 
-graphql                         | entity.name.function.tagged-template.js
-<Generic>(                      | 
-'                               | punctuation.definition.string.template.begin.js
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-'                               | punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query =                   | 
-graphql                         | entity.name.function.tagged-template.js
-(                               | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-)                               | 
-;                               | 
-                                | 
-const query =                   | 
-graphql                         | entity.name.function.tagged-template.js
-(                               | 
-                                | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql
-\`                               | punctuation.definition.string.template.end.js
-,                               | 
-  [var1, var2],                 | 
-)                               | 
-;                               | 
-                                | 
-const queryWithInlineComment =  | 
-\`                               | taggedTemplates punctuation.definition.string.template.begin.js
-#graphql                        | taggedTemplates comment.line.graphql.js
-                                | taggedTemplates meta.embedded.block.graphql
-query                           | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-user                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
-}                               | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | taggedTemplates punctuation.definition.string.template.end.js
-;                               | 
-                                | 
-const queryWithLeadingComment = | 
-                                | 
-/* GraphQL */                   | comment.graphql.js
-                                | 
-\`                               | punctuation.definition.string.template.begin.js
-                                | meta.embedded.block.graphql
-query                           | meta.embedded.block.graphql keyword.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-user                            | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
-(                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-id                              | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
-5                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
-"                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
-,                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
-name                            | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
-:                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
- boolean                        | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
-)                               | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-{                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-something                       | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
-                                | meta.embedded.block.graphql meta.selectionset.graphql
-}                               | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
-\`                               | punctuation.definition.string.template.end.js
-;                               | 
-                                | 
+/* eslint-disable */                                                 | 
+// @ts-nocheck                                                       | 
+                                                                     | 
+gql                                                                  | entity.name.function.tagged-template.js
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                                 | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
+graphql                                                              | entity.name.function.tagged-template.js
+<SomeGeneric>                                                        | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                                 | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+                                                                     | 
+graphql                                                              | entity.name.function.tagged-template.js
+<SomeGeneric>                                                        | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                                 | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+graphql                                                              | entity.name.function.tagged-template.js
+<Generic>(                                                           | 
+'                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+graphql                                                              | entity.name.function.tagged-template.js
+(                                                                    | 
+'                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+graphql                                                              | entity.name.function.tagged-template.js
+<Generic>(                                                           | 
+'                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+graphql                                                              | entity.name.function.tagged-template.js
+(                                                                    | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const query =                                                        | 
+graphql                                                              | entity.name.function.tagged-template.js
+(                                                                    | 
+                                                                     | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+,                                                                    | 
+  [var1, var2],                                                      | 
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const queryWithInlineComment =                                       | 
+\`                                                                    | taggedTemplates punctuation.definition.string.template.begin.js
+#graphql                                                             | taggedTemplates comment.line.graphql.js
+                                                                     | taggedTemplates meta.embedded.block.graphql
+query                                                                | taggedTemplates meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+user                                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                                   | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                                 | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                             | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                            | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | taggedTemplates meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | taggedTemplates punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
+const queryWithLeadingComment =                                      | 
+                                                                     | 
+/* GraphQL */                                                        | comment.graphql.js
+                                                                     | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+                                                                     | meta.embedded.block.graphql
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+user                                                                 | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+(                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+5                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+,                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.comma.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql
+name                                                                 | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql variable.parameter.graphql
+:                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql punctuation.colon.graphql
+ boolean                                                             | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql constant.character.enum.graphql
+)                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+something                                                            | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
+const response = await client.graphql<Response>(graphql, { issue }); | 
+                                                                     | 
+if (response) {                                                      | 
+  const afterAmplify = true;                                         | 
+}                                                                    | 
+                                                                     | 
+foo.graphql();                                                       | 
+                                                                     | 
+const afterMember = 'after';                                         | 
+                                                                     | 
+graphql.experimental                                                 | entity.name.function.tagged-template.js
+(                                                                    | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+obj.graphql.experimental(\`query { id }\`);                            | 
+                                                                     | 
+const afterExperimental = true;                                      | 
+                                                                     | 
 `;
 
 exports[`inline.graphql grammar > should tokenize a simple vue sfc comp file 1`] = `

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/js-grammar.spec.ts.snap
@@ -459,6 +459,10 @@ const queryWithLeadingAboveComment =                       |
                                                            | 
 const response = await client.graphql(graphql, { issue }); | 
                                                            | 
+client. graphql(graphql, { issue });                       | 
+                                                           | 
+client./* comment */graphql(graphql, { issue });           | 
+                                                           | 
 if (response) {                                            | 
   const afterAmplify = true;                               | 
 }                                                          | 
@@ -631,6 +635,36 @@ id                                                                   | meta.embe
 )                                                                    | 
 ;                                                                    | 
                                                                      | 
+const nestedQuery =                                                  | 
+graphql                                                              | entity.name.function.tagged-template.js
+<Result<User>>(                                                      | 
+'                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+'                                                                    | punctuation.definition.string.template.end.js
+)                                                                    | 
+;                                                                    | 
+                                                                     | 
+const nestedTaggedQuery =                                            | 
+                                                                     | 
+graphql                                                              | entity.name.function.tagged-template.js
+<Result<User>>                                                       | 
+\`                                                                    | punctuation.definition.string.template.begin.js
+query                                                                | meta.embedded.block.graphql keyword.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+{                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+id                                                                   | meta.embedded.block.graphql meta.selectionset.graphql variable.graphql
+                                                                     | meta.embedded.block.graphql meta.selectionset.graphql
+}                                                                    | meta.embedded.block.graphql meta.selectionset.graphql punctuation.operation.graphql
+\`                                                                    | punctuation.definition.string.template.end.js
+;                                                                    | 
+                                                                     | 
 const query =                                                        | 
 graphql                                                              | entity.name.function.tagged-template.js
 (                                                                    | 
@@ -766,6 +800,10 @@ something                                                            | meta.embe
 ;                                                                    | 
                                                                      | 
 const response = await client.graphql<Response>(graphql, { issue }); | 
+                                                                     | 
+client. graphql<Response>(graphql, { issue });                       | 
+                                                                     | 
+client./* comment */graphql<Response>(graphql, { issue });           | 
                                                                      | 
 if (response) {                                                      | 
   const afterAmplify = true;                                         | 

--- a/packages/vscode-graphql-syntax/tests/__utilities__/utilities.ts
+++ b/packages/vscode-graphql-syntax/tests/__utilities__/utilities.ts
@@ -103,8 +103,14 @@ async function vscodeOnigurumaLib() {
 }
 
 function loadConfiguration() {
-  return packageJson.contributes.grammars.map(grammar => ({
-    ...grammar,
-    path: path.join(__dirname, '..', '..', grammar.path),
-  }));
+  return [
+    ...packageJson.contributes.grammars.map(grammar => ({
+      ...grammar,
+      path: path.join(__dirname, '..', '..', grammar.path),
+    })),
+    {
+      scopeName: 'source.ts.test',
+      path: path.join(__dirname, '..', '__fixtures__', 'source.ts.json'),
+    },
+  ];
 }

--- a/packages/vscode-graphql-syntax/tests/js-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/js-grammar.spec.ts
@@ -8,6 +8,17 @@ describe('inline.graphql grammar', () => {
     const result = await tokenizeFile('__fixtures__/test.ts', scope);
     expect(result).toMatchSnapshot();
   });
+  it('should not tokenize multiline member calls as GraphQL', async () => {
+    const result = await tokenizeFile(
+      '__fixtures__/multiline-member.ts',
+      'source.ts.test',
+    );
+    expect(
+      result.some(token =>
+        token.scopes.includes('meta.embedded.block.graphql'),
+      ),
+    ).toBe(false);
+  });
   it('should tokenize a simple ecmascript file', async () => {
     const result = await tokenizeFile('__fixtures__/test.js', scope);
     expect(result).toMatchSnapshot();

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -254,3 +254,4 @@ wonka
 yoshiakis
 zdravo
 zustand
+alnum


### PR DESCRIPTION
## Summary

The `vscode-graphql-syntax` TextMate grammar treated a bare `graphql` / `gql` identifier as an embedded-GraphQL trigger even when it appeared as a member access, so `client.graphql<Response>(...)` and `foo.graphql()` were highlighted as embedded GraphQL and broke downstream JS/TS scoping (regression from #3540). This restricts the trigger to genuine tagged-template / helper calls.

## Why

The injection regex now requires the keyword not to be preceded by a member/identifier boundary, so member calls (`.graphql()`, private `#graphql()`) are excluded, and it preserves quoted angle brackets inside generic arguments (`graphql<Result<User>>(...)`). Cross-line member access is handled as far as a single-line TextMate grammar can. The bulk of the diff is regenerated tokenizer snapshots reflecting the corrected scoping.

## Testing

`vitest run tests/js-grammar.spec.ts` in `packages/vscode-graphql-syntax` -- passes, with fixtures added for member calls, private-member calls, and generic arguments.

Closes #3810
