### PR TITLE
Disable GPU for Cypress's Electron browser in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,6 +138,10 @@ jobs:
         with:
           install: false
           command: yarn e2e
+        env:
+          # GitHub runners have no usable GPU; Electron's GPU process can
+          # crash (dawn/Vulkan) and wedge the browser mid-run
+          ELECTRON_EXTRA_LAUNCH_ARGS: --disable-gpu
       - uses: actions/upload-artifact@v7
         if: failure()
         with:


### PR DESCRIPTION
The PR Cypress job has flaked three times since July:

- [July 11](https://github.com/graphql/graphiql/actions/runs/29142257631)
- [July 12](https://github.com/graphql/graphiql/actions/runs/29205056576)
- [August 29](https://github.com/graphql/graphiql/actions/runs/33260100561)

Each run relaunches Electron, then times out in `cy.visit`; the failure screenshot shows the app had rendered. The failing logs also include Dawn/Vulkan GPU-process crashes, while a [passing run](https://github.com/graphql/graphiql/actions/runs/33259452404) from the same day does not. This resembles [Cypress issue #23801](https://github.com/cypress-io/cypress/issues/23801).

This passes `--disable-gpu` to Cypress Electron through [`ELECTRON_EXTRA_LAUNCH_ARGS`](https://docs.cypress.io/app/references/launching-browsers#Electron-Browser). I cannot prove the GPU crash causes the flake, so if it recurs with this flag, we should try Cypress retries or Chrome.