### PR TITLE
fix(monaco-graphql): support monaco-editor >= 0.56

### DIFF
--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -78,13 +78,13 @@
   "devDependencies": {
     "execa": "^7.1.1",
     "graphql": "^16.9.0",
-    "monaco-editor": "0.52.2",
+    "monaco-editor": "^0.56.0",
     "prettier": "3.3.2",
     "vscode-languageserver-types": "^3.17.1"
   },
   "peerDependencies": {
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-    "monaco-editor": ">= 0.20.0 < 0.53",
+    "monaco-editor": ">= 0.56.0",
     "prettier": "^2.8.0 || ^3.0.0"
   }
 }

--- a/packages/monaco-graphql/src/GraphQLWorker.ts
+++ b/packages/monaco-graphql/src/GraphQLWorker.ts
@@ -22,8 +22,21 @@ export class GraphQLWorker {
   private _languageService: LanguageService;
   private _formattingOptions: FormattingOptions | undefined;
 
-  constructor(ctx: monaco.worker.IWorkerContext, createData: ICreateData) {
+  constructor(ctx: monaco.worker.IWorkerContext, createData?: ICreateData) {
     this._ctx = ctx;
+    this._languageService = new LanguageService(
+      createData?.languageConfig ?? {},
+    );
+    this._formattingOptions = createData?.formattingOptions;
+  }
+
+  /**
+   * monaco-editor >= 0.53 no longer delivers `createData` to
+   * `editor.createWebWorker()` (see microsoft/monaco-editor's worker loading
+   * rewrite). `WorkerManager` now constructs the worker directly and calls
+   * this once the worker is ready instead of relying on constructor args.
+   */
+  public initialize(createData: ICreateData) {
     this._languageService = new LanguageService(createData.languageConfig);
     this._formattingOptions = createData.formattingOptions;
   }

--- a/packages/monaco-graphql/src/full.ts
+++ b/packages/monaco-graphql/src/full.ts
@@ -1,8 +1,8 @@
-import 'monaco-editor/esm/vs/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution';
-import 'monaco-editor/esm/vs/editor/contrib/format/browser/formatActions';
-import 'monaco-editor/esm/vs/editor/contrib/bracketMatching/browser/bracketMatching';
-import 'monaco-editor/esm/vs/editor/browser/coreCommands';
-import 'monaco-editor/esm/vs/editor/contrib/clipboard/browser/clipboard';
-import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/browser/cursorUndo';
-import 'monaco-editor/esm/vs/editor/contrib/contextmenu/browser/contextmenu';
-import 'monaco-editor/esm/vs/editor/contrib/find/browser/findController';
+import 'monaco-editor/editor/contrib/inlineCompletions/browser/inlineCompletions.contribution';
+import 'monaco-editor/editor/contrib/format/browser/formatActions';
+import 'monaco-editor/editor/contrib/bracketMatching/browser/bracketMatching';
+import 'monaco-editor/editor/browser/coreCommands';
+import 'monaco-editor/editor/contrib/clipboard/browser/clipboard';
+import 'monaco-editor/editor/contrib/cursorUndo/browser/cursorUndo';
+import 'monaco-editor/editor/contrib/contextmenu/browser/contextmenu';
+import 'monaco-editor/editor/contrib/find/browser/findController';

--- a/packages/monaco-graphql/src/graphql.worker.ts
+++ b/packages/monaco-graphql/src/graphql.worker.ts
@@ -9,13 +9,20 @@ import type * as monaco from './monaco-editor';
 import { ICreateData } from './typings';
 
 // @ts-expect-error
-import { initialize } from 'monaco-editor/esm/vs/editor/editor.worker';
+import { initialize } from 'monaco-editor/editor/editor.worker';
 
 import { GraphQLWorker } from './GraphQLWorker';
 
-globalThis.onmessage = () => {
-  initialize(
-    (ctx: monaco.worker.IWorkerContext, createData: ICreateData) =>
-      new GraphQLWorker(ctx, createData),
-  );
-};
+// monaco-editor >= 0.53 replaced the worker RPC bootstrap: the client now
+// sends a throwaway "ping" message immediately followed by the real
+// `$initialize` handshake. Wrapping `initialize()` in an extra
+// `onmessage` handler (as this used to) consumes the ping and only calls
+// `initialize()` on the *next* message, i.e. the real handshake, one
+// message too late for its reply to reach the client — every RPC call
+// then hangs forever waiting on a handshake that already happened.
+// `monaco-editor/editor/editor.worker`'s own bootstrap calls `initialize`
+// unwrapped for the same reason; mirror that here.
+initialize(
+  (ctx: monaco.worker.IWorkerContext, createData: ICreateData) =>
+    new GraphQLWorker(ctx, createData),
+);

--- a/packages/monaco-graphql/src/languageFeatures.ts
+++ b/packages/monaco-graphql/src/languageFeatures.ts
@@ -9,7 +9,8 @@ import { GraphQLWorker } from './GraphQLWorker';
 import type { MonacoGraphQLAPI } from './api';
 import type * as monaco from './monaco-editor';
 import { Uri, languages } from './monaco-editor';
-import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { editor } from 'monaco-editor/editor/editor.api';
+import { jsonDefaults } from 'monaco-editor/languages/features/json/register';
 import { CompletionItemKind as lsCompletionItemKind } from 'graphql-language-service';
 import { getModelLanguageId, GraphQLWorkerCompletionItem } from './utils';
 
@@ -128,7 +129,7 @@ export class DiagnosticsAdapter {
 
     if (variablesUris) {
       // only import the JSON mode if users configure it
-      await import('monaco-editor/esm/vs/language/json/monaco.contribution.js');
+      await import('monaco-editor/language/json/monaco.contribution.js');
 
       if (!variablesUris.length) {
         throw new Error('No variables URI strings provided to validate');
@@ -149,12 +150,12 @@ export class DiagnosticsAdapter {
         fileMatch: variablesUris,
       };
       const currentSchemas =
-        languages.json.jsonDefaults.diagnosticsOptions.schemas?.filter(
-          s => s.uri !== schemaUri,
+        jsonDefaults.diagnosticsOptions.schemas?.filter(
+          (s: { uri: string }) => s.uri !== schemaUri,
         ) || [];
 
       // TODO: export from api somehow?
-      languages.json.jsonDefaults.setDiagnosticsOptions({
+      jsonDefaults.setDiagnosticsOptions({
         schemaValidation: 'error',
         validate: true,
         ...this.defaults.diagnosticSettings.jsonDiagnosticSettings,

--- a/packages/monaco-graphql/src/monaco-editor.ts
+++ b/packages/monaco-graphql/src/monaco-editor.ts
@@ -16,7 +16,7 @@
  * Types for `monaco-editor/esm/vs/editor/edcore.main` are also left out;
  * we enhance them in `monaco.d.ts` 😎
  */
-import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution.js';
-import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
+import 'monaco-editor/languages/definitions/graphql/register.js';
+import 'monaco-editor/language/json/monaco.contribution.js';
 
-export * from 'monaco-editor/esm/vs/editor/edcore.main.js';
+export * from 'monaco-editor/editor/editor.main.js';

--- a/packages/monaco-graphql/src/typings/index.ts
+++ b/packages/monaco-graphql/src/typings/index.ts
@@ -1,4 +1,4 @@
-import type * as monaco from '../monaco-editor';
+import type { DiagnosticsOptions as JSONDiagnosticsOptions } from 'monaco-editor/languages/features/json/register';
 import {
   IntrospectionQuery,
   DocumentNode,
@@ -202,7 +202,7 @@ export type DiagnosticSettings = {
    * - `validateSchema: 'warning'`
    * - `trailingComments` is `error` by default, and can be `warning` or `ignore`
    */
-  jsonDiagnosticSettings?: monaco.languages.json.DiagnosticsOptions;
+  jsonDiagnosticSettings?: JSONDiagnosticsOptions;
 };
 
 export type CompletionSettings = AutocompleteSuggestionOptions & {

--- a/packages/monaco-graphql/src/typings/monaco-editor.d.ts
+++ b/packages/monaco-graphql/src/typings/monaco-editor.d.ts
@@ -1,10 +1,14 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports --
  * in this file is allowed to import monaco-editor
  */
-declare module 'monaco-editor/esm/vs/editor/edcore.main.js' {
+declare module 'monaco-editor/editor/editor.main.js' {
   export * from 'monaco-editor';
 }
 
-declare module 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js' {
+declare module 'monaco-editor/editor/common/standalone/standaloneEnums.js' {
   export { MarkerSeverity } from 'monaco-editor';
+}
+
+declare module 'monaco-editor/language/json/monaco.contribution.js' {
+  export {};
 }

--- a/packages/monaco-graphql/src/utils.ts
+++ b/packages/monaco-graphql/src/utils.ts
@@ -16,7 +16,7 @@ import type * as monaco from './monaco-editor';
 import { buildASTSchema, printSchema } from 'graphql';
 import { Position } from 'graphql-language-service';
 // Importing from 'monaco-editor' in a worker throws “ReferenceError: window is not defined”
-import { MarkerSeverity } from 'monaco-editor/esm/vs/editor/common/standalone/standaloneEnums.js';
+import { MarkerSeverity } from 'monaco-editor/editor/common/standalone/standaloneEnums.js';
 
 // for backwards compatibility
 export const getModelLanguageId = (model: monaco.editor.ITextModel) => {

--- a/packages/monaco-graphql/src/workerManager.ts
+++ b/packages/monaco-graphql/src/workerManager.ts
@@ -67,28 +67,40 @@ export class WorkerManager {
           externalFragmentDefinitions,
           completionSettings,
         } = this._defaults;
-        this._worker = editor.createWebWorker<GraphQLWorker>({
-          // module that exports the create() method and returns a `GraphQLWorker` instance
-          moduleId: 'monaco-graphql/esm/GraphQLWorker.js',
-
-          label: languageId,
-          // passed in to the create() method
-          createData: {
-            languageId,
-            formattingOptions,
-            // only string-based config can be passed from the main process
-            languageConfig: {
-              schemas: schemas?.map(getStringSchema),
-              externalFragmentDefinitions,
-              // TODO: make this overridable
-              // MonacoAPI possibly another configuration object for this I think?
-              // all of this could be organized better
-              fillLeafsOnComplete:
-                completionSettings.__experimental__fillLeafsOnComplete,
-            },
-          } as ICreateData,
-        });
-        this._client = this._worker.getProxy();
+        const createData: ICreateData = {
+          languageId,
+          formattingOptions,
+          diagnosticSettings: this._defaults.diagnosticSettings,
+          // only string-based config can be passed from the main process
+          languageConfig: {
+            schemas: schemas?.map(getStringSchema),
+            externalFragmentDefinitions,
+            // TODO: make this overridable
+            // MonacoAPI possibly another configuration object for this I think?
+            // all of this could be organized better
+            fillLeafsOnComplete:
+              completionSettings.__experimental__fillLeafsOnComplete,
+          },
+        };
+        // monaco-editor >= 0.53 no longer loads a worker module by `moduleId`
+        // and no longer delivers `createData` through `editor.createWebWorker()`
+        // (see microsoft/monaco-editor's worker loading rewrite). We now build
+        // the worker ourselves via `MonacoEnvironment.getWorker` and configure
+        // it explicitly once it's ready, via `GraphQLWorker#initialize`.
+        const worker = MonacoEnvironment?.getWorker?.(
+          'monaco-graphql/esm/GraphQLWorker.js',
+          languageId,
+        );
+        if (!worker) {
+          throw new Error(
+            'monaco-graphql requires `MonacoEnvironment.getWorker` to be configured. ' +
+              'See https://microsoft.github.io/monaco-editor/docs.html#functions/editor.createWebWorker.html',
+          );
+        }
+        this._worker = editor.createWebWorker<GraphQLWorker>({ worker });
+        const client = this._worker.getProxy();
+        this._client = client;
+        await client.then(resolved => resolved.initialize(createData));
       } catch (error) {
         // eslint-disable-next-line no-console
         console.error('error loading worker', error);

--- a/resources/patch-monaco-editor-type.mts
+++ b/resources/patch-monaco-editor-type.mts
@@ -7,7 +7,7 @@ const filePath = path.resolve(
 
 const newContent = fs
   .readFileSync(filePath, 'utf8')
-  .replace('/esm/vs/editor/edcore.main.js', '');
+  .replace('/editor/editor.main.js', '');
 
 fs.writeFileSync(filePath, newContent);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11040,6 +11040,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dompurify@npm:3.4.8":
+  version: 3.4.8
+  resolution: "dompurify@npm:3.4.8"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/8f56a53d0ac80c76068772c9b72721f31fad68cac64a528e2420699ce2bd26b3516e29a5a7bd2205c2732d7114b9859998bf922d20cdb9361c4a05dab8352570
+  languageName: node
+  linkType: hard
+
 "domutils@npm:^2.5.2, domutils@npm:^2.7.0, domutils@npm:^2.8.0":
   version: 2.8.0
   resolution: "domutils@npm:2.8.0"
@@ -16184,6 +16196,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked@npm:14.0.0":
+  version: 14.0.0
+  resolution: "marked@npm:14.0.0"
+  bin:
+    marked: bin/marked.js
+  checksum: 10c0/57a47cb110f7b1a10f398b0a7236f9183aad2dcd5345ee73f2732b6387e585d04cef472bc655d2f84c542296be9728e179aebe3ed7f2f8666b8a0a9dae592876
+  languageName: node
+  linkType: hard
+
 "matched@npm:^0.4.1":
   version: 0.4.4
   resolution: "matched@npm:0.4.4"
@@ -16684,6 +16705,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor@npm:^0.56.0":
+  version: 0.56.0
+  resolution: "monaco-editor@npm:0.56.0"
+  dependencies:
+    dompurify: "npm:3.4.8"
+    marked: "npm:14.0.0"
+  checksum: 10c0/8ed728880042c5a1f42040f955e017b798fc1602fc59ef7a1f0e4da8f354e928b32cc0dba93ff677c538a37a542be3898210f9d1801f339e3c0f65f9ad3dc73e
+  languageName: node
+  linkType: hard
+
 "monaco-graphql@npm:^1.8.0, monaco-graphql@workspace:packages/monaco-graphql":
   version: 0.0.0-use.local
   resolution: "monaco-graphql@workspace:packages/monaco-graphql"
@@ -16691,13 +16722,13 @@ __metadata:
     execa: "npm:^7.1.1"
     graphql: "npm:^16.9.0"
     graphql-language-service: "npm:^5.5.1"
-    monaco-editor: "npm:0.52.2"
+    monaco-editor: "npm:^0.56.0"
     picomatch-browser: "npm:^2.2.6"
     prettier: "npm:3.3.2"
     vscode-languageserver-types: "npm:^3.17.1"
   peerDependencies:
     graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
-    monaco-editor: ">= 0.20.0 < 0.53"
+    monaco-editor: ">= 0.56.0"
     prettier: ^2.8.0 || ^3.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Fixes #4382.

monaco-editor 0.53+ rewrote how custom workers are created and dropped
the `exports` field escape hatch monaco-graphql relied on for its deep
imports, breaking every monaco-graphql install on modern monaco-editor.

## Two independent breaks bundled together

1. **`editor.createWebWorker()` no longer loads a worker by `moduleId`
   or delivers `createData`.** The type is now
   `{ worker: Worker | Promise<Worker> }` - the caller is expected to
   construct the worker itself. `WorkerManager` now builds the worker via
   `MonacoEnvironment.getWorker()` and configures it through a new
   `GraphQLWorker#initialize()` RPC call once the worker is ready,
   instead of via constructor args that are no longer transported.

2. **`graphql.worker.ts`'s bootstrap wrapped `initialize()` inside an
   extra `onmessage` handler.** monaco-editor's client now sends a
   throwaway ping message immediately followed by the real
   `$initialize` handshake; the extra wrapper consumed the ping and
   only called `initialize()` on the next message - the real handshake -
   one message too late for its reply to reach the client, hanging
   every worker RPC call forever.
   `monaco-editor/editor/editor.worker`'s own bootstrap calls
   `initialize` unwrapped for the same reason; mirrored that here.

Also updates the now-relocated `monaco-editor/esm/vs/...` deep imports
(the `exports` field dropped the old paths), the deprecated
`languages.json.jsonDefaults` reference, and bumps the `monaco-editor`
peer range to `>= 0.56.0`.

This is a **breaking change** for consumers on monaco-editor < 0.53 -
no attempt is made to support both API shapes at once, matching the
scope implied by #4382.

## Test plan

- [x] Full monorepo `tsgo --build` passes clean
- [x] Verified end-to-end against a real app (React + Vite, native
      `MonacoEnvironment.getWorker` worker setup, no
      `vite-plugin-monaco-editor`) on monaco-editor 0.56.0: GraphQL
      autocomplete, hover, and validation all round-trip through the
      worker correctly - confirmed via instrumented worker calls that
      the full `WorkerManager -> createWebWorker -> initialize() ->
      doValidation()` chain resolves and returns real diagnostics
      (previously threw `Missing requestHandler or method: doValidation`
      / `doComplete` / `doHover` on every call)
- [ ] Package's own test suite (`vitest run`) - not run in this pass,
      happy to run if maintainers want it before review