### PR TITLE
fix(graphql-language-service): anchor diagnostics at highlighted node

### DIFF
--- a/.changeset/diagnostic-range-aliased-field.md
+++ b/.changeset/diagnostic-range-aliased-field.md
@@ -1,0 +1,5 @@
+---
+'graphql-language-service': patch
+---
+
+Anchor validation diagnostics at the highlighted node's own position, so the range for an unknown aliased field covers the field name rather than the alias, and the range for an unknown directive covers its name rather than starting at the `@`.

--- a/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
+++ b/packages/graphql-language-service/src/interface/__tests__/getDiagnostics.test.ts
@@ -79,6 +79,44 @@ describe('getDiagnostics', () => {
     ]);
   });
 
+  it('highlights the field name of an aliased field, not the alias', () => {
+    const errors = validateQuery(parse('{ heroName: title }'), schema);
+    expect(errors).toMatchObject([
+      {
+        message: 'Cannot query field "title" on type "Query".',
+        range: {
+          end: {
+            character: 18,
+            line: 0,
+          },
+          start: {
+            character: 12,
+            line: 0,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('highlights the directive name, not the "@" that precedes it', () => {
+    const errors = validateQuery(parse('{ hero @nope { name } }'), schema);
+    expect(errors).toMatchObject([
+      {
+        message: 'Unknown directive "@nope".',
+        range: {
+          end: {
+            character: 13,
+            line: 0,
+          },
+          start: {
+            character: 8,
+            line: 0,
+          },
+        },
+      },
+    ]);
+  });
+
   it('catches multi root validation errors without breaking (with a custom validation function that always throws errors)', () => {
     const error = validateQuery(parse('{ hero { name } } { seq }'), schema, [
       validationContext => {

--- a/packages/graphql-language-service/src/interface/getDiagnostics.ts
+++ b/packages/graphql-language-service/src/interface/getDiagnostics.ts
@@ -137,7 +137,7 @@ function annotations(
     return [];
   }
   const highlightedNodes: Diagnostic[] = [];
-  for (const [i, node] of error.nodes.entries()) {
+  for (const node of error.nodes) {
     const highlightNode =
       node.kind !== 'Variable' && 'name' in node && node.name !== undefined
         ? node.name
@@ -145,23 +145,19 @@ function annotations(
           ? node.variable
           : node;
     if (highlightNode) {
-      invariant(
-        error.locations,
-        'GraphQL validation error requires locations.',
-      );
-
-      // @ts-ignore
-      // https://github.com/microsoft/TypeScript/pull/32695
-      const loc = error.locations[i];
       const highlightLoc = getLocation(highlightNode);
-      const end = loc.column + (highlightLoc.end - highlightLoc.start);
+      // Anchor the range at the highlighted node's own start token. The
+      // enclosing node can begin earlier than its name, e.g. at an alias or
+      // at a directive's `@`.
+      const { line, column } = highlightLoc.startToken;
+      const end = column + (highlightLoc.end - highlightLoc.start);
       highlightedNodes.push({
         source: `GraphQL: ${type}`,
         message: error.message,
         severity,
         range: new Range(
-          new Position(loc.line - 1, loc.column - 1),
-          new Position(loc.line - 1, end),
+          new Position(line - 1, column - 1),
+          new Position(line - 1, end),
         ),
       });
     }


### PR DESCRIPTION
## Summary

- Validation diagnostics now take their start position from the highlighted node's own `loc.startToken` instead of `error.locations[i]`, which graphql-js sets to the start of the whole reported node. For an aliased field that is the alias, so the range started at the alias with the width of the field name and editors underlined the first N characters of the alias instead of the unknown field; an unknown directive was shifted one character left by its `@` for the same reason.
- Complementary to #4319, which fixes the range *end* (one character too long for LSP consumers, #4234). The end arithmetic is untouched here, so the two compose in either merge order.

## Test plan

- New `getDiagnostics` tests assert the full range for an unknown aliased field and for an unknown directive; both fail on `main` with the alias- and `@`-anchored ranges and pass with the fix.
- `yarn build`, `yarn types:check`, `yarn lint`, and the package's vitest suite (279 tests) pass.
