### PR TITLE
v6: align font tokens with the Roboto/Fira Code that actually ship

### DIFF
--- a/packages/graphiql-react/src/style/root.css
+++ b/packages/graphiql-react/src/style/root.css
@@ -33,8 +33,6 @@
   --alpha-background-light: 0.07;
 
   /* Font */
-  --font-family: 'Roboto', sans-serif;
-  --font-family-mono: 'Fira Code', monospace;
   --font-size-inline-code: calc(13rem / 16);
   --font-size-body: calc(15rem / 16);
   --font-size-h4: calc(18rem / 16);

--- a/packages/graphiql-react/src/style/tokens.css
+++ b/packages/graphiql-react/src/style/tokens.css
@@ -71,8 +71,8 @@
   --btn-primary-border: 62.22% 0.166 146; /* #2EA043 */
 
   /* Typography */
-  --font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --font-family-mono: 'JetBrains Mono', ui-monospace, monospace;
+  --font-family: 'Roboto', ui-sans-serif, system-ui, sans-serif;
+  --font-family-mono: 'Fira Code', ui-monospace, monospace;
   --letter-spacing-ui: -0.005em;
 
   /* Spacing scale */


### PR DESCRIPTION
## Summary

`tokens.css` declared `--font-family: 'Inter'` and `--font-family-mono: 'JetBrains Mono'`, but nothing in the app ever rendered in either. `root.css` redeclared both variables on `.graphiql-container`, pointing them back at Roboto and Fira Code, and that selector beats `:root` in the cascade. `packages/graphiql/src/style.css` only ever `@import`s the Roboto and Fira Code `@font-face` files, so Inter and JetBrains Mono weren't loaded to begin with — even if the cascade had gone the other way, the browser would have fallen through to the generic fallbacks.

We decided in #4426 to keep Roboto and Fira Code rather than swap the type system, so this points the canonical declaration in `tokens.css` at the fonts that actually ship and drops the now-redundant `.graphiql-container` override. One declaration, and it matches what you see. No font loading changes.

## Test plan

- [x] Open the app and inspect the query editor and any body text. Computed `font-family` resolves to Fira Code and Roboto respectively, same as before this change.
- [x] In DevTools, confirm `--font-family` on `.graphiql-container` now inherits from `:root` rather than being overridden locally, and that its value is Roboto.
- [x] Switch themes and density presets and confirm no type regressions anywhere in the app (top bar, status bar, doc explorer, history, response pane).

Refs: graphql/graphiql#4219
