### PR TITLE
v6: Fix doc explorer search popover shadow in light theme

### DIFF
--- a/.changeset/doc-explorer-search-shadow.md
+++ b/.changeset/doc-explorer-search-shadow.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/plugin-doc-explorer': patch
+---
+
+Fix the doc explorer search popover casting a heavy dark-themed shadow in light theme. It now uses the same theme-aware shadow token as every other popover in the app.

--- a/.changeset/doc-explorer-search-shadow.md
+++ b/.changeset/doc-explorer-search-shadow.md
@@ -1,5 +1,0 @@
----
-'@graphiql/plugin-doc-explorer': patch
----
-
-Fix the doc explorer search popover casting a heavy dark-themed shadow in light theme. It now uses the same theme-aware shadow token as every other popover in the app.

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -7,7 +7,7 @@
     & .graphiql-doc-explorer-search-input {
       background: oklch(var(--bg-canvas));
       border: 1px solid oklch(var(--border-default));
-      box-shadow: 0 4px 12px oklch(0% 0 0 / 0.3);
+      box-shadow: var(--shadow-popover);
     }
   }
 }
@@ -46,7 +46,7 @@
   background-color: oklch(var(--bg-canvas));
   border: 1px solid oklch(var(--border-default));
   border-radius: var(--border-radius-4);
-  box-shadow: 0 4px 12px oklch(0% 0 0 / 0.3);
+  box-shadow: var(--shadow-popover);
   max-height: 400px;
   overflow-y: auto;
   margin: 0;


### PR DESCRIPTION
## Summary

The doc explorer's search input and results popover had their shadow hardcoded to `0 4px 12px oklch(0% 0 0 / 0.3)`. That's the dark-theme value of `--shadow-popover`, pasted in as a literal instead of a reference, and it's missing the token's second, subtler shadow layer too. Every other popover in the app (dialog, dropdown, tooltip) reads `var(--shadow-popover)` and re-themes on its own, so in light theme this one was casting a shadow roughly four times heavier than its siblings. Both spots now read the token directly.

## Test plan

- [x] Switch to light theme, open the doc explorer, and focus the search box. The active-state input and the results popover both cast a soft, light-appropriate shadow, not a heavy dark one.
- [x] Switch to dark theme and confirm the search popover shadow still matches other popovers (dialog, dropdown, tooltip).

Refs: graphql/graphiql#4219
