### PR TITLE
v6: lock down the `@graphiql/react` public surface before 6.0.0

### DIFF
--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -44,6 +44,6 @@ export type { ResponseTableViewProps } from './response-table-view';
 export { ResponseTreeView } from './response-tree-view';
 export type { ResponseTreeViewProps } from './response-tree-view';
 export { VarHeadersStrip } from './var-headers-strip';
-export type { VarHeadersStripProps, VarTab } from './var-headers-strip';
+export type { VarHeadersStripProps, VarHeadersTab } from './var-headers-strip';
 export { SettingsDialog } from './settings-dialog';
 export type { SettingsDialogProps } from './settings-dialog';

--- a/packages/graphiql-react/src/components/index.ts
+++ b/packages/graphiql-react/src/components/index.ts
@@ -29,12 +29,11 @@ export type {
 } from './segmented-control';
 export { MethodPill } from './method-pill';
 export type { MethodPillProps, Operation } from './method-pill';
-export { TopBar, TopBarView } from './top-bar';
-export type { TopBarProps, TopBarViewProps } from './top-bar';
-export { StatusBar, StatusBarView } from './status-bar';
-export type { ConnectionStatus, StatusBarViewProps } from './status-bar';
-export { SidePanel, SidePanelView } from './side-panel';
-export type { SidePanelViewProps } from './side-panel';
+export { TopBar } from './top-bar';
+export type { TopBarProps } from './top-bar';
+export { StatusBar } from './status-bar';
+export type { ConnectionStatus } from './status-bar';
+export { SidePanel } from './side-panel';
 export { ActivityRail } from './activity-rail';
 export type { ActivityRailProps } from './activity-rail';
 export { ResponseHeader } from './response-header';

--- a/packages/graphiql-react/src/components/top-bar/index.tsx
+++ b/packages/graphiql-react/src/components/top-bar/index.tsx
@@ -11,7 +11,10 @@ import { Tooltip } from '../tooltip';
 import { DropdownMenu } from '../dropdown-menu';
 import { GraphQLLogoIcon, PlayIcon, ChevronDownIcon } from '../../icons';
 import { clsx } from 'clsx';
-import { getRunBlockReason, resolveActiveOperation } from '../../utility';
+import {
+  getRunBlockReason,
+  resolveActiveOperation,
+} from '../../utility/run-block';
 import './index.css';
 
 export type TopBarProps = {

--- a/packages/graphiql-react/src/components/var-headers-strip/index.tsx
+++ b/packages/graphiql-react/src/components/var-headers-strip/index.tsx
@@ -7,9 +7,9 @@ import { useEditorState } from '../../utility/hooks';
 import { tryParseJSONC } from '../../utility';
 import './index.css';
 
-export type VarTab = 'variables' | 'headers';
+export type VarHeadersTab = 'variables' | 'headers';
 
-const VAR_TAB_OPTIONS: { value: VarTab; label: string }[] = [
+const VAR_TAB_OPTIONS: { value: VarHeadersTab; label: string }[] = [
   { value: 'variables', label: 'Variables' },
   { value: 'headers', label: 'Headers' },
 ];
@@ -37,7 +37,7 @@ function useVariablesHint(): string | null {
 
 export type VarHeadersStripProps = {
   /** Which tab is shown initially. @default 'variables' */
-  defaultTab?: VarTab;
+  defaultTab?: VarHeadersTab;
   /**
    * Whether the headers tab and editor are available.
    * When `false`, only the variables editor is shown.
@@ -54,7 +54,7 @@ export const VarHeadersStrip: FC<VarHeadersStripProps> = ({
   onEditVariables,
   onEditHeaders,
 }) => {
-  const [varTab, setVarTab] = useState<VarTab>(
+  const [varTab, setVarTab] = useState<VarHeadersTab>(
     headersEditorEnabled ? defaultTab : 'variables',
   );
   const hint = useVariablesHint();

--- a/packages/graphiql-react/src/stores/execution.ts
+++ b/packages/graphiql-react/src/stores/execution.ts
@@ -17,11 +17,11 @@ import setValue from 'set-value';
 import getValue from 'get-value';
 
 import type { StateCreator } from 'zustand';
+import { tryParseJSONC } from '../utility';
 import {
-  tryParseJSONC,
   getRunBlockReason,
   resolveActiveOperation,
-} from '../utility';
+} from '../utility/run-block';
 import { Range } from '../utility/monaco-ssr';
 import { STORAGE_KEY } from '../constants';
 import type { SlicesWithActions, MonacoEditor } from '../types';

--- a/packages/graphiql-react/src/utility/index.ts
+++ b/packages/graphiql-react/src/utility/index.ts
@@ -9,11 +9,6 @@ export { debounce } from './debounce';
 export { formatJSONC, parseJSONC, tryParseJSONC } from './jsonc';
 export { markdown } from './markdown';
 export { pick } from './pick';
-export {
-  getRunBlockReason,
-  resolveActiveOperation,
-  MUTATION_REQUIRES_POST_REASON,
-} from './run-block';
 export { useDragResize } from './resize';
 export { typeCategory } from './type-category';
 export type { GraphQLTypeCategory } from './type-category';


### PR DESCRIPTION
## Summary

An audit of `@graphiql/react`'s public barrels turned up a handful of exports that read as internal or dangerously generic. None have docs or a changeset, which is itself the signal they weren't meant to be public. Since everything here is unreleased on `graphiql-6`, this is the last window to fix it without a deprecation cycle.

- `getRunBlockReason`, `resolveActiveOperation`, and `MUTATION_REQUIRES_POST_REASON` were re-exported from `utility/index.ts` even though they're pure Run-button implementation detail. Dropped from the barrel; the two internal call sites (`stores/execution.ts`, `top-bar`) now import `./run-block` directly.
- `VarTab` (exported alongside `VarHeadersStrip`) is about as generic as a type name gets in a shared package namespace. Renamed to `VarHeadersTab`.
- `TopBarView` / `StatusBarView` / `SidePanelView` (and their prop types) are the presentational half of a container/presentational split, exported alongside `TopBar` / `StatusBar` / `SidePanel`. Nothing outside `graphiql-react` imports them — even their own tests and stories already import from the component's own file, not the barrel — so they read as Storybook plumbing, not consumer API. Dropped from the barrel. The container components stay public, and so do the genuine response views (`ResponseTreeView`, `ResponseTableView`), which are real documented JSON/Tree/Table components, not a naming coincidence with the `*View` pattern above.
- `PortalProvider` / `usePortalContainer` stay public. They're not leaked plumbing: `graphiql`'s own `<GraphiQL>` component uses them to wire its container element into Radix's dialog/tooltip/dropdown portals so themed content doesn't fall back to rendering into `document.body`. Anyone assembling a custom shell around `@graphiql/react` components directly needs the same hook. The contract is already documented in the module's JSDoc.

Refs: graphql/graphiql#4219
