### PR TITLE
v6: adjust `MessageProcessor` schema line assertions

### DIFF
--- a/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
+++ b/packages/graphql-language-service-server/src/__tests__/MessageProcessor.spec.ts
@@ -436,7 +436,7 @@ describe('MessageProcessor with config', () => {
         character: 0,
       },
       end: {
-        line: 109 + offset,
+        line: 112 + offset,
         character: 1,
       },
     });
@@ -450,11 +450,11 @@ describe('MessageProcessor with config', () => {
     // this might break, please adjust if you see a failure here
     expect(serializeRange(schemaDefs[0].range)).toEqual({
       start: {
-        line: 111 + offset,
+        line: 114 + offset,
         character: 0,
       },
       end: {
-        line: 119 + offset,
+        line: 122 + offset,
         character: 1,
       },
     });


### PR DESCRIPTION
`MessageProcessor.spec.ts` asserts the definition ranges of a type in the generated schema by absolute line number. The `Test` type grew by three lines when the `json` custom-scalar field from #4448 merged in from `main` and landed alongside the query builder fields already on this branch. This updates the expected line numbers.

## Test plan

- [x] `yarn test` passes for `graphql-language-service-server` (9 files, 116 passing, 1 skipped)
- [x] Vitest Unit Tests goes green on this PR, and on a v6 PR rebased on top of it