### PR TITLE
feat(graphql-language-service): support GraphQL 17 fragment arguments

### DIFF
--- a/.changeset/tidy-fragments-argue.md
+++ b/.changeset/tidy-fragments-argue.md
@@ -12,3 +12,6 @@ Add opt-in GraphQL 17 fragment argument syntax support to parsing, validation,
 type information, autocomplete, hover, and editor integrations. Enable it with
 `experimentalFragmentArguments: true`; it defaults to `false` until server
 capabilities can advertise support.
+
+Also fix variable autocomplete to respect operation and fragment scope while
+including variables from operations that spread the current fragment.

--- a/.changeset/tidy-fragments-argue.md
+++ b/.changeset/tidy-fragments-argue.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': minor
+---
+
+Add GraphQL 17 fragment argument syntax support to parsing, validation, type information, and autocomplete.

--- a/.changeset/tidy-fragments-argue.md
+++ b/.changeset/tidy-fragments-argue.md
@@ -1,5 +1,14 @@
 ---
 'graphql-language-service': minor
+'graphql-language-service-server': minor
+'monaco-graphql': minor
+'@graphiql/react': minor
+'graphiql': minor
+'codemirror-graphql': patch
+'cm6-graphql': patch
 ---
 
-Add GraphQL 17 fragment argument syntax support to parsing, validation, type information, and autocomplete.
+Add opt-in GraphQL 17 fragment argument syntax support to parsing, validation,
+type information, autocomplete, hover, and editor integrations. Enable it with
+`experimentalFragmentArguments: true`; it defaults to `false` until server
+capabilities can advertise support.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,6 +78,24 @@ jobs:
           path: ${{ env.BUILD-CACHE-LIST }}
       - run: yarn test
 
+  graphql-17-fragment-arguments:
+    name: GraphQL 17 Fragment Arguments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.node-version'
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn workspace graphql-language-service add --dev graphql@17.0.2
+      - name: Build and typecheck graphql-language-service
+        run: yarn workspace graphql-language-service exec tsc
+      - name: Test fragment argument integration
+        run: >-
+          yarn vitest run packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
+
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,7 +88,8 @@ jobs:
           node-version-file: '.node-version'
           cache: yarn
       - run: yarn install --immutable
-      - run: yarn workspace graphql-language-service add --dev graphql@17.0.2
+      - run: yarn set resolution 'graphql@npm:^16.9.0' 'npm:17.0.2'
+      - run: yarn install
       - name: Build and typecheck graphql-language-service
         run: yarn workspace graphql-language-service exec tsc
       - name: Test fragment argument integration

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,8 +88,7 @@ jobs:
           node-version-file: '.node-version'
           cache: yarn
       - run: yarn install --immutable
-      - run: yarn set resolution 'graphql@npm:^16.9.0' 'npm:17.0.2'
-      - run: yarn install
+      - run: yarn workspace graphql-language-service add --dev graphql@17.0.2
       - name: Build and typecheck graphql-language-service
         run: yarn workspace graphql-language-service exec tsc
       - name: Test fragment argument integration

--- a/packages/cm6-graphql/src/lint.ts
+++ b/packages/cm6-graphql/src/lint.ts
@@ -39,7 +39,14 @@ export const lint: Extension = linter(
         },
       ];
     }
-    const results = getDiagnostics(view.state.doc.toString(), schema);
+    const results = getDiagnostics(
+      view.state.doc.toString(),
+      schema,
+      undefined,
+      undefined,
+      undefined,
+      options?.autocompleteOptions,
+    );
 
     return results
       .map((item): Diagnostic | null => {

--- a/packages/codemirror-graphql/src/lint.ts
+++ b/packages/codemirror-graphql/src/lint.ts
@@ -9,7 +9,10 @@
 
 import CodeMirror from 'codemirror';
 import { FragmentDefinitionNode, GraphQLSchema, ValidationRule } from 'graphql';
-import { getDiagnostics } from 'graphql-language-service';
+import {
+  getDiagnostics,
+  GraphQLLanguageServiceOptions,
+} from 'graphql-language-service';
 
 const SEVERITY = ['error', 'warning', 'information', 'hint'];
 const TYPE: Record<string, string> = {
@@ -22,6 +25,7 @@ interface GraphQLLintOptions {
   schema?: GraphQLSchema;
   validationRules: ValidationRule[];
   externalFragments?: string | FragmentDefinitionNode[];
+  languageServiceOptions?: GraphQLLanguageServiceOptions;
 }
 
 /**
@@ -42,13 +46,19 @@ CodeMirror.registerHelper(
   'lint',
   'graphql',
   (text: string, options: GraphQLLintOptions): CodeMirror.Annotation[] => {
-    const { schema, validationRules, externalFragments } = options;
+    const {
+      schema,
+      validationRules,
+      externalFragments,
+      languageServiceOptions,
+    } = options;
     const rawResults = getDiagnostics(
       text,
       schema,
       validationRules,
       undefined,
       externalFragments,
+      languageServiceOptions,
     );
 
     const results = rawResults.map(error => ({

--- a/packages/graphiql-react/src/components/operation-editor.tsx
+++ b/packages/graphiql-react/src/components/operation-editor.tsx
@@ -82,6 +82,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     ),
   );
   const ref = useRef<HTMLDivElement>(null!);
+  const { monacoGraphQL, monaco } = useMonaco();
   const onClickReferenceRef = useRef<OperationEditorProps['onClickReference']>(
     null!,
   );
@@ -158,7 +159,14 @@ export const OperationEditor: FC<OperationEditorProps> = ({
     */
 
   function getAndUpdateOperationFacts(editorInstance: MonacoEditor) {
-    const operationFacts = getOperationFacts(schema, editorInstance.getValue());
+    const operationFacts = getOperationFacts(
+      schema,
+      editorInstance.getValue(),
+      {
+        experimentalFragmentArguments:
+          monacoGraphQL?.experimentalFragmentArguments,
+      },
+    );
     // Update the operation name should any query names change.
     const newOperationName = getSelectedOperationName(
       operations,
@@ -205,8 +213,6 @@ export const OperationEditor: FC<OperationEditorProps> = ({
       run();
     };
   }, [operationName, operations, run, setOperationName]);
-
-  const { monacoGraphQL, monaco } = useMonaco();
 
   useEffect(() => {
     if (!monaco || !monacoGraphQL) {

--- a/packages/graphiql-react/src/components/provider.tsx
+++ b/packages/graphiql-react/src/components/provider.tsx
@@ -57,6 +57,8 @@ interface GraphiQLProviderProps
     ThemeProps,
     StorageProps {
   children: ReactNode;
+  /** Enable experimental fragment arguments in the operation editor. */
+  experimentalFragmentArguments?: boolean;
 }
 
 type GraphiQLStore = UseBoundStore<StoreApi<SlicesWithActions>>;
@@ -128,7 +130,9 @@ useEffect(() => {
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    void actions.initialize();
+    void actions.initialize({
+      experimentalFragmentArguments: props.experimentalFragmentArguments,
+    });
     setMounted(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/graphiql-react/src/stores/monaco.ts
+++ b/packages/graphiql-react/src/stores/monaco.ts
@@ -1,5 +1,8 @@
 import { createStore } from 'zustand';
-import type { MonacoGraphQLAPI } from 'monaco-graphql';
+import type {
+  MonacoGraphQLAPI,
+  MonacoGraphQLInitializeConfig,
+} from 'monaco-graphql';
 import { createBoundedUseStore } from '../utility';
 import {
   JSON_DIAGNOSTIC_OPTIONS,
@@ -12,7 +15,12 @@ interface MonacoStoreType {
   monaco?: typeof import('monaco-editor');
   monacoGraphQL?: MonacoGraphQLAPI;
   actions: {
-    initialize: () => Promise<void>;
+    initialize: (
+      options?: Pick<
+        MonacoGraphQLInitializeConfig,
+        'experimentalFragmentArguments'
+      >,
+    ) => Promise<void>;
   };
 }
 
@@ -65,7 +73,7 @@ async function patchFirefox() {
  */
 export const monacoStore = createStore<MonacoStoreType>((set, get) => ({
   actions: {
-    async initialize() {
+    async initialize(options) {
       const isInitialized = Boolean(get().monaco);
       if (isInitialized) {
         return;
@@ -88,6 +96,7 @@ export const monacoStore = createStore<MonacoStoreType>((set, get) => ({
       }
       const monacoGraphQL = initializeMode({
         diagnosticSettings: MONACO_GRAPHQL_DIAGNOSTIC_SETTINGS,
+        ...options,
       });
       set({ monaco, monacoGraphQL });
     },

--- a/packages/graphiql/README.md
+++ b/packages/graphiql/README.md
@@ -117,6 +117,10 @@ const root = createRoot(document.getElementById('root'));
 root.render(<GraphiQL fetcher={fetcher} />);
 ```
 
+When the connected server supports GraphQL.js 17 fragment arguments, opt in
+with `<GraphiQL fetcher={fetcher} experimentalFragmentArguments />`. The syntax
+is disabled by default.
+
 ## Customize
 
 GraphiQL supports customization in UI and behavior by accepting React props and

--- a/packages/graphql-language-service-server/README.md
+++ b/packages/graphql-language-service-server/README.md
@@ -167,6 +167,8 @@ module.exports = {
       enableValidation: true,
       // (experimental) enhanced auto expansion of graphql leaf fields and arguments
       fillLeafsOnComplete: true,
+      // enable GraphQL.js 17 experimental fragment arguments across language features
+      experimentalFragmentArguments: true,
       // instead of jumping directly to the SDL file, you can override definition peek/jump results to point to different files or locations
       // (for example, source files for your schema in any language!)
       // based on Relay vscode's pathToLocateCommand

--- a/packages/graphql-language-service-server/src/GraphQLCache.ts
+++ b/packages/graphql-language-service-server/src/GraphQLCache.ts
@@ -18,6 +18,7 @@ import {
   parse,
   visit,
 } from 'graphql';
+import type { ParseOptions } from 'graphql';
 import type {
   CachedContent,
   GraphQLFileMetadata,
@@ -162,6 +163,17 @@ export class GraphQLCache {
 
   getGraphQLConfig = (): GraphQLConfig => this._graphQLConfig;
 
+  _parseGraphQL = (query: string, filePath?: Uri): DocumentNode => {
+    const projectConfig = filePath
+      ? this.getProjectForFile(filePath)
+      : undefined;
+    return parse(query, {
+      experimentalFragmentArguments:
+        projectConfig?.extensions?.languageService
+          ?.experimentalFragmentArguments === true,
+    } as ParseOptions);
+  };
+
   getProjectForFile = (uri: string): GraphQLProjectConfig | void => {
     try {
       const project = this._graphQLConfig.getProjectForFile(
@@ -184,6 +196,7 @@ export class GraphQLCache {
   getFragmentDependencies = async (
     query: string,
     fragmentDefinitions?: Map<string, FragmentInfo> | null,
+    experimentalFragmentArguments = false,
   ): Promise<FragmentInfo[]> => {
     // If there isn't context for fragment references,
     // return an empty array.
@@ -194,7 +207,9 @@ export class GraphQLCache {
     // Return an empty array.
     let parsedQuery;
     try {
-      parsedQuery = parse(query);
+      parsedQuery = parse(query, {
+        experimentalFragmentArguments,
+      } as ParseOptions);
     } catch {
       return [];
     }
@@ -452,7 +467,7 @@ export class GraphQLCache {
     const asts = contents.map(({ query }) => {
       try {
         return {
-          ast: parse(query),
+          ast: this._parseGraphQL(query, filePath),
           query,
         };
       } catch {
@@ -507,7 +522,7 @@ export class GraphQLCache {
     const asts = contents.map(({ query }) => {
       try {
         return {
-          ast: parse(query),
+          ast: this._parseGraphQL(query, filePath),
           query,
         };
       } catch {
@@ -821,7 +836,7 @@ export class GraphQLCache {
         }
 
         for (const { query } of queries) {
-          asts.push(parse(query));
+          asts.push(this._parseGraphQL(query, filePath));
         }
         return {
           filePath,

--- a/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
+++ b/packages/graphql-language-service-server/src/GraphQLLanguageService.ts
@@ -17,7 +17,6 @@ import {
   FieldNode,
   GraphQLError,
   Kind,
-  parse,
   print,
   isTypeDefinitionNode,
   ArgumentNode,
@@ -47,6 +46,7 @@ import {
   getTypeInfo,
   DefinitionQueryResponse,
   getDefinitionQueryResultForArgument,
+  parseDocument,
 } from 'graphql-language-service';
 
 import type { GraphQLCache } from './GraphQLCache';
@@ -88,6 +88,14 @@ function getKind(tree: OutlineTree) {
   return KIND_TO_SYMBOL_KIND[tree.kind];
 }
 
+function fragmentArgumentOptions(projectConfig: GraphQLProjectConfig) {
+  return {
+    experimentalFragmentArguments:
+      projectConfig.extensions?.languageService
+        ?.experimentalFragmentArguments === true,
+  };
+}
+
 export class GraphQLLanguageService {
   _graphQLCache: GraphQLCache;
   _graphQLConfig: GraphQLConfig;
@@ -121,9 +129,10 @@ export class GraphQLLanguageService {
       return [];
     }
     const { schema: schemaPath, name: projectName, extensions } = projectConfig;
+    const experimentalOptions = fragmentArgumentOptions(projectConfig);
 
     try {
-      const documentAST = parse(document);
+      const documentAST = parseDocument(document, experimentalOptions);
       if (!schemaPath || uri !== schemaPath) {
         documentHasExtensions = documentAST.definitions.some(definition => {
           switch (definition.kind) {
@@ -174,6 +183,7 @@ export class GraphQLLanguageService {
       await this._graphQLCache.getFragmentDependencies(
         document,
         fragmentDefinitions,
+        experimentalOptions.experimentalFragmentArguments,
       );
 
     const dependenciesSource = fragmentDependencies.reduce(
@@ -185,7 +195,7 @@ export class GraphQLLanguageService {
 
     let validationAst = null;
     try {
-      validationAst = parse(source);
+      validationAst = parseDocument(source, experimentalOptions);
     } catch {
       // the query string is already checked to be parsed properly - errors
       // from this parse must be from corrupted fragment dependencies.
@@ -244,6 +254,7 @@ export class GraphQLLanguageService {
       fragmentInfo,
       {
         uri: filePath,
+        ...fragmentArgumentOptions(projectConfig),
         fillLeafsOnComplete:
           projectConfig?.extensions?.languageService?.fillLeafsOnComplete ??
           false,
@@ -264,7 +275,10 @@ export class GraphQLLanguageService {
     const schema = await this._graphQLCache.getSchema(projectConfig.name);
 
     if (schema) {
-      return getHoverInformation(schema, query, position, undefined, options);
+      return getHoverInformation(schema, query, position, undefined, {
+        ...fragmentArgumentOptions(projectConfig),
+        ...options,
+      });
     }
     return '';
   }
@@ -286,7 +300,7 @@ export class GraphQLLanguageService {
     }
     let ast;
     try {
-      ast = parse(query);
+      ast = parseDocument(query, fragmentArgumentOptions(projectConfig));
     } catch {
       return null;
     }
@@ -360,7 +374,7 @@ export class GraphQLLanguageService {
     document: string,
     filePath: Uri,
   ): Promise<SymbolInformation[]> {
-    const outline = await this.getOutline(document);
+    const outline = await this.getOutline(document, filePath);
     if (!outline) {
       return [];
     }
@@ -539,7 +553,14 @@ export class GraphQLLanguageService {
     );
   }
 
-  async getOutline(documentText: string): Promise<Outline | null> {
-    return getOutline(documentText);
+  async getOutline(
+    documentText: string,
+    filePath?: Uri,
+  ): Promise<Outline | null> {
+    const projectConfig = filePath ? this.getConfigForURI(filePath) : undefined;
+    return getOutline(
+      documentText,
+      projectConfig ? fragmentArgumentOptions(projectConfig) : undefined,
+    );
   }
 }

--- a/packages/graphql-language-service/README.md
+++ b/packages/graphql-language-service/README.md
@@ -34,9 +34,11 @@ by an IDE plugin, a browser application or desktop application.
 A standalone online, immutable, dependency-free parser for
 [GraphQL](https://graphql.org), used by the LSP interface methods.
 
-With GraphQL.js 17, executable documents are parsed with experimental fragment
-arguments enabled so diagnostics, outlines, operation facts, and autocomplete
-all understand fragment variable definitions and fragment spread arguments.
+With GraphQL.js 17, fragment variable definitions and fragment spread arguments
+can be enabled for parsing, diagnostics, outlines, operation facts, autocomplete,
+and hover information. Pass `experimentalFragmentArguments: true` through the
+relevant language-service options. The feature defaults to `false` because the
+connected GraphQL server must also support the experimental syntax.
 
 ## Utils
 

--- a/packages/graphql-language-service/README.md
+++ b/packages/graphql-language-service/README.md
@@ -32,7 +32,11 @@ by an IDE plugin, a browser application or desktop application.
 ## Parser
 
 A standalone online, immutable, dependency-free parser for
-[GraphQL](https://graphql.org), used by the LSP interface methods
+[GraphQL](https://graphql.org), used by the LSP interface methods.
+
+With GraphQL.js 17, executable documents are parsed with experimental fragment
+arguments enabled so diagnostics, outlines, operation facts, and autocomplete
+all understand fragment variable definitions and fragment spread arguments.
 
 ## Utils
 

--- a/packages/graphql-language-service/src/index.ts
+++ b/packages/graphql-language-service/src/index.ts
@@ -61,6 +61,7 @@ export {
   getDefinitionState,
   getFieldDef,
   getContextAtPosition,
+  parseDocument,
 } from './parser';
 
 export type {
@@ -98,6 +99,7 @@ export type {
   OutlineTree,
   FragmentInfo,
   GraphQLFileInfo,
+  GraphQLLanguageServiceOptions,
   FileChangeType,
   GraphQLCache,
   GraphQLExtensionDeclaration,

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
@@ -99,7 +99,7 @@ describe('getAutocompleteSuggestions', () => {
       point,
       undefined,
       externalFragments,
-      options,
+      { experimentalFragmentArguments: true, ...options },
     )
       .filter(field => !['__schema', '__type'].includes(field.label))
       .sort((a, b) => a.label.localeCompare(b.label))

--- a/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getAutocompleteSuggestions.test.ts
@@ -428,6 +428,55 @@ describe('getAutocompleteSuggestions', () => {
       ]);
     });
 
+    it('provides input type suggestions for fragment variables', () => {
+      const result = testSuggestions(
+        'fragment SomeFragment($exampleVariable: ) on Human { name }',
+        new Position(0, 40),
+      );
+      expect(result).toEqual([
+        ...metaArgs,
+        { label: 'Boolean', documentation: GraphQLBoolean.description },
+        { label: 'Episode' },
+        { label: 'InputType' },
+        { label: 'Int', documentation: GraphQLInt.description },
+        { label: 'String', documentation: GraphQLString.description },
+      ]);
+    });
+
+    it('provides argument suggestions for fragment spreads', () => {
+      const query =
+        'fragment CharacterDetails($episode: Episode!, $id: String) on Human { name } query { human(id: "1") { ...CharacterDetails(';
+
+      expect(testSuggestions(query, new Position(0, query.length))).toEqual([
+        {
+          label: 'episode',
+          insertText: 'episode: ',
+          command: suggestionCommand,
+          insertTextFormat: 2,
+          labelDetails: { detail: ' Episode!' },
+        },
+        {
+          label: 'id',
+          insertText: 'id: ',
+          command: suggestionCommand,
+          insertTextFormat: 2,
+          labelDetails: { detail: ' String' },
+        },
+      ]);
+    });
+
+    it('uses fragment variable types for argument value suggestions', () => {
+      const query =
+        'fragment CharacterDetails($episode: Episode!) on Human { name } query { human(id: "1") { ...CharacterDetails(episode: ) } }';
+      const cursor = query.indexOf('episode: )') + 'episode: '.length;
+
+      expect(testSuggestions(query, new Position(0, cursor))).toEqual([
+        { label: 'EMPIRE', detail: 'Episode' },
+        { label: 'JEDI', detail: 'Episode' },
+        { label: 'NEWHOPE', detail: 'Episode' },
+      ]);
+    });
+
     it('provides filtered input type suggestions', () => {
       const result = testSuggestions(
         'query($exampleVariable: In) { ',
@@ -504,6 +553,52 @@ describe('getAutocompleteSuggestions', () => {
       );
       expect(result).toEqual([
         { label: '$ep', insertText: 'ep', detail: 'Episode' },
+      ]);
+    });
+
+    it('does not suggest fragment variables in operation scope', () => {
+      const query =
+        'fragment Frag($fragmentEpisode: Episode!) on Human { name } query($operationEpisode: Episode!){ hero(episode: $ }';
+
+      expect(
+        testSuggestions(query, new Position(0, query.lastIndexOf('$ }') + 1)),
+      ).toEqual([
+        {
+          label: '$operationEpisode',
+          insertText: 'operationEpisode',
+          detail: 'Episode',
+        },
+      ]);
+    });
+
+    it('does not let fragment variables shadow operation variables', () => {
+      const query =
+        'fragment Frag($episode: String!) on Human { name } query($episode: Episode!){ hero(episode: $ }';
+
+      expect(
+        testSuggestions(query, new Position(0, query.lastIndexOf('$ }') + 1)),
+      ).toEqual([
+        { label: '$episode', insertText: 'episode', detail: 'Episode' },
+      ]);
+    });
+
+    it('suggests local and reachable operation variables in fragment scope', () => {
+      const query =
+        'query($operationValue: Boolean!){ human(id: "1") { ...Frag(localValue: $operationValue) } } fragment Frag($localValue: Boolean!) on Human { name @include(if: $ }';
+
+      expect(
+        testSuggestions(query, new Position(0, query.lastIndexOf('$ }') + 1)),
+      ).toEqual([
+        {
+          label: '$localValue',
+          insertText: 'localValue',
+          detail: 'Boolean',
+        },
+        {
+          label: '$operationValue',
+          insertText: 'operationValue',
+          detail: 'Boolean',
+        },
       ]);
     });
 
@@ -601,6 +696,33 @@ describe('getAutocompleteSuggestions', () => {
       ]);
     });
 
+    it.runIf(Number.parseInt(graphQLVersion, 10) >= 17)(
+      'provides argument suggestions for external fragments',
+      () => {
+        const externalFragments = parse(
+          'fragment CharacterDetails($episode: Episode!) on Human { name }',
+          { experimentalFragmentArguments: true },
+        ).definitions as FragmentDefinitionNode[];
+        const query = 'query { human(id: "1") { ...CharacterDetails(';
+
+        expect(
+          testSuggestions(
+            query,
+            new Position(0, query.length),
+            externalFragments,
+          ),
+        ).toEqual([
+          {
+            label: 'episode',
+            insertText: 'episode: ',
+            command: suggestionCommand,
+            insertTextFormat: 2,
+            labelDetails: { detail: ' Episode!' },
+          },
+        ]);
+      },
+    );
+
     it('provides correct directive suggestions', () => {
       expect(testSuggestions('{ test @ }', new Position(0, 8))).toEqual(
         expectedDirectiveSuggestions,
@@ -628,7 +750,7 @@ describe('getAutocompleteSuggestions', () => {
           insertText: 'reason: ',
           documentation: GraphQLDeprecatedDirective.args[0].description,
           labelDetails: {
-            detail: ' String',
+            detail: ` ${GraphQLDeprecatedDirective.args[0].type}`,
           },
         },
       ]);

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
@@ -146,6 +146,10 @@ describe('getDiagnostics', () => {
           }
         `,
         schema,
+        undefined,
+        undefined,
+        undefined,
+        { experimentalFragmentArguments: true },
       );
 
       expect(errors).toEqual([]);
@@ -167,6 +171,10 @@ describe('getDiagnostics', () => {
           }
         `,
         schema,
+        undefined,
+        undefined,
+        undefined,
+        { experimentalFragmentArguments: true },
       );
 
       expect(errors.map(error => error.message)).toEqual(
@@ -175,6 +183,19 @@ describe('getDiagnostics', () => {
           expect.stringContaining('showName'),
         ]),
       );
+    },
+  );
+
+  it.runIf(Number.parseInt(version, 10) >= 17)(
+    'does not enable fragment arguments by default',
+    () => {
+      const errors = getDiagnostics(
+        'fragment Details($id: ID!) on Human { id }',
+        schema,
+      );
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].source).toBe('GraphQL: Syntax');
     },
   );
 

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
@@ -131,6 +131,53 @@ describe('getDiagnostics', () => {
     expect(errors.length).toEqual(0);
   });
 
+  it.runIf(Number.parseInt(version, 10) >= 17)(
+    'parses and validates fragment arguments with GraphQL 17',
+    () => {
+      const errors = getDiagnostics(
+        `
+          query Hero($showName: Boolean!) {
+            human(id: "1") {
+              ...HumanDetails(showName: $showName)
+            }
+          }
+          fragment HumanDetails($showName: Boolean!) on Human {
+            name @include(if: $showName)
+          }
+        `,
+        schema,
+      );
+
+      expect(errors).toEqual([]);
+    },
+  );
+
+  it.runIf(Number.parseInt(version, 10) >= 17)(
+    'reports validation errors for invalid fragment arguments',
+    () => {
+      const errors = getDiagnostics(
+        `
+          query Hero {
+            human(id: "1") {
+              ...HumanDetails(unknown: true)
+            }
+          }
+          fragment HumanDetails($showName: Boolean!) on Human {
+            name @include(if: $showName)
+          }
+        `,
+        schema,
+      );
+
+      expect(errors.map(error => error.message)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('Unknown argument "unknown"'),
+          expect.stringContaining('showName'),
+        ]),
+      );
+    },
+  );
+
   it('catches a syntax error in the SDL', () => {
     const errors = getDiagnostics(
       `

--- a/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
@@ -132,9 +132,12 @@ describe('getHoverInformation', () => {
   it('provides fragment argument type information', () => {
     const query =
       'fragment Details($id: String!) on TestType { testField } query { thing { ...Details(id: "x") } }';
-    const actual = testHover(
+    const actual = getHoverInformation(
+      schema,
       query,
       new Position(0, query.lastIndexOf('id:') + 1),
+      undefined,
+      { experimentalFragmentArguments: true },
     );
 
     expect(actual).toEqual('(id: String!)');

--- a/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getHoverInformation.test.ts
@@ -129,6 +129,17 @@ describe('getHoverInformation', () => {
     expect(actual).toEqual('Color.GREEN');
   });
 
+  it('provides fragment argument type information', () => {
+    const query =
+      'fragment Details($id: String!) on TestType { testField } query { thing { ...Details(id: "x") } }';
+    const actual = testHover(
+      query,
+      new Position(0, query.lastIndexOf('id:') + 1),
+    );
+
+    expect(actual).toEqual('(id: String!)');
+  });
+
   it('provides variable type information', () => {
     const actual = testHover(
       'query($who: String!) { parameterizedField(id: $who) { testField } }',

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -66,7 +66,6 @@ import {
   getDefinitionState,
   GraphQLDocumentMode,
   parseDocument,
-  getFragmentDefinitions,
 } from '../parser';
 import {
   hintList,
@@ -77,8 +76,9 @@ import {
 } from './autocompleteUtils';
 
 import { InsertTextMode } from 'vscode-languageserver-types';
+import { getFragmentDefinitions } from './getFragmentDefinitions';
 
-export { runOnlineParser, getTypeInfo, getFragmentDefinitions };
+export { runOnlineParser, getTypeInfo };
 
 export const SuggestionCommand = {
   command: 'editor.action.triggerSuggest',

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -49,6 +49,7 @@ import {
   AllTypeInfo,
   IPosition,
   CompletionItemKind,
+  GraphQLLanguageServiceOptions,
   InsertTextFormat,
 } from '../types';
 
@@ -85,11 +86,14 @@ export const SuggestionCommand = {
   title: 'Suggestions',
 };
 
-const collectFragmentDefs = (op: string | undefined) => {
+const collectFragmentDefs = (
+  op: string | undefined,
+  options?: GraphQLLanguageServiceOptions,
+) => {
   const externalFragments: FragmentDefinitionNode[] = [];
   if (op) {
     try {
-      visit(parseDocument(op), {
+      visit(parseDocument(op, options), {
         FragmentDefinition(def) {
           externalFragments.push(def);
         },
@@ -101,7 +105,7 @@ const collectFragmentDefs = (op: string | undefined) => {
   return externalFragments;
 };
 
-export type AutocompleteSuggestionOptions = {
+export type AutocompleteSuggestionOptions = GraphQLLanguageServiceOptions & {
   /**
    * EXPERIMENTAL: Automatically fill required leaf nodes recursively
    * upon triggering code completion events.
@@ -141,10 +145,10 @@ export function getAutocompleteSuggestions(
     ...options,
     schema,
   } as InternalAutocompleteOptions;
-  const fragmentDefinitions = getFragmentDefinitions(queryText);
+  const fragmentDefinitions = getFragmentDefinitions(queryText, options);
   const providedFragmentDefinitions = Array.isArray(fragmentDefs)
     ? fragmentDefs
-    : collectFragmentDefs(fragmentDefs);
+    : collectFragmentDefs(fragmentDefs, options);
   for (const definition of providedFragmentDefinitions) {
     if (
       !fragmentDefinitions.some(
@@ -366,6 +370,7 @@ export function getAutocompleteSuggestions(
       queryText,
       schema,
       token,
+      options,
     );
     return hintList(
       token,
@@ -875,6 +880,7 @@ export function getVariableCompletions(
   queryText: string,
   schema: GraphQLSchema,
   token: ContextToken,
+  options?: GraphQLLanguageServiceOptions,
 ): CompletionItem[] {
   let variableName: null | string = null;
   let variableScope: string | undefined;
@@ -883,73 +889,77 @@ export function getVariableCompletions(
   const fragmentSpreadsByScope = new Map<string, Set<string>>();
   const operationScopes = new Set<string>();
 
-  runOnlineParser(queryText, (_, state: State) => {
-    const scope = getDefinitionKey(state);
-    const definition = getDefinitionState(state);
-    if (!scope || !definition) {
-      return;
-    }
-
-    if (
-      definition.kind === RuleKinds.QUERY ||
-      definition.kind === RuleKinds.MUTATION ||
-      definition.kind === RuleKinds.SUBSCRIPTION ||
-      definition.kind === RuleKinds.SHORT_QUERY
-    ) {
-      operationScopes.add(scope);
-    }
-
-    if (state.kind === RuleKinds.FRAGMENT_SPREAD && state.name) {
-      const spreads = fragmentSpreadsByScope.get(scope) ?? new Set<string>();
-      spreads.add(state.name);
-      fragmentSpreadsByScope.set(scope, spreads);
-    }
-
-    if (
-      state.kind === RuleKinds.VARIABLE &&
-      state.name &&
-      stateContains(state, RuleKinds.VARIABLE_DEFINITION)
-    ) {
-      variableName = state.name;
-      variableScope = scope;
-    }
-    if (
-      state.kind === RuleKinds.NAMED_TYPE &&
-      variableName &&
-      variableScope === scope
-    ) {
-      const parentDefinition = getParentDefinition(state, RuleKinds.TYPE);
-      if (parentDefinition?.type) {
-        variableType = schema.getType(
-          parentDefinition.type,
-        ) as GraphQLInputObjectType;
-      }
-    }
-
-    if (variableName && variableType && variableScope === scope) {
-      const definitions =
-        definitionsByScope.get(scope) ?? new Map<string, CompletionItem>();
-      if (!definitions.has(variableName)) {
-        const replaceString =
-          token.string === '$' || token.state.kind === RuleKinds.VARIABLE
-            ? variableName
-            : '$' + variableName;
-        definitions.set(variableName, {
-          detail: variableType.toString(),
-          insertText: replaceString,
-          label: '$' + variableName,
-          rawInsert: replaceString,
-          type: variableType,
-          kind: CompletionItemKind.Variable,
-        } as CompletionItem);
-        definitionsByScope.set(scope, definitions);
+  runOnlineParser(
+    queryText,
+    (_, state: State) => {
+      const scope = getDefinitionKey(state);
+      const definition = getDefinitionState(state);
+      if (!scope || !definition) {
+        return;
       }
 
-      variableName = null;
-      variableScope = undefined;
-      variableType = null;
-    }
-  });
+      if (
+        definition.kind === RuleKinds.QUERY ||
+        definition.kind === RuleKinds.MUTATION ||
+        definition.kind === RuleKinds.SUBSCRIPTION ||
+        definition.kind === RuleKinds.SHORT_QUERY
+      ) {
+        operationScopes.add(scope);
+      }
+
+      if (state.kind === RuleKinds.FRAGMENT_SPREAD && state.name) {
+        const spreads = fragmentSpreadsByScope.get(scope) ?? new Set<string>();
+        spreads.add(state.name);
+        fragmentSpreadsByScope.set(scope, spreads);
+      }
+
+      if (
+        state.kind === RuleKinds.VARIABLE &&
+        state.name &&
+        stateContains(state, RuleKinds.VARIABLE_DEFINITION)
+      ) {
+        variableName = state.name;
+        variableScope = scope;
+      }
+      if (
+        state.kind === RuleKinds.NAMED_TYPE &&
+        variableName &&
+        variableScope === scope
+      ) {
+        const parentDefinition = getParentDefinition(state, RuleKinds.TYPE);
+        if (parentDefinition?.type) {
+          variableType = schema.getType(
+            parentDefinition.type,
+          ) as GraphQLInputObjectType;
+        }
+      }
+
+      if (variableName && variableType && variableScope === scope) {
+        const definitions =
+          definitionsByScope.get(scope) ?? new Map<string, CompletionItem>();
+        if (!definitions.has(variableName)) {
+          const replaceString =
+            token.string === '$' || token.state.kind === RuleKinds.VARIABLE
+              ? variableName
+              : '$' + variableName;
+          definitions.set(variableName, {
+            detail: variableType.toString(),
+            insertText: replaceString,
+            label: '$' + variableName,
+            rawInsert: replaceString,
+            type: variableType,
+            kind: CompletionItemKind.Variable,
+          } as CompletionItem);
+          definitionsByScope.set(scope, definitions);
+        }
+
+        variableName = null;
+        variableScope = undefined;
+        variableType = null;
+      }
+    },
+    options,
+  );
 
   const currentDefinition = getDefinitionState(token.state);
   const currentScope = getDefinitionKey(token.state);

--- a/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
+++ b/packages/graphql-language-service/src/interface/getAutocompleteSuggestions.ts
@@ -22,7 +22,6 @@ import {
   GraphQLObjectType,
   Kind,
   DirectiveLocation,
-  GraphQLArgument,
   // isNonNullType,
   isScalarType,
   isObjectType,
@@ -43,7 +42,6 @@ import {
   isCompositeType,
   isInputType,
   visit,
-  parse,
 } from 'graphql';
 
 import {
@@ -67,6 +65,8 @@ import {
   getContextAtPosition,
   getDefinitionState,
   GraphQLDocumentMode,
+  parseDocument,
+  getFragmentDefinitions,
 } from '../parser';
 import {
   hintList,
@@ -78,7 +78,7 @@ import {
 
 import { InsertTextMode } from 'vscode-languageserver-types';
 
-export { runOnlineParser, getTypeInfo };
+export { runOnlineParser, getTypeInfo, getFragmentDefinitions };
 
 export const SuggestionCommand = {
   command: 'editor.action.triggerSuggest',
@@ -89,7 +89,7 @@ const collectFragmentDefs = (op: string | undefined) => {
   const externalFragments: FragmentDefinitionNode[] = [];
   if (op) {
     try {
-      visit(parse(op), {
+      visit(parseDocument(op), {
         FragmentDefinition(def) {
           externalFragments.push(def);
         },
@@ -141,13 +141,26 @@ export function getAutocompleteSuggestions(
     ...options,
     schema,
   } as InternalAutocompleteOptions;
+  const fragmentDefinitions = getFragmentDefinitions(queryText);
+  const providedFragmentDefinitions = Array.isArray(fragmentDefs)
+    ? fragmentDefs
+    : collectFragmentDefs(fragmentDefs);
+  for (const definition of providedFragmentDefinitions) {
+    if (
+      !fragmentDefinitions.some(
+        existing => existing.name.value === definition.name.value,
+      )
+    ) {
+      fragmentDefinitions.push(definition);
+    }
+  }
 
   const context = getContextAtPosition(
     queryText,
     cursor,
     schema,
     contextToken,
-    options,
+    { ...options, fragmentDefinitions },
     1,
   );
   if (!context) {
@@ -282,14 +295,16 @@ export function getAutocompleteSuggestions(
   // Argument names
   if (
     kind === RuleKinds.ARGUMENTS ||
-    (kind === RuleKinds.ARGUMENT && step === 0)
+    kind === RuleKinds.FRAGMENT_ARGUMENTS ||
+    ((kind === RuleKinds.ARGUMENT || kind === RuleKinds.FRAGMENT_ARGUMENT) &&
+      step === 0)
   ) {
     const { argDefs } = typeInfo;
     if (argDefs) {
       return hintList(
         token,
         argDefs.map(
-          (argDef: GraphQLArgument): CompletionItem => ({
+          (argDef): CompletionItem => ({
             label: argDef.name,
             insertText: getInputInsertText(argDef.name + ': ', argDef.type),
             insertTextMode: InsertTextMode.adjustIndentation,
@@ -339,7 +354,8 @@ export function getAutocompleteSuggestions(
     kind === RuleKinds.ENUM_VALUE ||
     (kind === RuleKinds.LIST_VALUE && step === 1) ||
     (kind === RuleKinds.OBJECT_FIELD && step === 2) ||
-    (kind === RuleKinds.ARGUMENT && step === 2)
+    ((kind === RuleKinds.ARGUMENT || kind === RuleKinds.FRAGMENT_ARGUMENT) &&
+      step === 2)
   ) {
     return getSuggestionsForInputValues(token, typeInfo, queryText, schema);
   }
@@ -378,10 +394,7 @@ export function getAutocompleteSuggestions(
       token,
       typeInfo,
       schema,
-      queryText,
-      Array.isArray(fragmentDefs)
-        ? fragmentDefs
-        : collectFragmentDefs(fragmentDefs),
+      fragmentDefinitions,
     );
   }
 
@@ -783,22 +796,13 @@ function getSuggestionsForFragmentSpread(
   token: ContextToken,
   typeInfo: AllTypeInfo,
   schema: GraphQLSchema,
-  queryText: string,
-  fragmentDefs?: FragmentDefinitionNode[],
+  fragmentDefinitions: ReadonlyArray<FragmentDefinitionNode>,
 ): Array<CompletionItem> {
-  if (!queryText) {
-    return [];
-  }
   const typeMap = schema.getTypeMap();
   const defState = getDefinitionState(token.state);
-  const fragments = getFragmentDefinitions(queryText);
-
-  if (fragmentDefs && fragmentDefs.length > 0) {
-    fragments.push(...fragmentDefs);
-  }
 
   // Filter down to only the fragments which may exist here.
-  const relevantFrags = fragments.filter(
+  const relevantFrags = fragmentDefinitions.filter(
     frag =>
       // Only include fragments with known types.
       typeMap[frag.typeCondition.name.value] &&
@@ -849,87 +853,154 @@ const getParentDefinition = (state: State, kind: RuleKind) => {
   }
 };
 
+function getDefinitionKey(state: State): string | undefined {
+  const definition = getDefinitionState(state);
+  return definition?.kind
+    ? `${definition.kind}:${definition.name ?? ''}`
+    : undefined;
+}
+
+function stateContains(state: State, kind: RuleKind): boolean {
+  let current: State | null | undefined = state;
+  while (current?.kind) {
+    if (current.kind === kind) {
+      return true;
+    }
+    current = current.prevState;
+  }
+  return false;
+}
+
 export function getVariableCompletions(
   queryText: string,
   schema: GraphQLSchema,
   token: ContextToken,
 ): CompletionItem[] {
   let variableName: null | string = null;
+  let variableScope: string | undefined;
   let variableType: GraphQLInputObjectType | undefined | null;
-  const definitions: Record<string, any> = Object.create({});
+  const definitionsByScope = new Map<string, Map<string, CompletionItem>>();
+  const fragmentSpreadsByScope = new Map<string, Set<string>>();
+  const operationScopes = new Set<string>();
 
   runOnlineParser(queryText, (_, state: State) => {
-    // TODO: gather this as part of `AllTypeInfo`, as I don't think it's optimal to re-run the parser like this
-    if (state?.kind === RuleKinds.VARIABLE && state.name) {
-      variableName = state.name;
+    const scope = getDefinitionKey(state);
+    const definition = getDefinitionState(state);
+    if (!scope || !definition) {
+      return;
     }
-    if (state?.kind === RuleKinds.NAMED_TYPE && variableName) {
+
+    if (
+      definition.kind === RuleKinds.QUERY ||
+      definition.kind === RuleKinds.MUTATION ||
+      definition.kind === RuleKinds.SUBSCRIPTION ||
+      definition.kind === RuleKinds.SHORT_QUERY
+    ) {
+      operationScopes.add(scope);
+    }
+
+    if (state.kind === RuleKinds.FRAGMENT_SPREAD && state.name) {
+      const spreads = fragmentSpreadsByScope.get(scope) ?? new Set<string>();
+      spreads.add(state.name);
+      fragmentSpreadsByScope.set(scope, spreads);
+    }
+
+    if (
+      state.kind === RuleKinds.VARIABLE &&
+      state.name &&
+      stateContains(state, RuleKinds.VARIABLE_DEFINITION)
+    ) {
+      variableName = state.name;
+      variableScope = scope;
+    }
+    if (
+      state.kind === RuleKinds.NAMED_TYPE &&
+      variableName &&
+      variableScope === scope
+    ) {
       const parentDefinition = getParentDefinition(state, RuleKinds.TYPE);
       if (parentDefinition?.type) {
         variableType = schema.getType(
-          parentDefinition?.type,
+          parentDefinition.type,
         ) as GraphQLInputObjectType;
       }
     }
 
-    if (variableName && variableType && !definitions[variableName]) {
-      // append `$` if the `token.string` is not already `$`, or describing a variable
-      // this appears to take care of it everywhere
-      const replaceString =
-        token.string === '$' || token?.state?.kind === 'Variable'
-          ? variableName
-          : '$' + variableName;
-      definitions[variableName] = {
-        detail: variableType.toString(),
-        insertText: replaceString,
-        label: '$' + variableName,
-        rawInsert: replaceString,
-        type: variableType,
-        kind: CompletionItemKind.Variable,
-      } as CompletionItem;
+    if (variableName && variableType && variableScope === scope) {
+      const definitions =
+        definitionsByScope.get(scope) ?? new Map<string, CompletionItem>();
+      if (!definitions.has(variableName)) {
+        const replaceString =
+          token.string === '$' || token.state.kind === RuleKinds.VARIABLE
+            ? variableName
+            : '$' + variableName;
+        definitions.set(variableName, {
+          detail: variableType.toString(),
+          insertText: replaceString,
+          label: '$' + variableName,
+          rawInsert: replaceString,
+          type: variableType,
+          kind: CompletionItemKind.Variable,
+        } as CompletionItem);
+        definitionsByScope.set(scope, definitions);
+      }
 
       variableName = null;
+      variableScope = undefined;
       variableType = null;
     }
   });
 
-  return objectValues(definitions);
-}
+  const currentDefinition = getDefinitionState(token.state);
+  const currentScope = getDefinitionKey(token.state);
+  if (!currentDefinition || !currentScope) {
+    return [];
+  }
 
-export function getFragmentDefinitions(
-  queryText: string,
-): Array<FragmentDefinitionNode> {
-  const fragmentDefs: FragmentDefinitionNode[] = [];
-  runOnlineParser(queryText, (_, state: State) => {
-    if (
-      state.kind === RuleKinds.FRAGMENT_DEFINITION &&
-      state.name &&
-      state.type
-    ) {
-      fragmentDefs.push({
-        kind: RuleKinds.FRAGMENT_DEFINITION,
-        name: {
-          kind: Kind.NAME,
-          value: state.name,
-        },
+  const visibleDefinitions = new Map(
+    definitionsByScope.get(currentScope) ?? [],
+  );
+  if (currentDefinition.kind === RuleKinds.FRAGMENT_DEFINITION) {
+    const reachesFragment = (
+      scope: string,
+      fragmentName: string,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (visited.has(scope)) {
+        return false;
+      }
+      visited.add(scope);
+      const spreads = fragmentSpreadsByScope.get(scope);
+      if (spreads?.has(fragmentName)) {
+        return true;
+      }
+      return [...(spreads ?? [])].some(spreadName =>
+        reachesFragment(
+          `${RuleKinds.FRAGMENT_DEFINITION}:${spreadName}`,
+          fragmentName,
+          visited,
+        ),
+      );
+    };
 
-        selectionSet: {
-          kind: RuleKinds.SELECTION_SET,
-          selections: [],
-        },
-
-        typeCondition: {
-          kind: RuleKinds.NAMED_TYPE,
-          name: {
-            kind: Kind.NAME,
-            value: state.type,
-          },
-        },
-      });
+    for (const operationScope of operationScopes) {
+      if (
+        currentDefinition.name &&
+        reachesFragment(operationScope, currentDefinition.name)
+      ) {
+        for (const [name, definition] of definitionsByScope.get(
+          operationScope,
+        ) ?? []) {
+          // Fragment variables shadow operation variables with the same name.
+          if (!visibleDefinitions.has(name)) {
+            visibleDefinitions.set(name, definition);
+          }
+        }
+      }
     }
-  });
+  }
 
-  return fragmentDefs;
+  return [...visibleDefinitions.values()];
 }
 
 function getSuggestionsForVariableDefinition(

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -19,10 +19,9 @@ import {
   print,
   validate,
   NoDeprecatedCustomRule,
-  parse,
 } from 'graphql';
 
-import { CharacterStream, onlineParser } from '../parser';
+import { CharacterStream, onlineParser, parseDocument } from '../parser';
 
 import { Range, validateWithCustomRules, Position } from '../utils';
 
@@ -76,7 +75,7 @@ export function getDiagnostics(
   }
   const enhancedQuery = fragments ? `${query}\n\n${fragments}` : query;
   try {
-    ast = parse(enhancedQuery);
+    ast = parseDocument(enhancedQuery);
   } catch (error) {
     if (error instanceof GraphQLError) {
       const range = getRange(

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -27,7 +27,7 @@ import { Range, validateWithCustomRules, Position } from '../utils';
 
 import { DiagnosticSeverity, Diagnostic } from 'vscode-languageserver-types';
 
-import { IRange } from '../types';
+import { GraphQLLanguageServiceOptions, IRange } from '../types';
 
 // this doesn't work without the 'as', kinda goofy
 
@@ -61,6 +61,7 @@ export function getDiagnostics(
   customRules?: Array<ValidationRule>,
   isRelayCompatMode?: boolean,
   externalFragments?: FragmentDefinitionNode[] | string,
+  options?: GraphQLLanguageServiceOptions,
 ): Array<Diagnostic> {
   let ast = null;
   let fragments = '';
@@ -75,7 +76,7 @@ export function getDiagnostics(
   }
   const enhancedQuery = fragments ? `${query}\n\n${fragments}` : query;
   try {
-    ast = parseDocument(enhancedQuery);
+    ast = parseDocument(enhancedQuery, options);
   } catch (error) {
     if (error instanceof GraphQLError) {
       const range = getRange(

--- a/packages/graphql-language-service/src/interface/getFragmentDefinitions.ts
+++ b/packages/graphql-language-service/src/interface/getFragmentDefinitions.ts
@@ -1,8 +1,12 @@
 import { FragmentDefinitionNode, Kind, VariableDefinitionNode } from 'graphql';
-import { getDefinitionState } from './getTypeInfo';
-import { runOnlineParser } from './api';
-import { parseDocument } from './parseDocument';
-import { RuleKind, RuleKinds, State } from './types';
+import {
+  getDefinitionState,
+  parseDocument,
+  RuleKind,
+  RuleKinds,
+  runOnlineParser,
+  State,
+} from '../parser';
 
 type FragmentDefinitionWithVariables = FragmentDefinitionNode & {
   readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;

--- a/packages/graphql-language-service/src/interface/getFragmentDefinitions.ts
+++ b/packages/graphql-language-service/src/interface/getFragmentDefinitions.ts
@@ -7,6 +7,7 @@ import {
   runOnlineParser,
   State,
 } from '../parser';
+import type { GraphQLLanguageServiceOptions } from '../types';
 
 type FragmentDefinitionWithVariables = FragmentDefinitionNode & {
   readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
@@ -25,9 +26,10 @@ function findState(state: State, kind: RuleKind): State | undefined {
 /** Collect fragment definitions from complete or partially typed documents. */
 export function getFragmentDefinitions(
   queryText: string,
+  options?: GraphQLLanguageServiceOptions,
 ): Array<FragmentDefinitionNode> {
   try {
-    return parseDocument(queryText).definitions.filter(
+    return parseDocument(queryText, options).definitions.filter(
       definition => definition.kind === Kind.FRAGMENT_DEFINITION,
     );
   } catch {
@@ -42,88 +44,92 @@ export function getFragmentDefinitions(
     | undefined;
   let previousPosition = '';
 
-  runOnlineParser(queryText, (stream, state: State, _style, line) => {
-    const position = `${line}:${stream.getCurrentPosition()}`;
-    if (position === previousPosition) {
-      return;
-    }
-    previousPosition = position;
-
-    const token = stream.current();
-    const definitionState = getDefinitionState(state);
-    const fragmentState =
-      definitionState?.kind === RuleKinds.FRAGMENT_DEFINITION
-        ? definitionState
-        : undefined;
-    const variableDefinitionsState = findState(
-      state,
-      RuleKinds.VARIABLE_DEFINITIONS,
-    );
-
-    if (
-      !activeVariables &&
-      fragmentState?.name &&
-      variableDefinitionsState &&
-      token.trim() === '('
-    ) {
-      activeVariables = {
-        fragmentName: fragmentState.name,
-        source: token,
-        line,
-      };
-    } else if (activeVariables) {
-      if (line !== activeVariables.line) {
-        activeVariables.source += '\n';
-        activeVariables.line = line;
+  runOnlineParser(
+    queryText,
+    (stream, state: State, _style, line) => {
+      const position = `${line}:${stream.getCurrentPosition()}`;
+      if (position === previousPosition) {
+        return;
       }
+      previousPosition = position;
+
+      const token = stream.current();
+      const definitionState = getDefinitionState(state);
+      const fragmentState =
+        definitionState?.kind === RuleKinds.FRAGMENT_DEFINITION
+          ? definitionState
+          : undefined;
+      const variableDefinitionsState = findState(
+        state,
+        RuleKinds.VARIABLE_DEFINITIONS,
+      );
+
       if (
-        variableDefinitionsState ||
-        (fragmentState?.name === activeVariables.fragmentName &&
-          token.trim() === ')')
+        !activeVariables &&
+        fragmentState?.name &&
+        variableDefinitionsState &&
+        token.trim() === '('
       ) {
-        activeVariables.source += token;
-      }
-      if (!variableDefinitionsState && token.trim() === ')') {
-        try {
-          const operation = parseDocument(
-            `query${activeVariables.source} { __typename }`,
-          ).definitions[0];
-          if (operation.kind === Kind.OPERATION_DEFINITION) {
-            variables.set(
-              activeVariables.fragmentName,
-              operation.variableDefinitions ?? [],
-            );
-          }
-        } catch {
-          // Keep the fragment usable for name completion even when its
-          // variable definitions are incomplete.
+        activeVariables = {
+          fragmentName: fragmentState.name,
+          source: token,
+          line,
+        };
+      } else if (activeVariables) {
+        if (line !== activeVariables.line) {
+          activeVariables.source += '\n';
+          activeVariables.line = line;
         }
-        activeVariables = undefined;
+        if (
+          variableDefinitionsState ||
+          (fragmentState?.name === activeVariables.fragmentName &&
+            token.trim() === ')')
+        ) {
+          activeVariables.source += token;
+        }
+        if (!variableDefinitionsState && token.trim() === ')') {
+          try {
+            const operation = parseDocument(
+              `query${activeVariables.source} { __typename }`,
+            ).definitions[0];
+            if (operation.kind === Kind.OPERATION_DEFINITION) {
+              variables.set(
+                activeVariables.fragmentName,
+                operation.variableDefinitions ?? [],
+              );
+            }
+          } catch {
+            // Keep the fragment usable for name completion even when its
+            // variable definitions are incomplete.
+          }
+          activeVariables = undefined;
+        }
       }
-    }
 
-    if (fragmentState?.name && fragmentState.type) {
-      fragments.set(fragmentState.name, {
-        kind: RuleKinds.FRAGMENT_DEFINITION,
-        name: {
-          kind: Kind.NAME,
-          value: fragmentState.name,
-        },
-        variableDefinitions: variables.get(fragmentState.name),
-        selectionSet: {
-          kind: RuleKinds.SELECTION_SET,
-          selections: [],
-        },
-        typeCondition: {
-          kind: RuleKinds.NAMED_TYPE,
+      if (fragmentState?.name && fragmentState.type) {
+        fragments.set(fragmentState.name, {
+          kind: RuleKinds.FRAGMENT_DEFINITION,
           name: {
             kind: Kind.NAME,
-            value: fragmentState.type,
+            value: fragmentState.name,
           },
-        },
-      });
-    }
-  });
+          variableDefinitions: variables.get(fragmentState.name),
+          selectionSet: {
+            kind: RuleKinds.SELECTION_SET,
+            selections: [],
+          },
+          typeCondition: {
+            kind: RuleKinds.NAMED_TYPE,
+            name: {
+              kind: Kind.NAME,
+              value: fragmentState.type,
+            },
+          },
+        });
+      }
+    },
+    options,
+  );
 
   return [...fragments.values()];
 }

--- a/packages/graphql-language-service/src/interface/getHoverInformation.ts
+++ b/packages/graphql-language-service/src/interface/getHoverInformation.ts
@@ -21,13 +21,19 @@ import {
   GraphQLFieldConfig,
 } from 'graphql';
 import type { ContextToken } from '../parser';
-import { AllTypeInfo, IPosition } from '../types';
+import {
+  AllTypeInfo,
+  GraphQLLanguageServiceOptions,
+  IPosition,
+} from '../types';
 
 import { Hover } from 'vscode-languageserver-types';
 import { getContextAtPosition, RuleKinds } from '../parser';
 import { getFragmentDefinitions } from './getFragmentDefinitions';
 
-export type HoverConfig = { useMarkdown?: boolean };
+export type HoverConfig = GraphQLLanguageServiceOptions & {
+  useMarkdown?: boolean;
+};
 
 export function getHoverInformation(
   schema: GraphQLSchema,
@@ -43,7 +49,8 @@ export function getHoverInformation(
     schema,
     contextToken,
     {
-      fragmentDefinitions: getFragmentDefinitions(queryText),
+      fragmentDefinitions: getFragmentDefinitions(queryText, config),
+      experimentalFragmentArguments: config?.experimentalFragmentArguments,
     },
   );
   if (!context) {

--- a/packages/graphql-language-service/src/interface/getHoverInformation.ts
+++ b/packages/graphql-language-service/src/interface/getHoverInformation.ts
@@ -24,11 +24,8 @@ import type { ContextToken } from '../parser';
 import { AllTypeInfo, IPosition } from '../types';
 
 import { Hover } from 'vscode-languageserver-types';
-import {
-  getContextAtPosition,
-  getFragmentDefinitions,
-  RuleKinds,
-} from '../parser';
+import { getContextAtPosition, RuleKinds } from '../parser';
+import { getFragmentDefinitions } from './getFragmentDefinitions';
 
 export type HoverConfig = { useMarkdown?: boolean };
 

--- a/packages/graphql-language-service/src/interface/getHoverInformation.ts
+++ b/packages/graphql-language-service/src/interface/getHoverInformation.ts
@@ -24,7 +24,11 @@ import type { ContextToken } from '../parser';
 import { AllTypeInfo, IPosition } from '../types';
 
 import { Hover } from 'vscode-languageserver-types';
-import { getContextAtPosition } from '../parser';
+import {
+  getContextAtPosition,
+  getFragmentDefinitions,
+  RuleKinds,
+} from '../parser';
 
 export type HoverConfig = { useMarkdown?: boolean };
 
@@ -36,7 +40,15 @@ export function getHoverInformation(
   config?: HoverConfig,
 ): Hover['contents'] {
   const options = { ...config, schema };
-  const context = getContextAtPosition(queryText, cursor, schema, contextToken);
+  const context = getContextAtPosition(
+    queryText,
+    cursor,
+    schema,
+    contextToken,
+    {
+      fragmentDefinitions: getFragmentDefinitions(queryText),
+    },
+  );
   if (!context) {
     return '';
   }
@@ -74,10 +86,14 @@ export function getHoverInformation(
     renderDescription(into, options, typeInfo.type);
     return into.join('').trim();
   }
-  if (kind === 'Argument' && step === 0 && typeInfo.argDef) {
+  if (
+    (kind === RuleKinds.ARGUMENT || kind === RuleKinds.FRAGMENT_ARGUMENT) &&
+    step === 0 &&
+    typeInfo.argDef
+  ) {
     const into: string[] = [];
     renderMdCodeStart(into, options);
-    renderArg(into, typeInfo, options);
+    renderArg(into, typeInfo, options, kind === RuleKinds.ARGUMENT);
     renderMdCodeEnd(into, options);
     renderDescription(into, options, typeInfo.argDef);
     return into.join('').trim();
@@ -157,10 +173,11 @@ export function renderArg(
   into: string[],
   typeInfo: AllTypeInfo,
   options: HoverConfig,
+  qualify = true,
 ) {
-  if (typeInfo.directiveDef) {
+  if (qualify && typeInfo.directiveDef) {
     renderDirective(into, typeInfo, options);
-  } else if (typeInfo.fieldDef) {
+  } else if (qualify && typeInfo.fieldDef) {
     renderQualifiedField(into, typeInfo, options);
   }
 

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -13,6 +13,7 @@ import {
   TokenKind,
   IPosition,
   OutlineTree,
+  GraphQLLanguageServiceOptions,
 } from '../types';
 
 import {
@@ -74,10 +75,13 @@ type OutlineTreeConverterType = Partial<{
   [key in OutlineableKinds]: (node: any) => OutlineTreeResult;
 }>;
 
-export function getOutline(documentText: string): Outline | null {
+export function getOutline(
+  documentText: string,
+  options?: GraphQLLanguageServiceOptions,
+): Outline | null {
   let ast;
   try {
-    ast = parseDocument(documentText);
+    ast = parseDocument(documentText, options);
   } catch {
     return null;
   }

--- a/packages/graphql-language-service/src/interface/getOutline.ts
+++ b/packages/graphql-language-service/src/interface/getOutline.ts
@@ -17,7 +17,6 @@ import {
 
 import {
   Kind,
-  parse,
   visit,
   FieldNode,
   InlineFragmentNode,
@@ -37,6 +36,7 @@ import {
   EnumValueDefinitionNode,
 } from 'graphql';
 
+import { parseDocument } from '../parser';
 import { offsetToPosition } from '../utils';
 
 export type OutlineableKinds =
@@ -77,7 +77,7 @@ type OutlineTreeConverterType = Partial<{
 export function getOutline(documentText: string): Outline | null {
   let ast;
   try {
-    ast = parse(documentText);
+    ast = parseDocument(documentText);
   } catch {
     return null;
   }

--- a/packages/graphql-language-service/src/interface/index.ts
+++ b/packages/graphql-language-service/src/interface/index.ts
@@ -15,5 +15,7 @@ export * from './getDefinition';
 
 export * from './getDiagnostics';
 
+export { getFragmentDefinitions } from './getFragmentDefinitions';
+
 export { getOutline } from './getOutline';
 export { getHoverInformation, HoverConfig } from './getHoverInformation';

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -143,7 +143,14 @@ export const ParseRules: { [name: string]: ParseRule } = {
 
   Arguments: [p('('), list('Argument'), p(')')],
   Argument: [name('attribute'), p(':'), 'Value'],
-  FragmentSpread: [p('...'), name('def'), list('Directive')],
+  FragmentArguments: [p('('), list('FragmentArgument'), p(')')],
+  FragmentArgument: [name('attribute'), p(':'), 'Value'],
+  FragmentSpread: [
+    p('...'),
+    name('def'),
+    opt('FragmentArguments'),
+    list('Directive'),
+  ],
   InlineFragment: [
     p('...'),
     opt('TypeCondition'),
@@ -154,6 +161,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
   FragmentDefinition: [
     word('fragment'),
     opt(butNot(name('def'), [word('on')])),
+    opt('VariableDefinitions'),
     'TypeCondition',
     list('Directive'),
     'SelectionSet',

--- a/packages/graphql-language-service/src/parser/Rules.ts
+++ b/packages/graphql-language-service/src/parser/Rules.ts
@@ -143,14 +143,7 @@ export const ParseRules: { [name: string]: ParseRule } = {
 
   Arguments: [p('('), list('Argument'), p(')')],
   Argument: [name('attribute'), p(':'), 'Value'],
-  FragmentArguments: [p('('), list('FragmentArgument'), p(')')],
-  FragmentArgument: [name('attribute'), p(':'), 'Value'],
-  FragmentSpread: [
-    p('...'),
-    name('def'),
-    opt('FragmentArguments'),
-    list('Directive'),
-  ],
+  FragmentSpread: [p('...'), name('def'), list('Directive')],
   InlineFragment: [
     p('...'),
     opt('TypeCondition'),
@@ -161,7 +154,6 @@ export const ParseRules: { [name: string]: ParseRule } = {
   FragmentDefinition: [
     word('fragment'),
     opt(butNot(name('def'), [word('on')])),
-    opt('VariableDefinitions'),
     'TypeCondition',
     list('Directive'),
     'SelectionSet',
@@ -339,6 +331,26 @@ export const ParseRules: { [name: string]: ParseRule } = {
   [Kind.UNION_TYPE_EXTENSION]: ['UnionDef'],
   [Kind.ENUM_TYPE_EXTENSION]: ['EnumDef'],
   [Kind.INPUT_OBJECT_TYPE_EXTENSION]: ['InputDef'],
+};
+
+export const ExperimentalFragmentArgumentParseRules: typeof ParseRules = {
+  ...ParseRules,
+  FragmentArguments: [p('('), list('FragmentArgument'), p(')')],
+  FragmentArgument: [name('attribute'), p(':'), 'Value'],
+  FragmentSpread: [
+    p('...'),
+    name('def'),
+    opt('FragmentArguments'),
+    list('Directive'),
+  ],
+  FragmentDefinition: [
+    word('fragment'),
+    opt(butNot(name('def'), [word('on')])),
+    opt('VariableDefinitions'),
+    'TypeCondition',
+    list('Directive'),
+    'SelectionSet',
+  ],
 };
 
 // A keyword Token.

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
@@ -412,13 +412,16 @@ describe('onlineParser', () => {
     });
 
     it('parses fragment arguments on a fragment spread', () => {
-      const { t } = getUtils(`
+      const { t } = getUtils(
+        `
         query SomeQuery {
           someField {
             ...SomeFragment(count: 6)
           }
         }
-      `);
+      `,
+        { experimentalFragmentArguments: true },
+      );
 
       t.keyword('query', { kind: 'Query' });
       t.def('SomeQuery');
@@ -438,11 +441,14 @@ describe('onlineParser', () => {
     });
 
     it('parses variable definitions on a fragment definition', () => {
-      const { t, stream } = getUtils(`
+      const { t, stream } = getUtils(
+        `
         fragment SomeFragment($count: Int) on SomeType {
           someField
         }
-      `);
+      `,
+        { experimentalFragmentArguments: true },
+      );
 
       t.keyword('fragment', { kind: 'FragmentDefinition' });
       t.def('SomeFragment');

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParser.test.ts
@@ -411,6 +411,56 @@ describe('onlineParser', () => {
       t.eol();
     });
 
+    it('parses fragment arguments on a fragment spread', () => {
+      const { t } = getUtils(`
+        query SomeQuery {
+          someField {
+            ...SomeFragment(count: 6)
+          }
+        }
+      `);
+
+      t.keyword('query', { kind: 'Query' });
+      t.def('SomeQuery');
+      t.punctuation('{', { kind: 'SelectionSet' });
+      t.property('someField', { kind: 'Field' });
+      t.punctuation('{', { kind: 'SelectionSet' });
+      t.punctuation('...', { kind: 'FragmentSpread' });
+      t.def('SomeFragment');
+      t.punctuation(/\(/, { kind: 'FragmentArguments' });
+      t.attribute('count', { kind: 'FragmentArgument' });
+      t.punctuation(':');
+      t.value('Number', '6', { kind: 'NumberValue' });
+      t.punctuation(/\)/, { kind: 'FragmentSpread' });
+      t.punctuation('}', { kind: 'SelectionSet' });
+      t.punctuation('}', { kind: 'Document' });
+      t.eol();
+    });
+
+    it('parses variable definitions on a fragment definition', () => {
+      const { t, stream } = getUtils(`
+        fragment SomeFragment($count: Int) on SomeType {
+          someField
+        }
+      `);
+
+      t.keyword('fragment', { kind: 'FragmentDefinition' });
+      t.def('SomeFragment');
+      expectVarsDef(
+        { t, stream },
+        {
+          onKind: 'FragmentDefinition',
+          vars: [{ name: 'count', type: 'Int' }],
+        },
+      );
+      t.keyword('on', { kind: 'TypeCondition' });
+      t.name('SomeType', { kind: 'NamedType' });
+      t.punctuation('{', { kind: 'SelectionSet' });
+      t.property('someField', { kind: 'Field' });
+      t.punctuation('}', { kind: 'Document' });
+      t.eol();
+    });
+
     it('parses mutation', () => {
       const { t } = getUtils(`
         mutation SomeMutation {

--- a/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
+++ b/packages/graphql-language-service/src/parser/__tests__/OnlineParserUtils.ts
@@ -64,8 +64,11 @@ type Utils = { t: IAssertRules; stream?: CharacterStream };
 
 type Args = { name?: string; onKind?: RuleKind; args?: any[]; vars?: any[] };
 
-export const getUtils = (source: string) => {
-  const parser = OnlineParser();
+export const getUtils = (
+  source: string,
+  parserOptions?: Parameters<typeof OnlineParser>[0],
+) => {
+  const parser = OnlineParser(parserOptions);
   const stream = new CharacterStream(source);
   const state = parser.startState();
 

--- a/packages/graphql-language-service/src/parser/api.ts
+++ b/packages/graphql-language-service/src/parser/api.ts
@@ -14,8 +14,15 @@ import {
   ContextToken,
   State,
   getTypeInfo,
+  parseDocument,
 } from '.';
-import { BREAK, GraphQLSchema, Kind, parse, visit } from 'graphql';
+import {
+  BREAK,
+  FragmentDefinitionNode,
+  GraphQLSchema,
+  Kind,
+  visit,
+} from 'graphql';
 
 export type ParserCallbackFn = (
   stream: CharacterStream,
@@ -101,7 +108,7 @@ const getParsedMode = (sdl: string | undefined): GraphQLDocumentMode => {
   let mode = GraphQLDocumentMode.UNKNOWN;
   if (sdl) {
     try {
-      visit(parse(sdl), {
+      visit(parseDocument(sdl), {
         enter(node) {
           if (node.kind === 'Document') {
             mode = GraphQLDocumentMode.EXECUTABLE;
@@ -175,7 +182,11 @@ export function getContextAtPosition(
   cursor: IPosition,
   schema: GraphQLSchema,
   contextToken?: ContextToken,
-  options?: { mode?: GraphQLDocumentMode; uri?: string },
+  options?: {
+    mode?: GraphQLDocumentMode;
+    uri?: string;
+    fragmentDefinitions?: ReadonlyArray<FragmentDefinitionNode>;
+  },
   offset = 0,
 ): {
   token: ContextToken;
@@ -197,7 +208,11 @@ export function getContextAtPosition(
 
   // relieve flow errors by checking if `state` exists
 
-  const typeInfo = getTypeInfo(schema, token.state);
+  const typeInfo = getTypeInfo(
+    schema,
+    token.state,
+    options?.fragmentDefinitions,
+  );
   const mode = options?.mode || getDocumentMode(queryText, options?.uri);
   return {
     token,

--- a/packages/graphql-language-service/src/parser/api.ts
+++ b/packages/graphql-language-service/src/parser/api.ts
@@ -23,6 +23,7 @@ import {
   Kind,
   visit,
 } from 'graphql';
+import type { GraphQLLanguageServiceOptions } from '../types';
 
 export type ParserCallbackFn = (
   stream: CharacterStream,
@@ -41,9 +42,10 @@ export type ParserCallbackFn = (
 export function runOnlineParser(
   queryText: string,
   callback: ParserCallbackFn,
+  options?: GraphQLLanguageServiceOptions,
 ): ContextToken {
   const lines = queryText.split('\n');
-  const parser = onlineParser();
+  const parser = onlineParser(options);
   let state = parser.startState();
   let style = '';
 
@@ -104,11 +106,14 @@ export const TYPE_SYSTEM_KINDS: Kind[] = [
   Kind.INPUT_OBJECT_TYPE_EXTENSION,
 ];
 
-const getParsedMode = (sdl: string | undefined): GraphQLDocumentMode => {
+const getParsedMode = (
+  sdl: string | undefined,
+  options?: GraphQLLanguageServiceOptions,
+): GraphQLDocumentMode => {
   let mode = GraphQLDocumentMode.UNKNOWN;
   if (sdl) {
     try {
-      visit(parseDocument(sdl), {
+      visit(parseDocument(sdl, options), {
         enter(node) {
           if (node.kind === 'Document') {
             mode = GraphQLDocumentMode.EXECUTABLE;
@@ -131,11 +136,12 @@ const getParsedMode = (sdl: string | undefined): GraphQLDocumentMode => {
 export function getDocumentMode(
   documentText: string,
   uri?: string,
+  options?: GraphQLLanguageServiceOptions,
 ): GraphQLDocumentMode {
   if (uri?.endsWith('.graphqls')) {
     return GraphQLDocumentMode.TYPE_SYSTEM;
   }
-  return getParsedMode(documentText);
+  return getParsedMode(documentText, options);
 }
 
 /**
@@ -145,22 +151,27 @@ export function getTokenAtPosition(
   queryText: string,
   cursor: IPosition,
   offset = 0,
+  options?: GraphQLLanguageServiceOptions,
 ): ContextToken {
   let styleAtCursor = null;
   let stateAtCursor = null;
   let stringAtCursor = null;
-  const token = runOnlineParser(queryText, (stream, state, style, index) => {
-    if (
-      index !== cursor.line ||
-      stream.getCurrentPosition() + offset < cursor.character + 1
-    ) {
-      return;
-    }
-    styleAtCursor = style;
-    stateAtCursor = { ...state };
-    stringAtCursor = stream.current();
-    return 'BREAK';
-  });
+  const token = runOnlineParser(
+    queryText,
+    (stream, state, style, index) => {
+      if (
+        index !== cursor.line ||
+        stream.getCurrentPosition() + offset < cursor.character + 1
+      ) {
+        return;
+      }
+      styleAtCursor = style;
+      stateAtCursor = { ...state };
+      stringAtCursor = stream.current();
+      return 'BREAK';
+    },
+    options,
+  );
 
   // Return the state/style of parsed token in case those at cursor aren't
   // available.
@@ -186,6 +197,7 @@ export function getContextAtPosition(
     mode?: GraphQLDocumentMode;
     uri?: string;
     fragmentDefinitions?: ReadonlyArray<FragmentDefinitionNode>;
+    experimentalFragmentArguments?: boolean;
   },
   offset = 0,
 ): {
@@ -195,7 +207,7 @@ export function getContextAtPosition(
   mode: GraphQLDocumentMode;
 } | null {
   const token: ContextToken =
-    contextToken || getTokenAtPosition(queryText, cursor, offset);
+    contextToken || getTokenAtPosition(queryText, cursor, offset, options);
   if (!token) {
     return null;
   }
@@ -213,7 +225,8 @@ export function getContextAtPosition(
     token.state,
     options?.fragmentDefinitions,
   );
-  const mode = options?.mode || getDocumentMode(queryText, options?.uri);
+  const mode =
+    options?.mode || getDocumentMode(queryText, options?.uri, options);
   return {
     token,
     state,

--- a/packages/graphql-language-service/src/parser/getFragmentDefinitions.ts
+++ b/packages/graphql-language-service/src/parser/getFragmentDefinitions.ts
@@ -1,0 +1,125 @@
+import { FragmentDefinitionNode, Kind, VariableDefinitionNode } from 'graphql';
+import { getDefinitionState } from './getTypeInfo';
+import { runOnlineParser } from './api';
+import { parseDocument } from './parseDocument';
+import { RuleKind, RuleKinds, State } from './types';
+
+type FragmentDefinitionWithVariables = FragmentDefinitionNode & {
+  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+};
+
+function findState(state: State, kind: RuleKind): State | undefined {
+  let current: State | null | undefined = state;
+  while (current?.kind) {
+    if (current.kind === kind) {
+      return current;
+    }
+    current = current.prevState;
+  }
+}
+
+/** Collect fragment definitions from complete or partially typed documents. */
+export function getFragmentDefinitions(
+  queryText: string,
+): Array<FragmentDefinitionNode> {
+  try {
+    return parseDocument(queryText).definitions.filter(
+      definition => definition.kind === Kind.FRAGMENT_DEFINITION,
+    );
+  } catch {
+    // The document is commonly incomplete during completion. Fall back to the
+    // error-tolerant online parser below.
+  }
+
+  const fragments = new Map<string, FragmentDefinitionWithVariables>();
+  const variables = new Map<string, ReadonlyArray<VariableDefinitionNode>>();
+  let activeVariables:
+    | { fragmentName: string; source: string; line: number }
+    | undefined;
+  let previousPosition = '';
+
+  runOnlineParser(queryText, (stream, state: State, _style, line) => {
+    const position = `${line}:${stream.getCurrentPosition()}`;
+    if (position === previousPosition) {
+      return;
+    }
+    previousPosition = position;
+
+    const token = stream.current();
+    const definitionState = getDefinitionState(state);
+    const fragmentState =
+      definitionState?.kind === RuleKinds.FRAGMENT_DEFINITION
+        ? definitionState
+        : undefined;
+    const variableDefinitionsState = findState(
+      state,
+      RuleKinds.VARIABLE_DEFINITIONS,
+    );
+
+    if (
+      !activeVariables &&
+      fragmentState?.name &&
+      variableDefinitionsState &&
+      token.trim() === '('
+    ) {
+      activeVariables = {
+        fragmentName: fragmentState.name,
+        source: token,
+        line,
+      };
+    } else if (activeVariables) {
+      if (line !== activeVariables.line) {
+        activeVariables.source += '\n';
+        activeVariables.line = line;
+      }
+      if (
+        variableDefinitionsState ||
+        (fragmentState?.name === activeVariables.fragmentName &&
+          token.trim() === ')')
+      ) {
+        activeVariables.source += token;
+      }
+      if (!variableDefinitionsState && token.trim() === ')') {
+        try {
+          const operation = parseDocument(
+            `query${activeVariables.source} { __typename }`,
+          ).definitions[0];
+          if (operation.kind === Kind.OPERATION_DEFINITION) {
+            variables.set(
+              activeVariables.fragmentName,
+              operation.variableDefinitions ?? [],
+            );
+          }
+        } catch {
+          // Keep the fragment usable for name completion even when its
+          // variable definitions are incomplete.
+        }
+        activeVariables = undefined;
+      }
+    }
+
+    if (fragmentState?.name && fragmentState.type) {
+      fragments.set(fragmentState.name, {
+        kind: RuleKinds.FRAGMENT_DEFINITION,
+        name: {
+          kind: Kind.NAME,
+          value: fragmentState.name,
+        },
+        variableDefinitions: variables.get(fragmentState.name),
+        selectionSet: {
+          kind: RuleKinds.SELECTION_SET,
+          selections: [],
+        },
+        typeCondition: {
+          kind: RuleKinds.NAMED_TYPE,
+          name: {
+            kind: Kind.NAME,
+            value: fragmentState.type,
+          },
+        },
+      });
+    }
+  });
+
+  return [...fragments.values()];
+}

--- a/packages/graphql-language-service/src/parser/getTypeInfo.ts
+++ b/packages/graphql-language-service/src/parser/getTypeInfo.ts
@@ -24,6 +24,10 @@ import {
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
   isCompositeType,
+  FragmentDefinitionNode,
+  VariableDefinitionNode,
+  typeFromAST,
+  GraphQLInputType,
 } from 'graphql';
 
 import { AllTypeInfo } from '../types';
@@ -93,9 +97,42 @@ export function getDefinitionState(
 
 // Utility for collecting rich type information given any token's state
 // from the graphql-mode parser.
+type FragmentDefinitionWithVariables = FragmentDefinitionNode & {
+  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+};
+
+function getFragmentArguments(
+  schema: GraphQLSchema,
+  fragmentDefinitions: ReadonlyArray<FragmentDefinitionNode>,
+  fragmentName: string | null | undefined,
+): NonNullable<AllTypeInfo['argDefs']> | null {
+  if (!fragmentName) {
+    return null;
+  }
+  const fragment = fragmentDefinitions.find(
+    definition => definition.name.value === fragmentName,
+  ) as FragmentDefinitionWithVariables | undefined;
+
+  return (
+    fragment?.variableDefinitions?.flatMap(definition => {
+      const argumentType = typeFromAST(schema, definition.type);
+      return argumentType
+        ? [
+            {
+              name: definition.variable.name.value,
+              type: argumentType as GraphQLInputType,
+              description: undefined,
+            },
+          ]
+        : [];
+    }) ?? null
+  );
+}
+
 export function getTypeInfo(
   schema: GraphQLSchema,
   tokenState: State,
+  fragmentDefinitions: ReadonlyArray<FragmentDefinitionNode> = [],
 ): AllTypeInfo {
   let argDef: AllTypeInfo['argDef'];
   let argDefs: AllTypeInfo['argDefs'];
@@ -168,7 +205,8 @@ export function getTypeInfo(
         }
 
         break;
-      case RuleKinds.ARGUMENTS: {
+      case RuleKinds.ARGUMENTS:
+      case RuleKinds.FRAGMENT_ARGUMENTS: {
         if (state.prevState) {
           switch (state.prevState.kind) {
             case RuleKinds.FIELD:
@@ -177,6 +215,13 @@ export function getTypeInfo(
             case RuleKinds.DIRECTIVE:
               argDefs =
                 directiveDef && (directiveDef.args as GraphQLArgument[]);
+              break;
+            case RuleKinds.FRAGMENT_SPREAD:
+              argDefs = getFragmentArguments(
+                schema,
+                fragmentDefinitions,
+                state.prevState.name,
+              );
               break;
             // TODO: needs more tests
             case RuleKinds.ALIASED_FIELD: {
@@ -205,6 +250,7 @@ export function getTypeInfo(
         break;
       }
       case RuleKinds.ARGUMENT:
+      case RuleKinds.FRAGMENT_ARGUMENT:
         if (argDefs) {
           for (let i = 0; i < argDefs.length; i++) {
             if (argDefs[i].name === state.name) {

--- a/packages/graphql-language-service/src/parser/index.ts
+++ b/packages/graphql-language-service/src/parser/index.ts
@@ -26,8 +26,6 @@ export {
 
 export { getTypeInfo, getDefinitionState, getFieldDef } from './getTypeInfo';
 
-export { getFragmentDefinitions } from './getFragmentDefinitions';
-
 export { parseDocument } from './parseDocument';
 
 export * from './types';

--- a/packages/graphql-language-service/src/parser/index.ts
+++ b/packages/graphql-language-service/src/parser/index.ts
@@ -26,4 +26,8 @@ export {
 
 export { getTypeInfo, getDefinitionState, getFieldDef } from './getTypeInfo';
 
+export { getFragmentDefinitions } from './getFragmentDefinitions';
+
+export { parseDocument } from './parseDocument';
+
 export * from './types';

--- a/packages/graphql-language-service/src/parser/onlineParser.ts
+++ b/packages/graphql-language-service/src/parser/onlineParser.ts
@@ -30,7 +30,12 @@
 import CharacterStream from './CharacterStream';
 import { State, Token, Rule, RuleKind } from './types';
 
-import { LexRules, ParseRules, isIgnored } from './Rules';
+import {
+  ExperimentalFragmentArgumentParseRules,
+  LexRules,
+  ParseRules,
+  isIgnored,
+} from './Rules';
 import { Kind } from 'graphql';
 
 export type ParserOptions = {
@@ -40,17 +45,23 @@ export type ParserOptions = {
   editorConfig: { [name: string]: any };
 };
 
-export default function onlineParser(
-  options: ParserOptions = {
-    eatWhitespace: stream => stream.eatWhile(isIgnored),
-    lexRules: LexRules,
-    parseRules: ParseRules,
-    editorConfig: {},
-  },
-): {
+export type OnlineParserOptions = Partial<ParserOptions> & {
+  experimentalFragmentArguments?: boolean;
+};
+
+export default function onlineParser(options: OnlineParserOptions = {}): {
   startState: () => State;
   token: (stream: CharacterStream, state: State) => string;
 } {
+  const parserOptions: ParserOptions = {
+    eatWhitespace: stream => stream.eatWhile(isIgnored),
+    lexRules: LexRules,
+    parseRules: options.experimentalFragmentArguments
+      ? ExperimentalFragmentArgumentParseRules
+      : ParseRules,
+    editorConfig: {},
+    ...options,
+  };
   return {
     startState() {
       const initialState = {
@@ -64,11 +75,11 @@ export default function onlineParser(
         prevState: null,
       };
 
-      pushRule(options.parseRules, initialState, Kind.DOCUMENT);
+      pushRule(parserOptions.parseRules, initialState, Kind.DOCUMENT);
       return initialState;
     },
     token(stream: CharacterStream, state: State) {
-      return getToken(stream, state, options);
+      return getToken(stream, state, parserOptions);
     },
   };
 }

--- a/packages/graphql-language-service/src/parser/parseDocument.ts
+++ b/packages/graphql-language-service/src/parser/parseDocument.ts
@@ -1,16 +1,13 @@
 import { DocumentNode, ParseOptions, Source, parse } from 'graphql';
 
-type FragmentArgumentParseOptions = ParseOptions & {
+export type GraphQLParseOptions = ParseOptions & {
   experimentalFragmentArguments?: boolean;
 };
 
-/** Parse executable documents with GraphQL.js 17 fragment arguments enabled. */
+/** Parse GraphQL documents, including explicitly enabled experimental syntax. */
 export function parseDocument(
   source: string | Source,
-  options?: ParseOptions,
+  options?: GraphQLParseOptions,
 ): DocumentNode {
-  return parse(source, {
-    ...options,
-    experimentalFragmentArguments: true,
-  } as FragmentArgumentParseOptions);
+  return parse(source, options as ParseOptions);
 }

--- a/packages/graphql-language-service/src/parser/parseDocument.ts
+++ b/packages/graphql-language-service/src/parser/parseDocument.ts
@@ -1,0 +1,16 @@
+import { DocumentNode, ParseOptions, Source, parse } from 'graphql';
+
+type FragmentArgumentParseOptions = ParseOptions & {
+  experimentalFragmentArguments?: boolean;
+};
+
+/** Parse executable documents with GraphQL.js 17 fragment arguments enabled. */
+export function parseDocument(
+  source: string | Source,
+  options?: ParseOptions,
+): DocumentNode {
+  return parse(source, {
+    ...options,
+    experimentalFragmentArguments: true,
+  } as FragmentArgumentParseOptions);
+}

--- a/packages/graphql-language-service/src/parser/types.ts
+++ b/packages/graphql-language-service/src/parser/types.ts
@@ -58,6 +58,8 @@ export type State = {
 export const AdditionalRuleKinds: _AdditionalRuleKinds = {
   ALIASED_FIELD: 'AliasedField',
   ARGUMENTS: 'Arguments',
+  FRAGMENT_ARGUMENTS: 'FragmentArguments',
+  FRAGMENT_ARGUMENT: 'FragmentArgument',
   SHORT_QUERY: 'ShortQuery',
   QUERY: 'Query',
   MUTATION: 'Mutation',
@@ -90,6 +92,8 @@ export const AdditionalRuleKinds: _AdditionalRuleKinds = {
 export type _AdditionalRuleKinds = {
   ALIASED_FIELD: 'AliasedField';
   ARGUMENTS: 'Arguments';
+  FRAGMENT_ARGUMENTS: 'FragmentArguments';
+  FRAGMENT_ARGUMENT: 'FragmentArgument';
   SHORT_QUERY: 'ShortQuery';
   QUERY: 'Query';
   MUTATION: 'Mutation';

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -131,6 +131,11 @@ export type GraphQLFileInfo = {
   mtime: number;
 };
 
+export type ArgumentInfo = Pick<
+  GraphQLArgument,
+  'name' | 'type' | 'description'
+>;
+
 export type AllTypeInfo = {
   type: Maybe<GraphQLType>;
   parentType: Maybe<GraphQLType>;
@@ -138,8 +143,8 @@ export type AllTypeInfo = {
   directiveDef: Maybe<GraphQLDirective>;
   fieldDef: Maybe<GraphQLField<any, any>>;
   enumValue: Maybe<GraphQLEnumValue>;
-  argDef: Maybe<GraphQLArgument>;
-  argDefs: Maybe<GraphQLArgument[]>;
+  argDef: Maybe<ArgumentInfo>;
+  argDefs: Maybe<ArgumentInfo[]>;
   objectFieldDefs: Maybe<GraphQLInputFieldMap>;
   interfaceDef: Maybe<GraphQLInterfaceType>;
   objectTypeDef: Maybe<GraphQLObjectType>;

--- a/packages/graphql-language-service/src/types.ts
+++ b/packages/graphql-language-service/src/types.ts
@@ -131,6 +131,11 @@ export type GraphQLFileInfo = {
   mtime: number;
 };
 
+/** Experimental GraphQL language features that must be explicitly enabled. */
+export type GraphQLLanguageServiceOptions = {
+  experimentalFragmentArguments?: boolean;
+};
+
 export type ArgumentInfo = Pick<
   GraphQLArgument,
   'name' | 'type' | 'description'

--- a/packages/graphql-language-service/src/utils/fragmentDependencies.ts
+++ b/packages/graphql-language-service/src/utils/fragmentDependencies.ts
@@ -8,10 +8,12 @@
 import { DocumentNode, FragmentDefinitionNode, visit } from 'graphql';
 import nullthrows from 'nullthrows';
 import { parseDocument } from '../parser';
+import type { GraphQLLanguageServiceOptions } from '../types';
 
 export const getFragmentDependencies = (
   operationString: string,
   fragmentDefinitions?: Map<string, FragmentDefinitionNode> | null,
+  options?: GraphQLLanguageServiceOptions,
 ): FragmentDefinitionNode[] => {
   // If there isn't context for fragment references,
   // return an empty array.
@@ -22,7 +24,7 @@ export const getFragmentDependencies = (
   // Return an empty array.
   let parsedOperation;
   try {
-    parsedOperation = parseDocument(operationString);
+    parsedOperation = parseDocument(operationString, options);
   } catch {
     return [];
   }

--- a/packages/graphql-language-service/src/utils/fragmentDependencies.ts
+++ b/packages/graphql-language-service/src/utils/fragmentDependencies.ts
@@ -5,8 +5,9 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { DocumentNode, FragmentDefinitionNode, parse, visit } from 'graphql';
+import { DocumentNode, FragmentDefinitionNode, visit } from 'graphql';
 import nullthrows from 'nullthrows';
+import { parseDocument } from '../parser';
 
 export const getFragmentDependencies = (
   operationString: string,
@@ -21,7 +22,7 @@ export const getFragmentDependencies = (
   // Return an empty array.
   let parsedOperation;
   try {
-    parsedOperation = parse(operationString);
+    parsedOperation = parseDocument(operationString);
   } catch {
     return [];
   }

--- a/packages/graphql-language-service/src/utils/getOperationFacts.ts
+++ b/packages/graphql-language-service/src/utils/getOperationFacts.ts
@@ -4,7 +4,8 @@
  *  This source code is licensed under the MIT license found in the
  *  LICENSE file in the root directory of this source tree.
  */
-import { parse, visit } from 'graphql';
+import { visit } from 'graphql';
+import { parseDocument } from '../parser';
 import { collectVariables } from './collectVariables';
 
 import type { VariableToType } from './collectVariables';
@@ -85,7 +86,7 @@ export default function getOperationFacts(
   }
 
   try {
-    const documentAST = parse(documentString);
+    const documentAST = parseDocument(documentString);
     return {
       ...getOperationASTFacts(documentAST, schema),
       documentAST,

--- a/packages/graphql-language-service/src/utils/getOperationFacts.ts
+++ b/packages/graphql-language-service/src/utils/getOperationFacts.ts
@@ -9,6 +9,7 @@ import { parseDocument } from '../parser';
 import { collectVariables } from './collectVariables';
 
 import type { VariableToType } from './collectVariables';
+import type { GraphQLLanguageServiceOptions } from '../types';
 import type {
   GraphQLSchema,
   DocumentNode,
@@ -80,13 +81,14 @@ export type QueryFacts = OperationFacts;
 export default function getOperationFacts(
   schema?: GraphQLSchema | null,
   documentString?: string | null,
+  options?: GraphQLLanguageServiceOptions,
 ): OperationFacts | undefined {
   if (!documentString) {
     return;
   }
 
   try {
-    const documentAST = parseDocument(documentString);
+    const documentAST = parseDocument(documentString, options);
     return {
       ...getOperationASTFacts(documentAST, schema),
       documentAST,

--- a/packages/monaco-graphql/README.md
+++ b/packages/monaco-graphql/README.md
@@ -60,6 +60,8 @@ import GraphQLWorker from 'worker-loader!monaco-graphql/esm/graphql.worker';
 
 // instantiates the worker & language features with the schema!
 const MonacoGraphQLAPI = initializeMode({
+  // Opt in only when the connected server supports fragment arguments.
+  experimentalFragmentArguments: true,
   schemas: [
     {
       schema: myGraphqlSchema as GraphQLSchema,

--- a/packages/monaco-graphql/src/LanguageService.ts
+++ b/packages/monaco-graphql/src/LanguageService.ts
@@ -50,6 +50,7 @@ export class LanguageService {
     null;
   private _externalFragmentDefinitionsString: string | null = null;
   private _completionSettings: AutocompleteSuggestionOptions;
+  private _experimentalFragmentArguments = false;
   constructor({
     parser,
     schemas,
@@ -58,6 +59,7 @@ export class LanguageService {
     customValidationRules,
     fillLeafsOnComplete,
     completionSettings,
+    experimentalFragmentArguments,
   }: GraphQLLanguageConfig) {
     this._schemaLoader = defaultSchemaLoader;
     if (schemas) {
@@ -72,6 +74,8 @@ export class LanguageService {
       fillLeafsOnComplete:
         completionSettings?.fillLeafsOnComplete ?? fillLeafsOnComplete,
     };
+    this._experimentalFragmentArguments =
+      experimentalFragmentArguments ?? false;
 
     if (parseOptions) {
       this._parseOptions = parseOptions;
@@ -140,7 +144,7 @@ export class LanguageService {
     ) {
       const definitionNodes: FragmentDefinitionNode[] = [];
       try {
-        visit(this._parser(this._externalFragmentDefinitionsString), {
+        visit(this.parse(this._externalFragmentDefinitionsString), {
           FragmentDefinition(node) {
             definitionNodes.push(node);
           },
@@ -195,7 +199,11 @@ export class LanguageService {
    * @returns {DocumentNode}
    */
   public parse(text: string | Source, options?: ParseOptions): DocumentNode {
-    return this._parser(text, options || this._parseOptions);
+    return this._parser(text, {
+      ...this._parseOptions,
+      ...options,
+      experimentalFragmentArguments: this._experimentalFragmentArguments,
+    } as ParseOptions);
   }
   /**
    * get completion for the given uri and matching schema
@@ -219,7 +227,11 @@ export class LanguageService {
       position,
       undefined,
       this.getExternalFragmentDefinitions(),
-      { uri, ...this._completionSettings },
+      {
+        uri,
+        ...this._completionSettings,
+        experimentalFragmentArguments: this._experimentalFragmentArguments,
+      },
     );
   };
   /**
@@ -240,6 +252,9 @@ export class LanguageService {
       customRules ?? this._customValidationRules,
       false,
       this.getExternalFragmentDefinitions(),
+      {
+        experimentalFragmentArguments: this._experimentalFragmentArguments,
+      },
     );
   };
 
@@ -258,6 +273,7 @@ export class LanguageService {
         undefined,
         {
           useMarkdown: true,
+          experimentalFragmentArguments: this._experimentalFragmentArguments,
           ...options,
         },
       );

--- a/packages/monaco-graphql/src/api.ts
+++ b/packages/monaco-graphql/src/api.ts
@@ -32,6 +32,7 @@ export interface MonacoGraphQLAPIOptions
       | 'formattingOptions'
       | 'diagnosticSettings'
       | 'completionSettings'
+      | 'experimentalFragmentArguments'
     > {
   languageId: string;
 }
@@ -48,6 +49,7 @@ export class MonacoGraphQLAPI {
   private _modeConfiguration: ModeConfiguration;
   private _diagnosticSettings: DiagnosticSettings;
   private _completionSettings: CompletionSettings;
+  private _experimentalFragmentArguments: boolean;
   private _schemas: SchemaConfig[] | null = null;
   private _schemasById: Record<string, SchemaConfig> = Object.create(null);
   private _languageId: string;
@@ -60,6 +62,7 @@ export class MonacoGraphQLAPI {
     formattingOptions,
     diagnosticSettings,
     completionSettings,
+    experimentalFragmentArguments,
   }: MonacoGraphQLAPIOptions) {
     this._languageId = languageId;
 
@@ -70,6 +73,7 @@ export class MonacoGraphQLAPI {
     this._completionSettings = completionSettings;
     this._diagnosticSettings = diagnosticSettings;
     this._formattingOptions = formattingOptions;
+    this._experimentalFragmentArguments = experimentalFragmentArguments;
   }
 
   public get onDidChange(): monaco.IEvent<MonacoGraphQLAPI> {
@@ -107,6 +111,10 @@ export class MonacoGraphQLAPI {
         this._completionSettings.__experimental__fillLeafsOnComplete ??
         this._completionSettings.fillLeafsOnComplete,
     };
+  }
+
+  public get experimentalFragmentArguments(): boolean {
+    return this._experimentalFragmentArguments;
   }
 
   public get externalFragmentDefinitions() {
@@ -164,6 +172,7 @@ export function create(
       modeConfiguration: modeConfigurationDefault,
       diagnosticSettings: diagnosticSettingDefault,
       completionSettings: completionSettingDefault,
+      experimentalFragmentArguments: false,
     });
   }
   const {
@@ -172,6 +181,7 @@ export function create(
     modeConfiguration,
     diagnosticSettings,
     completionSettings,
+    experimentalFragmentArguments,
   } = config;
   return new MonacoGraphQLAPI({
     languageId,
@@ -196,6 +206,7 @@ export function create(
       ...completionSettingDefault,
       ...completionSettings,
     },
+    experimentalFragmentArguments: experimentalFragmentArguments ?? false,
   });
 }
 

--- a/packages/monaco-graphql/src/typings/index.ts
+++ b/packages/monaco-graphql/src/typings/index.ts
@@ -90,6 +90,8 @@ export type SchemaLoader = (
  * in a custom webworker. see the readme.
  */
 export type GraphQLLanguageConfig = {
+  /** Enable experimental fragment arguments across language features. */
+  experimentalFragmentArguments?: boolean;
   /**
    * Provide a parser that matches `graphql` `parse()` signature
    * Used for internal document parsing operations
@@ -219,6 +221,8 @@ export interface MonacoGraphQLInitializeConfig extends Pick<
   GraphQLLanguageConfig,
   'schemas'
 > {
+  /** Enable experimental fragment arguments across language features. */
+  experimentalFragmentArguments?: boolean;
   /**
    * custom (experimental) settings for autocompletion behavior
    */

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -66,6 +66,7 @@ export class WorkerManager {
           schemas,
           externalFragmentDefinitions,
           completionSettings,
+          experimentalFragmentArguments,
         } = this._defaults;
         this._worker = editor.createWebWorker<GraphQLWorker>({
           // module that exports the create() method and returns a `GraphQLWorker` instance
@@ -80,6 +81,7 @@ export class WorkerManager {
             languageConfig: {
               schemas: schemas?.map(getStringSchema),
               externalFragmentDefinitions,
+              experimentalFragmentArguments,
               // TODO: make this overridable
               // MonacoAPI possibly another configuration object for this I think?
               // all of this could be organized better


### PR DESCRIPTION
Revives #3761 now that GraphQL.js 17 ships experimental fragment argument support.

## What changed

- parse fragment variable definitions and fragment spread arguments in the online parser
- enable GraphQL.js 17's `experimentalFragmentArguments` parser option across diagnostics, outlines, operation facts, fragment dependencies, document mode detection, and external fragments
- resolve fragment variable definitions into language-service type information
- autocomplete fragment argument names and values, including incomplete documents and external fragments
- keep variable completion scope-aware across operations and fragments, including fragment-local shadowing and transitively reachable operations
- show fragment argument type hover information
- validate fragment arguments with GraphQL.js 17's specified rules
- add a dedicated GraphQL 17 CI job and a release changeset