### PR TITLE
v6: Unify list-row hover across the Doc Explorer and History panels

### DIFF
--- a/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/fields-list.css
@@ -61,9 +61,10 @@
   cursor: pointer;
   text-align: left;
   width: 100%;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: oklch(var(--fg-default) / 0.04);
+    background: oklch(var(--bg-subtle));
   }
 
   &:focus-visible {
@@ -72,7 +73,7 @@
   }
 }
 
-/* Active row — blue accent */
+/* Active row — blue accent, reserved for the selected field */
 .graphiql-doc-explorer-field-row--active {
   background: oklch(var(--accent-blue) / 0.08);
   border-left-color: oklch(var(--accent-blue));

--- a/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/schema-documentation.css
@@ -36,9 +36,10 @@
   width: 100%;
   font-family: var(--font-family-mono);
   font-size: 12px;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: oklch(var(--fg-default) / 0.04);
+    background: oklch(var(--bg-subtle));
   }
 
   &:focus-visible {
@@ -72,9 +73,10 @@
   cursor: pointer;
   text-align: left;
   width: 100%;
+  transition: background var(--transition-fast);
 
   &:hover {
-    background: oklch(var(--fg-default) / 0.04);
+    background: oklch(var(--bg-subtle));
   }
 
   &:focus-visible {

--- a/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search-row.css
@@ -67,17 +67,11 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     cursor: pointer;
+    transition: background-color var(--transition-fast);
 
-    &[data-headlessui-state='active'] {
-      background-color: oklch(var(--fg-default) / 0.08);
-    }
-
+    &[data-headlessui-state='active'],
     &:hover {
-      background-color: oklch(var(--fg-default) / 0.12);
-    }
-
-    &[data-headlessui-state='active']:hover {
-      background-color: oklch(var(--fg-default) / 0.16);
+      background-color: oklch(var(--bg-subtle));
     }
 
     & + [role='option'] {

--- a/packages/graphiql-plugin-doc-explorer/src/components/search.css
+++ b/packages/graphiql-plugin-doc-explorer/src/components/search.css
@@ -72,17 +72,11 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+  transition: background-color var(--transition-fast);
 
-  &[data-headlessui-state='active'] {
-    background-color: oklch(var(--fg-default) / 0.08);
-  }
-
+  &[data-headlessui-state='active'],
   &:hover {
-    background-color: oklch(var(--fg-default) / 0.12);
-  }
-
-  &[data-headlessui-state='active']:hover {
-    background-color: oklch(var(--fg-default) / 0.16);
+    background-color: oklch(var(--bg-subtle));
   }
 
   & + & {

--- a/packages/graphiql-plugin-history/src/style.css
+++ b/packages/graphiql-plugin-history/src/style.css
@@ -23,11 +23,14 @@
   border-bottom: 1px solid oklch(var(--border-default));
   display: flex;
   align-items: stretch;
+  transition: background-color var(--transition-fast);
 
   &:hover {
-    background-color: oklch(var(--accent-blue) / 0.06);
+    background-color: oklch(var(--bg-subtle));
   }
 
+  /* Editing (rename) is an active state, not a hover — keeps the accent-blue
+     tint reserved for active/selected. */
   &.editable {
     background-color: oklch(var(--accent-blue) / 0.08);
 
@@ -129,10 +132,13 @@
   display: flex;
   padding: var(--px-6);
   border-radius: var(--radius-sm);
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
 
   &:hover {
     color: oklch(var(--fg-default));
-    background-color: oklch(var(--fg-default) / 0.06);
+    background-color: oklch(var(--bg-subtle));
   }
 
   & > svg {

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -97,6 +97,9 @@
   /* Shadows */
   --shadow-popover:
     0 4px 12px oklch(0% 0 0 / 0.3), 0 1px 3px oklch(0% 0 0 / 0.15);
+
+  /* Motion */
+  --transition-fast: 120ms ease;
 }
 
 [data-theme='light'] {


### PR DESCRIPTION
## Summary

List rows across the side panels had four different "this row is highlighted" recipes doing the same job. Activity rail, dropdown menu items, and Collections rows all used a flat `oklch(var(--bg-subtle))` background on hover, which is the pattern the rest of the app's interactive chrome had already settled on. Doc explorer rows instead tinted with `--fg-default` at a few different alpha values, History rows tinted with `--accent-blue`, and History's own action icons (rename/favorite/delete) used yet a fourth recipe (`--fg-default` at a different alpha again), all in the same file as the third.

Doc explorer (fields list, schema overview, and both search listboxes) and History now hover with the same flat `--bg-subtle` background as Collections, and History's action icons match too. `--accent-blue` is reserved for genuine active/selected state: the active field row in doc explorer, and the editable/rename row in History, both of which are untouched.

Separately, only three files in the whole app had a hover `transition`, each with its own duration (120ms, 100ms, 120ms/150ms), while nearly everything else snapped instantly. Rather than pick a side, this PR adds a single `--transition-fast: 120ms ease` token to `tokens.css` and applies it to every row hover touched here, so the newly-unified hover reads as one consistent, intentional motion instead of an arbitrary mix. The three pre-existing transition durations elsewhere are unchanged for now, out of scope for this pass.

## Test plan

- [x] Hover rows in the Doc Explorer (schema types, fields, search results), History, and Collections panels; confirm all three show the same subtle flat highlight, no blue or gray tint.
- [x] Select/activate a row (e.g. the currently-viewed field in the Doc Explorer, or a row being renamed in History) and confirm it uses the accent-blue treatment, clearly distinct from plain hover.
- [x] Confirm hover feels consistent across panels, including the small action icons (rename/favorite/delete) on History rows.
- [x] Check both Dark and Light themes.

Refs: #4228
