### PR TITLE
v6: don't create an empty tab on reload when no editor state was stored

### DIFF
--- a/.changeset/fix-phantom-tab-on-reload.md
+++ b/.changeset/fix-phantom-tab-on-reload.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix an extra empty tab being created on reload. The `query`/`variables`/`headers` storage keys are only written on edit, so reloading a session that never touched the editors found no stored editor state matching any tab and pushed a new empty one.

--- a/packages/graphiql-react/src/utility/tabs.spec.ts
+++ b/packages/graphiql-react/src/utility/tabs.spec.ts
@@ -143,6 +143,32 @@ describe('getDefaultTabState', () => {
     });
   });
 
+  it('does not create an extra tab on reload when no editor state was stored', () => {
+    const storage = new StorageAPI();
+    // First visit: no storage at all, so the default tab is created…
+    const initial = getDefaultTabState({
+      defaultQuery: '# Default',
+      headers: null,
+      query: null,
+      variables: null,
+      storage,
+    });
+    // …and persisted, while the query/variables/headers storage keys are
+    // only written on edit, so they remain empty.
+    storage.set(STORAGE_KEY.tabs, serializeTabState(initial));
+
+    const reloaded = getDefaultTabState({
+      defaultQuery: '# Default',
+      headers: null,
+      query: null,
+      variables: null,
+      storage,
+    });
+    storage.clear();
+    expect(reloaded.tabs).toHaveLength(1);
+    expect(reloaded.activeTabIndex).toBe(0);
+  });
+
   it('returns initial tabs', () => {
     expect(
       getDefaultTabState({

--- a/packages/graphiql-react/src/utility/tabs.ts
+++ b/packages/graphiql-react/src/utility/tabs.ts
@@ -127,8 +127,21 @@ export function getDefaultTabState({
         }
       }
 
+      // The individual query/variables/headers storage keys are only written
+      // on edit. When all of them are empty there is no editor state to
+      // restore into a tab — pushing one anyway would add an empty tab on
+      // every reload of a session that never touched the editors.
+      const hasStoredEditorState =
+        query != null || variables != null || headersForHash != null;
+
       if (matchingTabIndex >= 0) {
         parsed.activeTabIndex = matchingTabIndex;
+      } else if (!hasStoredEditorState && parsed.tabs.length > 0) {
+        // Keep the stored active tab, but make sure the index is in range.
+        parsed.activeTabIndex = Math.min(
+          Math.max(parsed.activeTabIndex, 0),
+          parsed.tabs.length - 1,
+        );
       } else {
         const operationName = query ? fuzzyExtractOperationName(query) : null;
         parsed.tabs.push({


### PR DESCRIPTION
Load GraphiQL with empty storage, don't touch anything, and reload: a second `<untitled>` tab appears, empty and active, next to the default tab. Every fresh-visit-then-reload session starts with two tabs instead of one.

The cause is in `getDefaultTabState`. The `query`/`variables`/`headers` storage keys are only written on edit, so after a first visit that never touched the editors they're all still `null`. On reload the function hashes those `null`s, finds no stored tab with a matching hash (the default tab hashes its `defaultQuery` contents), and takes the "preserve the stored editor state in a new tab" branch, pushing a tab made entirely of `null`s. That branch exists to carry editor content forward from pre-tabs storage; when all three keys are empty there's nothing to carry.

The fix skips the push when none of the three keys hold a value and storage already has at least one tab, keeping the stored `activeTabIndex` (clamped to the tab range, since that index is no longer unconditionally rewritten on this path).

Reproduction is the first commit (the new test fails on `graphiql-6`: it gets 2 tabs where it expects 1), fix is the second.

I could see this predating v6 in principle, but I haven't verified against v5; the hash-match-then-push logic is unchanged from `main`, so if v5's CodeMirror editors also never wrote the storage keys on mount it has the same behavior.