### PR TITLE
fix(vscode-graphql-syntax): separate defaults from descriptions

### DIFF
--- a/.changeset/fix-default-description-boundaries.md
+++ b/.changeset/fix-default-description-boundaries.md
@@ -1,0 +1,5 @@
+---
+'vscode-graphql-syntax': patch
+---
+
+Fix highlighting of compact defaults and descriptions that follow default values on the same line.

--- a/packages/vscode-graphql-syntax/grammars/graphql.json
+++ b/packages/vscode-graphql-syntax/grammars/graphql.json
@@ -341,9 +341,8 @@
       }
     },
     "graphql-variable-assignment": {
-      "begin": "\\s(=)",
-      "end": "(?=[\n,)])",
-      "applyEndPatternLast": 1,
+      "begin": "\\s*(=)",
+      "end": "(?=[\n,)])|(?<=[_0-9A-Za-z\"])|(?<=\\])|(?<=})",
       "beginCaptures": {
         "1": { "name": "punctuation.assignment.graphql" }
       },

--- a/packages/vscode-graphql-syntax/tests/__fixtures__/default-description-boundaries.txt
+++ b/packages/vscode-graphql-syntax/tests/__fixtures__/default-description-boundaries.txt
@@ -1,0 +1,25 @@
+input DefaultBoundaries {
+  compact: String="compact input default"
+  compactBlock: String="""compact input block default"""
+
+  first: String = "first input default" "Single-line input description" second: String
+  third: String = """third input default""" """Block input description""" fourth: String
+  fifth: [String!] = ["one", "two"] "After input list default" sixth: String
+  seventh: FilterInput = { enabled: true } "After input object default" eighth: String
+}
+
+input FilterInput {
+  enabled: Boolean
+}
+
+type Query {
+  field(
+    compact: String="compact argument default"
+    compactBlock: String="""compact argument block default"""
+
+    first: String = "first argument default" "Single-line argument description" second: String
+    third: String = """third argument default""" """Block argument description""" fourth: String
+    fifth: [String!] = ["one", "two"] "After argument list default" sixth: String
+    seventh: FilterInput = { enabled: true } "After argument object default" eighth: String
+  ): String
+}

--- a/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
+++ b/packages/vscode-graphql-syntax/tests/graphql-grammar.spec.ts
@@ -50,6 +50,53 @@ describe('source.graphql grammar', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('should separate defaults from following descriptions', async () => {
+    const result = await tokenizeFile(
+      '__fixtures__/default-description-boundaries.txt',
+      scope,
+    );
+    for (const text of [
+      'compact input default',
+      'first input default',
+      'compact argument default',
+      'first argument default',
+    ]) {
+      expect(result.find(token => token.text === text)?.scopes).toContain(
+        'string.quoted.double.graphql',
+      );
+    }
+    for (const text of [
+      'compact input block default',
+      'third input default',
+      'compact argument block default',
+      'third argument default',
+    ]) {
+      expect(result.find(token => token.text === text)?.scopes).toContain(
+        'string.quoted.triple.graphql',
+      );
+    }
+    for (const text of [
+      'Single-line input description',
+      'After input list default',
+      'After input object default',
+      'Single-line argument description',
+      'After argument list default',
+      'After argument object default',
+    ]) {
+      expect(result.find(token => token.text === text)?.scopes).toContain(
+        'comment.line.documentation.graphql',
+      );
+    }
+    for (const text of [
+      'Block input description',
+      'Block argument description',
+    ]) {
+      expect(result.find(token => token.text === text)?.scopes).toContain(
+        'comment.block.documentation.graphql',
+      );
+    }
+  });
+
   it('should tokenize a simple query', async () => {
     const result = await tokenizeFile('__fixtures__/query.graphql', scope);
     expect(result).toMatchSnapshot();


### PR DESCRIPTION
[#4491](https://github.com/graphql/graphiql/pull/4491) corrected field and argument boundaries before quoted descriptions, but a nested `graphql-variable-assignment` can still own the rest of the line.

```graphql
input Example {
  compact: String="default"
  first: String = "default" "Second field" second: String
}
```

The compact default is scoped as documentation, while `"Second field"` is scoped as another string value. Both forms are valid because [GraphQL treats whitespace and line terminators as insignificant](https://spec.graphql.org/September2025/#sec-White-Space).

This changes the assignment rule to accept optional whitespace before `=` and close after one scalar, string, list, or object value. The surrounding field or argument rule can then recognize the next string as a description.
