### PR TITLE
[Do not merge until 1.0] v6: restore caret ranges for internal `@graphiql/react` and `@graphiql/toolkit` deps

### DIFF
--- a/.changeset/restore-caret-internal-ranges.md
+++ b/.changeset/restore-caret-internal-ranges.md
@@ -1,0 +1,11 @@
+---
+'graphiql': patch
+'@graphiql/react': patch
+'@graphiql/plugin-collections': patch
+'@graphiql/plugin-doc-explorer': patch
+'@graphiql/plugin-history': patch
+'@graphiql/plugin-query-builder': patch
+'@graphiql/plugin-code-exporter': patch
+---
+
+Restore caret ranges (`^1.0.0`) for internal `@graphiql/react` and `@graphiql/toolkit` dependencies. Now that stable versions are published, caret ranges can no longer resolve to prereleases, so the exact pins from the beta cycle are unnecessary.

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -38,13 +38,13 @@
     "graphiql-code-exporter": "^3.0.3"
   },
   "peerDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "@vitejs/plugin-react": "^4.4.1",
     "graphql": "^16.9.0",
     "react": "^19.1.0",

--- a/packages/graphiql-plugin-collections/package.json
+++ b/packages/graphiql-plugin-collections/package.json
@@ -42,13 +42,13 @@
     "zustand": "^5"
   },
   "peerDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
@@ -51,7 +51,7 @@
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-vitest": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",

--- a/packages/graphiql-plugin-history/package.json
+++ b/packages/graphiql-plugin-history/package.json
@@ -37,18 +37,18 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
-    "@graphiql/toolkit": "1.0.0-beta.0",
+    "@graphiql/toolkit": "^1.0.0",
     "clsx": "^1.2.1",
     "react-compiler-runtime": "19.1.0-rc.1",
     "zustand": "^5"
   },
   "devDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "@testing-library/react": "^16.1.0",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.3",

--- a/packages/graphiql-plugin-query-builder/package.json
+++ b/packages/graphiql-plugin-query-builder/package.json
@@ -41,7 +41,7 @@
     "build-storybook": "storybook build"
   },
   "peerDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
@@ -50,7 +50,7 @@
     "react-compiler-runtime": "19.1.0-rc.1"
   },
   "devDependencies": {
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-vitest": "^10.3.6",
     "@storybook/react-vite": "^10.3.6",

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -52,7 +52,7 @@
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
-    "@graphiql/toolkit": "1.0.0-beta.0",
+    "@graphiql/toolkit": "^1.0.0",
     "@radix-ui/react-dialog": "^1.1",
     "@radix-ui/react-dropdown-menu": "^2.1",
     "@radix-ui/react-tooltip": "^1.2",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -55,7 +55,7 @@
     "@graphiql/plugin-doc-explorer": "^1.0.0-beta.0",
     "@graphiql/plugin-history": "^1.0.0-beta.0",
     "@graphiql/plugin-query-builder": "^1.0.0-beta.0",
-    "@graphiql/react": "1.0.0-beta.0",
+    "@graphiql/react": "^1.0.0",
     "clsx": "^1.2.1",
     "react-compiler-runtime": "19.1.0-rc.1"
   },
@@ -65,7 +65,7 @@
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
-    "@graphiql/toolkit": "1.0.0-beta.0",
+    "@graphiql/toolkit": "^1.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
This is the scheduled unwind of #4471, parked as a draft so it doesn't get forgotten. It exists to be merged right after v6 exits prerelease, and not a moment before.

#4471 pinned every internal `@graphiql/react` and `@graphiql/toolkit` range to an exact beta version because caret ranges anchored at a prerelease (`^1.0.0-beta.x`) resolve to the `1.0.0-next.*` builds published in 2022 (`next` > `beta` in semver's alphabetical prerelease ordering). Once stable `1.0.0` exists that hazard is gone for good: a caret anchored at a stable version never matches prereleases at all. So the pins are beta-cycle scaffolding, and this PR swaps them back to `^1.0.0`.

Two properties of this PR are deliberate:

- **It cannot be merged early by accident.** `^1.0.0` is unresolvable while only prereleases of these packages exist, so install fails in CI until stable `1.0.0` is actually published. Red checks here are the interlock working, not a problem to fix.
- **The diff will rot, and that's fine.** Changesets rewrites the exact pins on every beta publish (`1.0.0-beta.1`, `beta.2`, ...), so this branch will conflict with `graphiql-6` over time. Don't resolve conflicts by hand; regenerate the change at merge time.

To refresh right after `changeset pre exit` and the final 1.0 Version Packages merge:

```sh
git fetch origin graphiql-6 && git reset --hard origin/graphiql-6
perl -pi -e 's/("\@graphiql\/(?:react|toolkit)": ")\d[^"]*"/${1}^1.0.0"/' packages/*/package.json
yarn install
git add -A && git commit -m 'restore caret ranges for internal deps' && git push -f
```

The lockfile isn't updated in this branch for the same reason CI is red: `yarn install` can't resolve `^1.0.0` yet. The `yarn install` in the refresh steps handles it when the time comes.

Ref: #4471