### PR TITLE
fix(vscode-graphql-syntax): correct consecutive description highlighting

### DIFF
--- a/.changeset/fix-consecutive-descriptions.md
+++ b/.changeset/fix-consecutive-descriptions.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Fix highlighting of consecutive field and argument descriptions without separating commas, preventing description punctuation from causing subsequent code to be highlighted as documentation.

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -388,7 +388,6 @@
       },
       "patterns": [
         { "include": "#graphql-comment" },
-        { "include": "#graphql-block-string-value" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-arguments" },
         { "include": "#literal-quasi-embedded" },

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -131,7 +131,7 @@
     "graphql-type-definition": {
       "comment": "key (optionalArgs): Type",
       "begin": "\\s*([_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
-      "end": "(?=\\s*(([_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(})))|\\s*(,)",
+      "end": "(?=\\s*(([_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(})))|\\s*(,)|(?=\\s*\")",
       "beginCaptures": {
         "1": { "name": "variable.graphql" }
       },
@@ -278,7 +278,7 @@
       "comment": "variable: type = value,.... which may be a list",
       "name": "meta.variables.graphql",
       "begin": "\\s*(\\$?[_A-Za-z][_0-9A-Za-z]*)(?=\\s*\\(|:)",
-      "end": "(?=\\s*((\\$?[_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(}|\\))))|\\s*(,)",
+      "end": "(?=\\s*((\\$?[_A-Za-z][_0-9A-Za-z]*)\\s*(\\(|:)|(}|\\))))|\\s*(,)|(?=\\s*\")",
       "beginCaptures": {
         "1": { "name": "variable.parameter.graphql" }
       },

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/consecutive-descriptions.graphql
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/consecutive-descriptions.graphql
@@ -1,0 +1,50 @@
+extend type Query {
+  users(
+    "First argument"
+    first: Int
+    "Second argument, with punctuation: (value)"
+    second: Int
+    """
+    Third argument
+    """
+    third: [ID!]
+    "Fourth argument"
+    fourth: String = "default value"
+    "Fifth argument"
+    fifth: String = """
+    block default
+    """
+  ): [User!] @deprecated(reason: "use user")
+
+  # prettier-ignore
+  "Next field"
+  user("Inline first" id: ID "Inline second" name: String): User
+
+  """
+  Block field description
+  """
+  other: User
+
+  "Final field"
+  final: String
+}
+
+input Filter {
+  first: Int
+  "Input field description"
+  second: String = "input default"
+  """
+  Block input description
+  """
+  third: String
+}
+
+directive @example(
+  first: Int
+  "Directive argument description"
+  second: String
+) on FIELD_DEFINITION
+
+type User {
+  id: ID!
+}

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/consecutive-descriptions.graphql
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/consecutive-descriptions.graphql
@@ -48,3 +48,24 @@ directive @example(
 type User {
   id: ID!
 }
+
+type DirectiveDescriptions {
+  first: String @index
+  """
+  After directive without arguments
+  """
+  second: String @index(unique: false)
+  """
+  After directive with arguments
+  """
+  third: String
+    @deprecated(
+      reason: """
+      block directive argument
+      """
+    )
+  """
+  After directive with block string
+  """
+  fourth: String
+}

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
@@ -219,6 +219,71 @@ ID                                         | meta.type.interface.graphql meta.ty
 !                                          | meta.type.interface.graphql meta.type.object.graphql keyword.operator.nulltype.graphql
 }                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
                                            | 
+type                                       | meta.type.interface.graphql keyword.type.graphql
+                                           | meta.type.interface.graphql
+DirectiveDescriptions                      | meta.type.interface.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+{                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+first                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+@index                                     | meta.type.interface.graphql meta.type.object.graphql entity.name.function.directive.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+  After directive without arguments        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+second                                     | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+@index                                     | meta.type.interface.graphql meta.type.object.graphql entity.name.function.directive.graphql
+(                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+unique                                     | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+false                                      | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql constant.language.boolean.graphql
+)                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+  After directive with arguments           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+third                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+@deprecated                                | meta.type.interface.graphql meta.type.object.graphql entity.name.function.directive.graphql
+(                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+reason                                     | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
+      block directive argument             | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.triple.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.triple.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+)                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+  After directive with block string        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+fourth                                     | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+}                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | 
 `;
 
 exports[`source.graphql grammar > should tokenize a simple query 1`] = `

--- a/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
+++ b/packages/vscode-graphql-syntax/tests/__snapshots__/graphql-grammar.spec.ts.snap
@@ -1,5 +1,226 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`source.graphql grammar > should preserve consecutive descriptions and subsequent definitions 1`] = `
+extend                                     | meta.type.interface.graphql keyword.type.graphql
+                                           | meta.type.interface.graphql
+type                                       | meta.type.interface.graphql keyword.type.graphql
+                                           | meta.type.interface.graphql
+Query                                      | meta.type.interface.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+{                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+users                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+(                                          | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+First argument                             | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+first                                      | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+Int                                        | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Second argument, with punctuation: (value) | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+second                                     | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+Int                                        | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+    Third argument                         | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+third                                      | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql
+[                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql meta.brace.square.graphql
+ID                                         | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql support.type.builtin.graphql
+!                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql keyword.operator.nulltype.graphql
+]                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql meta.type.list.graphql meta.brace.square.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Fourth argument                            | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+fourth                                     | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+=                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.assignment.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+default value                              | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Fifth argument                             | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+fifth                                      | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+=                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.assignment.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.triple.graphql punctuation.definition.string.begin.graphql
+    block default                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.triple.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.triple.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql string.quoted.triple.graphql punctuation.definition.string.end.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+)                                          | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql
+[                                          | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql meta.brace.square.graphql
+User                                       | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql support.type.graphql
+!                                          | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql keyword.operator.nulltype.graphql
+]                                          | meta.type.interface.graphql meta.type.object.graphql meta.type.list.graphql meta.brace.square.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+@deprecated                                | meta.type.interface.graphql meta.type.object.graphql entity.name.function.directive.graphql
+(                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+reason                                     | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+use user                                   | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+)                                          | meta.type.interface.graphql meta.type.object.graphql meta.arguments.graphql meta.brace.round.directive.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.line.graphql.js punctuation.whitespace.comment.leading.graphql
+# prettier-ignore                          | meta.type.interface.graphql meta.type.object.graphql comment.line.graphql.js
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Next field                                 | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+user                                       | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+(                                          | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Inline first                               | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+id                                         | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+ID                                         | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Inline second                              | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+name                                       | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql variable.parameter.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql meta.variables.graphql support.type.builtin.graphql
+)                                          | meta.type.interface.graphql meta.type.object.graphql meta.brace.round.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+User                                       | meta.type.interface.graphql meta.type.object.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+  Block field description                  | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+other                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+User                                       | meta.type.interface.graphql meta.type.object.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Final field                                | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+final                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+}                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | 
+input                                      | meta.type.interface.graphql keyword.input.graphql
+                                           | meta.type.interface.graphql
+Filter                                     | meta.type.interface.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+{                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+first                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+Int                                        | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Input field description                    | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql comment.line.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+second                                     | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+=                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.assignment.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql punctuation.definition.string.begin.graphql
+input default                              | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql
+"                                          | meta.type.interface.graphql meta.type.object.graphql string.quoted.double.graphql punctuation.definition.string.end.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+  Block input description                  | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+"""                                        | meta.type.interface.graphql meta.type.object.graphql comment.block.documentation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+third                                      | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+String                                     | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+}                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | 
+directive                                  | keyword.directive.graphql
+                                           | 
+@example                                   | entity.name.function.directive.graphql
+(                                          | meta.brace.round.graphql
+                                           | meta.variables.graphql
+first                                      | meta.variables.graphql variable.parameter.graphql
+:                                          | meta.variables.graphql punctuation.colon.graphql
+                                           | meta.variables.graphql
+Int                                        | meta.variables.graphql support.type.builtin.graphql
+                                           | 
+"                                          | comment.line.documentation.graphql punctuation.whitespace.comment.leading.graphql
+Directive argument description             | comment.line.documentation.graphql
+"                                          | comment.line.documentation.graphql
+                                           | meta.variables.graphql
+second                                     | meta.variables.graphql variable.parameter.graphql
+:                                          | meta.variables.graphql punctuation.colon.graphql
+                                           | meta.variables.graphql
+String                                     | meta.variables.graphql support.type.builtin.graphql
+)                                          | meta.brace.round.graphql
+                                           | 
+on                                         | keyword.on.graphql
+                                           | 
+FIELD_DEFINITION                           | support.type.location.graphql
+                                           | 
+type                                       | meta.type.interface.graphql keyword.type.graphql
+                                           | meta.type.interface.graphql
+User                                       | meta.type.interface.graphql support.type.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+{                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+id                                         | meta.type.interface.graphql meta.type.object.graphql variable.graphql
+:                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.colon.graphql
+                                           | meta.type.interface.graphql meta.type.object.graphql
+ID                                         | meta.type.interface.graphql meta.type.object.graphql support.type.builtin.graphql
+!                                          | meta.type.interface.graphql meta.type.object.graphql keyword.operator.nulltype.graphql
+}                                          | meta.type.interface.graphql meta.type.object.graphql punctuation.operation.graphql
+                                           | 
+`;
+
 exports[`source.graphql grammar > should tokenize a simple query 1`] = `
 query  | keyword.operation.graphql
        | 

--- a/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
@@ -4,6 +4,44 @@ import { tokenizeFile } from './__utilities__/utilities';
 describe('source.graphql grammar', () => {
   const scope = 'source.graphql';
 
+  it('should preserve consecutive descriptions and subsequent definitions', async () => {
+    const result = await tokenizeFile(
+      '__fixtures__/consecutive-descriptions.graphql',
+      scope,
+    );
+    for (const text of [
+      'Second argument, with punctuation: (value)',
+      'Fourth argument',
+      'Fifth argument',
+      'Next field',
+      'Inline second',
+      'Final field',
+      'Input field description',
+      'Directive argument description',
+    ]) {
+      expect(
+        result.find(token => token.text.trim() === text)?.scopes,
+      ).toContain('comment.line.documentation.graphql');
+    }
+    for (const text of ['Third argument', 'Block input description']) {
+      expect(
+        result.find(token => token.text.trim() === text)?.scopes,
+      ).toContain('comment.block.documentation.graphql');
+    }
+    for (const text of ['default value', 'input default', 'use user']) {
+      expect(result.find(token => token.text === text)?.scopes).toContain(
+        'string.quoted.double.graphql',
+      );
+    }
+    expect(
+      result.find(token => token.text.trim() === 'block default')?.scopes,
+    ).toContain('string.quoted.triple.graphql');
+    expect(result.find(token => token.text === 'final')?.scopes).toContain(
+      'variable.graphql',
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   it('should tokenize a simple query', async () => {
     const result = await tokenizeFile('__fixtures__/query.graphql', scope);
     expect(result).toMatchSnapshot();

--- a/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
@@ -23,7 +23,13 @@ describe('source.graphql grammar', () => {
         result.find(token => token.text.trim() === text)?.scopes,
       ).toContain('comment.line.documentation.graphql');
     }
-    for (const text of ['Third argument', 'Block input description']) {
+    for (const text of [
+      'Third argument',
+      'Block input description',
+      'After directive without arguments',
+      'After directive with arguments',
+      'After directive with block string',
+    ]) {
       expect(
         result.find(token => token.text.trim() === text)?.scopes,
       ).toContain('comment.block.documentation.graphql');
@@ -33,9 +39,11 @@ describe('source.graphql grammar', () => {
         'string.quoted.double.graphql',
       );
     }
-    expect(
-      result.find(token => token.text.trim() === 'block default')?.scopes,
-    ).toContain('string.quoted.triple.graphql');
+    for (const text of ['block default', 'block directive argument']) {
+      expect(
+        result.find(token => token.text.trim() === text)?.scopes,
+      ).toContain('string.quoted.triple.graphql');
+    }
     expect(result.find(token => token.text === 'final')?.scopes).toContain(
       'variable.graphql',
     );


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #4385.

Field and argument definitions did not end before a following description. Without a separating comma, descriptions were tokenized inside the previous definition. Commas within description text could then shift quote pairing and cause subsequent code to be highlighted as documentation.

End these definitions before description strings while preserving string-value highlighting.

## Reproduction

Open this schema with GraphQL: Syntax Highlighting 1.3.12:

```graphql
type Query {
  users(
    "First argument"
    first: Int
    "Second argument, with punctuation"
    second: Int
  ): String

  """Next field"""
  next: String
}
```

Expected: descriptions are highlighted as documentation and field definitions retain their normal highlighting.

Actual: the second description is misclassified, and subsequent code can be highlighted as documentation.

While writing this PR, I found that GitHub's own graphql code rendering can directly reproduce this issue. Maybe GitHub uses this repository?

<img width="361" height="221" alt="image" src="https://github.com/user-attachments/assets/48fdf32e-c95b-41e8-b506-893f61d458f5" />

## Validation

- Added a regression fixture, scope assertions, and snapshot coverage.
- Confirmed the regression test fails before the fix.
- Syntax extension tests: 17 passed.
- Root `yarn build` and `yarn test` passed.
- Formatting and lint checks passed for the changed grammar/test files.
- Packaged and installed a local VSIX; manually verified the fix in VS Code.