### PR TITLE
feat(graphiql-react): expose customScalarSchemas for the variable editor

### DIFF
--- a/.changeset/expose-custom-scalar-schemas.md
+++ b/.changeset/expose-custom-scalar-schemas.md
@@ -1,0 +1,6 @@
+---
+'@graphiql/react': minor
+'graphiql': minor
+---
+
+Add `customScalarSchemas` prop to `GraphiQLProvider`/`GraphiQL`, forwarded to `monaco-graphql`'s per-schema `customScalarSchemas` config. Without it, the variable editor's live JSON Schema linter assumes every custom scalar only accepts primitives (string, number, boolean, integer) and reports a spurious "Incorrect type" error for scalars that legitimately accept objects or arrays (e.g. a `JSON` or `GeoJSON` scalar). `graphql-language-service` and `monaco-graphql` already supported this per-scalar override; `@graphiql/react` just never exposed it.

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -59,6 +59,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
   const {
     initialQuery,
     schema,
+    customScalarSchemas,
     referencePlugin,
     operations,
     operationName,
@@ -70,6 +71,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     pick(
       'initialQuery',
       'schema',
+      'customScalarSchemas',
       'referencePlugin',
       'operations',
       'operationName',
@@ -273,7 +275,11 @@ export const OperationEditor: FC<OperationEditorProps> = ({
       return;
     }
     monacoGraphQL.setSchemaConfig([
-      { uri: `${uriInstanceId}${URI_NAME.schema}`, schema },
+      {
+        uri: `${uriInstanceId}${URI_NAME.schema}`,
+        schema,
+        customScalarSchemas,
+      },
     ]);
     monacoGraphQL.setExternalFragmentDefinitions([
       ...externalFragments.values(),
@@ -338,6 +344,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     return cleanupDisposables(disposables);
   }, [
     schema,
+    customScalarSchemas,
     referencePlugin,
     setSchemaReference,
     setVisiblePlugin,

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -151,6 +151,7 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
   onCopyQuery,
   onPrettifyQuery = DEFAULT_PRETTIFY_QUERY,
 
+  customScalarSchemas,
   dangerouslyAssumeSchemaIsValid = false,
   fetcher,
   inputValueDeprecation = false,
@@ -269,6 +270,7 @@ const InnerGraphiQLProvider: FC<GraphiQLProviderProps> = ({
           referencePlugin,
         })(...args);
         const schemaSlice = createSchemaSlice({
+          customScalarSchemas,
           inputValueDeprecation,
           introspectionQueryName,
           onSchemaChange,

--- a/packages/graphiql-react/src/stores/schema.ts
+++ b/packages/graphiql-react/src/stores/schema.ts
@@ -12,6 +12,7 @@ import {
   GraphQLSchema,
   IntrospectionQuery,
 } from 'graphql';
+import type { JSONSchema6 } from 'graphql-language-service';
 import type { Dispatch } from 'react';
 import type { StateCreator } from 'zustand';
 import type { SlicesWithActions, SchemaReference } from '../types';
@@ -22,6 +23,7 @@ type MaybeGraphQLSchema = GraphQLSchema | null | undefined;
 type CreateSchemaSlice = (
   initial: Pick<
     SchemaSlice,
+    | 'customScalarSchemas'
     | 'inputValueDeprecation'
     | 'introspectionQueryName'
     | 'onSchemaChange'
@@ -167,6 +169,7 @@ export const createSchemaSlice: CreateSchemaSlice = initial => (set, get) => ({
 
 export interface SchemaSlice extends Pick<
   SchemaProps,
+  | 'customScalarSchemas'
   | 'inputValueDeprecation'
   | 'introspectionQueryName'
   | 'schemaDescription'
@@ -289,4 +292,26 @@ export interface SchemaProps {
    * @see {@link https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts|Utility for creating the introspection query}
    */
   schemaDescription?: boolean;
+
+  /**
+   * JSON Schema fragments used to validate custom scalars in the variable
+   * editor. Without this, the variable editor's live JSON Schema linter
+   * assumes every custom scalar only accepts primitives (string, number,
+   * boolean, integer), and will report an "Incorrect type" error
+   * for any custom scalar that legitimately accepts an object or array
+   * (e.g. a `JSON` or `GeoJSON` scalar).
+   *
+   * Pass an empty object (`{}`) for a scalar to accept any JSON value, or
+   * a more specific schema to constrain it further.
+   * @example
+   * ```ts
+   * {
+   *   customScalarSchemas: {
+   *     GeoJSON: {},
+   *     DateTime: { type: 'string', format: 'date-time' },
+   *   }
+   * }
+   * ```
+   */
+  customScalarSchemas?: Record<string, JSONSchema6>;
 }

--- a/packages/graphiql/cypress/e2e/lint.cy.ts
+++ b/packages/graphiql/cypress/e2e/lint.cy.ts
@@ -138,6 +138,22 @@ describe('Linting', () => {
     );
   });
 
+  it('Does not mark object variables for a custom scalar with a configured customScalarSchemas as error', () => {
+    cy.visitWithOp({
+      query: /* GraphQL */ `
+        query WithVariables($jsonArg: JSON) {
+          hasArgs(json: $jsonArg)
+        }
+      `,
+      variables: {
+        jsonArg: { foo: 'bar' },
+      },
+    })
+      .contains('foo')
+      .should('not.have.class', 'CodeMirror-lint-mark')
+      .and('not.have.class', 'CodeMirror-lint-mark-error');
+  });
+
   it('Marks GraphQL syntax errors as error', () => {
     cy.visitWithOp({
       query: /* GraphQL */ `

--- a/packages/graphiql/src/e2e.ts
+++ b/packages/graphiql/src/e2e.ts
@@ -125,6 +125,9 @@ const props: ComponentProps<typeof GraphiQL> = {
   onTabChange,
   forcedTheme: parameters.forcedTheme,
   defaultTheme: parameters.defaultTheme,
+  customScalarSchemas: {
+    JSON: {},
+  },
 };
 
 function App() {

--- a/packages/graphiql/test/schema.js
+++ b/packages/graphiql/test/schema.js
@@ -22,11 +22,21 @@ export function createSchema({
   GraphQLString,
   GraphQLID,
   GraphQLList,
+  GraphQLScalarType,
   GraphQLDeferDirective,
   GraphQLStreamDirective,
   specifiedDirectives,
   version,
 }) {
+  const GraphQLJSON = new GraphQLScalarType({
+    name: 'JSON',
+    description: 'A scalar that accepts arbitrary JSON values.',
+    serialize: value => value,
+    parseValue: value => value,
+    parseLiteral() {
+      throw new TypeError('JSON literals are not supported, use variables.');
+    },
+  });
   const directives =
     parseInt(version, 10) > 16
       ? [...specifiedDirectives, GraphQLDeferDirective, GraphQLStreamDirective]
@@ -337,6 +347,10 @@ And external image:
           id: { type: GraphQLID },
           enum: { type: TestEnum },
           object: { type: TestInputObject },
+          json: {
+            type: GraphQLJSON,
+            description: 'A custom scalar that accepts any JSON value',
+          },
           defaultValue: {
             type: GraphQLString,
             defaultValue: 'test default value',

--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
@@ -436,7 +436,7 @@ describe('MessageProcessor with config', () => {
         character: 0,
       },
       end: {
-        line: 106 + offset,
+        line: 109 + offset,
         character: 1,
       },
     });
@@ -450,11 +450,11 @@ describe('MessageProcessor with config', () => {
     // this might break, please adjust if you see a failure here
     expect(serializeRange(schemaDefs[0].range)).toEqual({
       start: {
-        line: 108 + offset,
+        line: 111 + offset,
         character: 0,
       },
       end: {
-        line: 116 + offset,
+        line: 119 + offset,
         character: 1,
       },
     });

--- a/resources/custom-words.txt
+++ b/resources/custom-words.txt
@@ -178,6 +178,7 @@ proto
 qlapi
 qlid
 qlide
+qljson
 quasis
 ractive
 randomthing


### PR DESCRIPTION

## Summary

Adds an optional `customScalarSchemas` prop to `@graphiql/react`, so custom GraphQL scalars that legitimately hold objects/arrays (a `JSON` scalar, a `GeoJSON` scalar, etc.) aren't flagged by the variable editor's live JSON Schema linter with a false-positive "Incorrect type. Expected one of string, number, boolean, integer." error.

Both `graphql-language-service` (`scalarSchemas` option, added in #3376) and `monaco-graphql` (`SchemaConfig.customScalarSchemas`) already support this per-scalar override. `@graphiql/react`'s `operation-editor.tsx` was the missing link: it registers the schema with Monaco via a hardcoded `{ uri, schema }`, with no way for a consumer to add the third field.

Fixes #4447. See that issue for the full problem description.

## Changes

- `stores/schema.ts`: added `customScalarSchemas?: Record<string, JSONSchema6>` to `SchemaProps`, threaded through `SchemaSlice` and `CreateSchemaSlice`.
- `components/provider.tsx`: destructures the new prop, passes it into `createSchemaSlice(...)`.
- `components/operation-editor.tsx`: reads it from the store and includes it in the `monacoGraphQL.setSchemaConfig(...)` call (and its effect's dependency array).

Existing behavior for anyone not passing the prop is unchanged.

## Usage

```tsx
<GraphiQL
  fetcher={fetcher}
  customScalarSchemas={{
    GeoJSON: {}, // accept any JSON value
    DateTime: { type: 'string', format: 'date-time' },
  }}
/>
```
