### PR TITLE
v6: Make the font-size setting reach the doc explorer, headers, and pills

### DIFF
--- a/packages/graphiql-plugin-collections/src/index.css
+++ b/packages/graphiql-plugin-collections/src/index.css
@@ -12,7 +12,7 @@
 
 .graphiql-collections-status {
   padding: var(--px-4) var(--px-12);
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--accent-green));
 }
 
@@ -29,7 +29,7 @@
 .graphiql-collections-loading {
   padding: var(--px-8) var(--px-12);
   color: oklch(var(--fg-subtle));
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
 }
 
 .graphiql-collections-toolbar {
@@ -55,7 +55,7 @@
   padding: var(--px-4) var(--px-8);
   border-radius: var(--border-radius-4);
   color: oklch(var(--fg-subtle));
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
 }
 
 .graphiql-collections-action:hover {
@@ -126,7 +126,7 @@
 }
 
 .graphiql-collection-badge {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   background: oklch(var(--bg-subtle));
   padding: 0 var(--px-6);
@@ -134,7 +134,7 @@
 }
 
 .graphiql-collection-chevron {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   flex-shrink: 0;
 }
@@ -199,7 +199,7 @@
 
 .graphiql-collection-empty-hint {
   padding: var(--px-6) var(--px-12) var(--px-8) var(--px-20);
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   font-style: italic;
 }
@@ -264,7 +264,7 @@
 }
 
 .graphiql-collection-item-description {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   overflow: hidden;
   text-overflow: ellipsis;
@@ -294,7 +294,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--px-4);
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
 }
 
@@ -349,14 +349,14 @@
 }
 
 .graphiql-import-export-mode legend {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   margin-bottom: var(--px-4);
 }
 
 .graphiql-import-export-error {
   color: oklch(var(--accent-red));
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
 }
 
 /* Conflict dialog */
@@ -380,7 +380,7 @@
 
 .graphiql-conflict-review-hint-label {
   margin: 0;
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
 }
 
@@ -417,13 +417,13 @@
 }
 
 .graphiql-conflict-review-collection {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   white-space: nowrap;
 }
 
 .graphiql-conflict-review-hint {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   white-space: nowrap;
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/argument.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/argument.css
@@ -17,6 +17,6 @@
 }
 
 .graphiql-doc-explorer-argument-deprecation-label {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   font-weight: var(--font-weight-medium);
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/deprecation-reason.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/deprecation-reason.css
@@ -7,6 +7,6 @@
 }
 
 .graphiql-doc-explorer-deprecation-label {
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   font-weight: var(--font-weight-medium);
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/field-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/field-card.css
@@ -12,26 +12,26 @@
 
 .graphiql-doc-explorer-field-card-name {
   font-family: var(--font-family-mono);
-  font-size: 14px;
+  font-size: var(--font-size-mono);
   font-weight: 600;
   color: oklch(var(--accent-green-light));
 }
 
 .graphiql-doc-explorer-field-card-colon {
   font-family: var(--font-family-mono);
-  font-size: 14px;
+  font-size: var(--font-size-mono);
   color: oklch(var(--fg-muted));
 }
 
 .graphiql-doc-explorer-field-card-type {
   font-family: var(--font-family-mono);
-  font-size: 14px;
+  font-size: var(--font-size-mono);
   color: oklch(var(--fg-default));
 }
 
 .graphiql-doc-explorer-field-card-description {
   margin: 0 0 var(--px-6);
-  font-size: 12px;
+  font-size: var(--font-size-mono);
   color: oklch(var(--fg-muted));
   line-height: 17px;
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
@@ -16,7 +16,7 @@
   border: none;
   cursor: pointer;
   color: oklch(var(--fg-subtle));
-  font-size: 10px;
+  font-size: var(--font-size-eyebrow);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -93,7 +93,7 @@
   align-items: baseline;
   gap: var(--px-6);
   font-family: var(--font-family-mono);
-  font-size: 12px;
+  font-size: var(--font-size-mono);
 }
 
 .graphiql-doc-explorer-field-row-name {
@@ -112,7 +112,7 @@
 
 /* Optional description */
 .graphiql-doc-explorer-field-row-desc {
-  font-size: 11px;
+  font-size: var(--font-size-small);
   color: oklch(var(--fg-subtle));
   line-height: 15px;
 }

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -116,7 +116,7 @@
 
 .graphiql-doc-explorer-search-divider {
   color: oklch(var(--fg-muted));
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   font-weight: var(--font-weight-medium);
   margin-top: var(--px-8);
   padding: var(--px-8) var(--px-12);

--- a/packages/graphiql-plugin-doc-explorer/src/components/section.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/section.css
@@ -1,7 +1,7 @@
 .graphiql-doc-explorer-section-title {
   align-items: center;
   display: flex;
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   font-weight: var(--font-weight-medium);
   line-height: 1;
 

--- a/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/type-card.css
@@ -15,7 +15,7 @@
   background: oklch(var(--accent-blue) / 0.12);
   color: oklch(var(--accent-blue));
   font-family: var(--font-family-mono);
-  font-size: 10px;
+  font-size: var(--font-size-eyebrow);
   font-weight: 600;
   border-radius: var(--radius-sm);
   text-transform: uppercase;
@@ -25,7 +25,7 @@
 
 .graphiql-doc-explorer-type-card-name {
   font-family: var(--font-family-mono);
-  font-size: 14px;
+  font-size: var(--font-size-mono);
   font-weight: 600;
   color: oklch(var(--fg-strong));
   overflow-x: hidden;
@@ -35,7 +35,7 @@
 
 .graphiql-doc-explorer-type-card-description {
   margin: 0 0 var(--px-6);
-  font-size: 12px;
+  font-size: var(--font-size-mono);
   color: oklch(var(--fg-muted));
   line-height: 17px;
 }
@@ -47,7 +47,7 @@
   align-items: center;
   gap: var(--px-6);
   margin-top: var(--px-6);
-  font-size: 10.5px;
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
 }
 

--- a/packages/graphiql-plugin-history/src/style.css
+++ b/packages/graphiql-plugin-history/src/style.css
@@ -16,7 +16,7 @@
 .graphiql-history-empty {
   padding: var(--px-8) var(--px-12);
   color: oklch(var(--fg-subtle));
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
 }
 
 .graphiql-history-item {

--- a/packages/graphiql-react/src/components/method-pill/index.css
+++ b/packages/graphiql-react/src/components/method-pill/index.css
@@ -5,7 +5,7 @@
   padding: 1px 5px;
   border-radius: var(--radius-sm);
   font-family: var(--font-family-mono);
-  font-size: 9px;
+  font-size: var(--font-size-eyebrow);
   font-weight: 700;
   letter-spacing: 0.04em;
   line-height: 1.4;

--- a/packages/graphiql-react/src/components/panel-header/index.css
+++ b/packages/graphiql-react/src/components/panel-header/index.css
@@ -17,7 +17,7 @@
   margin: 0;
   color: oklch(var(--fg-strong));
   font-family: var(--font-family);
-  font-size: 12px;
+  font-size: var(--font-size-mono);
   font-weight: 600;
   line-height: 1.3;
 }

--- a/packages/graphiql-react/src/components/response-header/index.css
+++ b/packages/graphiql-react/src/components/response-header/index.css
@@ -14,7 +14,7 @@
   align-items: center;
   gap: var(--px-6);
   font-family: var(--font-family-mono);
-  font-size: 11.5px;
+  font-size: var(--font-size-mono);
   line-height: 1;
 }
 
@@ -47,7 +47,7 @@
 
 .graphiql-response-meta {
   font-family: var(--font-family-mono);
-  font-size: 11.5px;
+  font-size: var(--font-size-mono);
   color: oklch(var(--fg-muted));
   line-height: 1;
 }
@@ -118,7 +118,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--px-6);
-  font-size: 11.5px;
+  font-size: var(--font-size-small);
   line-height: 1;
   color: oklch(var(--fg-default));
 }

--- a/packages/graphiql-react/src/components/var-headers-strip/index.css
+++ b/packages/graphiql-react/src/components/var-headers-strip/index.css
@@ -16,7 +16,7 @@
 
 .graphiql-var-hint {
   margin-left: auto;
-  font-size: var(--font-size-hint);
+  font-size: var(--font-size-eyebrow);
   color: oklch(var(--fg-subtle));
   white-space: nowrap;
 }

--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -35,7 +35,6 @@
   /* Font */
   --font-family: 'Roboto', sans-serif;
   --font-family-mono: 'Fira Code', monospace;
-  --font-size-hint: calc(12rem / 16);
   --font-size-inline-code: calc(13rem / 16);
   --font-size-body: calc(15rem / 16);
   --font-size-h4: calc(18rem / 16);


### PR DESCRIPTION
## Summary

- The doc-explorer's `field-card`, `type-card`, and `fields-list` all hardcoded `font-size` in px (11.5px, 14px, 10px, 9px, and more), so none of that text grew or shrank with the font-size preset. They now read `--font-size-mono`, `--font-size-small`, or `--font-size-eyebrow` depending on which is closest to the original size.
- `response-header`, `panel-header`, and `method-pill` had the same problem: fixed px values that ignored Settings > Font size entirely. Migrated to the matching tokens.
- The legacy `--font-size-hint` token (`root.css`) was a frozen value that never scaled with the preset, at ~19 call sites across `var-headers-strip`, the collections plugin, the history plugin, and the doc-explorer plugin. Every usage now points at `--font-size-eyebrow` instead, and the dead `--font-size-hint` definition is gone.
- Along the way, found that `--font-size-body` itself is silently shadowed by a frozen legacy value in `root.css` (same class of bug, but out of scope here, so flagged separately). Avoided that token in the new mappings and used `--font-size-mono` for the mono-family names/types instead, since it actually rescales.

## Test plan

- [x] Open Settings, set Font Size to Large or Extra Large, then open the Documentation Explorer. Confirm type names, field names/types, descriptions, and the "FIELDS · N" section label all grow with it (they previously stayed fixed).
- [x] Run a query and confirm the response header (status code, timing, size) grows with the font-size setting.
- [x] Confirm panel headers (e.g. the "History" and "Documentation Explorer" panel titles) grow with the setting.
- [x] Confirm method pills (QRY/MUT/SUB badges) grow with the setting.
- [x] Set the font size back to Default and confirm everything returns to its original size with nothing shifted or clipped.
- [x] Check both Dark and Light themes at a couple of font-size presets to confirm nothing overlaps or truncates awkwardly at the larger sizes.

Refs: #4228
