### PR TITLE
v6: document Monaco worker setup, warn against `setup-workers/vite` in Vite apps

### DIFF
--- a/docs/migration/graphiql-6.0.0.md
+++ b/docs/migration/graphiql-6.0.0.md
@@ -14,8 +14,9 @@ If something in your integration breaks that isn't covered here, please open an 
 6. [New first-party plugins](#new-first-party-plugins)
 7. [`@graphiql/plugin-explorer` removal](#graphiqlplugin-explorer-removal)
 8. [Theme, density, and font-size settings](#theme-density-and-font-size-settings)
-9. [Considering for removal in v7](#considering-for-removal-in-v7)
-10. [Other notes](#other-notes)
+9. [Monaco worker setup](#monaco-worker-setup)
+10. [Considering for removal in v7](#considering-for-removal-in-v7)
+11. [Other notes](#other-notes)
 
 ## Overview
 
@@ -605,6 +606,27 @@ If you embed GraphiQL in a product with its own theme system and don't want user
 ```
 
 `forcedTheme` accepts `'light'`, `'dark'`, or `'system'`, and hides the theme control in the settings dialog entirely (density and font size remain user-adjustable). There isn't an equivalent forced prop for density or font size today — if you need to pin those too, set the `data-density` / `data-font-size` attribute on your container yourself after mount and it'll take precedence over whatever the settings dialog last wrote, until the user changes it again from the dialog.
+
+## Monaco worker setup
+
+Nothing changed here since v5 — Monaco's web workers still have to be wired up
+per bundler, exactly as described in the
+[5.0.0 migration guide](./graphiql-5.0.0.md). This section exists because the
+`graphiql/setup-workers/*` exports make it easy to guess wrong for Vite:
+
+- **Vite**: use
+  [`vite-plugin-monaco-editor`](https://www.npmjs.com/package/vite-plugin-monaco-editor)
+  as shown in the [Vite example](../../examples/graphiql-vite/vite.config.mjs).
+  Do **not** import `graphiql/setup-workers/vite` from a Vite app — despite the
+  name, it cannot work there: Vite pre-bundles dependencies with esbuild, which
+  can't process the `?worker` imports inside the published file, and the dev
+  server fails to start. (The export exists for toolchains that process
+  dependency sources with Vite's own transform pipeline, e.g. building a
+  bundled artifact from source.)
+- **Webpack / Turbopack (Next.js)**: `import 'graphiql/setup-workers/webpack'`.
+- **ESM CDN (esm.sh)**: `import 'graphiql/setup-workers/esm.sh'`, or wire
+  `globalThis.MonacoEnvironment` yourself with `?worker` URLs as shown in the
+  [CDN example](../../examples/graphiql-cdn/index.html).
 
 ## Considering for removal in v7
 

--- a/packages/graphiql-react/src/setup-workers/vite.ts
+++ b/packages/graphiql-react/src/setup-workers/vite.ts
@@ -4,7 +4,17 @@ import GraphQLWorker from 'monaco-graphql/esm/graphql.worker.js?worker';
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker.js?worker';
 
 /**
- * Setup Monaco Editor workers for Vite.
+ * Setup Monaco Editor workers for toolchains that run dependency sources
+ * through Vite's own transform pipeline (e.g. building a bundled artifact from
+ * source, or Vitest with this package linked as source).
+ *
+ * ⚠️ This module does NOT work when imported from an ordinary Vite app: Vite
+ * pre-bundles dependencies with esbuild, which cannot process the `?worker`
+ * imports below, and the dev server fails to start. Vite apps must configure
+ * workers with `vite-plugin-monaco-editor` instead — see the "Monaco worker
+ * setup" section of docs/migration/graphiql-6.0.0.md and the
+ * examples/graphiql-vite example.
+ *
  * Vite needs to know ahead of time that you are loading a web worker.
  * Vite doesn’t support instantiating web workers directly from bare module imports like:
  *

--- a/packages/graphiql/src/setup-workers/vite.ts
+++ b/packages/graphiql/src/setup-workers/vite.ts
@@ -1,1 +1,8 @@
+/**
+ * ⚠️ Not for ordinary Vite apps: Vite pre-bundles dependencies with esbuild,
+ * which cannot process the `?worker` imports inside this module, and the dev
+ * server fails to start. Vite apps must configure workers with
+ * `vite-plugin-monaco-editor` instead — see the "Monaco worker setup" section
+ * of docs/migration/graphiql-6.0.0.md.
+ */
 import '@graphiql/react/setup-workers/vite';


### PR DESCRIPTION
The v6 migration guide says nothing about Monaco worker setup, and the `graphiql` exports map offers `./setup-workers/vite`, which reads like the thing a Vite user should import. It isn't: Vite pre-bundles dependencies with esbuild, which can't process the `?worker` imports inside the published file, and the dev server dies on startup with `Cannot read file: .../monaco-editor/esm/vs/editor/editor.worker.js?worker`. I hit this setting up a fresh Vite app against the published beta. Excluding the package from `optimizeDeps` isn't a workaround worth documenting either (it serves the entire dependency graph unbundled; the page never got past blank in my test).

The working Vite path is `vite-plugin-monaco-editor`, which is what `examples/graphiql-vite` and the 5.0.0 migration guide already use. This adds a "Monaco worker setup" section to the 6.0.0 migration doc pointing Vite users there (and listing the webpack and esm.sh variants, which do work as exports), and puts a warning in the JSDoc of both `setup-workers/vite` modules so the next person who finds the export through the exports map learns its actual audience: toolchains that run dependency sources through Vite's own transform pipeline, like this repo's CDN bundle build.

Whether `graphiql/setup-workers/vite` should stay publicly exported at all is a separate call I didn't make here; docs and warnings only.