### PR TITLE
v6: Clear the light-theme accessibility baseline

### DIFF
--- a/packages/graphiql-react/src/components/tabs/index.tsx
+++ b/packages/graphiql-react/src/components/tabs/index.tsx
@@ -1,4 +1,10 @@
-import { ComponentPropsWithoutRef, forwardRef, ReactNode } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  createContext,
+  forwardRef,
+  ReactNode,
+  useContext,
+} from 'react';
 import { clsx } from 'clsx';
 import { Reorder } from 'framer-motion';
 import { CloseIcon } from '../../icons';
@@ -10,29 +16,31 @@ interface TabProps extends ComponentPropsWithoutRef<typeof Reorder.Item> {
   isDirty?: boolean;
 }
 
+const TabContext = createContext({ isActive: false });
+
 const TabRoot = forwardRef<HTMLLIElement, TabProps>(
   ({ isActive, isDirty, value, children, className, ...props }, ref) => (
     <Reorder.Item
       {...props}
       ref={ref}
       value={value}
-      aria-selected={isActive}
       dragElastic={false} // Prevent over scrolling of container
-      role="tab"
       className={clsx(
         'graphiql-tab',
         isActive && 'graphiql-tab-active',
         className,
       )}
     >
-      {children}
-      {isDirty && (
-        <span
-          className="graphiql-tab-dirty"
-          aria-label="Unsaved changes"
-          role="status"
-        />
-      )}
+      <TabContext.Provider value={{ isActive: Boolean(isActive) }}>
+        {children}
+        {isDirty && (
+          <span
+            className="graphiql-tab-dirty"
+            aria-label="Unsaved changes"
+            role="status"
+          />
+        )}
+      </TabContext.Provider>
     </Reorder.Item>
   ),
 );
@@ -41,16 +49,21 @@ TabRoot.displayName = 'Tab';
 const TabButton = forwardRef<
   HTMLButtonElement,
   ComponentPropsWithoutRef<'button'>
->(({ children, className, ...props }, ref) => (
-  <UnStyledButton
-    {...props}
-    ref={ref}
-    type="button"
-    className={clsx('graphiql-tab-button', className)}
-  >
-    {children}
-  </UnStyledButton>
-));
+>(({ children, className, ...props }, ref) => {
+  const { isActive } = useContext(TabContext);
+
+  return (
+    <UnStyledButton
+      {...props}
+      ref={ref}
+      type="button"
+      aria-pressed={isActive}
+      className={clsx('graphiql-tab-button', className)}
+    >
+      {children}
+    </UnStyledButton>
+  );
+});
 TabButton.displayName = 'Tab.Button';
 
 const TabClose = forwardRef<
@@ -89,7 +102,6 @@ export const Tabs = forwardRef<HTMLUListElement, TabsProps>(
       values={values}
       onReorder={onReorder}
       axis="x"
-      role="tablist"
       className={clsx('graphiql-tabs', className)}
     >
       {children}

--- a/packages/graphiql-react/src/components/tabs/tabs.stories.tsx
+++ b/packages/graphiql-react/src/components/tabs/tabs.stories.tsx
@@ -5,15 +5,6 @@ import { Tab, Tabs } from './';
 const meta: Meta = {
   title: 'Primitives/Tabs',
   tags: ['autodocs'],
-  parameters: {
-    a11y: {
-      // The Tab primitive renders `<li role="tab">` containing a child button,
-      // which axe flags as `nested-interactive`. Fixing it cleanly means
-      // restructuring the primitive's ARIA model; that's out of scope for the
-      // restyle.
-      config: { rules: [{ id: 'nested-interactive', enabled: false }] },
-    },
-  },
 };
 
 export default meta;

--- a/packages/graphiql-react/src/components/top-bar/index.css
+++ b/packages/graphiql-react/src/components/top-bar/index.css
@@ -98,10 +98,16 @@
 @keyframes graphiql-top-bar-method-pulse {
   0%,
   100% {
-    opacity: 1;
+    box-shadow: 0 0 0 0 oklch(var(--accent-orange) / 0.35);
   }
   50% {
-    opacity: 0.55;
+    box-shadow: 0 0 0 3px oklch(var(--accent-orange) / 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .graphiql-top-bar-method-toggle--attention {
+    animation: none;
   }
 }
 

--- a/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
+++ b/packages/graphiql-react/src/components/top-bar/top-bar.stories.tsx
@@ -120,6 +120,20 @@ export const CustomBrand: Story = {
 
 /** GET selected with a mutation in the editor: Run disabled, method toggle highlighted. */
 export const MutationBlockedOverGet: Story = {
+  globals: { theme: 'light' },
+  decorators: [
+    Story => (
+      <>
+        <style>{`
+          .graphiql-top-bar-method-toggle--attention {
+            animation-delay: -0.7s !important;
+            animation-play-state: paused !important;
+          }
+        `}</style>
+        <Story />
+      </>
+    ),
+  ],
   render: () => (
     <Tooltip.Provider>
       <TopBarView

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -273,7 +273,11 @@ const getTokenRules = (
     { token: 'operator.gql', foreground: t.fgMuted },
     { token: 'delimiter.gql', foreground: t.fgMuted },
     // comments
-    { token: 'comment.gql', foreground: t.fgDisabled, fontStyle: 'italic' },
+    {
+      token: 'comment.gql',
+      foreground: theme === 'light' ? t.fgMuted : t.fgDisabled,
+      fontStyle: 'italic',
+    },
     // definition names (identifiers following 'fragment'/'query'/etc.)
     // are caught by key.identifier.gql above, but named fragments benefit
     // from the green-light accent to mirror the design's "name" slot.

--- a/packages/graphiql-react/src/constants.ts
+++ b/packages/graphiql-react/src/constants.ts
@@ -220,6 +220,7 @@ const getBaseColors = (
   const t = TOKEN_COLORS[theme];
   return {
     'editor.background': '#ffffff00', // transparent — editor inherits container bg
+    'editorLineNumber.dimmedForeground': `#${t.fgMuted}`,
     'scrollbar.shadow': '#ffffff00',
     'textLink.foreground': `#${t.accentGreen}`,
     'textLink.activeForeground': `#${t.accentGreen}`,

--- a/packages/graphiql-react/src/stores/monaco-themes.test.ts
+++ b/packages/graphiql-react/src/stores/monaco-themes.test.ts
@@ -60,6 +60,10 @@ describe('MONACO_THEME_DATA light', () => {
     expect(light.colors?.['editor.background']).toBe('#ffffff00');
   });
 
+  it('uses readable foreground for dimmed line numbers', () => {
+    expect(light.colors?.['editorLineNumber.dimmedForeground']).toBe('#636E7B');
+  });
+
   it('colors keyword tokens with accent-pink light variant', () => {
     const rule = light.rules.find(r => r.token === 'keyword.gql');
     expect(rule?.foreground).toBe('CF222E');

--- a/packages/graphiql-react/src/stores/monaco-themes.test.ts
+++ b/packages/graphiql-react/src/stores/monaco-themes.test.ts
@@ -79,6 +79,11 @@ describe('MONACO_THEME_DATA light', () => {
     const rule = light.rules.find(r => r.token === 'comment.gql');
     expect(rule?.fontStyle).toBe('italic');
   });
+
+  it('uses readable foreground for comments', () => {
+    const rule = light.rules.find(r => r.token === 'comment.gql');
+    expect(rule?.foreground).toBe('636E7B');
+  });
 });
 
 describe('MONACO_THEME_DATA symmetry', () => {

--- a/packages/graphiql/cypress/.a11y-baseline.json
+++ b/packages/graphiql/cypress/.a11y-baseline.json
@@ -3,53 +3,22 @@
     {
       "id": "color-contrast",
       "impact": "serious",
-      "nodeCount": 1
-    },
-    {
-      "id": "nested-interactive",
-      "impact": "serious",
-      "nodeCount": 1
+      "nodeCount": 21
     }
   ],
-  "post-run": [
-    {
-      "id": "color-contrast",
-      "impact": "serious",
-      "nodeCount": 2
-    },
-    {
-      "id": "nested-interactive",
-      "impact": "serious",
-      "nodeCount": 1
-    }
-  ],
+  "post-run": [],
   "docs-open": [
     {
       "id": "color-contrast",
       "impact": "serious",
-      "nodeCount": 21
-    },
-    {
-      "id": "link-in-text-block",
-      "impact": "serious",
-      "nodeCount": 1
-    },
-    {
-      "id": "nested-interactive",
-      "impact": "serious",
-      "nodeCount": 1
+      "nodeCount": 19
     }
   ],
   "history-open": [
     {
       "id": "color-contrast",
       "impact": "serious",
-      "nodeCount": 1
-    },
-    {
-      "id": "nested-interactive",
-      "impact": "serious",
-      "nodeCount": 1
+      "nodeCount": 19
     }
   ]
 }

--- a/packages/graphiql/cypress/.a11y-baseline.json
+++ b/packages/graphiql/cypress/.a11y-baseline.json
@@ -1,24 +1,6 @@
 {
-  "initial": [
-    {
-      "id": "color-contrast",
-      "impact": "serious",
-      "nodeCount": 21
-    }
-  ],
+  "initial": [],
   "post-run": [],
-  "docs-open": [
-    {
-      "id": "color-contrast",
-      "impact": "serious",
-      "nodeCount": 19
-    }
-  ],
-  "history-open": [
-    {
-      "id": "color-contrast",
-      "impact": "serious",
-      "nodeCount": 19
-    }
-  ]
+  "docs-open": [],
+  "history-open": []
 }

--- a/packages/graphiql/cypress/e2e/a11y.cy.ts
+++ b/packages/graphiql/cypress/e2e/a11y.cy.ts
@@ -32,18 +32,12 @@ function toSummary(v: {
 }
 
 function checkOrCapture(checkpoint: string) {
-  cy.checkA11y(
+  return cy.checkA11y(
     undefined,
     RULESET,
     violations => {
       if (UPDATE_BASELINE) {
         accumulated[checkpoint] = violations.map(toSummary);
-        // Task runs in Node; path is relative to the package root.
-        // cypress.config.ts wires up the writeBaseline task.
-        cy.task('writeBaseline', {
-          filePath: 'cypress/.a11y-baseline.json',
-          data: { ...(baseline as Baseline), ...accumulated },
-        });
       } else {
         const baselineEntries: ViolationSummary[] =
           (baseline as Baseline)[checkpoint] ?? [];
@@ -70,6 +64,17 @@ function checkOrCapture(checkpoint: string) {
 }
 
 describe('a11y baseline', () => {
+  after(() => {
+    if (UPDATE_BASELINE) {
+      // Task runs in Node; path is relative to the package root.
+      // cypress.config.ts wires up the writeBaseline task.
+      cy.task('writeBaseline', {
+        filePath: 'cypress/.a11y-baseline.json',
+        data: { ...(baseline as Baseline), ...accumulated },
+      });
+    }
+  });
+
   beforeEach(() => {
     cy.clearAllLocalStorage();
     cy.visit('/');
@@ -77,7 +82,7 @@ describe('a11y baseline', () => {
   });
 
   it('initial render has no new violations', () => {
-    checkOrCapture('initial');
+    return checkOrCapture('initial');
   });
 
   it('after running a query has no new violations', () => {
@@ -89,7 +94,7 @@ describe('a11y baseline', () => {
     // Wait for the response panel to populate before scanning
     cy.get('section.result-window').should('not.have.text', '');
     cy.injectAxe();
-    checkOrCapture('post-run');
+    return checkOrCapture('post-run');
   });
 
   it('with docs panel open has no new violations', () => {
@@ -97,7 +102,7 @@ describe('a11y baseline', () => {
     cy.get('.graphiql-activity-rail-item').eq(0).click();
     cy.get('.graphiql-doc-explorer').should('be.visible');
     cy.injectAxe();
-    checkOrCapture('docs-open');
+    return checkOrCapture('docs-open');
   });
 
   it('with history panel open has no new violations', () => {
@@ -105,6 +110,6 @@ describe('a11y baseline', () => {
     cy.get('button[aria-label="Show History"]').click();
     cy.get('.graphiql-history').should('be.visible');
     cy.injectAxe();
-    checkOrCapture('history-open');
+    return checkOrCapture('history-open');
   });
 });

--- a/packages/graphiql/cypress/e2e/a11y.cy.ts
+++ b/packages/graphiql/cypress/e2e/a11y.cy.ts
@@ -48,7 +48,14 @@ function checkOrCapture(checkpoint: string) {
         const newViolations = violations.filter(v => !baselineKeys.has(v.id));
         if (newViolations.length > 0) {
           const summary = newViolations
-            .map(v => `${v.id} (${v.impact}): ${v.help}`)
+            .map(v => {
+              const nodes = v.nodes
+                .map(
+                  node => `  ${node.target.join(' ')}: ${node.failureSummary}`,
+                )
+                .join('\n');
+              return `${v.id} (${v.impact}): ${v.help}\n${nodes}`;
+            })
             .join('\n');
           throw new Error(
             `New a11y violations at "${checkpoint}":\n${summary}`,

--- a/packages/graphiql/cypress/e2e/a11y.cy.ts
+++ b/packages/graphiql/cypress/e2e/a11y.cy.ts
@@ -21,6 +21,7 @@ const RULESET = {
 };
 
 const accumulated: Baseline = {};
+const POST_RUN_QUERY = '{ __typename }';
 
 function toSummary(v: {
   id: string;
@@ -70,6 +71,7 @@ function checkOrCapture(checkpoint: string) {
 
 describe('a11y baseline', () => {
   beforeEach(() => {
+    cy.clearAllLocalStorage();
     cy.visit('/');
     cy.injectAxe();
   });
@@ -79,6 +81,10 @@ describe('a11y baseline', () => {
   });
 
   it('after running a query has no new violations', () => {
+    cy.visitWithOp({ query: POST_RUN_QUERY });
+    cy.contains('.graphiql-query-editor .view-line', '__typename').should(
+      'be.visible',
+    );
     cy.clickExecuteQuery();
     // Wait for the response panel to populate before scanning
     cy.get('section.result-window').should('not.have.text', '');

--- a/packages/graphiql/src/GraphiQL.tsx
+++ b/packages/graphiql/src/GraphiQL.tsx
@@ -571,7 +571,7 @@ export const GraphiQLInterface: FC<GraphiQLInterfaceProps> = ({
                       </div>
                     </div>
                     <div
-                      role="tabpanel"
+                      role="region"
                       id="graphiql-session" // used by aria-controls="graphiql-session"
                       aria-labelledby={`${TAB_CLASS_PREFIX}${activeTabIndex}`}
                     >


### PR DESCRIPTION
The v6 light-theme accessibility baselines currently accept failures in query-tab semantics, text contrast, and an unnamed documentation link. The final audit also found that the blocked-method animation drops its 11px label to 2.47:1 contrast, Monaco comments render at 2.48:1 against the light editor background, and Monaco's dimmed final line number can render at 1.74:1.

This keeps the method label at full opacity while pulsing a halo, represents query tabs as a native list of independent selection and close buttons, and uses the muted theme token for Monaco comments and dimmed line numbers. The app axe baseline is empty after those fixes. The capture step now writes once after the complete Cypress run, so updating one checkpoint can't discard findings collected from another.

The commits are intended to be read in order. Commits 1–2 reproduce and fix the method-label contrast issue, commits 3–4 expose and fix the query-tab structure, commits 7–8 reproduce and fix the Monaco comment contrast issue, and commits 11–12 cover the dimmed line number. The intervening commits make the app audit deterministic, remove the final baseline, and report exact failing targets.

No changeset. The pending v6 redesign changeset already covers this work.

Refs: graphql/graphiql#4219
