### PR TITLE
Don't create an empty tab on reload when no editor state was stored

### DIFF
--- a/.changeset/fix-reload-extra-tab.md
+++ b/.changeset/fix-reload-extra-tab.md
@@ -1,0 +1,5 @@
+---
+'@graphiql/react': patch
+---
+
+Fix an extra empty tab being created on reload. The `query`/`variables`/`headers` storage keys are only written on edit, so reloading a session that never touched the editors found no stored editor state matching any tab and pushed a new empty one.

--- a/packages/graphiql-react/src/utility/tabs.spec.ts
+++ b/packages/graphiql-react/src/utility/tabs.spec.ts
@@ -5,6 +5,7 @@ import {
   fuzzyExtractOperationName,
   getDefaultTabState,
   clearHeadersFromTabs,
+  serializeTabState,
 } from './tabs';
 import { STORAGE_KEY } from '../constants';
 
@@ -122,6 +123,32 @@ describe('getDefaultTabState', () => {
         }),
       ],
     });
+  });
+
+  it('does not create an extra tab on reload when no editor state was stored', () => {
+    const storage = new StorageAPI();
+    // First visit: no storage at all, so the default tab is created…
+    const initial = getDefaultTabState({
+      defaultQuery: '# Default',
+      headers: null,
+      query: null,
+      variables: null,
+      storage,
+    });
+    // …and persisted, while the query/variables/headers storage keys are
+    // only written on edit, so they remain empty.
+    storage.set(STORAGE_KEY.tabs, serializeTabState(initial));
+
+    const reloaded = getDefaultTabState({
+      defaultQuery: '# Default',
+      headers: null,
+      query: null,
+      variables: null,
+      storage,
+    });
+    storage.clear();
+    expect(reloaded.tabs).toHaveLength(1);
+    expect(reloaded.activeTabIndex).toBe(0);
   });
 
   it('returns initial tabs', () => {

--- a/packages/graphiql-react/src/utility/tabs.ts
+++ b/packages/graphiql-react/src/utility/tabs.ts
@@ -119,8 +119,21 @@ export function getDefaultTabState({
         }
       }
 
+      // The individual query/variables/headers storage keys are only written
+      // on edit. When all of them are empty there is no editor state to
+      // restore into a tab — pushing one anyway would add an empty tab on
+      // every reload of a session that never touched the editors.
+      const hasStoredEditorState =
+        query != null || variables != null || headersForHash != null;
+
       if (matchingTabIndex >= 0) {
         parsed.activeTabIndex = matchingTabIndex;
+      } else if (!hasStoredEditorState && parsed.tabs.length > 0) {
+        // Keep the stored active tab, but make sure the index is in range.
+        parsed.activeTabIndex = Math.min(
+          Math.max(parsed.activeTabIndex, 0),
+          parsed.tabs.length - 1,
+        );
       } else {
         const operationName = query ? fuzzyExtractOperationName(query) : null;
         parsed.tabs.push({


### PR DESCRIPTION
On a fresh load of GraphiQL, reloading the page causes a second tab to appear. Reproduction in the first commit, fix in the second.

The cause is in `getDefaultTabState`. The `query`/`variables`/`headers` storage keys are only written on edit, so after a first visit that never touched the editors they're all still `null`. On reload the function hashes those `null`s, finds no stored tab with a matching hash (the default tab hashes its `defaultQuery` contents), and takes the "preserve the stored editor state in a new tab" branch, pushing a tab made entirely of `null`s. That branch exists to carry editor content forward from pre-tabs storage; when all three keys are empty there's nothing to carry.

The fix skips the push when none of the three keys hold a value and storage already has at least one tab, keeping the stored `activeTabIndex` (clamped to the tab range, since that index is no longer unconditionally rewritten on this path).

This also resolves the long-open #2825: the headers-hash half of that report was fixed back then (the `headersForHash` logic), but its repro (a `headers` prop with `shouldPersistHeaders: false`, untouched editors, refresh) still created a tab through this same all-empty path — with this change, `headersForHash` is `undefined` and nothing is pushed. A typed query with non-persisted headers already matched correctly because `hashFromTabContents` coalesces `null`/`undefined` to `''`.

Fixes #2825
Fixes #4435
