### PR TITLE
v6: Require GraphQL.js 16.11 or 17

### DIFF
--- a/.changeset/drop-graphql-15.md
+++ b/.changeset/drop-graphql-15.md
@@ -1,0 +1,19 @@
+---
+'graphiql': major
+'@graphiql/react': major
+'@graphiql/toolkit': major
+'@graphiql/plugin-doc-explorer': major
+'@graphiql/plugin-collections': major
+'@graphiql/plugin-query-builder': major
+'@graphiql/plugin-code-exporter': major
+'cm6-graphql': major
+'codemirror-graphql': major
+'graphql-language-service': major
+'graphql-language-service-cli': major
+'graphql-language-service-server': major
+'monaco-graphql': major
+'vscode-graphql': major
+'vscode-graphql-execution': major
+---
+
+GraphQL.js 15 and 16.0–16.10 are no longer supported peer dependencies. The supported range is `^16.11.0 || ^17.0.0`. GraphQL.js 16.11 fixes OneOf input validation for nullable variables and tightens input-object coercion to reject arrays, giving GraphiQL 6 a correct baseline for OneOf inputs. Upgrade `graphql` before upgrading these packages.

--- a/.github/workflows/pr-graphql-compat-check.yml
+++ b/.github/workflows/pr-graphql-compat-check.yml
@@ -26,9 +26,9 @@ jobs:
           # test against the latest 16.x version, which might be newer than what we have
           - '^16'
           # test against the oldest version we support
-          - '^16.0.0'
-          # test against the latest alpha
-          - '^17.0.0-alpha'
+          - '16.11.0'
+          # test against the latest 17.x version
+          - '^17'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -43,13 +43,26 @@ jobs:
           path: node_modules
           key: node_modules-${{hashFiles('yarn.lock')}}
           restore-keys: node_modules-
+      - name: Install dependencies
+        run: yarn install --immutable
+
       - name: Force GraphQL ${{ matrix.release }} solution
         run: yarn repo:resolve graphql@${{ matrix.release }}
 
-      - run: yarn install --immutable
+      - run: yarn install --no-immutable
+
+      - name: Build
+        run: yarn build
 
       - name: Unit Tests
         run: yarn test
 
-      - name: Cypress
+      - name: Cypress (GraphQL 16)
+        if: matrix.release != '^17'
+        env:
+          CYPRESS_excludeSpecPattern: cypress/e2e/incremental-delivery.cy.ts
+        run: yarn e2e
+
+      - name: Cypress (GraphQL 17)
+        if: matrix.release == '^17'
         run: yarn e2e

--- a/docs/migration/graphiql-6.0.0.md
+++ b/docs/migration/graphiql-6.0.0.md
@@ -1,6 +1,6 @@
 # Upgrading `graphiql` to `6.0.0`
 
-GraphiQL 6 is a visual redesign built on a new OKLCH color system, plus a handful of mostly additive API changes: a `Transport` API that sits alongside the existing `Fetcher`, a settings dialog for theme/density/font-size, and two new first-party plugins (a visual query builder and operation collections) installed by default. The breaking changes are the removal of the hooks deprecated in v5 and the removal of the `GraphiQL.Toolbar` / `GraphiQL.Logo` composable slots, each with a drop-in replacement. See [discussion #4219](https://github.com/graphql/graphiql/discussions/4219) for the design background and to leave feedback.
+GraphiQL 6 is a visual redesign built on a new OKLCH color system, plus a handful of mostly additive API changes: a `Transport` API that sits alongside the existing `Fetcher`, a settings dialog for theme/density/font-size, and two new first-party plugins (a visual query builder and operation collections) installed by default. The breaking changes are the removal of the hooks deprecated in v5, the removal of the `GraphiQL.Toolbar` / `GraphiQL.Logo` composable slots, and the `graphql` peer dependency floor moving to `^16.11.0 || ^17.0.0`. The hook and slot removals each have a drop-in replacement. See [discussion #4219](https://github.com/graphql/graphiql/discussions/4219) for the design background and to leave feedback.
 
 If something in your integration breaks that isn't covered here, please open an issue and we'll add it.
 
@@ -13,9 +13,10 @@ If something in your integration breaks that isn't covered here, please open an 
 5. [New `transport` prop](#new-transport-prop)
 6. [New first-party plugins](#new-first-party-plugins)
 7. [`@graphiql/plugin-explorer` removal](#graphiqlplugin-explorer-removal)
-8. [Theme, density, and font-size settings](#theme-density-and-font-size-settings)
-9. [Considering for removal in v7](#considering-for-removal-in-v7)
-10. [Other notes](#other-notes)
+8. [GraphQL.js minimum version](#graphqljs-minimum-version)
+9. [Theme, density, and font-size settings](#theme-density-and-font-size-settings)
+10. [Considering for removal in v7](#considering-for-removal-in-v7)
+11. [Other notes](#other-notes)
 
 ## Overview
 
@@ -567,6 +568,12 @@ Check the [known limitations](../../packages/graphiql-plugin-query-builder/READM
 
 If you can't migrate before upgrading to v6, pin `@graphiql/plugin-explorer` to its last `5.x` release from npm and track the v5 LTS branch, where it stays maintained.
 
+## GraphQL.js minimum version
+
+GraphiQL 6 requires `graphql` `^16.11.0 || ^17.0.0`. GraphQL.js 16.11 fixes OneOf input validation for nullable variables and rejects arrays during input-object coercion, so earlier 16.x releases do not provide the behavior v6 expects. Upgrade `graphql` first.
+
+If you must remain on GraphQL.js 15 or 16.0–16.10, stay on `graphiql` 5.x and the matching previous majors of the other packages.
+
 ## Theme, density, and font-size settings
 
 v6 adds a settings dialog (the gear icon in the activity rail) with controls for theme, density, and font size, backed by a new `useGraphiQLSettings()` hook in `@graphiql/react`. Settings persist to `localStorage` and apply live via `data-*` attributes, so custom CSS can key off them the same way component internals do.
@@ -611,7 +618,6 @@ If you embed GraphiQL in a product with its own theme system and don't want user
 Nothing below is happening in v6. These are informal signals about where the project is headed, not commitments — flagging them now so a v7 major version isn't the first time you hear about them.
 
 - **React 18 support.** v6 still supports React 18 and 19 as peer dependencies. A future major version may drop React 18 once the React 19 adoption curve looks similar to where 18 was when 17 support was dropped.
-- **GraphQL.js 15 support.** Similarly, `graphql` `^15.5.0` remains a supported peer range in v6 alongside `^16` and `^17`. Expect the floor to move up in a future major version.
 - **The v5 HSL variable set.** The old `--color-*` variables are **deprecated in v6**. They're still defined — frozen at their v5 values — for backward compatibility, but no v6 component reads them: internal usage was migrated to the OKLCH tokens in `tokens.css` (see [CSS and retheming](#css-and-retheming)). A transparent compatibility shim isn't feasible, because the two systems use different color formats — `h, s%, l%` for `hsl()` versus `L% C H` for `oklch()` — so an old variable can't simply alias a new one. Expect the frozen definitions to be removed in v7. If your integration reads or sets the v5 variable names, migrate to the new tokens now (see [Migrating `--color-*` overrides](#migrating---color--overrides)) and weigh in on [discussion #4219](https://github.com/graphql/graphiql/discussions/4219).
 
 ## Other notes

--- a/examples/cm6-graphql-legacy-parcel/package.json
+++ b/examples/cm6-graphql-legacy-parcel/package.json
@@ -25,7 +25,7 @@
     "@codemirror/basic-setup": "^0.20",
     "@codemirror/language": "^0.20",
     "codemirror-graphql": "^2",
-    "graphql": "^16"
+    "graphql": "^16.14.2"
   },
   "devDependencies": {
     "parcel-bundler": "^1",

--- a/examples/cm6-graphql-parcel/package.json
+++ b/examples/cm6-graphql-parcel/package.json
@@ -30,7 +30,7 @@
     "@codemirror/theme-one-dark": "^6",
     "@codemirror/view": "^6",
     "cm6-graphql": "^0.0",
-    "graphql": "^16"
+    "graphql": "^16.14.2"
   },
   "devDependencies": {
     "parcel": "^2",

--- a/examples/graphiql-vite/package.json
+++ b/examples/graphiql-vite/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "graphiql": "^6.0.0-beta.1",
-    "graphql": "^16",
+    "graphql": "^16.14.2",
     "react": "^19",
     "react-dom": "^19"
   },

--- a/examples/graphiql-webpack/package.json
+++ b/examples/graphiql-webpack/package.json
@@ -13,7 +13,7 @@
     "@graphiql/react": "^1.0.0-beta.1",
     "@graphiql/toolkit": "^1.0.0-beta.0",
     "graphiql": "^6.0.0-beta.1",
-    "graphql": "^16",
+    "graphql": "^16.14.2",
     "graphql-ws": "^6",
     "react": "^19",
     "react-dom": "^19",

--- a/examples/monaco-graphql-nextjs/package.json
+++ b/examples/monaco-graphql-nextjs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@graphiql/toolkit": "^1.0.0-beta.0",
-    "graphql": "^16",
+    "graphql": "^16.14.2",
     "jsonc-parser": "^3",
     "monaco-editor": "^0.52",
     "monaco-graphql": "^1.8.0",

--- a/examples/monaco-graphql-react-vite/package.json
+++ b/examples/monaco-graphql-react-vite/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@graphiql/toolkit": "^1.0.0-beta.0",
-    "graphql": "^16",
+    "graphql": "^16.14.2",
     "graphql-language-service": "^5.6.0",
     "jsonc-parser": "^3",
     "monaco-editor": "^0.52",

--- a/examples/monaco-graphql-webpack/package.json
+++ b/examples/monaco-graphql-webpack/package.json
@@ -10,7 +10,7 @@
     "build-demo": "yarn build && mkdirp ../../packages/graphiql/monaco && cp -r dist/* ../../packages/graphiql/monaco/"
   },
   "dependencies": {
-    "graphql": "^16",
+    "graphql": "^16.14.2",
     "graphql-language-service": "^5.6.0",
     "json-schema": "^0.4",
     "jsonc-parser": "^3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "netlify-function",
   "private": true,
   "dependencies": {
-    "graphql": "^17.0.0-rc.0",
+    "graphql": "^16.14.2",
     "graphql-helix": "^1.13.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "repo:fix": "manypkg fix",
     "repo:resolve": "node scripts/set-resolution.mts",
     "t": "yarn test",
-    "test": "turbo run test --filter='./packages/*'",
+    "test": "yarn test:scripts && turbo run test --filter='./packages/*'",
+    "test:scripts": "node --test scripts/*.spec.mts",
     "build:tsc": "tsgo --build && node resources/patch-monaco-editor-type.mts",
     "wsrun:noexamples": "wsrun --exclude-missing --exclude example-monaco-graphql-react-vite --exclude example-monaco-graphql-nextjs --exclude example-monaco-graphql-webpack --exclude example-graphiql-webpack",
     "gen-agenda": "wgutils agenda gen"

--- a/packages/cm6-graphql/package.json
+++ b/packages/cm6-graphql/package.json
@@ -35,7 +35,7 @@
     "@lezer/generator": "^1.1.0",
     "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "typescript": "^5.8.0"
   },
   "peerDependencies": {
@@ -45,7 +45,7 @@
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "@lezer/highlight": "^1.0.0",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+    "graphql": "^16.11.0 || ^17.0.0"
   },
   "license": "MIT"
 }

--- a/packages/codemirror-graphql/package.json
+++ b/packages/codemirror-graphql/package.json
@@ -41,9 +41,8 @@
   "peerDependencies": {
     "@codemirror/language": "6.0.0",
     "codemirror": "^5.65.3",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+    "graphql": "^16.11.0 || ^17.0.0"
   },
-  "// TEMPORARILY PINNED until we fix graphql 15 support": "",
   "dependencies": {
     "@types/codemirror": "^0.0.90",
     "graphql-language-service": "5.6.0"
@@ -52,7 +51,7 @@
     "@codemirror/language": "^6.0.0",
     "codemirror": "^5.65.3",
     "cross-env": "^7.0.2",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "rimraf": "^3.0.2",
     "sane": "2.0.0"
   }

--- a/packages/graphiql-plugin-code-exporter/package.json
+++ b/packages/graphiql-plugin-code-exporter/package.json
@@ -39,14 +39,14 @@
   },
   "peerDependencies": {
     "@graphiql/react": "1.0.0-beta.1",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
   "devDependencies": {
     "@graphiql/react": "1.0.0-beta.1",
     "@vitejs/plugin-react": "^4.4.1",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "typescript": "^5.8.0",

--- a/packages/graphiql-plugin-collections/package.json
+++ b/packages/graphiql-plugin-collections/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@graphiql/react": "1.0.0-beta.1",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -53,7 +53,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^4.4.1",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "vite": "^6.3.4",

--- a/packages/graphiql-plugin-doc-explorer/package.json
+++ b/packages/graphiql-plugin-doc-explorer/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "@graphiql/react": "1.0.0-beta.1",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -60,7 +60,7 @@
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.3",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "storybook": "^10.3.6",

--- a/packages/graphiql-plugin-query-builder/package.json
+++ b/packages/graphiql-plugin-query-builder/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@graphiql/react": "1.0.0-beta.1",
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -60,7 +60,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.4.1",
     "babel-plugin-react-compiler": "19.1.0-rc.3",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "storybook": "^10.3.6",

--- a/packages/graphiql-react/package.json
+++ b/packages/graphiql-react/package.json
@@ -47,7 +47,7 @@
     "test": "vitest run --typecheck"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -84,7 +84,7 @@
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/browser-playwright": "^4.1.6",
     "babel-plugin-react-compiler": "19.1.0-rc.3",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "playwright": "^1.60.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/graphiql-toolkit/package.json
+++ b/packages/graphiql-toolkit/package.json
@@ -29,14 +29,14 @@
     "meros": "^1.1.4"
   },
   "devDependencies": {
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "graphql-ws": "^6.0.8",
     "isomorphic-fetch": "^3.0.0",
     "subscriptions-transport-ws": "0.11.0",
     "tsup": "^8.2.4"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "graphql-ws": ">= 4.5.0"
   },
   "peerDependenciesMeta": {

--- a/packages/graphiql/cypress/e2e/docs.cy.ts
+++ b/packages/graphiql/cypress/e2e/docs.cy.ts
@@ -1,5 +1,3 @@
-import { version } from 'graphql';
-
 beforeEach(() => {
   cy.visit('/');
 });
@@ -105,13 +103,7 @@ describe('GraphQL DocExplorer - deprecated fields', () => {
   });
 });
 
-let describeOrSkip = describe.skip;
-
-if (!version.includes('15.5')) {
-  describeOrSkip = describe;
-}
-
-describeOrSkip('GraphQL DocExplorer - deprecated arguments', () => {
+describe('GraphQL DocExplorer - deprecated arguments', () => {
   it('should show deprecated arguments category title', () => {
     // Open doc explorer
     cy.get('.graphiql-activity-rail-item').eq(0).click();

--- a/packages/graphiql/cypress/e2e/errors.cy.ts
+++ b/packages/graphiql/cypress/e2e/errors.cy.ts
@@ -1,4 +1,4 @@
-import { GraphQLError, version } from 'graphql';
+import { GraphQLError } from 'graphql';
 
 describe('Errors', () => {
   it('Should show an error when the HTTP request fails', () => {
@@ -33,9 +33,8 @@ describe('Errors', () => {
      * We can't use `cy.assertQueryResult` here because the stack contains line
      * and column numbers of the `index.umd.js` bundle which are not stable.
      */
-    const expected = version.startsWith('15')
-      ? 'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \\"<img src=x onerror=alert(document.'
-      : 'Names must only contain [_a-zA-Z0-9] but \\"<img src=x onerror=alert(document.';
+    const expected =
+      'Names must only contain [_a-zA-Z0-9] but \\"<img src=x onerror=alert(document.';
     cy.containQueryResult(expected);
   });
 

--- a/packages/graphiql/cypress/e2e/lint.cy.ts
+++ b/packages/graphiql/cypress/e2e/lint.cy.ts
@@ -1,5 +1,3 @@
-import { version as graphqlVersion } from 'graphql';
-
 describe('Linting', () => {
   it('Does not mark valid fields', () => {
     cy.visitWithOp({
@@ -168,9 +166,7 @@ describe('Linting', () => {
     }).assertLinterMarkWithMessage(
       '+++',
       'error',
-      graphqlVersion.startsWith('15.')
-        ? 'Syntax Error: Cannot parse the unexpected character "+".'
-        : 'Syntax Error: Unexpected character: "+".',
+      'Syntax Error: Unexpected character: "+".',
     );
   });
 });

--- a/packages/graphiql/cypress/e2e/prettify.cy.ts
+++ b/packages/graphiql/cypress/e2e/prettify.cy.ts
@@ -1,12 +1,3 @@
-import { version } from 'graphql';
-
-let describeOrSkip = describe.skip;
-
-// hard to account for the extra \n between 15/16 so these only run for 16 for now
-if (parseInt(version, 10) > 15) {
-  describeOrSkip = describe;
-}
-
 const prettifiedQuery = `{
   longDescriptionType {
     id
@@ -25,7 +16,7 @@ const brokenQuery = 'longDescriptionType {id}}';
 
 const brokenVariables = '"a": 1}';
 
-describeOrSkip('GraphiQL Prettify', () => {
+describe('GraphiQL Prettify', () => {
   it('should work while click on prettify button', () => {
     const rawQuery = '{  test\n\nid  }';
     const resultQuery = '{ test id }';

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -60,7 +60,7 @@
     "react-compiler-runtime": "19.1.0-rc.1"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"
   },
@@ -78,7 +78,7 @@
     "cypress": "^13.13.2",
     "cypress-axe": "^1",
     "cypress-real-events": "^1.15.0",
-    "graphql": "^16.11.0",
+    "graphql": "^16.14.2",
     "graphql-ws": "^5.5.5",
     "lightningcss": "^1.29.3",
     "react": "^19.1.0",

--- a/packages/graphiql/src/e2e.ts
+++ b/packages/graphiql/src/e2e.ts
@@ -96,7 +96,6 @@ function getSchemaUrl(): string {
 // how you can customize GraphiQL by providing different values or
 // additional child elements.
 const root = ReactDOM.createRoot(document.getElementById('graphiql')!);
-const graphqlVersion = GraphiQL.GraphQL.version;
 
 const props: ComponentProps<typeof GraphiQL> = {
   transport: GraphiQL.createTransport({
@@ -120,7 +119,7 @@ const props: ComponentProps<typeof GraphiQL> = {
   defaultEditorToolsVisibility: true,
   isHeadersEditorEnabled: true,
   shouldPersistHeaders: true,
-  inputValueDeprecation: !graphqlVersion.includes('15.5'),
+  inputValueDeprecation: true,
   confirmCloseTab:
     parameters.confirmCloseTab === 'true' ? confirmCloseTab : undefined,
   onPrettifyQuery:

--- a/packages/graphiql/test/package.json
+++ b/packages/graphiql/test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "express": "^4.20.0",
-    "graphql": "^17.0.0-rc.0",
+    "graphql": "^17.0.2",
     "graphql-helix": "^1.13.0",
     "graphql-ws": "^6.0.8",
     "ws": "8.21.0"

--- a/packages/graphql-language-service-cli/package.json
+++ b/packages/graphql-language-service-cli/package.json
@@ -36,7 +36,7 @@
     "LSP"
   ],
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+    "graphql": "^16.11.0 || ^17.0.0"
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
@@ -46,6 +46,6 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "graphql": "^16.9.0"
+    "graphql": "^16.14.2"
   }
 }

--- a/packages/graphql-language-service-server/package.json
+++ b/packages/graphql-language-service-server/package.json
@@ -38,7 +38,7 @@
   "module": "esm/index.js",
   "typings": "esm/index.d.ts",
   "peerDependencies": {
-    "graphql": "^16.0.0"
+    "graphql": "^16.11.0 || ^17.0.0"
   },
   "COMMENT": "please do not remove dependencies without thorough testing. many dependencies are not imported directly, as they are peer dependencies",
   "dependencies": {
@@ -71,7 +71,7 @@
     "@types/debounce-promise": "^3.1.9",
     "@types/glob": "^8.1.0",
     "@types/mkdirp": "^1.0.1",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "msw": "^2.13.4"
   }
 }

--- a/packages/graphql-language-service/package.json
+++ b/packages/graphql-language-service/package.json
@@ -32,7 +32,7 @@
     "graphql": "./dist/temp-bin.js"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+    "graphql": "^16.11.0 || ^17.0.0"
   },
   "dependencies": {
     "debounce-promise": "^3.1.2",
@@ -45,7 +45,7 @@
     "@types/json-schema": "7.0.9",
     "@types/picomatch": "^2.3.0",
     "benchmark": "^2.1.4",
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "graphql-config": "^5.1.6",
     "lodash": "^4.18.1",
     "platform": "^1.3.5",

--- a/packages/monaco-graphql/package.json
+++ b/packages/monaco-graphql/package.json
@@ -76,13 +76,13 @@
     "picomatch-browser": "^2.2.6"
   },
   "devDependencies": {
-    "graphql": "^16.9.0",
+    "graphql": "^16.14.2",
     "monaco-editor": "0.52.2",
     "prettier": "3.3.2",
     "vscode-languageserver-types": "^3.17.1"
   },
   "peerDependencies": {
-    "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+    "graphql": "^16.11.0 || ^17.0.0",
     "monaco-editor": ">= 0.20.0 < 0.53",
     "prettier": "^2.8.0 || ^3.0.0"
   }

--- a/packages/vscode-graphql-execution/package.json
+++ b/packages/vscode-graphql-execution/package.json
@@ -106,7 +106,7 @@
     "cosmiconfig": "8.2.0",
     "cosmiconfig-toml-loader": "^1.0.0",
     "dotenv": "10.0.0",
-    "graphql": "^16.9.0 || ^17.0.0-rc.0",
+    "graphql": "^16.14.2",
     "graphql-config": "^5.1.6",
     "graphql-ws": "6.0.8",
     "nullthrows": "1.1.1",

--- a/packages/vscode-graphql/package.json
+++ b/packages/vscode-graphql/package.json
@@ -186,7 +186,7 @@
     "ovsx": "0.8.3"
   },
   "dependencies": {
-    "graphql": "^16.9.0 || ^17.0.0-rc.0",
+    "graphql": "^16.14.2",
     "graphql-language-service-server": "^2.14.9",
     "typescript": "^5.8.0",
     "vscode-languageclient": "8.0.2"

--- a/scripts/set-resolution.mts
+++ b/scripts/set-resolution.mts
@@ -1,6 +1,8 @@
 import { writeFile } from 'node:fs/promises';
 import pkgJson from '../package.json' with { type: 'json' };
 
+const packageJsonPath = new URL('../package.json', import.meta.url);
+
 async function setResolution(): Promise<void> {
   const tag = process.argv[2];
   if (!tag) {
@@ -13,7 +15,7 @@ async function setResolution(): Promise<void> {
   }
 
   await writeFile(
-    '../package.json',
+    packageJsonPath,
     JSON.stringify(
       {
         ...pkgJson,

--- a/scripts/set-resolution.spec.mts
+++ b/scripts/set-resolution.spec.mts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+
+const execFileAsync = promisify(execFile);
+
+test('updates the repository package.json', async () => {
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'set-resolution-'));
+  const projectRoot = join(fixtureRoot, 'project');
+  const scriptsDirectory = join(projectRoot, 'scripts');
+  const packageJsonPath = join(projectRoot, 'package.json');
+
+  try {
+    await mkdir(scriptsDirectory, { recursive: true });
+    await copyFile(
+      new URL('./set-resolution.mts', import.meta.url),
+      join(scriptsDirectory, 'set-resolution.mts'),
+    );
+    await writeFile(
+      packageJsonPath,
+      JSON.stringify({ resolutions: { react: '18.3.1' } }),
+    );
+
+    await execFileAsync(
+      process.execPath,
+      ['scripts/set-resolution.mts', 'graphql@16.11.0'],
+      { cwd: projectRoot },
+    );
+
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+    assert.deepEqual(packageJson.resolutions, {
+      graphql: '16.11.0',
+      react: '18.3.1',
+    });
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3687,7 +3687,7 @@ __metadata:
     "@graphiql/react": "npm:1.0.0-beta.1"
     "@vitejs/plugin-react": "npm:^4.4.1"
     graphiql-code-exporter: "npm:^3.0.3"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     typescript: "npm:^5.8.0"
@@ -3695,7 +3695,7 @@ __metadata:
     vite-plugin-dts: "npm:^4.0.1"
   peerDependencies:
     "@graphiql/react": 1.0.0-beta.1
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0-alpha.2
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -3710,7 +3710,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     react: "npm:^19.1.0"
     react-dom: "npm:^19.1.0"
     vite: "npm:^6.3.4"
@@ -3720,7 +3720,7 @@ __metadata:
     zustand: "npm:^5"
   peerDependencies:
     "@graphiql/react": 1.0.0-beta.1
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -3740,7 +3740,7 @@ __metadata:
     "@testing-library/react": "npm:^16.3.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
     babel-plugin-react-compiler: "npm:19.1.0-rc.3"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     react: "npm:^19.1.0"
     react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
@@ -3750,7 +3750,7 @@ __metadata:
     zustand: "npm:^5"
   peerDependencies:
     "@graphiql/react": 1.0.0-beta.1
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -3793,7 +3793,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14.6.1"
     "@vitejs/plugin-react": "npm:^4.4.1"
     babel-plugin-react-compiler: "npm:19.1.0-rc.3"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     react: "npm:^19.1.0"
     react-compiler-runtime: "npm:19.1.0-rc.1"
     react-dom: "npm:^19.1.0"
@@ -3802,7 +3802,7 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.3"
   peerDependencies:
     "@graphiql/react": 1.0.0-beta.1
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -3833,7 +3833,7 @@ __metadata:
     clsx: "npm:^1.2.1"
     framer-motion: "npm:^12.12"
     get-value: "npm:^3.0.1"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.6.0"
     jsonc-parser: "npm:^3.3.1"
     markdown-it: "npm:^14.2.0"
@@ -3852,7 +3852,7 @@ __metadata:
     vite-plugin-svgr: "npm:^4.3.0"
     zustand: "npm:^5"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -3863,14 +3863,14 @@ __metadata:
   resolution: "@graphiql/toolkit@workspace:packages/graphiql-toolkit"
   dependencies:
     "@n1ru4l/push-pull-async-iterable-iterator": "npm:^3.1.0"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-ws: "npm:^6.0.8"
     isomorphic-fetch: "npm:^3.0.0"
     meros: "npm:^1.1.4"
     subscriptions-transport-ws: "npm:0.11.0"
     tsup: "npm:^8.2.4"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     graphql-ws: ">= 4.5.0"
   peerDependenciesMeta:
     graphql-ws:
@@ -10602,7 +10602,7 @@ __metadata:
     "@lezer/generator": "npm:^1.1.0"
     "@lezer/highlight": "npm:^1.0.0"
     "@lezer/lr": "npm:^1.0.0"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.3.0"
     typescript: "npm:^5.8.0"
   peerDependencies:
@@ -10612,7 +10612,7 @@ __metadata:
     "@codemirror/state": ^6.0.0
     "@codemirror/view": ^6.0.0
     "@lezer/highlight": ^1.0.0
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -10638,14 +10638,14 @@ __metadata:
     "@types/codemirror": "npm:^0.0.90"
     codemirror: "npm:^5.65.3"
     cross-env: "npm:^7.0.2"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:5.6.0"
     rimraf: "npm:^3.0.2"
     sane: "npm:2.0.0"
   peerDependencies:
     "@codemirror/language": 6.0.0
     codemirror: ^5.65.3
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -13022,7 +13022,7 @@ __metadata:
   dependencies:
     "@vitejs/plugin-react": "npm:^4"
     graphiql: "npm:^6.0.0-beta.1"
-    graphql: "npm:^16"
+    graphql: "npm:^16.14.2"
     react: "npm:^19"
     react-dom: "npm:^19"
     vite: "npm:^6"
@@ -13048,7 +13048,7 @@ __metadata:
     css-loader: "npm:^6"
     file-loader: "npm:^6"
     graphiql: "npm:^6.0.0-beta.1"
-    graphql: "npm:^16"
+    graphql: "npm:^16.14.2"
     graphql-ws: "npm:^6"
     html-webpack-plugin: "npm:^5"
     react: "npm:^19"
@@ -13072,7 +13072,7 @@ __metadata:
     "@graphiql/toolkit": "npm:^1.0.0-beta.0"
     "@types/node": "npm:^24"
     "@types/react": "npm:^19"
-    graphql: "npm:^16"
+    graphql: "npm:^16.14.2"
     jsonc-parser: "npm:^3"
     monaco-editor: "npm:^0.52"
     monaco-graphql: "npm:^1.8.0"
@@ -13089,7 +13089,7 @@ __metadata:
   dependencies:
     "@graphiql/toolkit": "npm:^1.0.0-beta.0"
     "@vitejs/plugin-react": "npm:^4"
-    graphql: "npm:^16"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.6.0"
     jsonc-parser: "npm:^3"
     monaco-editor: "npm:^0.52"
@@ -13117,7 +13117,7 @@ __metadata:
     css-loader: "npm:^6"
     file-loader: "npm:^6"
     fork-ts-checker-webpack-plugin: "npm:^7"
-    graphql: "npm:^16"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.6.0"
     html-webpack-plugin: "npm:^5"
     json-schema: "npm:^0.4"
@@ -14653,7 +14653,7 @@ __metadata:
     cypress: "npm:^13.13.2"
     cypress-axe: "npm:^1"
     cypress-real-events: "npm:^1.15.0"
-    graphql: "npm:^16.11.0"
+    graphql: "npm:^16.14.2"
     graphql-ws: "npm:^5.5.5"
     lightningcss: "npm:^1.29.3"
     react: "npm:^19.1.0"
@@ -14665,7 +14665,7 @@ __metadata:
     vite-plugin-dts: "npm:^4.5.3"
     vitest-canvas-mock: "npm:^1.1.4"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
   languageName: unknown
@@ -14711,12 +14711,12 @@ __metadata:
   dependencies:
     "@babel/polyfill": "npm:^7.12.1"
     "@types/yargs": "npm:16.0.5"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.3.0"
     graphql-language-service-server: "npm:^2.14.0"
     yargs: "npm:^16.2.0"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
   bin:
     graphql-lsp: ./bin/graphql.js
   languageName: unknown
@@ -14738,7 +14738,7 @@ __metadata:
     dotenv: "npm:10.0.0"
     fast-glob: "npm:^3.2.7"
     glob: "npm:^7.2.0"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-config: "npm:^5.1.6"
     graphql-language-service: "npm:^5.5.2"
     lru-cache: "npm:^10.2.0"
@@ -14756,7 +14756,7 @@ __metadata:
     vscode-uri: "npm:^3.0.2"
     vue: "npm:^3.2.0"
   peerDependencies:
-    graphql: ^16.0.0
+    graphql: ^16.11.0 || ^17.0.0
   languageName: unknown
   linkType: soft
 
@@ -14770,7 +14770,7 @@ __metadata:
     "@types/picomatch": "npm:^2.3.0"
     benchmark: "npm:^2.1.4"
     debounce-promise: "npm:^3.1.2"
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-config: "npm:^5.1.6"
     lodash: "npm:^4.18.1"
     nullthrows: "npm:^1.0.0"
@@ -14779,7 +14779,7 @@ __metadata:
     typescript: "npm:^5.8.0"
     vscode-languageserver-types: "npm:^3.17.1"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
   bin:
     graphql: ./dist/temp-bin.js
   languageName: unknown
@@ -14813,17 +14813,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:^16, graphql@npm:^16.11.0, graphql@npm:^16.13.2, graphql@npm:^16.9.0":
-  version: 16.13.2
-  resolution: "graphql@npm:16.13.2"
-  checksum: 10c0/64e822a0a0e4398781e4bc9765b88d370c08261498b517add4b878038ef7be2005b6b394a79a5102b9379d57052f60bc7f23fec8f39808d101984a74772ebd9d
+"graphql@npm:^16.13.2, graphql@npm:^16.14.2":
+  version: 16.14.2
+  resolution: "graphql@npm:16.14.2"
+  checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
   languageName: node
   linkType: hard
 
-"graphql@npm:^16.9.0 || ^17.0.0-rc.0, graphql@npm:^17.0.0-rc.0":
-  version: 17.0.0-rc.0
-  resolution: "graphql@npm:17.0.0-rc.0"
-  checksum: 10c0/06139f3df45496226d013d4f1a43a2aedb1e20b6a20c4a5b3cf099e5f5708275218ccf6ffdc47be9e35dda2c1ab70b6110aedb87900e3ddf47930acca54517b3
+"graphql@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "graphql@npm:17.0.2"
+  checksum: 10c0/766546216b891439ed09fd8584963df2013e26f2f79f096036eaaa2788c38964e049c8a142d68e3afdabdd8bbe70042639e83f0f4b82edbc7c6850421f072bb6
   languageName: node
   linkType: hard
 
@@ -17760,14 +17760,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "monaco-graphql@workspace:packages/monaco-graphql"
   dependencies:
-    graphql: "npm:^16.9.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service: "npm:^5.5.1"
     monaco-editor: "npm:0.52.2"
     picomatch-browser: "npm:^2.2.6"
     prettier: "npm:3.3.2"
     vscode-languageserver-types: "npm:^3.17.1"
   peerDependencies:
-    graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
+    graphql: ^16.11.0 || ^17.0.0
     monaco-editor: ">= 0.20.0 < 0.53"
     prettier: ^2.8.0 || ^3.0.0
   languageName: unknown
@@ -17989,7 +17989,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "netlify-function@workspace:functions"
   dependencies:
-    graphql: "npm:^17.0.0-rc.0"
+    graphql: "npm:^16.14.2"
     graphql-helix: "npm:^1.13.0"
   languageName: unknown
   linkType: soft
@@ -22330,7 +22330,7 @@ __metadata:
   resolution: "test-server@workspace:packages/graphiql/test"
   dependencies:
     express: "npm:^4.20.0"
-    graphql: "npm:^17.0.0-rc.0"
+    graphql: "npm:^17.0.2"
     graphql-helix: "npm:^1.13.0"
     graphql-ws: "npm:^6.0.8"
     ws: "npm:8.21.0"
@@ -23587,7 +23587,7 @@ __metadata:
     cosmiconfig-toml-loader: "npm:^1.0.0"
     dotenv: "npm:10.0.0"
     esbuild: "npm:0.28.1"
-    graphql: "npm:^16.9.0 || ^17.0.0-rc.0"
+    graphql: "npm:^16.14.2"
     graphql-config: "npm:^5.1.6"
     graphql-ws: "npm:6.0.8"
     nullthrows: "npm:1.1.1"
@@ -23617,7 +23617,7 @@ __metadata:
     "@types/vscode": "npm:1.62.0"
     "@vscode/vsce": "npm:^2.22.1-2"
     esbuild: "npm:0.18.10"
-    graphql: "npm:^16.9.0 || ^17.0.0-rc.0"
+    graphql: "npm:^16.14.2"
     graphql-language-service-server: "npm:^2.14.9"
     ovsx: "npm:0.8.3"
     typescript: "npm:^5.8.0"


### PR DESCRIPTION
The v6 packages are already receiving major releases, so this is the right time to raise their GraphQL.js peer ranges to `^16.11.0 || ^17.0.0`. This drops releases that predate the OneOf input fixes.

Package development uses the latest v16, `^16.14.2`, because some upstream tools do not yet support GraphQL 17. The isolated incremental-delivery test server uses the latest GraphQL 17, `^17.0.2`.
