### PR TITLE
Configure monthly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,33 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: 'weekly'
-    # 0 disables version-update PRs; security updates still open (separate internal limit)
-    open-pull-requests-limit: 0
+      interval: monthly
+    open-pull-requests-limit: 50
+    groups:
+      non-major-dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        # Dependabot cannot exclude dependencies based on their current version, so keep this list in sync with current 0.x dependencies.
+        exclude-patterns:
+          - '@changesets/changelog-github'
+          - '@codemirror/buildhelper'
+          - '@types/codemirror'
+          - '@types/copy'
+          - '@whatwg-node/fetch'
+          - copy
+          - esbuild
+          - graphiql-explorer
+          - json-schema
+          - monaco-editor
+          - ovsx
+          - oxfmt
+          - regenerator-runtime
+          - subscriptions-transport-ws
+          - svelte2tsx
+          - typedoc
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Dependabot version updates are currently disabled by `open-pull-requests-limit: 0`, leaving routine upgrades to be handled manually. This enables a monthly npm update job and groups minor and patch releases into one PR. Major updates and external dependencies currently below `1.0` are excluded from that group, so Dependabot opens an individual PR for each one.

Dependabot can't select a group based on the current version, so the `exclude-patterns` list needs to stay aligned with external dependencies on `0.x`. Repo-owned GraphiQL workspaces are intentionally absent from that list. `open-pull-requests-limit: 50` prevents [Dependabot's default five-PR limit](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit) from deferring unmatched updates until a later monthly run.

Security updates remain independent of the monthly version-update group.
